### PR TITLE
HDE-2744 added support of security params for searchById interaction

### DIFF
--- a/src/middleware/fhir/router.js
+++ b/src/middleware/fhir/router.js
@@ -309,6 +309,7 @@ class FhirRouter {
                 throw new Error(`${profileName} is an invalid profile configuration, please see the wiki for ` + 'instructions on how to enable a profile in your server, ' + 'https://github.com/Asymmetrik/node-fhir-server-core/wiki/Profile');
             } // Enable all provided operations for this profile
 
+            let securityParameters = parameters.filter((parameter) => parameter.name === '_security');
 
             if (profile.operation && profile.operation.length) {
                 this.enableOperationRoutesForProfile(app, config, profile, profileName, parameters, corsDefaults);
@@ -331,7 +332,6 @@ class FhirRouter {
                         route.args = [routeArgs.BASE];
                         break;
 
-                    case INTERACTIONS.SEARCH_BY_ID:
                     case INTERACTIONS.UPDATE:
                     case INTERACTIONS.DELETE:
                     case INTERACTIONS.PATCH:
@@ -341,6 +341,9 @@ class FhirRouter {
                     case INTERACTIONS.SEARCH:
                     case INTERACTIONS.HISTORY:
                         route.args = [routeArgs.BASE, ...parameters];
+                        break;
+                    case INTERACTIONS.SEARCH_BY_ID:
+                        route.args = [routeArgs.BASE, routeArgs.ID, ...securityParameters];
                         break;
 
                     case INTERACTIONS.HISTORY_BY_ID:

--- a/src/tests/patient/search_by_id/search_by_id.test.js
+++ b/src/tests/patient/search_by_id/search_by_id.test.js
@@ -45,9 +45,13 @@ describe('PatientReturnIdTests', () => {
             expect(resp).toHaveResourceCount(1);
 
 
-            resp = await request.get('/4_0_0/Patient/00100000000').set(getHeaders());
+            resp = await request.get('/4_0_0/Patient/00100000000?_security=https://www.icanbwell.com/access|medstar').set(getHeaders());
             // noinspection JSUnresolvedFunction
             expect(resp).toHaveResponse(expectedSinglePatientResource[0]);
+
+            resp = await request.get('/4_0_0/Patient/00100000000?_security=https://www.icanbwell.com/access|random').set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveStatusCode(404);
 
             resp = await request.post('/4_0_0/Patient/_search?id=00100000000').set(getHeaders());
             // noinspection JSUnresolvedFunction


### PR DESCRIPTION
When we hit fhir server to fetch data of a resource using single id, in that case we are not considering security params. I have added code changes to consider security params while querying over db.