### PR TITLE
EFS-111 add proxy patient ID to proxy rewrite result

### DIFF
--- a/src/tests/searchParameters/search_by_proxy_patient/search_by_proxy_patient/fixtures/Observation/observation3.json
+++ b/src/tests/searchParameters/search_by_proxy_patient/search_by_proxy_patient/fixtures/Observation/observation3.json
@@ -1,0 +1,53 @@
+{
+    "resourceType": "Observation",
+    "id": "2354-InDiabetesCohort",
+    "meta": {
+        "versionId": "2",
+        "lastUpdated": "2021-12-15T15:30:30+00:00",
+        "source": "/patients",
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "healthsystem3"
+            },
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "healthsystem3"
+            },
+            {
+                "system": "https://www.icanbwell.com/vendor",
+                "code": "B"
+            },
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "B"
+            }
+        ]
+    },
+    "status": "final",
+    "code": {
+        "coding": [
+            {
+                "system": "http://www.icanbwell.com/cql/library",
+                "code": "BMI001"
+            },
+            {
+                "system": "http://www.icanbwell.com/cql/libraryVersion",
+                "code": "1.0.0"
+            },
+            {
+                "system": "http://www.icanbwell.com/cql/rule",
+                "code": "InDiabetesCohort"
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/person.m65633"
+    },
+    "effectivePeriod": {
+        "start": "2021-01-01T00:00:00.000Z",
+        "end": "2021-12-31T00:00:00.000Z"
+    },
+    "issued": "2021-01-01T12:00:00Z",
+    "valueBoolean": false
+}

--- a/src/tests/searchParameters/search_by_proxy_patient/search_by_proxy_patient/fixtures/expected/expectedObservationProxyPatientWithDirectLink.json
+++ b/src/tests/searchParameters/search_by_proxy_patient/search_by_proxy_patient/fixtures/expected/expectedObservationProxyPatientWithDirectLink.json
@@ -1,0 +1,169 @@
+{
+  "entry": [
+    {
+      "resource": {
+        "code": {
+          "coding": [
+            {
+              "code": "BMI001",
+              "system": "http://www.icanbwell.com/cql/library"
+            },
+            {
+              "code": "1.0.0",
+              "system": "http://www.icanbwell.com/cql/libraryVersion"
+            },
+            {
+              "code": "InAgeCohort",
+              "system": "http://www.icanbwell.com/cql/rule"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "end": "2021-12-31T00:00:00.000Z",
+          "start": "2021-01-01T00:00:00.000Z"
+        },
+        "id": "2354-InAgeCohort",
+        "issued": "2021-01-01T12:00:00Z",
+        "meta": {
+          "security": [
+            {
+              "code": "healthsystem1",
+              "system": "https://www.icanbwell.com/owner"
+            },
+            {
+              "code": "healthsystem1",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "B",
+              "system": "https://www.icanbwell.com/vendor"
+            },
+            {
+              "code": "B",
+              "system": "https://www.icanbwell.com/access"
+            }
+          ],
+          "source": "/patients",
+          "versionId": "1"
+        },
+        "resourceType": "Observation",
+        "status": "final",
+        "subject": {
+          "reference": "Patient/00100000000"
+        },
+        "valueBoolean": false
+      }
+    },
+    {
+      "resource": {
+        "code": {
+          "coding": [
+            {
+              "code": "BMI001",
+              "system": "http://www.icanbwell.com/cql/library"
+            },
+            {
+              "code": "1.0.0",
+              "system": "http://www.icanbwell.com/cql/libraryVersion"
+            },
+            {
+              "code": "InDiabetesCohort",
+              "system": "http://www.icanbwell.com/cql/rule"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "end": "2021-12-31T00:00:00.000Z",
+          "start": "2021-01-01T00:00:00.000Z"
+        },
+        "id": "2354-InDiabetesCohort",
+        "issued": "2021-01-01T12:00:00Z",
+        "meta": {
+          "security": [
+            {
+              "code": "healthsystem3",
+              "system": "https://www.icanbwell.com/owner"
+            },
+            {
+              "code": "healthsystem3",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "B",
+              "system": "https://www.icanbwell.com/vendor"
+            },
+            {
+              "code": "B",
+              "system": "https://www.icanbwell.com/access"
+            }
+          ],
+          "source": "/patients",
+          "versionId": "1"
+        },
+        "resourceType": "Observation",
+        "status": "final",
+        "subject": {
+          "reference": "Patient/person.m65633"
+        },
+        "valueBoolean": false
+      }
+    },
+    {
+      "resource": {
+        "code": {
+          "coding": [
+            {
+              "code": "BMI001",
+              "system": "http://www.icanbwell.com/cql/library"
+            },
+            {
+              "code": "1.0.0",
+              "system": "http://www.icanbwell.com/cql/libraryVersion"
+            },
+            {
+              "code": "InAgeCohort",
+              "system": "http://www.icanbwell.com/cql/rule"
+            }
+          ]
+        },
+        "effectivePeriod": {
+          "end": "2021-12-31T00:00:00.000Z",
+          "start": "2021-01-01T00:00:00.000Z"
+        },
+        "id": "2354-InGenderCohort",
+        "issued": "2021-01-01T12:00:00Z",
+        "meta": {
+          "security": [
+            {
+              "code": "healthsystem2",
+              "system": "https://www.icanbwell.com/owner"
+            },
+            {
+              "code": "healthsystem2",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "B",
+              "system": "https://www.icanbwell.com/vendor"
+            },
+            {
+              "code": "B",
+              "system": "https://www.icanbwell.com/access"
+            }
+          ],
+          "source": "/patients",
+          "versionId": "1"
+        },
+        "resourceType": "Observation",
+        "status": "final",
+        "subject": {
+          "reference": "Patient/00200000000"
+        },
+        "valueBoolean": false
+      }
+    }
+  ],
+  "resourceType": "Bundle",
+  "total": 0,
+  "type": "searchset"
+}

--- a/src/utils/personToPatientIdsExpander.js
+++ b/src/utils/personToPatientIdsExpander.js
@@ -49,6 +49,8 @@ class PersonToPatientIdsExpander {
             }
         );
         if (patientIds && patientIds.length > 0) {
+            // Also include the proxy patient ID for resources that are associated with the proxy patient directly
+            patientIds.push(`${personProxyPrefix}${personId}`);
             if (includePatientPrefix) {
                 patientIds = patientIds.map(p => `${patientReferencePrefix}${p}`);
             }


### PR DESCRIPTION
EFS-111
Include proxy patient ID in result of rewriting proxy patient ID to associated patient IDs, allowing resources associated directly with the proxy patient ID to be included in the response bundle.