### PR TITLE
EFS-98 Publish Patient Change event for Proxy Patient

### DIFF
--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -137,6 +137,7 @@ const createContainer = function () {
             patientChangeTopic: env.KAFKA_PATIENT_CHANGE_TOPIC || 'business.events',
             taskChangeTopic: env.KAFKA_TASK_CHANGE_TOPIC || 'business.events',
             observationChangeTopic: env.KAFKA_OBSERVATION_CHANGE_TOPIC || 'business.events',
+            bwellPersonFinder: c.bwellPersonFinder
         }
     ));
 

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -71,6 +71,7 @@ const {AccessColumnHandler} = require('./preSaveHandlers/handlers/accessColumnHa
 const {SourceAssigningAuthorityColumnHandler} = require('./preSaveHandlers/handlers/sourceAssigningAuthorityColumnHandler');
 const {PersonToPatientIdsExpander} = require('./utils/personToPatientIdsExpander');
 const {AdminPersonPatientLinkManager} = require('./admin/adminPersonPatientLinkManager');
+const {BwellPersonFinder} = require('./utils/bwellPersonFinder');
 
 /**
  * Creates a container and sets up all the services
@@ -521,6 +522,10 @@ const createContainer = function () {
     container.register('adminPersonPatientLinkManager', (c) => new AdminPersonPatientLinkManager({
         databaseQueryFactory: c.databaseQueryFactory,
         databaseUpdateFactory: c.databaseUpdateFactory
+    }));
+
+    container.register('bwellPersonFinder', (c) => new BwellPersonFinder({
+        databaseQueryFactory: c.databaseQueryFactory
     }));
 
     return container;

--- a/src/tests/dataLayer/databaseBulkInserter/databaseBulkInserter.test.js
+++ b/src/tests/dataLayer/databaseBulkInserter/databaseBulkInserter.test.js
@@ -17,6 +17,7 @@ class MockChangeEventProducer extends ChangeEventProducer {
      * @param {string} patientChangeTopic
      * @param {string} taskChangeTopic
      * @param {string} observationChangeTopic
+     * @param {BwellPersonFinder} bwellPersonFinder
      */
     constructor({
                     kafkaClient,
@@ -24,6 +25,7 @@ class MockChangeEventProducer extends ChangeEventProducer {
                     patientChangeTopic,
                     taskChangeTopic,
                     observationChangeTopic,
+                    bwellPersonFinder
                 }) {
         super({
             kafkaClient,
@@ -31,6 +33,7 @@ class MockChangeEventProducer extends ChangeEventProducer {
             patientChangeTopic,
             taskChangeTopic,
             observationChangeTopic,
+            bwellPersonFinder
         });
     }
 }
@@ -61,6 +64,7 @@ describe('databaseBulkInserter Tests', () => {
                             taskChangeTopic: env.KAFKA_PATIENT_CHANGE_TOPIC || 'business.events',
                             observationChangeTopic:
                                 env.KAFKA_PATIENT_CHANGE_TOPIC || 'business.events',
+                            bwellPersonFinder: c.bwellPersonFinder
                         })
                 );
                 return container1;

--- a/src/tests/patient/change_events/change_events.test.js
+++ b/src/tests/patient/change_events/change_events.test.js
@@ -210,5 +210,46 @@ describe('Patient Change Event Tests', () => {
             expect(messageValue3.action).toBe('C');
             expect(messageValue3.agent[0].who.reference).toBe('Observation/2354-InAgeCohort');
         });
+        test('creating a new observation updates patient if no associated proxy patient', async () => {
+            const request = await createTestRequest();
+            /**
+             * @type {PostRequestProcessor}
+             */
+            const postRequestProcessor = getTestContainer().postRequestProcessor;
+            /**
+             * @type {MockKafkaClient}
+             */
+            const mockKafkaClient = getTestContainer().kafkaClient;
+            mockKafkaClient.clear();
+
+            let resp = await request
+                .get('/4_0_0/Observation')
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResourceCount(0);
+
+            resp = await request
+                .post('/4_0_0/Observation/0/$merge')
+                .send(observation1Resource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            // wait for post request processing to finish
+            await postRequestProcessor.waitTillDoneAsync();
+            /**
+             * @type {KafkaClientMessage[]}
+             */
+            const messages = mockKafkaClient.getMessages();
+            expect(messages.length).toBe(2);
+            const messageValue = JSON.parse(messages[0].value);
+            expect(messageValue.resourceType).toBe('AuditEvent');
+            expect(messageValue.action).toBe('U');
+            expect(messageValue.agent[0].who.reference).toBe('Patient/2354');
+            const messageValue2 = JSON.parse(messages[1].value);
+            expect(messageValue2.resourceType).toBe('AuditEvent');
+            expect(messageValue2.action).toBe('C');
+            expect(messageValue2.agent[0].who.reference).toBe('Observation/2354-InAgeCohort');
+        });
     });
 });

