### PR TITLE
convert _lastUpdated search param to use date type

### DIFF
--- a/src/dist/js/search.js
+++ b/src/dist/js/search.js
@@ -5,12 +5,21 @@ resetButtonElement.addEventListener('click', resetSubmit);
 formElement.addEventListener('submit', submitSearchForm);
 
 const dateRangeElement = document.getElementById('_lastUpdateRange');
-const datepicker = new DateRangePicker(dateRangeElement, {
+const dateRangePicker = new DateRangePicker(dateRangeElement, {
     autohide: true,
     format: 'yyyy-mm-dd',
     clearBtn: true,
     allowOneSidedRange: true,
 });
+
+const dateElement = document.getElementById('datePicker');
+const datePicker = dateElement
+    ? new Datepicker(dateElement, {
+          autohide: true,
+          format: 'yyyy-mm-dd',
+          clearBtn: true,
+      })
+    : null;
 
 function advSearch(event) {
     if (event) {

--- a/src/middleware/htmlRenderer.js
+++ b/src/middleware/htmlRenderer.js
@@ -1,7 +1,7 @@
 /**
  * This middleware detects if the request is from a web browser user-agent and returns HTML rendered views
  */
-const {resourceDefinitions} = require('../utils/resourceDefinitions');
+const { resourceDefinitions } = require('../utils/resourceDefinitions');
 const {
     searchFormData,
     advSearchFormData,
@@ -10,7 +10,7 @@ const {
     limit,
     searchUtils,
 } = require('../utils/searchForm.util');
-const {shouldReturnHtml} = require('../utils/requestHelpers');
+const { shouldReturnHtml } = require('../utils/requestHelpers');
 
 /**
  * middleware to render HTML
@@ -20,7 +20,7 @@ const {shouldReturnHtml} = require('../utils/requestHelpers');
  */
 const htmlRenderer = (req, res, next) => {
     const parts = req.url.split(/[/?,&]+/);
-    if (parts && (parts.length > 2) && !parts.includes('raw=1') && parts[1] === '4_0_0') {
+    if (parts && parts.length > 2 && !parts.includes('raw=1') && parts[1] === '4_0_0') {
         const resourceName = parts[2];
         // If the request is from a browser for HTML then return HTML page instead of json
         if (shouldReturnHtml(req)) {
@@ -64,8 +64,8 @@ const htmlRenderer = (req, res, next) => {
                     advSearchFormData: advSearchFormData(req, resourceName),
                     resourceName: resourceName,
                     currentYear: new Date().getFullYear(),
-                    lastUpdateStart: lastUpdateStart(req, 'above'),
-                    lastUpdateEnd: lastUpdateEnd(req, 'below'),
+                    lastUpdateStart: lastUpdateStart(req, 0),
+                    lastUpdateEnd: lastUpdateEnd(req, 1),
                     limit: limit,
                     searchUtils: searchUtils,
                     searchMethod: req.method,

--- a/src/operations/query/r4.js
+++ b/src/operations/query/r4.js
@@ -43,7 +43,7 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
     }
     // ---- end of backward compatibility mappings ---
 
-    // ---- start of range logic to args sent from the search form   ---
+    // ---- start of add range logic to args sent from the search form   ---
     const lastUpdatedArray = args['_lastUpdated'];
     const newUpdatedArray = [];
     lastUpdatedArray.forEach((value, i) => {
@@ -56,7 +56,7 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
     if (newUpdatedArray.length > 0) {
         args['_lastUpdated'] = newUpdatedArray;
     }
-    // ---- end of range logic to args sent from the search form   ---
+    // ---- end of add range logic to args sent from the search form   ---
 
     /**
      * list of columns used in the query

--- a/src/operations/query/r4.js
+++ b/src/operations/query/r4.js
@@ -1,16 +1,16 @@
-const {fhirFilterTypes} = require('./customQueries');
-const {searchParameterQueries} = require('../../searchParameters/searchParameters');
-const {filterById} = require('./filters/id');
-const {filterByString} = require('./filters/string');
-const {filterByUri} = require('./filters/uri');
-const {filterByDateTime} = require('./filters/dateTime');
-const {filterByToken} = require('./filters/token');
-const {filterByReference} = require('./filters/reference');
-const {filterByMissing} = require('./filters/missing');
-const {filterByContains} = require('./filters/contains');
-const {filterByAboveAndBelow, filterByAbove, filterByBelow} = require('./filters/aboveAndBelow');
-const {convertGraphQLParameters} = require('./convertGraphQLParameters');
-const {filterByPartialText} = require('./filters/partialText');
+const { fhirFilterTypes } = require('./customQueries');
+const { searchParameterQueries } = require('../../searchParameters/searchParameters');
+const { filterById } = require('./filters/id');
+const { filterByString } = require('./filters/string');
+const { filterByUri } = require('./filters/uri');
+const { filterByDateTime } = require('./filters/dateTime');
+const { filterByToken } = require('./filters/token');
+const { filterByReference } = require('./filters/reference');
+const { filterByMissing } = require('./filters/missing');
+const { filterByContains } = require('./filters/contains');
+const { filterByAboveAndBelow, filterByAbove, filterByBelow } = require('./filters/aboveAndBelow');
+const { convertGraphQLParameters } = require('./convertGraphQLParameters');
+const { filterByPartialText } = require('./filters/partialText');
 
 // /**
 //  * @type {import('winston').logger}
@@ -41,6 +41,16 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
     if (args['onset_date'] && !args['onset-date']) {
         args['onset-date'] = args['onset_date'];
     }
+    if (args['_lastUpdated:below']) {
+        const belowValue = args['_lastUpdated:below'];
+        args['_lastUpdated'] = `lt${belowValue}`;
+        delete args['_lastUpdated:below'];
+    }
+    if (args['_lastUpdated:above']) {
+        const aboveValue = args['_lastUpdated:above'];
+        args['_lastUpdated'] = `gt${aboveValue}`;
+        delete args['_lastUpdated:above'];
+    }
 
     // ---- end of backward compatibility mappings ---
 
@@ -60,9 +70,10 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
     // add FHIR queries
     for (const [resourceType, resourceObj] of Object.entries(searchParameterQueries)) {
         if (resourceType === resourceName || resourceType === 'Resource') {
-            for (const [ /** @type {string} **/ queryParameter,
-                /** @type {import('../common/types').SearchParameterDefinition} **/ propertyObj]
-                of Object.entries(resourceObj)) {
+            for (const [
+                /** @type {string} **/ queryParameter,
+                /** @type {import('../common/types').SearchParameterDefinition} **/ propertyObj,
+            ] of Object.entries(resourceObj)) {
                 /**
                  * @type {string | string[]}
                  */
@@ -90,13 +101,24 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
                         case fhirFilterTypes.date:
                         case fhirFilterTypes.period:
                         case fhirFilterTypes.instant:
-                            filterByDateTime(queryParameterValue, propertyObj, and_segments, resourceName, columns);
+                            filterByDateTime(
+                                queryParameterValue,
+                                propertyObj,
+                                and_segments,
+                                resourceName,
+                                columns
+                            );
                             break;
                         case fhirFilterTypes.token:
                             filterByToken(queryParameterValue, propertyObj, and_segments, columns);
                             break;
                         case fhirFilterTypes.reference:
-                            filterByReference(propertyObj, and_segments, queryParameterValue, columns);
+                            filterByReference(
+                                propertyObj,
+                                and_segments,
+                                queryParameterValue,
+                                columns
+                            );
                             break;
                         default:
                             throw new Error('Unknown type=' + propertyObj.type);

--- a/src/operations/query/r4.js
+++ b/src/operations/query/r4.js
@@ -44,17 +44,19 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
     // ---- end of backward compatibility mappings ---
 
     // ---- start of add range logic to args sent from the search form   ---
-    const lastUpdatedArray = args['_lastUpdated'];
-    const newUpdatedArray = [];
-    lastUpdatedArray.forEach((value, i) => {
-        const currentPrefix = value.replace(/[^a-z]/gi, '');
-        const newPrefix = i === 0 ? 'gt' : 'lt';
-        if (currentPrefix.length === 0) {
-            newUpdatedArray.push(newPrefix + value);
+    if (args['_lastUpdated'] && Array.isArray(args['_lastUpdated'])) {
+        const lastUpdatedArray = args['_lastUpdated'];
+        const newUpdatedArray = [];
+        lastUpdatedArray.forEach((value, i) => {
+            const currentPrefix = value.replace(/[^a-z]/gi, '');
+            const newPrefix = i === 0 ? 'gt' : 'lt';
+            if (currentPrefix.length === 0) {
+                newUpdatedArray.push(newPrefix + value);
+            }
+        });
+        if (newUpdatedArray.length > 0) {
+            args['_lastUpdated'] = newUpdatedArray;
         }
-    });
-    if (newUpdatedArray.length > 0) {
-        args['_lastUpdated'] = newUpdatedArray;
     }
     // ---- end of add range logic to args sent from the search form   ---
 

--- a/src/operations/query/r4.js
+++ b/src/operations/query/r4.js
@@ -49,9 +49,10 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
         const lastUpdatedArray = args['_lastUpdated'];
         const gtValue = lastUpdatedArray.at(0);
         const ltValue = lastUpdatedArray.at(1);
+        const hasRange = gtValue.indexOf('gt') > -1 || gtValue.indexOf('lt') > -1;
         args['_lastUpdated'] = [
-            gtValue.indexOf('gt') > -1 ? gtValue : `gt${gtValue}`,
-            ltValue.indexOf('lt') > -1 ? ltValue : `lt${ltValue}`,
+            hasRange ? gtValue : `gt${gtValue}`,
+            hasRange ? ltValue : `lt${ltValue}`,
         ];
     }
 

--- a/src/operations/query/r4.js
+++ b/src/operations/query/r4.js
@@ -41,6 +41,9 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
     if (args['onset_date'] && !args['onset-date']) {
         args['onset-date'] = args['onset_date'];
     }
+    // ---- end of backward compatibility mappings ---
+
+    // ---- start of range logic to args sent from the search form   ---
     if (
         args['_lastUpdated'] &&
         Array.isArray(args['_lastUpdated']) &&
@@ -49,14 +52,17 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
         const lastUpdatedArray = args['_lastUpdated'];
         const gtValue = lastUpdatedArray.at(0);
         const ltValue = lastUpdatedArray.at(1);
-        const hasRange = gtValue.indexOf('gt') > -1 || gtValue.indexOf('lt') > -1;
-        args['_lastUpdated'] = [
-            hasRange ? gtValue : `gt${gtValue}`,
-            hasRange ? ltValue : `lt${ltValue}`,
-        ];
+        const hasRange = gtValue.at(0) === 'g';
+        const lastUpdatedValue = [];
+        if (gtValue.trim() !== '') {
+            lastUpdatedValue.push(hasRange ? gtValue : `gt${gtValue}`);
+        }
+        if (ltValue.trim() !== '') {
+            lastUpdatedValue.push(hasRange ? ltValue : `lt${ltValue}`);
+        }
+        args['_lastUpdated'] = lastUpdatedValue;
     }
-
-    // ---- end of backward compatibility mappings ---
+    // ---- end of range logic to args sent from the search form   ---
 
     /**
      * list of columns used in the query

--- a/src/operations/query/r4.js
+++ b/src/operations/query/r4.js
@@ -44,23 +44,17 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
     // ---- end of backward compatibility mappings ---
 
     // ---- start of range logic to args sent from the search form   ---
-    if (
-        args['_lastUpdated'] &&
-        Array.isArray(args['_lastUpdated']) &&
-        args['_lastUpdated'].length > 1
-    ) {
-        const lastUpdatedArray = args['_lastUpdated'];
-        const gtValue = lastUpdatedArray.at(0);
-        const ltValue = lastUpdatedArray.at(1);
-        const hasRange = gtValue.at(0) === 'g';
-        const lastUpdatedValue = [];
-        if (gtValue.trim() !== '') {
-            lastUpdatedValue.push(hasRange ? gtValue : `gt${gtValue}`);
+    const lastUpdatedArray = args['_lastUpdated'];
+    const newUpdatedArray = [];
+    lastUpdatedArray.forEach((value, i) => {
+        const currentPrefix = value.replace(/[^a-z]/gi, '');
+        const newPrefix = i === 0 ? 'gt' : 'lt';
+        if (currentPrefix.length === 0) {
+            newUpdatedArray.push(newPrefix + value);
         }
-        if (ltValue.trim() !== '') {
-            lastUpdatedValue.push(hasRange ? ltValue : `lt${ltValue}`);
-        }
-        args['_lastUpdated'] = lastUpdatedValue;
+    });
+    if (newUpdatedArray.length > 0) {
+        args['_lastUpdated'] = newUpdatedArray;
     }
     // ---- end of range logic to args sent from the search form   ---
 

--- a/src/operations/query/r4.js
+++ b/src/operations/query/r4.js
@@ -47,7 +47,12 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
         args['_lastUpdated'].length > 1
     ) {
         const lastUpdatedArray = args['_lastUpdated'];
-        args['_lastUpdated'] = [`gt${lastUpdatedArray.at(0)}`, `lt${lastUpdatedArray.at(1)}`];
+        const gtValue = lastUpdatedArray.at(0);
+        const ltValue = lastUpdatedArray.at(1);
+        args['_lastUpdated'] = [
+            gtValue.indexOf('gt') > -1 ? gtValue : `gt${gtValue}`,
+            ltValue.indexOf('lt') > -1 ? ltValue : `lt${ltValue}`,
+        ];
     }
 
     // ---- end of backward compatibility mappings ---

--- a/src/operations/query/r4.js
+++ b/src/operations/query/r4.js
@@ -41,15 +41,13 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
     if (args['onset_date'] && !args['onset-date']) {
         args['onset-date'] = args['onset_date'];
     }
-    if (args['_lastUpdated:below']) {
-        const belowValue = args['_lastUpdated:below'];
-        args['_lastUpdated'] = `lt${belowValue}`;
-        delete args['_lastUpdated:below'];
-    }
-    if (args['_lastUpdated:above']) {
-        const aboveValue = args['_lastUpdated:above'];
-        args['_lastUpdated'] = `gt${aboveValue}`;
-        delete args['_lastUpdated:above'];
+    if (
+        args['_lastUpdated'] &&
+        Array.isArray(args['_lastUpdated']) &&
+        args['_lastUpdated'].length > 1
+    ) {
+        const lastUpdatedArray = args['_lastUpdated'];
+        args['_lastUpdated'] = [`gt${lastUpdatedArray.at(0)}`, `lt${lastUpdatedArray.at(1)}`];
     }
 
     // ---- end of backward compatibility mappings ---

--- a/src/operations/query/r4.js
+++ b/src/operations/query/r4.js
@@ -50,7 +50,7 @@ module.exports.buildR4SearchQuery = (resourceName, args) => {
         lastUpdatedArray.forEach((value, i) => {
             const currentPrefix = value.replace(/[^a-z]/gi, '');
             const newPrefix = i === 0 ? 'gt' : 'lt';
-            if (currentPrefix.length === 0) {
+            if (currentPrefix.length === 0 && value !== '') {
                 newUpdatedArray.push(newPrefix + value);
             }
         });

--- a/src/utils/searchForm.util.js
+++ b/src/utils/searchForm.util.js
@@ -141,15 +141,9 @@ const getHasNext = (res) => {
     return res.resources.length === searchLimit;
 };
 
-const getLastUpdate = function (req, modifier) {
+const getLastUpdate = function (req, index) {
     const searchParams = getSearchParams(req);
-    let dateString = '';
-    Object.keys(searchParams).forEach((key) => {
-        if (key.includes('_lastUpdated') && key.includes(modifier)) {
-            dateString = searchParams[`${key}`];
-        }
-    });
-    return dateString;
+    return searchParams['_lastUpdated'] ? searchParams['_lastUpdated'].at(index) : '';
 };
 
 const zeroPad = (number) => {

--- a/src/utils/searchForm.util.js
+++ b/src/utils/searchForm.util.js
@@ -74,6 +74,18 @@ function getOrganizationForm(params) {
     return formElements;
 }
 
+function getEncounterForm(params) {
+    const formElements = [];
+    formElements.push({
+        columnHeader: 'Period',
+        label: 'Date',
+        name: 'date',
+        sortField: 'period',
+        value: params.date ? params.date : '',
+    });
+    return formElements;
+}
+
 const getFormData = (req, resourceName) => {
     const params = getModifierParams(req);
     let formData = [];
@@ -87,6 +99,9 @@ const getFormData = (req, resourceName) => {
             break;
         case 'Organization':
             formData = formData.concat(getOrganizationForm(params));
+            break;
+        case 'Encounter':
+            formData = formData.concat(getEncounterForm(params));
             break;
     }
 

--- a/src/views/pages/SearchResult.ejs
+++ b/src/views/pages/SearchResult.ejs
@@ -35,8 +35,10 @@
                             <% formData.forEach(function(field){%>
                             <td>
                                 <!-- prettier-ignore -->
-                                <% if(field.columnHeader === 'Period'){ %>
-                                    <%= searchUtils.formatDate(res.period.start) %> to <%= searchUtils.formatDate(res.period.end) %>
+                                <% if(field.columnHeader === 'Period' && res.period){ %>
+                                    <%= res.period.start ? searchUtils.formatDate(res.period.start) : '' %>
+                                    <%= res.period.start && res.period.end ? 'to' : '' %>
+                                    <%= res.period.end ? searchUtils.formatDate(res.period.end) : '' %>
                                 <% } else { %>
                                     <%= searchUtils.fieldValue(res,field.name) %>
                                 <% } %>

--- a/src/views/pages/SearchResult.ejs
+++ b/src/views/pages/SearchResult.ejs
@@ -15,7 +15,7 @@
                         <tr>
                             <% formData.forEach(function(field){%>
                             <th data-field="<%= field.sortField %>">
-                                <%= field.label %><i
+                                <%= field.columnHeader ? field.columnHeader : field.label %><i
                                     class="fa<%= searchUtils.sortIcon(field.sortField, body._sort) %>"
                                 ></i>
                             </th>
@@ -33,7 +33,14 @@
                         <% resources.forEach(function(res, index){%>
                         <tr class="row-click" data-identifier="<%=res.id%>">
                             <% formData.forEach(function(field){%>
-                            <td><%= searchUtils.fieldValue(res,field.name) %></td>
+                            <td>
+                                <!-- prettier-ignore -->
+                                <% if(field.columnHeader === 'Period'){ %>
+                                    <%= searchUtils.formatDate(res.period.start) %> to <%= searchUtils.formatDate(res.period.end) %>
+                                <% } else { %>
+                                    <%= searchUtils.fieldValue(res,field.name) %>
+                                <% } %>
+                            </td>
                             <%})%>
                             <td><%= searchUtils.formatDate(res.meta.lastUpdated) %></td>
                         </tr>

--- a/src/views/partials/searchForm.ejs
+++ b/src/views/partials/searchForm.ejs
@@ -65,7 +65,7 @@ const resourceName = hasResource ? resourceDefinition.name : '';
             <input
                 type="text"
                 class="form-control"
-                name="_lastUpdated:above"
+                name="_lastUpdated"
                 placeholder="YYYY-MM-DD"
                 aria-label="Start Date"
                 value="<%= lastUpdateStart %>"
@@ -75,7 +75,7 @@ const resourceName = hasResource ? resourceDefinition.name : '';
             <input
                 type="text"
                 class="form-control"
-                name="_lastUpdated:below"
+                name="_lastUpdated"
                 placeholder="YYYY-MM-DD"
                 aria-label="End Date"
                 value="<%= lastUpdateEnd %>"

--- a/src/views/partials/searchForm.ejs
+++ b/src/views/partials/searchForm.ejs
@@ -83,7 +83,22 @@ const resourceName = hasResource ? resourceDefinition.name : '';
             />
         </div>
     </div>
-    <% for (var i = 0; i < formData.length; i++) { %>
+    <% for (var i = 0; i < formData.length; i++) { %> <% if(formData[i].name === 'date'){ %>
+    <div class="form-group">
+        <label for="<%= formData[i].name %>"><small><%= formData[i].label %></small></label>
+        <input
+            id="datePicker"
+            type="text"
+            class="form-control clear-allowed"
+            name="<%= formData[i].name %>"
+            value="<%= formData[i].value %>"
+            autocomplete="off"
+            placeholder="YYYY-MM-DD"
+            title="<%= formData[i].label %>"
+        />
+    </div>
+
+    <% } else { %>
     <div class="form-group form-group-clear">
         <label for="<%= formData[i].name %>" class="visually-hidden"
             ><%= formData[i].label %></label
@@ -102,6 +117,8 @@ const resourceName = hasResource ? resourceDefinition.name : '';
             class="fa fa-times clear-input <%= formData[i].value !== '' ? 'showInputClearLink' : '' %>"
         ></span>
     </div>
+    <% } %>
+
     <!-- prettier-ignore -->
     <% } %>
     <input type="hidden" name="identifier" />


### PR DESCRIPTION
The reason to still use _lastUpdated:below and _lastUpdated:above is to allow a simpler repopulation of the search form values