### PR TITLE
Check AUTH_ENABLED before validating scope

### DIFF
--- a/src/operations/security/scopesManager.js
+++ b/src/operations/security/scopesManager.js
@@ -178,9 +178,11 @@ class ScopesManager {
      * @return {boolean}
      */
     hasPatientScope({scope}) {
-        assertIsValid(scope);
-        if (scope.includes('patient/')) {
-            return true;
+        if (env.AUTH_ENABLED === '1') {
+            assertIsValid(scope);
+            if (scope.includes('patient/')) {
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
EFS-105
Update ScopesManager to only perform scope validation if AUTH_ENABLED is true. Otherwise, assume there is not a patient scope