### PR TITLE
CVP-1668: Fixed explain error for aggregation query

### DIFF
--- a/src/operations/search/searchBundle.js
+++ b/src/operations/search/searchBundle.js
@@ -264,7 +264,7 @@ class SearchBundleOperation {
             /**
              * @type {import('mongodb').Document[]}
              */
-            const explanations = (cursor && (args['_explain'] || args['_debug'] || env.LOGLEVEL === 'DEBUG')) ? await cursor.explainAsync() : [];
+            const explanations = (cursor && !useAggregationPipeline && (args['_explain'] || args['_debug'] || env.LOGLEVEL === 'DEBUG')) ? await cursor.explainAsync() : [];
             if (cursor && args['_explain']) {
                 // if explain is requested then don't return any results
                 cursor.clear();


### PR DESCRIPTION
Error:
`AggregateError: Option \"explain\" cannot be used on an aggregate call with writeConcern\n    at SearchBundleOperation.searchBundle (/srv/src/src/operations/search/searchBundle.js:386:19)\n    at async FhirDataSource.getResourcesBundle (/srv/src/src/graphql/v2/dataSource.js:330:24)\n    at async Object.getCodeSystemCodes (/srv/src/src/graphql/v2/resolvers/custom/codeSystem.js:58:20)`
Skipped query explanation for aggregation query. Need to be investigated further for long term fix.
Previous PR: https://github.com/icanbwell/fhir-server/pull/812