### PR TITLE
CVP-1668: Added get CodeSystem codes graphql query for optimized mongo query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "fast-json-patch": "^3.1.1",
         "fontawesome-4.7": "^4.7.0",
         "graphql": "^16.6.0",
+        "graphql-fields": "^2.0.3",
         "graphql-schema-linter": "^3.0.1",
         "helmet": "^6.0.1",
         "http-terminator": "^3.2.0",
@@ -10931,6 +10932,11 @@
       "peerDependencies": {
         "graphql": "*"
       }
+    },
+    "node_modules/graphql-fields": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graphql-fields/-/graphql-fields-2.0.3.tgz",
+      "integrity": "sha512-x3VE5lUcR4XCOxPIqaO4CE+bTK8u6gVouOdpQX9+EKHr+scqtK5Pp/l8nIGqIpN1TUlkKE6jDCCycm/WtLRAwA=="
     },
     "node_modules/graphql-schema-linter": {
       "version": "3.0.1",
@@ -27183,6 +27189,11 @@
       "requires": {
         "arrify": "^1.0.1"
       }
+    },
+    "graphql-fields": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graphql-fields/-/graphql-fields-2.0.3.tgz",
+      "integrity": "sha512-x3VE5lUcR4XCOxPIqaO4CE+bTK8u6gVouOdpQX9+EKHr+scqtK5Pp/l8nIGqIpN1TUlkKE6jDCCycm/WtLRAwA=="
     },
     "graphql-schema-linter": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "fast-json-patch": "^3.1.1",
     "fontawesome-4.7": "^4.7.0",
     "graphql": "^16.6.0",
+    "graphql-fields": "^2.0.3",
     "graphql-schema-linter": "^3.0.1",
     "helmet": "^6.0.1",
     "http-terminator": "^3.2.0",

--- a/src/dataLayer/databaseQueryManager.js
+++ b/src/dataLayer/databaseQueryManager.js
@@ -194,6 +194,53 @@ class DatabaseQueryManager {
     }
 
     /**
+     * Returns a DatabasePartitionedCursor by executing the query
+     * @param {import('mongodb').Filter<import('mongodb').DefaultSchema>} query
+     * @param projection
+     * @param {import('mongodb').FindOptions<import('mongodb').DefaultSchema>} options
+     * @return {DatabasePartitionedCursor}
+     */
+    async findUsingAggregationAsync({query, projection, options = null}) {
+        try {
+            /**
+             * @type {import('mongodb').Collection<import('mongodb').DefaultSchema>[]}
+             */
+            const collections = await this.resourceLocator.getOrCreateCollectionsForQueryAsync({query});
+            /**
+             * @type {CursorInfo[]}
+             */
+            const cursors = [];
+            for (const /** @type import('mongodb').Collection<import('mongodb').DefaultSchema> */ collection of collections) {
+                /**
+                 * @type {AggregationCursor<Document>}
+                 */
+                const cursor = collection.aggregate(
+                    [
+                        {
+                            $match: query,
+                        },
+                        {
+                            $project: projection,
+
+                        }
+                    ],
+                    options,
+                );
+                cursors.push({cursor, db: collection.dbName, collection: collection.collectionName});
+            }
+            return new DatabasePartitionedCursor({
+                base_version: this._base_version, resourceType: this._resourceType, cursors,
+                query
+            });
+        } catch (e) {
+            throw new RethrownError({
+                message: 'Error in findUsingAggregationAsync(): ' + `query: ${JSON.stringify(query)}`, error: e,
+                args: {query, options}
+            });
+        }
+    }
+
+    /**
      * Gets estimated count of ALL documents in a collection.  This does not accept a query
      * @param {import('mongodb').EstimatedDocumentCountOptions} options
      * @return {Promise<*>}

--- a/src/graphql/v2/dataSource.js
+++ b/src/graphql/v2/dataSource.js
@@ -320,9 +320,10 @@ class FhirDataSource extends DataSource {
      * @param {GraphQLContext} context
      * @param {Object} info
      * @param {string} resourceType
+     * @param {boolean} useAggregationPipeline
      * @return {Promise<Bundle>}
      */