--- a/src/tests/patient/change_events/change_events.test.js
+++ b/src/tests/patient/change_events/change_events.test.js
@@ -1,5 +1,6 @@
 // provider file
 const patient1Resource = require('./fixtures/patient/patient1.json');
+const person1Resource = require('./fixtures/person/person1.json');
 const observation1Resource = require('./fixtures/observation/observation1.json');
 
 // expected
@@ -56,7 +57,7 @@ describe('Patient Change Event Tests', () => {
             expect(messageValue.action).toBe('C');
             expect(messageValue.agent[0].who.reference).toBe('Patient/00100000000');
         });
-        test('creating a new observation works', async () => {
+        test('linking a new patient works', async () => {
             const request = await createTestRequest();
             /**
              * @type {PostRequestProcessor}
@@ -67,15 +68,19 @@ describe('Patient Change Event Tests', () => {
              */
             const mockKafkaClient = getTestContainer().kafkaClient;
             mockKafkaClient.clear();
-            let resp = await request
-                .get('/4_0_0/Observation')
-                .set(getHeaders());
+            let resp = await request.get('/4_0_0/Patient').set(getHeaders());
             // noinspection JSUnresolvedFunction
             expect(resp).toHaveResourceCount(0);
 
             resp = await request
-                .post('/4_0_0/Observation/0/$merge')
-                .send(observation1Resource)
+                .post('/4_0_0/Patient/1679033641/$merge?validate=true')
+                .send(patient1Resource)
+                .set(getHeaders());
+            mockKafkaClient.clear();
+
+            resp = await request
+                .put('/4_0_0/Person/0000000001000/$merge?validate=true')
+                .send(person1Resource)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
             expect(resp).toHaveMergeResponse({created: true});
@@ -87,10 +92,14 @@ describe('Patient Change Event Tests', () => {
              */
             const messages = mockKafkaClient.getMessages();
             expect(messages.length).toBe(2);
-            const messageValue = JSON.parse(messages[0].value);
-            expect(messageValue.resourceType).toBe('AuditEvent');
-            expect(messageValue.action).toBe('U');
-            expect(messageValue.agent[0].who.reference).toBe('Patient/2354');
+            const messageValue1 = JSON.parse(messages[0].value);
+            expect(messageValue1.resourceType).toBe('AuditEvent');
+            expect(messageValue1.action).toBe('C');
+            expect(messageValue1.agent[0].who.reference).toBe('Patient/00100000000');
+            const messageValue2 = JSON.parse(messages[0].value);
+            expect(messageValue2.resourceType).toBe('AuditEvent');
+            expect(messageValue2.action).toBe('U');
+            expect(messageValue2.agent[0].who.reference).toBe('Patient/person.???');
         });
     });
     describe('Observation Change Event Tests', () => {
@@ -124,7 +133,7 @@ describe('Patient Change Event Tests', () => {
              * @type {KafkaClientMessage[]}
              */
             const messages = mockKafkaClient.getMessages();
-            expect(messages.length).toBe(2);
+            expect(messages.length).toBe(3);
             const messageValue = JSON.parse(messages[0].value);
             expect(messageValue.resourceType).toBe('AuditEvent');
             expect(messageValue.action).toBe('U');
@@ -132,7 +141,11 @@ describe('Patient Change Event Tests', () => {
             const messageValue2 = JSON.parse(messages[1].value);
             expect(messageValue2.resourceType).toBe('AuditEvent');
             expect(messageValue2.action).toBe('C');
-            expect(messageValue2.agent[0].who.reference).toBe('Observation/2354-InAgeCohort');
+            expect(messageValue2.agent[0].who.reference).toBe('Patient/person.???');
+            const messageValue3 = JSON.parse(messages[2].value);
+            expect(messageValue3.resourceType).toBe('AuditEvent');
+            expect(messageValue3.action).toBe('C');
+            expect(messageValue3.agent[0].who.reference).toBe('Observation/2354-InAgeCohort');
         });
     });
 });

--- a/src/tests/patient/change_events/change_events.test.js
+++ b/src/tests/patient/change_events/change_events.test.js
@@ -1,6 +1,7 @@
 // provider file
 const patient1Resource = require('./fixtures/patient/patient1.json');
-const person1Resource = require('./fixtures/person/person1.json');
+const person1withlinkResource = require('./fixtures/person/person1_withlink.json');
+const person1nolinkResource = require('./fixtures/person/person1_nolink.json');
 const observation1Resource = require('./fixtures/observation/observation1.json');
 
 // expected
@@ -39,7 +40,7 @@ describe('Patient Change Event Tests', () => {
             expect(resp).toHaveResourceCount(0);
 
             resp = await request
-                .post('/4_0_0/Patient/1679033641/$merge?validate=true')
+                .post('/4_0_0/Patient/2354/$merge?validate=true')
                 .send(patient1Resource)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
@@ -55,9 +56,9 @@ describe('Patient Change Event Tests', () => {
             const messageValue = JSON.parse(messages[0].value);
             expect(messageValue.resourceType).toBe('AuditEvent');
             expect(messageValue.action).toBe('C');
-            expect(messageValue.agent[0].who.reference).toBe('Patient/00100000000');
+            expect(messageValue.agent[0].who.reference).toBe('Patient/2354');
         });
-        test('linking a new patient works', async () => {
+        test('creating a new person with a patient link updates proxy patient', async () => {
             const request = await createTestRequest();
             /**
              * @type {PostRequestProcessor}
@@ -73,14 +74,14 @@ describe('Patient Change Event Tests', () => {
             expect(resp).toHaveResourceCount(0);
 
             resp = await request
-                .post('/4_0_0/Patient/1679033641/$merge?validate=true')
+                .post('/4_0_0/Patient/2354/$merge?validate=true')
                 .send(patient1Resource)
                 .set(getHeaders());
-            mockKafkaClient.clear();
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
-                .put('/4_0_0/Person/0000000001000/$merge?validate=true')
-                .send(person1Resource)
+                .post('/4_0_0/Person/81236/$merge?validate=true')
+                .send(person1withlinkResource)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
             expect(resp).toHaveMergeResponse({created: true});
@@ -95,15 +96,13 @@ describe('Patient Change Event Tests', () => {
             const messageValue1 = JSON.parse(messages[0].value);
             expect(messageValue1.resourceType).toBe('AuditEvent');
             expect(messageValue1.action).toBe('C');
-            expect(messageValue1.agent[0].who.reference).toBe('Patient/00100000000');
-            const messageValue2 = JSON.parse(messages[0].value);
+            expect(messageValue1.agent[0].who.reference).toBe('Patient/2354');
+            const messageValue2 = JSON.parse(messages[1].value);
             expect(messageValue2.resourceType).toBe('AuditEvent');
-            expect(messageValue2.action).toBe('U');
-            expect(messageValue2.agent[0].who.reference).toBe('Patient/person.???');
+            expect(messageValue2.action).toBe('C');
+            expect(messageValue2.agent[0].who.reference).toBe('Patient/person.81236');
         });
-    });
-    describe('Observation Change Event Tests', () => {
-        test('creating a new observation works', async () => {
+        test('adding a patient link to an existing person updates proxy patient', async () => {
             const request = await createTestRequest();
             /**
              * @type {PostRequestProcessor}
@@ -114,7 +113,71 @@ describe('Patient Change Event Tests', () => {
              */
             const mockKafkaClient = getTestContainer().kafkaClient;
             mockKafkaClient.clear();
+            let resp = await request.get('/4_0_0/Patient').set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResourceCount(0);
+
+            resp = await request
+                .post('/4_0_0/Person/81236/$merge?validate=true')
+                .send(person1nolinkResource)
+                .set(getHeaders());
+
+            await postRequestProcessor.waitTillDoneAsync();
+            mockKafkaClient.clear();
+
+            resp = await request
+                .post('/4_0_0/Patient/2354/$merge?validate=true')
+                .send(patient1Resource)
+                .set(getHeaders());
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .put('/4_0_0/Person/81236')
+                .send(person1withlinkResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveStatusCode(200);
+
+            // wait for post request processing to finish
+            await postRequestProcessor.waitTillDoneAsync();
+            /**
+             * @type {KafkaClientMessage[]}
+             */
+            const messages = mockKafkaClient.getMessages();
+            expect(messages.length).toBe(2);
+            const messageValue1 = JSON.parse(messages[0].value);
+            expect(messageValue1.resourceType).toBe('AuditEvent');
+            expect(messageValue1.action).toBe('C');
+            expect(messageValue1.agent[0].who.reference).toBe('Patient/2354');
+            const messageValue2 = JSON.parse(messages[1].value);
+            expect(messageValue2.resourceType).toBe('AuditEvent');
+            expect(messageValue2.action).toBe('U');
+            expect(messageValue2.agent[0].who.reference).toBe('Patient/person.81236');
+        });
+    });
+    describe('Observation Change Event Tests', () => {
+        test('creating a new observation updates patient and proxy patient', async () => {
+            const request = await createTestRequest();
+            /**
+             * @type {PostRequestProcessor}
+             */
+            const postRequestProcessor = getTestContainer().postRequestProcessor;
+            /**
+             * @type {MockKafkaClient}
+             */
+            const mockKafkaClient = getTestContainer().kafkaClient;
+
             let resp = await request
+                .post('/4_0_0/Person/81236/$merge')
+                .send(person1withlinkResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            await postRequestProcessor.waitTillDoneAsync();
+            mockKafkaClient.clear();
+
+            resp = await request
                 .get('/4_0_0/Observation')
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
@@ -140,8 +203,8 @@ describe('Patient Change Event Tests', () => {
             expect(messageValue.agent[0].who.reference).toBe('Patient/2354');
             const messageValue2 = JSON.parse(messages[1].value);
             expect(messageValue2.resourceType).toBe('AuditEvent');
-            expect(messageValue2.action).toBe('C');
-            expect(messageValue2.agent[0].who.reference).toBe('Patient/person.???');
+            expect(messageValue2.action).toBe('U');
+            expect(messageValue2.agent[0].who.reference).toBe('Patient/person.81236');
             const messageValue3 = JSON.parse(messages[2].value);
             expect(messageValue3.resourceType).toBe('AuditEvent');
             expect(messageValue3.action).toBe('C');

--- a/src/tests/patient/change_events/fixtures/patient/patient1.json
+++ b/src/tests/patient/change_events/fixtures/patient/patient1.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "Patient",
-    "id": "00100000000",
+    "id": "2354",
     "meta": {
         "source": "http://medstarhealth.org/provider",
         "security": [

--- a/src/tests/patient/change_events/fixtures/person/person1.json
+++ b/src/tests/patient/change_events/fixtures/person/person1.json
@@ -1,0 +1,36 @@
+{
+    "resourceType": "Person",
+    "id": "0000000001000",
+    "meta": {
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "thedacare"
+            },
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "thedacare"
+            }
+        ]
+    },
+    "name": [
+        {
+            "use": "official",
+            "family": "Irving",
+            "given": [
+                "Lloyd"
+            ]
+        }
+    ],
+    "gender": "male",
+    "birthDate": "1996-03-03",
+    "link": [
+        {
+            "target": {
+                "reference": "Patient/00100000000",
+                "type": "Patient"
+            },
+            "assurance": "level4"
+        }
+    ]
+}

--- a/src/tests/patient/change_events/fixtures/person/person1_nolink.json
+++ b/src/tests/patient/change_events/fixtures/person/person1_nolink.json
@@ -1,0 +1,27 @@
+{
+    "resourceType": "Person",
+    "id": "81236",
+    "meta": {
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "thedacare"
+            },
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "thedacare"
+            }
+        ]
+    },
+    "name": [
+        {
+            "use": "official",
+            "family": "Irving",
+            "given": [
+                "Lloyd"
+            ]
+        }
+    ],
+    "gender": "male",
+    "birthDate": "1996-03-03"
+}

--- a/src/tests/patient/change_events/fixtures/person/person1_withlink.json
+++ b/src/tests/patient/change_events/fixtures/person/person1_withlink.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "Person",
-    "id": "0000000001000",
+    "id": "81236",
     "meta": {
         "security": [
             {
@@ -27,7 +27,7 @@
     "link": [
         {
             "target": {
-                "reference": "Patient/00100000000",
+                "reference": "Patient/2354",
                 "type": "Patient"
             },
             "assurance": "level4"

--- a/src/tests/utils/bwellPersonFinder/bwellPersonFinder.test.js
+++ b/src/tests/utils/bwellPersonFinder/bwellPersonFinder.test.js
@@ -1,0 +1,127 @@
+const bwellPerson_directLink = require('./fixtures/bwellPerson_directLink.json');
+const bwellPerson_indirectLink = require('./fixtures/bwellPerson_indirectLink.json');
+const linkedPerson1 = require('./fixtures/linkedPerson1.json');
+const linkedPerson2 = require('./fixtures/linkedPerson2.json');
+const linkedPerson1_cycle = require('./fixtures/linkedPerson1_cycle.json');
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    createTestRequest
+} = require('../../common');
+const { describe, expect, test, beforeEach, afterEach} = require('@jest/globals');
+const {createContainer} = require('../../../createContainer');
+
+describe('bwellPersonFinder Tests', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    test('search works with no linked Person', async () => {
+
+        const bwellPersonFinder = createContainer().bwellPersonFinder;
+        const result = await bwellPersonFinder.getBwellPersonIdAsync({ base_version: '4_0_0', patientId: 'Patient/1234' });
+
+        expect(!result);
+    });
+
+    test('search works with no linked bwell Person', async () => {
+
+        const request = await createTestRequest();
+        await request
+            .post('/4_0_0/Person/otherOne/$merge?validate=true')
+            .send(linkedPerson1)
+            .set(getHeaders());
+
+        const bwellPersonFinder = createContainer().bwellPersonFinder;
+        const result = await bwellPersonFinder.getBwellPersonIdAsync({ base_version: '4_0_0', patientId: 'Patient/1234' });
+
+        expect(!result);
+    });
+
+    test('search works with directly linked bwell Person', async () => {
+
+        const request = await createTestRequest();
+        await request
+            .post('/4_0_0/Person/81236/$merge?validate=true')
+            .send(bwellPerson_directLink)
+            .set(getHeaders());
+
+        const bwellPersonFinder = createContainer().bwellPersonFinder;
+        const result = await bwellPersonFinder.getBwellPersonIdAsync({ base_version: '4_0_0', patientId: 'Patient/1234' });
+
+        expect(result === '81235');
+    });
+
+    test('search works with indirectly linked bwell Person', async () => {
+
+        const request = await createTestRequest();
+        await request
+            .post('/4_0_0/Person/81236/$merge?validate=true')
+            .send(bwellPerson_indirectLink)
+            .set(getHeaders());
+
+        await request
+            .post('/4_0_0/Person/5678/$merge?validate=true')
+            .send(linkedPerson2)
+            .set(getHeaders());
+
+        await request
+            .post('/4_0_0/Person/otherOne/$merge?validate=true')
+            .send(linkedPerson1)
+            .set(getHeaders());
+
+        const bwellPersonFinder = createContainer().bwellPersonFinder;
+        const result = await bwellPersonFinder.getBwellPersonIdAsync({ base_version: '4_0_0', patientId: 'Patient/1234' });
+
+        expect(result === '81235');
+    });
+
+    test('search works with cycle and no linked bwell Person', async () => {
+
+        const request = await createTestRequest();
+        await request
+            .post('/4_0_0/Person/5678/$merge?validate=true')
+            .send(linkedPerson2)
+            .set(getHeaders());
+
+        await request
+            .post('/4_0_0/Person/otherOne/$merge?validate=true')
+            .send(linkedPerson1_cycle)
+            .set(getHeaders());
+
+        const bwellPersonFinder = createContainer().bwellPersonFinder;
+        const result = await bwellPersonFinder.getBwellPersonIdAsync({ base_version: '4_0_0', patientId: 'Patient/1234' });
+
+        expect(!result);
+    });
+
+    test('search works with cycle and linked bwell Person', async () => {
+
+        const request = await createTestRequest();
+        await request
+            .post('/4_0_0/Person/81236/$merge?validate=true')
+            .send(bwellPerson_indirectLink)
+            .set(getHeaders());
+
+        await request
+            .post('/4_0_0/Person/5678/$merge?validate=true')
+            .send(linkedPerson2)
+            .set(getHeaders());
+
+        await request
+            .post('/4_0_0/Person/otherOne/$merge?validate=true')
+            .send(linkedPerson1_cycle)
+            .set(getHeaders());
+
+        const bwellPersonFinder = createContainer().bwellPersonFinder;
+        const result = await bwellPersonFinder.getBwellPersonIdAsync({ base_version: '4_0_0', patientId: 'Patient/1234' });
+
+        expect(result === '81235');
+    });
+});

--- a/src/tests/utils/bwellPersonFinder/fixtures/bwellPerson_directLink.json
+++ b/src/tests/utils/bwellPersonFinder/fixtures/bwellPerson_directLink.json
@@ -23,5 +23,14 @@
         }
     ],
     "gender": "male",
-    "birthDate": "1996-03-03"
+    "birthDate": "1996-03-03",
+    "link": [
+        {
+            "target": {
+                "reference": "Patient/1234",
+                "type": "Patient"
+            },
+            "assurance": "level4"
+        }
+    ]
 }

--- a/src/tests/utils/bwellPersonFinder/fixtures/bwellPerson_indirectLink.json
+++ b/src/tests/utils/bwellPersonFinder/fixtures/bwellPerson_indirectLink.json
@@ -23,5 +23,14 @@
         }
     ],
     "gender": "male",
-    "birthDate": "1996-03-03"
+    "birthDate": "1996-03-03",
+    "link": [
+        {
+            "target": {
+                "reference": "Person/5678",
+                "type": "Person"
+            },
+            "assurance": "level4"
+        }
+    ]
 }

--- a/src/tests/utils/bwellPersonFinder/fixtures/linkedPerson1.json
+++ b/src/tests/utils/bwellPersonFinder/fixtures/linkedPerson1.json
@@ -1,15 +1,15 @@
 {
     "resourceType": "Person",
-    "id": "81236",
+    "id": "otherOne",
     "meta": {
         "security": [
             {
                 "system": "https://www.icanbwell.com/access",
-                "code": "bwell"
+                "code": "medstar"
             },
             {
                 "system": "https://www.icanbwell.com/owner",
-                "code": "bwell"
+                "code": "medstar"
             }
         ]
     },
@@ -23,5 +23,14 @@
         }
     ],
     "gender": "male",
-    "birthDate": "1996-03-03"
+    "birthDate": "1996-03-03",
+    "link": [
+        {
+            "target": {
+                "reference": "Patient/1234",
+                "type": "Patient"
+            },
+            "assurance": "level4"
+        }
+    ]
 }

--- a/src/tests/utils/bwellPersonFinder/fixtures/linkedPerson1_cycle.json
+++ b/src/tests/utils/bwellPersonFinder/fixtures/linkedPerson1_cycle.json
@@ -1,15 +1,15 @@
 {
     "resourceType": "Person",
-    "id": "81236",
+    "id": "otherOne",
     "meta": {
         "security": [
             {
                 "system": "https://www.icanbwell.com/access",
-                "code": "bwell"
+                "code": "medstar"
             },
             {
                 "system": "https://www.icanbwell.com/owner",
-                "code": "bwell"
+                "code": "medstar"
             }
         ]
     },
@@ -27,8 +27,15 @@
     "link": [
         {
             "target": {
-                "reference": "Patient/2354",
+                "reference": "Patient/1234",
                 "type": "Patient"
+            },
+            "assurance": "level4"
+        },
+        {
+            "target": {
+                "reference": "Person/5678",
+                "type": "Person"
             },
             "assurance": "level4"
         }

--- a/src/tests/utils/bwellPersonFinder/fixtures/linkedPerson2.json
+++ b/src/tests/utils/bwellPersonFinder/fixtures/linkedPerson2.json
@@ -1,15 +1,15 @@
 {
     "resourceType": "Person",
-    "id": "81236",
+    "id": "5678",
     "meta": {
         "security": [
             {
                 "system": "https://www.icanbwell.com/access",
-                "code": "bwell"
+                "code": "medstar"
             },
             {
                 "system": "https://www.icanbwell.com/owner",
-                "code": "bwell"
+                "code": "medstar"
             }
         ]
     },
@@ -23,5 +23,14 @@
         }
     ],
     "gender": "male",
-    "birthDate": "1996-03-03"
+    "birthDate": "1996-03-03",
+    "link": [
+        {
+            "target": {
+                "reference": "Person/otherOne",
+                "type": "Person"
+            },
+            "assurance": "level4"
+        }
+    ]
 }

--- a/src/utils/bwellPersonFinder.js
+++ b/src/utils/bwellPersonFinder.js
@@ -1,5 +1,8 @@
 const {assertTypeEquals} = require('./assertType');
 const {DatabaseQueryFactory} = require('../dataLayer/databaseQueryFactory');
+const {SecurityTagSystem} = require('./securityTagSystem');
+
+const BwellMasterPersonCode = 'bwell';
 
 class BwellPersonFinder {
     /**
@@ -55,8 +58,8 @@ class BwellPersonFinder {
         while (!foundPersonId && linkedPersons && await linkedPersons.hasNext()) {
             let nextPerson = await linkedPersons.next();
 
-            if (nextPerson.meta.security.find(s => s.system === 'https://www.icanbwell.com/access' && s.code === 'bwell') &&
-                nextPerson.meta.security.find(s => s.system === 'https://www.icanbwell.com/owner' && s.code === 'bwell')) {
+            if (nextPerson.meta.security.find(s => s.system === SecurityTagSystem.access && s.code === BwellMasterPersonCode) &&
+                nextPerson.meta.security.find(s => s.system === SecurityTagSystem.owner && s.code === BwellMasterPersonCode)) {
                 foundPersonId = nextPerson.id;
             }
             else {

--- a/src/utils/bwellPersonFinder.js
+++ b/src/utils/bwellPersonFinder.js
@@ -55,6 +55,8 @@ class BwellPersonFinder {
 
         let foundPersonId = null;
         let linkedPersons = await databaseQueryManager.findAsync({ query: { 'link.target.reference': currentSubject }});
+
+        // iterate over linked Persons (breadth search)
         while (!foundPersonId && linkedPersons && await linkedPersons.hasNext()) {
             let nextPerson = await linkedPersons.next();
 
@@ -63,6 +65,7 @@ class BwellPersonFinder {
                 foundPersonId = nextPerson.id;
             }
             else {
+                // recurse through to next layer of linked Persons (depth search)
                 foundPersonId = await this.searchForBwellPersonAsync({
                     currentSubject: `Person/${nextPerson.id}`,
                     databaseQueryManager: databaseQueryManager,

--- a/src/utils/bwellPersonFinder.js
+++ b/src/utils/bwellPersonFinder.js
@@ -31,7 +31,7 @@ class BwellPersonFinder {
         });
 
         let personId = null;
-        let person = await databaseQueryManager.findOneAsync({ query: { link: `Patient/${patientId}`}});
+        let person = await databaseQueryManager.findOneAsync({ query: { 'link.target.reference': `Patient/${patientId}`}});
         if (person) {
             personId = person.id;
         }

--- a/src/utils/bwellPersonFinder.js
+++ b/src/utils/bwellPersonFinder.js
@@ -1,0 +1,45 @@
+//const async = require('async');
+const {assertTypeEquals} = require('./assertType');
+const {DatabaseQueryFactory} = require('../dataLayer/databaseQueryFactory');
+
+class BwellPersonFinder {
+    /**
+     * constructor
+     * @param {DatabaseQueryFactory} databaseQueryFactory
+     */
+    constructor(
+        {
+            databaseQueryFactory
+        }
+    ) {
+        /**
+         * @type {DatabaseQueryFactory}
+         */
+        this.databaseQueryFactory = databaseQueryFactory;
+        assertTypeEquals(databaseQueryFactory, DatabaseQueryFactory);
+    }
+
+    /**
+     * finds the bwell person ID associated with a provided patient ID
+     * @param {string} patientId
+     * @return {Promise<string>}
+     */
+    async getBwellPersonIdAsync({patientId}) {
+        const databaseQueryManager = this.databaseQueryFactory.createQuery({
+            resourceType: 'Person',
+            base_version: '4_0_0'
+        });
+
+        let personId = null;
+        let person = await databaseQueryManager.findOneAsync({ query: { link: `Patient/${patientId}`}});
+        if (person) {
+            personId = person.id;
+        }
+
+        return personId;
+    }
+}
+
+module.exports = {
+    BwellPersonFinder
+};

--- a/src/utils/changeEventProducer.js
+++ b/src/utils/changeEventProducer.js
@@ -443,25 +443,25 @@ class ChangeEventProducer {
 
                 let personId = await this.bwellPersonFinder.getBwellPersonIdAsync({patientId: patientId});
                 if (personId) {
-                    const proxyPatientId = `Patient/person.${personId}`;
+                    const proxyPatientId = `person.${personId}`;
                     await this.onPatientChangeAsync({
-                            requestId, proxyPatientId, timestamp: currentDate
+                            requestId, patientId: proxyPatientId, timestamp: currentDate
                         }
                     );
                 }
             }
         }
         if (resourceType === 'Person') {
-            const proxyPatientId = `Patient/person.${doc.id}`;
+            const proxyPatientId = `person.${doc.id}`;
             if (eventType === 'C') {
                 await this.onPatientCreateAsync({
-                        requestId, proxyPatientId, timestamp: currentDate
+                        requestId, patientId: proxyPatientId, timestamp: currentDate
                     }
                 );
             }
             else {
                 await this.onPatientChangeAsync({
-                        requestId, proxyPatientId, timestamp: currentDate
+                        requestId, patientId: proxyPatientId, timestamp: currentDate
                     }
                 );
             }

--- a/src/utils/changeEventProducer.js
+++ b/src/utils/changeEventProducer.js
@@ -12,6 +12,7 @@ const AuditEventAgent = require('../fhir/classes/4_0_0/backbone_elements/auditEv
 const Reference = require('../fhir/classes/4_0_0/complex_types/reference');
 const AuditEventSource = require('../fhir/classes/4_0_0/backbone_elements/auditEventSource');
 const Period = require('../fhir/classes/4_0_0/complex_types/period');
+const {BwellPersonFinder} = require('./bwellPersonFinder');
 
 const Mutex = require('async-mutex').Mutex;
 const mutex = new Mutex();
@@ -27,13 +28,15 @@ class ChangeEventProducer {
      * @param {string} patientChangeTopic
      * @param {string} taskChangeTopic
      * @param {string} observationChangeTopic
+     * @param {BwellPersonFinder} bwellPersonFinder
      */
     constructor({
                     kafkaClient,
                     resourceManager,
                     patientChangeTopic,
                     taskChangeTopic,
-                    observationChangeTopic
+                    observationChangeTopic,
+                    bwellPersonFinder
                 }) {
         /**
          * @type {KafkaClient}
@@ -60,6 +63,11 @@ class ChangeEventProducer {
          */
         this.observationChangeTopic = observationChangeTopic;
         assertIsValid(observationChangeTopic);
+        /**
+         * @type {BwellPersonFinder}
+         */
+        this.bwellPersonFinder = bwellPersonFinder;
+        assertTypeEquals(bwellPersonFinder, BwellPersonFinder);
         /**
          * id, resource
          * @type {Map<string, Object>}
@@ -430,6 +438,30 @@ class ChangeEventProducer {
             } else {
                 await this.onPatientChangeAsync({
                         requestId, patientId, timestamp: currentDate
+                    }
+                );
+
+                let personId = await this.bwellPersonFinder.getBwellPersonIdAsync({patientId: patientId});
+                if (personId) {
+                    const proxyPatientId = `Patient/person.${personId}`;
+                    await this.onPatientChangeAsync({
+                            requestId, proxyPatientId, timestamp: currentDate
+                        }
+                    );
+                }
+            }
+        }
+        if (resourceType === 'Person') {
+            const proxyPatientId = `Patient/person.${doc.id}`;
+            if (eventType === 'C') {
+                await this.onPatientCreateAsync({
+                        requestId, proxyPatientId, timestamp: currentDate
+                    }
+                );
+            }
+            else {
+                await this.onPatientChangeAsync({
+                        requestId, proxyPatientId, timestamp: currentDate
                     }
                 );
             }

--- a/src/utils/changeEventProducer.js
+++ b/src/utils/changeEventProducer.js
@@ -425,6 +425,7 @@ class ChangeEventProducer {
          * @type {string}
          */
         const currentDate = moment.utc().format('YYYY-MM-DD');
+
         /**
          * @type {string|null}
          */


### PR DESCRIPTION
EFS-98
Update patient change events to fire 2 events: 1 for the specific Patient and 1 for the Proxy Patient (based on the linked bwell master person).