### PR TITLE
HP-2536 Add source type to patient change audit events

### DIFF
--- a/src/tests/patient/change_events/fixtures/observation/observation2.json
+++ b/src/tests/patient/change_events/fixtures/observation/observation2.json
@@ -1,0 +1,59 @@
+{
+    "resourceType": "Observation",
+    "id": "2354-InAgeCohort",
+    "meta": {
+        "versionId": "2",
+        "lastUpdated": "2021-12-15T15:30:30+00:00",
+        "source": "/patients",
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "A"
+            },
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "A"
+            },
+            {
+                "system": "https://www.icanbwell.com/vendor",
+                "code": "B"
+            },
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "B"
+            }
+        ]
+    },
+    "status": "final",
+    "code": {
+        "coding": [
+            {
+                "system": "http://www.icanbwell.com/cql/library",
+                "code": "BMI001"
+            },
+            {
+                "system": "http://www.icanbwell.com/cql/libraryVersion",
+                "code": "1.0.0"
+            },
+            {
+                "system": "http://www.icanbwell.com/cql/rule",
+                "code": "InAgeCohort"
+            }
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://www.icanbwell.com/sourceType",
+            "valueString": "cql-engine"
+        }
+    ],
+    "subject": {
+        "reference": "Patient/2354"
+    },
+    "effectivePeriod": {
+        "start": "2021-01-01T00:00:00.000Z",
+        "end": "2021-12-31T00:00:00.000Z"
+    },
+    "issued": "2021-01-01T12:00:00Z",
+    "valueBoolean": false
+}


### PR DESCRIPTION
HP-2536
If a sourceType extension is found on a created resource, then add that as a source.type on the generated Patient Change events. This is specifically used so that the cql-engine can publish that an Observation came from it and have the resulting event NOT instigate an additional run of the CQL Engine.