-    async getResourcesBundle(parent, args, context, info, resourceType) {
+    async getResourcesBundle(parent, args, context, info, resourceType, useAggregationPipeline = false) {
         this.createDataLoader(args);
         // https://www.apollographql.com/blog/graphql/filtering/how-to-search-and-filter-results-with-graphql/
 
@@ -334,7 +335,8 @@ class FhirDataSource extends DataSource {
                     _bundle: '1',
                     ...args
                 },
-                resourceType
+                resourceType,
+                useAggregationPipeline
             }
         );
         if (bundle.meta) {

--- a/src/graphql/v2/resolvers/custom/codeSystem.js
+++ b/src/graphql/v2/resolvers/custom/codeSystem.js
@@ -1,3 +1,6 @@
+const graphqlFields = require('graphql-fields');
+const { graphqlFieldsToMongoProjection } = require('../../../../utils/graphqlFieldsProjection');
+
 module.exports = {
     CodeSystem: {
         /**
@@ -26,6 +29,42 @@ module.exports = {
             } else {
                 return codeSystem.concept;
             }
+        },
+    },
+    Query: {
+        /**
+         * @param {Resource|null} parent
+         * @param {Object} args
+         * @param {GraphQLContext} context
+         * @param {Object} info
+         * @return {Promise<Resource>}
+         */
+        getCodeSystemCodes: async (parent, args, context, info) => {
+            // Add projection filter on the nested array i.e concept field and the graphql queried fields
+            let fields = graphqlFields(info);
+            let projection = {};
+            if (fields){
+                projection = graphqlFieldsToMongoProjection(fields?.['entry']?.['resource']);
+            }
+            if (args['code']){
+                projection['concept'] = {
+                    $filter: {
+                        input: '$concept',
+                        as: 'ct',
+                        cond: { $in: ['$$ct.code', args['code']] },
+                    },
+                };
+            }
+            return await context.dataApi.getResourcesBundle(
+                parent,
+                {
+                    projection, ...args,
+                },
+                context,
+                info,
+                'CodeSystem',
+                true
+            );
         },
     },
 };

--- a/src/graphql/v2/schemas/custom/codeSystem.graphql
+++ b/src/graphql/v2/schemas/custom/codeSystem.graphql
@@ -1,0 +1,16 @@
+"""
+getCodeSystemCodes
+    query to retrieve code system codes based on id and code filters
+"""
+type Query {
+    getCodeSystemCodes(
+        """
+        id of the CodeSystem resource
+        """
+        id: [String]
+        """
+        code in the concept objects of the CodeSystem resource
+        """
+        code: [String]
+    ): CodeSystemBundle
+}

--- a/src/operations/search/searchBundle.js
+++ b/src/operations/search/searchBundle.js
@@ -93,10 +93,11 @@ class SearchBundleOperation {
      * @param {FhirRequestInfo} requestInfo
      * @param {Object} args
      * @param {string} resourceType
+     * @param {boolean} useAggregationPipeline
      * @return {Promise<Bundle>} array of resources or a bundle
      */
     async searchBundle(
-        {requestInfo, args, resourceType}
+        {requestInfo, args, resourceType, useAggregationPipeline = false}
     ) {
         assertIsValid(requestInfo !== undefined);
         assertIsValid(args !== undefined);
@@ -219,7 +220,7 @@ class SearchBundleOperation {
                 {
                     resourceType, base_version,
                     args, columns, options, query,
-                    maxMongoTimeMS, user, isStreaming: false, useAccessIndex
+                    maxMongoTimeMS, user, isStreaming: false, useAccessIndex, useAggregationPipeline
                 });
             /**
              * @type {Set}

--- a/src/tests/graphql/field_filter/field_filter.test.js
+++ b/src/tests/graphql/field_filter/field_filter.test.js
@@ -24,6 +24,12 @@ const codeSystemQueryWithFilter = fs.readFileSync(
     'utf8'
 );
 
+// eslint-disable-next-line security/detect-non-literal-fs-filename
+const getCodeSystemCodesQueryWithFilter = fs.readFileSync(
+    path.resolve(__dirname, './fixtures/query_getcodesystemcodes_with_filter.graphql'),
+    'utf8'
+);
+
 const {
     commonBeforeEach,
     commonAfterEach,
@@ -224,6 +230,140 @@ describe('GraphQL CodeSystem Tests', () => {
         test('GraphQL Codeset with filter works with binary data with patient scope', async () => {
             const request = await createTestRequest();
             const graphqlQueryText = codeSystemQueryWithFilter.replace(/\\n/g, '');
+
+            let resp = await request
+                .post('/4_0_0/CodeSystem/1/$merge')
+                .send(codeSystem1WithBinaryResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse([{created: true}, {created: true}]);
+
+            resp = await request
+                .post('/4_0_0/Binary/1/$merge')
+                .send(binary1Resource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse([{created: true}, {created: true}]);
+
+            // add persons
+            resp = await request
+                .post('/4_0_0/Person/1/$merge')
+                .send(rootPersonResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse([{created: true}, {created: true}]);
+
+            resp = await request
+                .post('/4_0_0/Person/1/$merge')
+                .send(person123aResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse([{created: true}, {created: true}]);
+            /**
+             * @type {SimpleContainer}
+             */
+            const testContainer = getTestContainer();
+
+            /**
+             * @type {PostRequestProcessor}
+             */
+            const postRequestProcessor = testContainer.postRequestProcessor;
+            await postRequestProcessor.waitTillAllRequestsDoneAsync({timeoutInSeconds: 20});
+            /**
+             * @type {RequestSpecificCache}
+             */
+            const requestSpecificCache = testContainer.requestSpecificCache;
+            await requestSpecificCache.clearAllAsync();
+
+            const only_fhir_person_payload = {
+                'cognito:username': 'patient-123@example.com',
+                'custom:bwell_fhir_person_id': 'root-person',
+                scope: 'patient/*.read user/*.* access/*.*',
+                username: 'patient-123@example.com',
+            };
+
+            resp = await request
+                .post('/graphqlv2')
+                .send({
+                    operationName: null,
+                    variables: {},
+                    query: graphqlQueryText,
+                })
+                .set(getCustomGraphQLHeaders(only_fhir_person_payload));
+
+            console.log(resp.body);
+
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResponse(expectedGraphQlWithFilterBinaryResponse, r => {
+                if (r.codeSystem) {
+                    r.codeSystem.forEach(resource => {
+                        cleanMeta(resource);
+                    });
+                }
+                return r;
+            });
+            expect(resp.headers['x-request-id']).toBeDefined();
+
+            // uncomment this to test out timing of events
+            // await new Promise(resolve => setTimeout(resolve, 30 * 1000));
+        });
+
+        test('GraphQL Codeset with codes filter works properly', async () => {
+            const request = await createTestRequest();
+            const graphqlQueryText = getCodeSystemCodesQueryWithFilter.replace(/\\n/g, '');
+
+            let resp = await request
+                .post('/4_0_0/CodeSystem/1/$merge')
+                .send(codeSystem1Resource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse([{created: true}, {created: true}]);
+
+            /**
+             * @type {SimpleContainer}
+             */
+            const testContainer = getTestContainer();
+
+            /**
+             * @type {PostRequestProcessor}
+             */
+            const postRequestProcessor = testContainer.postRequestProcessor;
+            await postRequestProcessor.waitTillAllRequestsDoneAsync({timeoutInSeconds: 20});
+            /**
+             * @type {RequestSpecificCache}
+             */
+            const requestSpecificCache = testContainer.requestSpecificCache;
+            await requestSpecificCache.clearAllAsync();
+
+            resp = await request
+                .post('/graphqlv2')
+                .send({
+                    operationName: null,
+                    variables: {},
+                    query: graphqlQueryText,
+                })
+                .set({'X-Request-Id': 'd4c5546f-cd8a-4447-83e0-201f0da08bef', ...getGraphQLHeaders()});
+
+            console.log(resp.body);
+
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResponse(expectedGraphQlWithFilterResponse, r => {
+                if (r.codeSystem) {
+                    r.codeSystem.forEach(resource => {
+                        cleanMeta(resource);
+                    });
+                }
+                return r;
+            });
+            expect(resp.headers['x-request-id']).toBeDefined();
+            expect(resp.headers['x-request-id']).toEqual('d4c5546f-cd8a-4447-83e0-201f0da08bef');
+
+            // uncomment this to test out timing of events
+            // await new Promise(resolve => setTimeout(resolve, 30 * 1000));
+        });
+        test('GraphQL Codeset with filter works with binary data with patient scope', async () => {
+            const request = await createTestRequest();
+            const graphqlQueryText = getCodeSystemCodesQueryWithFilter.replace(/\\n/g, '');
 
             let resp = await request
                 .post('/4_0_0/CodeSystem/1/$merge')

--- a/src/tests/graphql/field_filter/fixtures/query_getcodesystemcodes_with_filter.graphql
+++ b/src/tests/graphql/field_filter/fixtures/query_getcodesystemcodes_with_filter.graphql
@@ -1,0 +1,19 @@
+query {
+    getCodeSystemCodes(code: ["3584-4"]) {
+        entry {
+            resource {
+                id
+                resourceType
+                status
+                concept {
+                    code
+                    display
+                    property {
+                        code
+                        valueString
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/utils/graphqlFieldsProjection.js
+++ b/src/utils/graphqlFieldsProjection.js
@@ -1,0 +1,22 @@
+/**
+ * This function updates any null, undefined, empty objects and empty arrays to 1
+ * @param {Object} obj
+ * @return {Object}
+ */
+const graphqlFieldsToMongoProjection = (obj) => {
+    Object
+        .entries(obj)
+        .forEach(([k, v]) => {
+            if (v && typeof v === 'object') {
+                graphqlFieldsToMongoProjection(v);
+            }
+            if (v && typeof v === 'object' && !Object.keys(v).length || v === null || v === undefined) {
+                obj[k] = 1;
+            }
+        });
+    return obj;
+};
+
+module.exports = {
+    graphqlFieldsToMongoProjection,
+};

--- a/src/utils/graphqlFieldsProjection.js
+++ b/src/utils/graphqlFieldsProjection.js
@@ -11,7 +11,7 @@ const graphqlFieldsToMongoProjection = (obj) => {
                 graphqlFieldsToMongoProjection(v);
             }
             if (v && typeof v === 'object' && !Object.keys(v).length || v === null || v === undefined) {
-                obj[k] = 1;
+                obj[`${k}`] = 1;
             }
         });
     return obj;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6255,6 +6255,11 @@
   dependencies:
     "arrify" "^1.0.1"
 
+"graphql-fields@^2.0.3":
+  "integrity" "sha512-x3VE5lUcR4XCOxPIqaO4CE+bTK8u6gVouOdpQX9+EKHr+scqtK5Pp/l8nIGqIpN1TUlkKE6jDCCycm/WtLRAwA=="
+  "resolved" "https://registry.npmjs.org/graphql-fields/-/graphql-fields-2.0.3.tgz"
+  "version" "2.0.3"
+
 "graphql-schema-linter@^3.0.1":
   "integrity" "sha512-+k4TGaWu1Ry740XiI/OZbzAC4omna5+S1rLjE0puPFSB99yORRdlX4U0+CWnwJuxh8FxLj5Ek2pDhsrSh9j5cQ=="
   "resolved" "https://registry.npmjs.org/graphql-schema-linter/-/graphql-schema-linter-3.0.1.tgz"


### PR DESCRIPTION
**Ticket:** https://icanbwell.atlassian.net/browse/CVP-1668

**Problem:** Fetching specific code from a CodeSystem currently retrieves the whole CodeSystem from the Mongo DB having a large number of codes in it.

**Solution:** Added a new GraphQL query for CodeSystem that uses the Mongo Aggregation pipeline query to filter on the concept code array of the CodeSystem Resource and return the filtered codes only from the DB.