### PR TITLE
ATHD-804: Fix ExplanationOfBenefit filterBy to use patient reference …

### DIFF
--- a/src/profiles.js
+++ b/src/profiles.js
@@ -2609,7 +2609,7 @@ const profiles = {
         service: './src/services/explanationofbenefit/explanationofbenefit.service.js',
         versions: [VERSIONS['4_0_0']],
         filterByPerson: true,
-        filterBy: 'subject.reference',
+        filterBy: 'patient.reference',
         operation: [
             {
                 name: 'everything',


### PR DESCRIPTION
 …instead of subject reference. 
 
In the  [EOB resource](http://hl7.org/fhir/R4B/explanationofbenefit.html#resource), a patient reference is used, not a subject reference. 