### PR TITLE
EFS-260 Set minminPoolSize for online archive to 0

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -99,7 +99,7 @@ if (env.AUDIT_EVENT_ONLINE_ARCHIVE_CLUSTER_MONGO_URL) {
     auditEventReadOnlyMongoConfig = {
         connection: auditEventReadOnlyMongoUrl,
         db_name: String(env.AUDIT_EVENT_MONGO_DB_NAME),
-        options: options,
+        options: {...options, ...{minPoolSize: env.AUDIT_EVENT_ONLINE_ARCHIVE_CLUSTER_MIN_POOL_SIZE ? parseInt(env.AUDIT_EVENT_ONLINE_ARCHIVE_CLUSTER_MIN_POOL_SIZE) : 0}},
     };
 } else {
     auditEventReadOnlyMongoConfig = auditEventMongoConfig;


### PR DESCRIPTION
As per doc: https://www.mongodb.com/docs/atlas/data-federation/supported-unsupported/limitations/
"
Having more than 60 guaranteed simultaneous connections per region to a federated database instance
"
So, updated the Online Archive connection minPool to zero such that it will create a connection on demand and does not create issues while the server startup.

Note: Once we get lots of requests for AuditEvent(60+ concurrent). We have to add rate limit for this individual API. Because online archive does not support:
- Having more than 60 guaranteed simultaneous connections per region to a federated database instance
- Running more than 30 simultaneous queries on your federated database instance

