### PR TITLE
EFS-132: Fixed x-request-id header fetch

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -167,4 +167,5 @@ module.exports = {
         '_summary', '_contained', '_containedType', '_query', '_filter', '_format', '_pretty', 'role', 'member',
         'onBehalfOf', 'period', 'practitionerId', 'patientId',
     ],
+    REQUEST_ID_HEADER: 'x-request-id',
 };

--- a/src/middleware/graphql/graphqlServer.js
+++ b/src/middleware/graphql/graphqlServer.js
@@ -62,7 +62,7 @@ const graphql = async (fnCreateContainer) => {
     async function getContext({req, res}) {
         const container = fnCreateContainer();
 
-        req.id = req.id || req.headers[REQUEST_ID_HEADER] || generateUUID();
+        req.id = req.id || req.headers[`${REQUEST_ID_HEADER}`] || generateUUID();
 
         /**
          * @type {FhirRequestInfo}

--- a/src/middleware/graphql/graphqlServer.js
+++ b/src/middleware/graphql/graphqlServer.js
@@ -4,6 +4,7 @@
 const {ApolloServer} = require('apollo-server-express');
 const {join} = require('path');
 const resolvers = require('../../graphql/v2/resolvers');
+const { REQUEST_ID_HEADER } = require('../../constants');
 const {loadFilesSync} = require('@graphql-tools/load-files');
 const {mergeTypeDefs} = require('@graphql-tools/merge');
 const {FhirDataSource} = require('../../graphql/v2/dataSource');
@@ -61,7 +62,7 @@ const graphql = async (fnCreateContainer) => {
     async function getContext({req, res}) {
         const container = fnCreateContainer();
 
-        req.id = req.id || req.headers['X-REQUEST-ID'] || generateUUID();
+        req.id = req.id || req.headers[REQUEST_ID_HEADER] || generateUUID();
 
         /**
          * @type {FhirRequestInfo}

--- a/src/middleware/graphql/graphqlServer1.js
+++ b/src/middleware/graphql/graphqlServer1.js
@@ -4,6 +4,7 @@
 const {ApolloServer} = require('apollo-server-express');
 const {join} = require('path');
 const resolvers = require('../../graphql/v1/resolvers');
+const { REQUEST_ID_HEADER } = require('../../constants');
 const {loadFilesSync} = require('@graphql-tools/load-files');
 const {mergeTypeDefs} = require('@graphql-tools/merge');
 
@@ -52,7 +53,7 @@ const graphql = async (fnCreateContainer) => {
                 // ApolloServerPluginLandingPageDisabled()
             ],
             context: async ({req, res}) => {
-                req.id = req.id || req.headers['X-REQUEST-ID'] || generateUUID();
+                req.id = req.id || req.headers[REQUEST_ID_HEADER] || generateUUID();
                 return {
                     req,
                     res,

--- a/src/middleware/graphql/graphqlServer1.js
+++ b/src/middleware/graphql/graphqlServer1.js
@@ -53,7 +53,7 @@ const graphql = async (fnCreateContainer) => {
                 // ApolloServerPluginLandingPageDisabled()
             ],
             context: async ({req, res}) => {
-                req.id = req.id || req.headers[REQUEST_ID_HEADER] || generateUUID();
+                req.id = req.id || req.headers[`${REQUEST_ID_HEADER}`] || generateUUID();
                 return {
                     req,
                     res,

--- a/src/routeHandlers/admin.js
+++ b/src/routeHandlers/admin.js
@@ -14,6 +14,7 @@ const {generateUUID} = require('../utils/uid.util');
 const scopeChecker = require('@asymmetrik/sof-scope-checker');
 const OperationOutcome = require('../fhir/classes/4_0_0/resources/operationOutcome');
 const OperationOutcomeIssue = require('../fhir/classes/4_0_0/backbone_elements/operationOutcomeIssue');
+const { REQUEST_ID_HEADER } = require('../constants');
 
 /**
  * shows indexes
@@ -105,7 +106,7 @@ async function handleAdmin(
     }
 
     try {
-        req.id = req.id || req.headers['X-REQUEST-ID'] || generateUUID();
+        req.id = req.id || req.headers[REQUEST_ID_HEADER] || generateUUID();
         const operation = req.params['op'];
         console.log(`op=${operation}`);
 

--- a/src/routeHandlers/admin.js
+++ b/src/routeHandlers/admin.js
@@ -106,7 +106,7 @@ async function handleAdmin(
     }
 
     try {
-        req.id = req.id || req.headers[REQUEST_ID_HEADER] || generateUUID();
+        req.id = req.id || req.headers[`${REQUEST_ID_HEADER}`] || generateUUID();
         const operation = req.params['op'];
         console.log(`op=${operation}`);
 

--- a/src/routeHandlers/fhirServer.js
+++ b/src/routeHandlers/fhirServer.js
@@ -133,7 +133,7 @@ class MyFHIRServer {
                 /** @type {import('http').ServerResponse} **/ res,
                 next
             ) => {
-                req.id = req.id || req.headers[REQUEST_ID_HEADER] || generateUUID();
+                req.id = req.id || req.headers[`${REQUEST_ID_HEADER}`] || generateUUID();
                 next();
             }
         );

--- a/src/routeHandlers/fhirServer.js
+++ b/src/routeHandlers/fhirServer.js
@@ -21,6 +21,7 @@ const {assertTypeEquals} = require('../utils/assertType');
 const passport = require('passport');
 const path = require('path');
 const contentType = require('content-type');
+const { REQUEST_ID_HEADER } = require('../constants');
 const {convertErrorToOperationOutcome} = require('../utils/convertErrorToOperationOutcome');
 
 class MyFHIRServer {
@@ -125,14 +126,14 @@ class MyFHIRServer {
             }
         });
 
-        // generate a unique ID for each request.  Use X-REQUEST-ID in header if sent.
+        // generate a unique ID for each request.  Use x-request-id in header if sent.
         this.app.use(
             (
                 /** @type {import('http').IncomingMessage} **/ req,
                 /** @type {import('http').ServerResponse} **/ res,
                 next
             ) => {
-                req.id = req.id || req.headers['X-REQUEST-ID'] || generateUUID();
+                req.id = req.id || req.headers[REQUEST_ID_HEADER] || generateUUID();
                 next();
             }
         );

--- a/src/tests/graphql/field_filter/field_filter.test.js
+++ b/src/tests/graphql/field_filter/field_filter.test.js
@@ -130,7 +130,7 @@ describe('GraphQL CodeSystem Tests', () => {
                     variables: {},
                     query: graphqlQueryText,
                 })
-                .set(getGraphQLHeaders());
+                .set({'x-request-id': 'd4c5546f-cd8a-4447-83e0-201f0da08bef', ...getGraphQLHeaders()});
 
             console.log(resp.body);
 
@@ -144,6 +144,7 @@ describe('GraphQL CodeSystem Tests', () => {
                 return r;
             });
             expect(resp.headers['x-request-id']).toBeDefined();
+            expect(resp.headers['x-request-id']).toEqual('d4c5546f-cd8a-4447-83e0-201f0da08bef');
 
             // uncomment this to test out timing of events
             // await new Promise(resolve => setTimeout(resolve, 30 * 1000));


### PR DESCRIPTION
1. `X-REQUEST-ID` was being fetched instead of `x-request-id` from the request headers. Moved it to a constant.
2. Updated a test case to validate it.