### PR TITLE
Graph route and QoL fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -182,7 +182,6 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
-      "funding": "https://opencollective.com/eslint",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -227,6 +226,9 @@
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@asymmetrik/node-fhir-server-core/node_modules/eslint-utils": {
@@ -1955,7 +1957,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2507,9 +2508,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
       "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==",
-      "funding": "https://github.com/sindresorhus/is?sponsor=1",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -3491,21 +3494,25 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "type-fest": "^0.11.0"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-escapes/node_modules/type-fest": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
       "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-red": {
@@ -3531,12 +3538,14 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "funding": "https://github.com/chalk/ansi-styles?sponsor=1",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ansi-styles/node_modules/color-convert": {
@@ -4677,7 +4686,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
       "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "ansi-align": "^3.0.0",
         "camelcase": "^5.3.1",
@@ -4690,6 +4698,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/boxen/node_modules/chalk": {
@@ -4918,12 +4929,14 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "pump": "^3.0.0"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/call-bind": {
@@ -5065,13 +5078,15 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "funding": "https://github.com/chalk/chalk?sponsor=1",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/char-regex": {
@@ -5279,7 +5294,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -5472,9 +5486,11 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -5500,9 +5516,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
       "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-tableau": {
@@ -6263,9 +6281,11 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
       "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
-      "funding": "https://github.com/sponsors/fb55",
       "engines": {
         "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -6551,21 +6571,25 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/decompress-response/node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/decompress-tar": {
@@ -6814,9 +6838,11 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
       "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -7084,11 +7110,13 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
       "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
-      "funding": "https://github.com/cheeriojs/dom-serializer?sponsor=1",
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
         "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
     "node_modules/dom-serializer/node_modules/domhandler": {
@@ -7141,12 +7169,14 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
       "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
-      "funding": "https://github.com/fb55/domhandler?sponsor=1",
       "dependencies": {
         "domelementtype": "^2.0.1"
       },
       "engines": {
         "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/domutils": {
@@ -7438,9 +7468,11 @@
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
       "integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
       "dev": true,
-      "funding": "https://github.com/sindresorhus/emittery?sponsor=1",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
@@ -7498,7 +7530,9 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "funding": "https://github.com/fb55/entities?sponsor=1"
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/enzyme": {
       "version": "3.11.0",
@@ -7762,8 +7796,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -7781,7 +7814,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
       "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
       "dev": true,
-      "funding": "https://opencollective.com/eslint",
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.3.0",
@@ -7826,6 +7858,9 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-plugin-security": {
@@ -7854,12 +7889,14 @@
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
       "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
-      "funding": "https://github.com/sponsors/mysticatea",
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -8816,12 +8853,14 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -9187,7 +9226,9 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
       "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
-      "funding": "https://ko-fi.com/tunnckoCore/commissions"
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.1.2",
@@ -9408,9 +9449,11 @@
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
       "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
       "dev": true,
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-proxy": {
@@ -9488,9 +9531,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -9680,12 +9720,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
       "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "ini": "1.3.7"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/global-modules": {
@@ -9716,12 +9758,14 @@
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
       "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "type-fest": "^0.8.1"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -9802,7 +9846,6 @@
       "version": "11.4.0",
       "resolved": "https://registry.npmjs.org/got/-/got-11.4.0.tgz",
       "integrity": "sha512-XysJZuZNVpaQ37Oo2LV90MIkPeYITehyy1A0QzO1JwOXm8EWuEf9eeGk2XuHePvLEGnm9AVOI37bHwD6KYyBtg==",
-      "funding": "https://github.com/sindresorhus/got?sponsor=1",
       "dependencies": {
         "@sindresorhus/is": "^2.1.1",
         "@szmarczak/http-timer": "^4.0.5",
@@ -9818,6 +9861,9 @@
       },
       "engines": {
         "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -10297,9 +10343,11 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/http2-wrapper": {
@@ -10432,25 +10480,29 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/imagemin-svgo/-/imagemin-svgo-7.1.0.tgz",
       "integrity": "sha512-0JlIZNWP0Luasn1HT82uB9nU9aa+vUj6kpT+MjPW11LbprXC+iC4HDwn1r4Q2/91qj4iy9tRZNsFySMlEpLdpg==",
-      "funding": "https://github.com/sindresorhus/imagemin-svgo?sponsor=1",
       "dependencies": {
         "is-svg": "^4.2.1",
         "svgo": "^1.3.2"
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/imagemin-svgo?sponsor=1"
       }
     },
     "node_modules/imagemin-svgo/node_modules/is-svg": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-4.2.1.tgz",
       "integrity": "sha512-PHx3ANecKsKNl5y5+Jvt53Y4J7MfMpbNZkv384QNiswMKAWIbvcqbPz+sYbFKJI8Xv3be01GSFniPmoaP+Ai5A==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "html-comment-regex": "^1.1.2"
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imagemin/node_modules/make-dir": {
@@ -10490,13 +10542,15 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
@@ -10804,12 +10858,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
       "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extendable": {
@@ -10832,9 +10888,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
       "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -10888,13 +10946,15 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
       "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "global-dirs": "^2.0.1",
         "is-path-inside": "^3.0.1"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -11121,9 +11181,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-url": {
@@ -11337,7 +11399,6 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
       "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
       "dev": true,
-      "funding": "https://github.com/sindresorhus/execa?sponsor=1",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -11351,6 +11412,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/jest-changed-files/node_modules/get-stream": {
@@ -11358,12 +11422,14 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "pump": "^3.0.0"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-changed-files/node_modules/is-stream": {
@@ -11573,7 +11639,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -11936,9 +12001,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
       "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
       "dev": true,
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-watcher": {
@@ -12024,12 +12091,14 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
       "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
-      "funding": "https://github.com/sponsors/panva",
       "dependencies": {
         "@panva/asn1.js": "^1.0.0"
       },
       "engines": {
         "node": ">=10.13.0 < 13 || >=13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/jpegtran-bin": {
@@ -12217,7 +12286,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -12882,13 +12950,15 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/logalot": {
@@ -13019,21 +13089,25 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
       "integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "semver": "^6.0.0"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir/node_modules/semver": {
@@ -13143,9 +13217,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-random": {
@@ -13579,8 +13655,7 @@
         "bson": "^1.1.4",
         "denque": "^1.4.1",
         "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "safe-buffer": "^5.1.2"
       },
       "engines": {
         "node": ">=4"
@@ -13646,7 +13721,6 @@
         "lockfile": "^1.0.4",
         "md5-file": "^5.0.0",
         "mkdirp": "^1.0.4",
-        "mongodb": "^3.5.9",
         "semver": "^7.3.2",
         "tar-stream": "^2.1.3",
         "tmp": "^0.2.1",
@@ -13665,9 +13739,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
       "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
       "dev": true,
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mongodb-memory-server-core/node_modules/cross-spawn": {
@@ -13689,7 +13765,6 @@
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
       "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
       "dev": true,
-      "funding": "https://github.com/avajs/find-cache-dir?sponsor=1",
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
@@ -13697,6 +13772,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
     "node_modules/mongodb-memory-server-core/node_modules/lru-cache": {
@@ -14370,25 +14448,29 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/open": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
       "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -14428,7 +14510,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
       "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "bl": "^4.0.3",
         "chalk": "^4.1.0",
@@ -14441,6 +14522,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ora/node_modules/bl": {
@@ -14519,9 +14603,11 @@
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
       "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
       "dev": true,
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-event": {
@@ -14555,12 +14641,14 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "p-try": "^2.0.0"
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
@@ -14578,12 +14666,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-map-series": {
@@ -14720,12 +14810,14 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "pump": "^3.0.0"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/package-json/node_modules/cacheable-request/node_modules/lowercase-keys": {
@@ -15021,9 +15113,11 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "funding": "https://github.com/sponsors/jonschlinkert",
       "engines": {
         "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/pidusage": {
@@ -15212,9 +15306,11 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pm2-deploy": {
@@ -16027,9 +16123,6 @@
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
       "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "dependencies": {
-        "clipboard": "^2.0.0"
-      },
       "optionalDependencies": {
         "clipboard": "^2.0.0"
       }
@@ -16320,9 +16413,11 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/raf": {
@@ -16591,7 +16686,6 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
       "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -16602,6 +16696,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/react-dev-utils/node_modules/ignore": {
@@ -16751,7 +16848,6 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
       "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
       "dev": true,
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "find-up": "^4.1.0",
         "read-pkg": "^5.2.0",
@@ -16759,6 +16855,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg/node_modules/parse-json": {
@@ -16766,7 +16865,6 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -16775,6 +16873,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
@@ -16909,9 +17010,11 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true,
-      "funding": "https://github.com/sponsors/mysticatea",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/regexpu-core": {
@@ -17651,21 +17754,25 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "type-fest": "^0.13.1"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-error/node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serve-favicon": {
@@ -17897,7 +18004,6 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
-      "funding": "https://github.com/chalk/slice-ansi?sponsor=1",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -17905,6 +18011,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
@@ -19512,9 +19621,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-outer": {
@@ -19941,9 +20052,11 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
       "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/terminal-link": {
@@ -19951,13 +20064,15 @@
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
       "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
       "dev": true,
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "supports-hyperlinks": "^2.0.0"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/test-exclude": {
@@ -20499,7 +20614,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
       "integrity": "sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==",
-      "funding": "https://github.com/yeoman/update-notifier?sponsor=1",
       "dependencies": {
         "boxen": "^4.2.0",
         "chalk": "^3.0.0",
@@ -20517,6 +20631,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
       }
     },
     "node_modules/update-notifier/node_modules/chalk": {
@@ -20882,12 +20999,14 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.3.tgz",
       "integrity": "sha512-OSOGH1QYiW5yVor9TtmXKQvt2vjQqbYS+DqmsZw+r7xDwLXEeT3JGW0ZppFmHx4diyXmxt238KFR3N9jzevBRg==",
-      "funding": "https://github.com/sponsors/sindresorhus",
       "dependencies": {
         "execa": "^1.0.0"
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/winston": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "NODE_ENV=production node src/index.js",
-    "dev": "NODE_ENV=development ./node_modules/pm2/bin/pm2-runtime start ./src/index.js;",
+    "dev": "NODE_ENV=development ./node_modules/pm2/bin/pm2-dev start ./src/index.js;",
     "test": "NODE_ENV=test npm run test:lint && npm run test:jest",
     "failed_tests": "NODE_ENV=test npm run test:lint && npm run test:jest --onlyFailures",
     "test:lint": "eslint \"src/**/*.js\"",

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -39,7 +39,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -81,7 +81,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -123,7 +123,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -165,7 +165,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -207,7 +207,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -249,7 +249,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -291,7 +291,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -333,7 +333,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -375,7 +375,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -417,7 +417,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -459,7 +459,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -501,7 +501,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -543,7 +543,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -585,7 +585,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -627,7 +627,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -669,7 +669,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -711,7 +711,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -753,7 +753,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -795,7 +795,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -837,7 +837,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -879,7 +879,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -921,7 +921,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -963,7 +963,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1005,7 +1005,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1047,7 +1047,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1089,7 +1089,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1131,7 +1131,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1173,7 +1173,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1215,7 +1215,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1257,7 +1257,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1299,7 +1299,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1341,7 +1341,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1383,7 +1383,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1425,7 +1425,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1467,7 +1467,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1509,7 +1509,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1551,7 +1551,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1593,7 +1593,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1635,7 +1635,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1677,7 +1677,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1719,7 +1719,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1761,7 +1761,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1803,7 +1803,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1845,7 +1845,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1887,7 +1887,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1929,7 +1929,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -1971,7 +1971,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2013,7 +2013,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2055,7 +2055,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2097,7 +2097,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2139,7 +2139,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2181,7 +2181,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2223,7 +2223,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2265,7 +2265,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2307,7 +2307,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2349,7 +2349,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2391,7 +2391,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2433,7 +2433,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2475,7 +2475,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2517,7 +2517,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2559,7 +2559,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2601,7 +2601,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2643,7 +2643,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2685,7 +2685,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2727,7 +2727,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2769,7 +2769,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2811,7 +2811,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2853,7 +2853,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2895,7 +2895,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2937,7 +2937,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -2979,7 +2979,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3021,7 +3021,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3063,7 +3063,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3105,7 +3105,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3147,7 +3147,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3189,7 +3189,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3231,7 +3231,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3273,7 +3273,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3315,7 +3315,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3357,7 +3357,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3399,7 +3399,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3441,7 +3441,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3483,7 +3483,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3525,7 +3525,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3567,7 +3567,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3609,7 +3609,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3651,7 +3651,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3693,7 +3693,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3735,7 +3735,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3777,7 +3777,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3819,7 +3819,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3861,7 +3861,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3903,7 +3903,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3945,7 +3945,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -3987,7 +3987,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4029,7 +4029,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4071,7 +4071,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4113,7 +4113,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4155,7 +4155,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4197,7 +4197,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4239,7 +4239,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4281,7 +4281,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4323,7 +4323,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4365,7 +4365,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4407,7 +4407,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4449,7 +4449,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4491,7 +4491,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4533,7 +4533,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4575,7 +4575,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4617,7 +4617,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4659,7 +4659,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4701,7 +4701,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4743,7 +4743,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4785,7 +4785,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4827,7 +4827,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+            route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4869,7 +4869,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4911,7 +4911,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4953,7 +4953,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -4995,7 +4995,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -5037,7 +5037,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -5079,7 +5079,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -5121,7 +5121,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -5163,7 +5163,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -5205,7 +5205,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -5247,7 +5247,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -5289,7 +5289,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -5331,7 +5331,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -5373,7 +5373,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -5415,7 +5415,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }
@@ -5435,7 +5435,7 @@ const profiles = {
           name: 'everything',
           route: '/$everything',
           method: 'GET',
-          reference: 'https://www.hl7.org/fhir/patient-operation-everything.html',
+            reference: 'https://www.hl7.org/fhir/patient-operation-everything.html',
         },
         {
           name: 'merge',
@@ -5457,7 +5457,7 @@ const profiles = {
         },
         {
           name: 'graph',
-          route: '/$graph',
+          route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
         }

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -2,7 +2,6 @@
 const { VERSIONS } = require('@asymmetrik/node-fhir-server-core').constants;
 // noinspection SpellCheckingInspection
 const profiles = {
-
     Account: {
       service: './src/services/account/account.service.js',
       versions: [VERSIONS['4_0_0']],
@@ -37,12 +36,18 @@ const profiles = {
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-validate.html',
         },
-        {
-          name: 'graph',
-          route: '/:id/$graph',
-          method: 'POST',
-          reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+          {
+              name: 'graph',
+              route: '/:id/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ActivityDefinition: {
@@ -84,7 +89,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     AdverseEvent: {
@@ -126,7 +137,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     AllergyIntolerance: {
@@ -168,7 +185,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Appointment: {
@@ -210,7 +233,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     AppointmentResponse: {
@@ -252,7 +281,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     AuditEvent: {
@@ -294,7 +329,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Basic: {
@@ -336,7 +377,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Binary: {
@@ -378,7 +425,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     BodyStructure: {
@@ -420,7 +473,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Bundle: {
@@ -462,7 +521,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     CapabilityStatement: {
@@ -504,7 +569,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     CarePlan: {
@@ -546,7 +617,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     CareTeam: {
@@ -588,7 +665,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ChargeItem: {
@@ -630,7 +713,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ChargeItemDefinition: {
@@ -672,7 +761,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Claim: {
@@ -714,7 +809,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ClaimResponse: {
@@ -756,7 +857,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ClinicalImpression: {
@@ -798,7 +905,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     CodeSystem: {
@@ -840,7 +953,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Communication: {
@@ -882,7 +1001,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     CommunicationRequest: {
@@ -924,7 +1049,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     CompartmentDefinition: {
@@ -966,7 +1097,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Composition: {
@@ -1008,7 +1145,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ConceptMap: {
@@ -1050,7 +1193,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Condition: {
@@ -1092,7 +1241,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Consent: {
@@ -1134,7 +1289,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Contract: {
@@ -1176,7 +1337,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Coverage: {
@@ -1218,7 +1385,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     CoverageEligibilityRequest: {
@@ -1260,7 +1433,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     CoverageEligibilityResponse: {
@@ -1302,7 +1481,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     DetectedIssue: {
@@ -1344,7 +1529,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Device: {
@@ -1386,7 +1577,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     DeviceDefinition: {
@@ -1428,7 +1625,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     DeviceMetric: {
@@ -1470,7 +1673,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     DeviceRequest: {
@@ -1512,7 +1721,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     DeviceUseStatement: {
@@ -1554,7 +1769,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     DiagnosticReport: {
@@ -1596,7 +1817,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     DocumentManifest: {
@@ -1638,7 +1865,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     DocumentReference: {
@@ -1680,7 +1913,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     EffectEvidenceSynthesis: {
@@ -1722,7 +1961,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Encounter: {
@@ -1764,7 +2009,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Endpoint: {
@@ -1806,7 +2057,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     EnrollmentRequest: {
@@ -1848,7 +2105,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     EnrollmentResponse: {
@@ -1890,7 +2153,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     EpisodeOfCare: {
@@ -1932,7 +2201,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     EventDefinition: {
@@ -1974,7 +2249,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ExampleScenario: {
@@ -2016,7 +2297,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ExplanationOfBenefit: {
@@ -2058,7 +2345,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     FamilyMemberHistory: {
@@ -2100,7 +2393,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Flag: {
@@ -2142,7 +2441,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Goal: {
@@ -2184,7 +2489,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     GraphDefinition: {
@@ -2226,7 +2537,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Group: {
@@ -2268,7 +2585,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     GuidanceResponse: {
@@ -2310,7 +2633,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     HealthcareService: {
@@ -2352,7 +2681,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ImagingStudy: {
@@ -2394,7 +2729,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Immunization: {
@@ -2436,7 +2777,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ImmunizationEvaluation: {
@@ -2478,7 +2825,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ImmunizationRecommendation: {
@@ -2520,7 +2873,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ImplementationGuide: {
@@ -2562,7 +2921,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     InsurancePlan: {
@@ -2604,7 +2969,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Invoice: {
@@ -2646,7 +3017,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Library: {
@@ -2688,7 +3065,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Linkage: {
@@ -2730,7 +3113,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     List: {
@@ -2772,7 +3161,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Location: {
@@ -2814,7 +3209,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Measure: {
@@ -2856,7 +3257,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MeasureReport: {
@@ -2898,7 +3305,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Media: {
@@ -2940,7 +3353,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Medication: {
@@ -2982,7 +3401,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MedicationAdministration: {
@@ -3024,7 +3449,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MedicationDispense: {
@@ -3066,7 +3497,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MedicationKnowledge: {
@@ -3108,7 +3545,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MedicationRequest: {
@@ -3150,7 +3593,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MedicationStatement: {
@@ -3192,7 +3641,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MedicinalProduct: {
@@ -3234,7 +3689,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MedicinalProductAuthorization: {
@@ -3276,7 +3737,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MedicinalProductContraindication: {
@@ -3318,7 +3785,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MedicinalProductIndication: {
@@ -3360,7 +3833,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MedicinalProductPackaged: {
@@ -3402,7 +3881,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MedicinalProductPharmaceutical: {
@@ -3444,7 +3929,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MessageDefinition: {
@@ -3486,7 +3977,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MessageHeader: {
@@ -3528,7 +4025,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     MolecularSequence: {
@@ -3570,7 +4073,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     NamingSystem: {
@@ -3612,7 +4121,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     NutritionOrder: {
@@ -3654,7 +4169,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Observation: {
@@ -3696,7 +4217,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     OperationDefinition: {
@@ -3738,7 +4265,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Organization: {
@@ -3780,7 +4313,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     OrganizationAffiliation: {
@@ -3822,7 +4361,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Patient: {
@@ -3864,7 +4409,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     PaymentNotice: {
@@ -3906,7 +4457,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     PaymentReconciliation: {
@@ -3948,7 +4505,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Person: {
@@ -3990,7 +4553,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     PlanDefinition: {
@@ -4032,7 +4601,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Practitioner: {
@@ -4074,7 +4649,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     PractitionerRole: {
@@ -4116,7 +4697,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Procedure: {
@@ -4158,7 +4745,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Provenance: {
@@ -4200,7 +4793,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Questionnaire: {
@@ -4242,7 +4841,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     QuestionnaireResponse: {
@@ -4284,7 +4889,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     RelatedPerson: {
@@ -4326,7 +4937,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     RequestGroup: {
@@ -4368,7 +4985,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ResearchDefinition: {
@@ -4410,7 +5033,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ResearchElementDefinition: {
@@ -4452,7 +5081,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ResearchStudy: {
@@ -4494,7 +5129,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ResearchSubject: {
@@ -4536,7 +5177,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     RiskAssessment: {
@@ -4578,7 +5225,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     RiskEvidenceSynthesis: {
@@ -4620,7 +5273,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Schedule: {
@@ -4662,7 +5321,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     SearchParameter: {
@@ -4704,7 +5369,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ServiceRequest: {
@@ -4746,7 +5417,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Slot: {
@@ -4788,7 +5465,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Specimen: {
@@ -4830,7 +5513,13 @@ const profiles = {
             route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     SpecimenDefinition: {
@@ -4872,7 +5561,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     StructureDefinition: {
@@ -4914,7 +5609,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     StructureMap: {
@@ -4956,7 +5657,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Subscription: {
@@ -4998,7 +5705,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Substance: {
@@ -5040,7 +5753,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     SubstanceSpecification: {
@@ -5082,7 +5801,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     SupplyDelivery: {
@@ -5124,7 +5849,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     SupplyRequest: {
@@ -5166,7 +5897,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     Task: {
@@ -5208,7 +5945,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     TerminologyCapabilities: {
@@ -5250,7 +5993,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     TestReport: {
@@ -5292,7 +6041,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     TestScript: {
@@ -5334,7 +6089,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     ValueSet: {
@@ -5376,7 +6137,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     VerificationResult: {
@@ -5418,7 +6185,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
     VisionPrescription: {
@@ -5460,7 +6233,13 @@ const profiles = {
           route: '/:id/$graph',
           method: 'POST',
           reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
-        }
+        },
+          {
+              name: 'graph',
+              route: '/$graph',
+              method: 'POST',
+              reference: 'https://www.hl7.org/fhir/resource-operation-graph.html',
+          }
       ],
     },
 };


### PR DESCRIPTION
- Changes the route for the $graph API endpoint to be in line with the FHIR standard
- Changes config for the pm2 server in dev so that it watches the filesystem and restarts on a change
- Updates the `graph` function so that it will find an id if it is specified via the URL rather than just looking at query parameters
- A couple of minor fixes to comments and log statements