### PR TITLE
ATHD-780: enable access to reverse proxy info

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -236,6 +236,11 @@ function createApp(fnCreateContainer) {
         createFhirApp(fnCreateContainer, app);
     }
     app.locals.currentYear = new Date().getFullYear();
+
+    // enables access to reverse proxy information
+    // https://expressjs.com/en/guide/behind-proxies.html
+    app.enable('trust proxy');
+
     return app;
 }
 


### PR DESCRIPTION
req.protocol is returning the incorrect value due to the reverse proxy. X-Forwarded-Proto can be set by the reverse proxy to tell the app whether it is https or http or even an invalid name

https://expressjs.com/en/guide/behind-proxies.html