### PR TITLE
EFS-283 Updated presave handler and fixMultipleSourceAssigningAuthority script to set only 1 authority

### DIFF
--- a/src/admin/scripts/fixMultipleSourceAssigningAuthority.js
+++ b/src/admin/scripts/fixMultipleSourceAssigningAuthority.js
@@ -51,6 +51,7 @@ async function main() {
                 useAuditDatabase: parameters.audit ? true : false,
                 includeHistoryCollections: parameters.includeHistoryCollections ? true : false,
                 fixMultipleOwners: parameters.fixMultipleOwners ? true : false,
+                filterRecords: parameters.filterRecords ? true : false,
                 adminLogger: new AdminLogger(),
                 mongoDatabaseManager: c.mongoDatabaseManager,
                 preSaveManager: c.preSaveManager,
@@ -79,7 +80,7 @@ async function main() {
  * NODE_OPTIONS=--max_old_space_size=8192 node --max-old-space-size=8192 src/admin/scripts/fixMultipleSourceAssigningAuthority.js --collections=all --batchSize=10000 --startFromCollection Practitioner_4_0_0
  * NODE_OPTIONS=--max_old_space_size=8192 node --max-old-space-size=8192 src/admin/scripts/fixMultipleSourceAssigningAuthority.js --collections=all --batchSize=10000 --startFromCollection Practitioner_4_0_0 --limit 10 --skip 10
  * NODE_OPTIONS=--max_old_space_size=8192 node --max-old-space-size=8192 src/admin/scripts/fixMultipleSourceAssigningAuthority.js --collections=all --batchSize=10000 --includeHistoryCollections
- * node src/admin/scripts/fixMultipleSourceAssigningAuthority.js --collections=Account_4_0_0 --batchSize=10000
+ * node src/admin/scripts/fixMultipleSourceAssigningAuthority.js --collections=Account_4_0_0 --batchSize=10000 --filterRecords
  * src/admin/scripts/fixMultipleSourceAssigningAuthority.js --collections=all --audit --batchSize=10000
  * NODE_OPTIONS=--max_old_space_size=8192 node --max-old-space-size=8192 src/admin/scripts/fixMultipleSourceAssigningAuthority.js --collections=AuditEvent_4_0_0_2023_02 --audit --batchSize=10000
  * node src/admin/scripts/fixMultipleSourceAssigningAuthority.js --collections=AuditEvent_4_0_0 --audit --batchSize=10000

--- a/src/admin/utils/fixMultipleSourceAssigningAuthority.js
+++ b/src/admin/utils/fixMultipleSourceAssigningAuthority.js
@@ -12,6 +12,10 @@ const { SecurityTagSystem } = require('../../utils/securityTagSystem');
 
 function fixPractitionerResource(resource, fixMultipleOwners) {
     let security = resource.meta.security || [];
+    if (!security.length){
+        console.log(`meta.security not present for resource _id: ${resource._id}. Skipping`);
+        return resource;
+    }
     const sourceAssigningAuthorities = security.filter(s => s.system === SecurityTagSystem.sourceAssigningAuthority);
     const source = resource.meta.source;
     let securityWithoutOriginalOwnersAndAuthority;
@@ -65,6 +69,10 @@ function fixPractitionerResource(resource, fixMultipleOwners) {
 
 function fixResource(resource) {
     let security = resource.meta.security || [];
+    if (!security.length){
+        console.log(`meta.security not present for resource _id: ${resource._id}. Skipping`);
+        return resource;
+    }
     const sourceAssigningAuthorities = security.filter(s => s.system === SecurityTagSystem.sourceAssigningAuthority);
     const owners = security.filter(s => s.system === SecurityTagSystem.owner);
     let securityWithoutOriginalAuthority = security.filter(

--- a/src/admin/utils/fixMultipleSourceAssigningAuthority.js
+++ b/src/admin/utils/fixMultipleSourceAssigningAuthority.js
@@ -32,18 +32,18 @@ function fixPractitionerResource(resource, fixMultipleOwners) {
         }
     } else {
         securityWithoutOriginalOwnersAndAuthority = security.filter(
-            s => SecurityTagSystem.sourceAssigningAuthority !== s.system
+            s => SecurityTagSystem.sourceAssigningAuthority !== s.system,
         );
     }
 
     let newSourceAssigningAuthority = sourceAssigningAuthorities.find(s => s.code === NPPES);
     if (!newSourceAssigningAuthority) {
         const npiIdentifier = resource.identifier.find(i => i.system === NPI_SYSTEM);
-        if (npiIdentifier && (npiIdentifier.value === resource.id || npiIdentifier.value === resource._sourceId)){
+        if (npiIdentifier && (npiIdentifier.value === resource.id || npiIdentifier.value === resource._sourceId)) {
             newSourceAssigningAuthority = new Coding({
-                    system: SecurityTagSystem.sourceAssigningAuthority,
-                    code: NPPES
-                });
+                system: SecurityTagSystem.sourceAssigningAuthority,
+                code: NPPES,
+            });
         }
     }
     if (!newSourceAssigningAuthority && source && PRACTITIONER_SOURCE_OWNER_MAP[`${source}`]) {
@@ -63,13 +63,37 @@ function fixPractitionerResource(resource, fixMultipleOwners) {
     return resource;
 }
 
+function fixResource(resource) {
+    let security = resource.meta.security || [];
+    const sourceAssigningAuthorities = security.filter(s => s.system === SecurityTagSystem.sourceAssigningAuthority);
+    const owners = security.filter(s => s.system === SecurityTagSystem.owner);
+    let securityWithoutOriginalAuthority = security.filter(
+        s => SecurityTagSystem.sourceAssigningAuthority !== s.system,
+    );
+
+    let newSourceAssigningAuthority = sourceAssigningAuthorities.length ? sourceAssigningAuthorities[0] : new Coding({
+        system: SecurityTagSystem.sourceAssigningAuthority,
+        code: owners[0],
+    });
+    securityWithoutOriginalAuthority.push(newSourceAssigningAuthority);
+    resource._sourceAssigningAuthority = newSourceAssigningAuthority.code;
+    resource.meta.security = securityWithoutOriginalAuthority;
+
+    let identifier = resource.identifier || [];
+    resource.identifier = identifier.filter(i => i.system !== IdentifierSystem.uuid);
+
+    delete resource._uuid;
+
+    return resource;
+}
+
 function fixMultipleAuthorities(resource, fixMultipleOwners) {
     const resourceFixFnMap = {
         'Practitioner': fixPractitionerResource,
     };
-    return resourceFixFnMap[`${resource.resourceType}`] ? resourceFixFnMap[`${resource.resourceType}`](resource, fixMultipleOwners) : resource;
+    return resourceFixFnMap[`${resource.resourceType}`] ? resourceFixFnMap[`${resource.resourceType}`](resource, fixMultipleOwners) : fixResource(resource);
 }
 
 module.exports = {
-    fixMultipleAuthorities
+    fixMultipleAuthorities,
 };

--- a/src/preSaveHandlers/handlers/sourceAssigningAuthorityColumnHandler.js
+++ b/src/preSaveHandlers/handlers/sourceAssigningAuthorityColumnHandler.js
@@ -22,14 +22,15 @@ class SourceAssigningAuthorityColumnHandler extends PreSaveHandler {
                     .map(s => s.code);
                 sourceAssigningAuthorityCodes = Array.from(new Set(sourceAssigningAuthorityCodes));
                 // add security tags
-                for (const code of sourceAssigningAuthorityCodes) {
+                if (sourceAssigningAuthorityCodes.length > 0){
                     resource.meta.security.push(new Coding({
                         system: SecurityTagSystem.sourceAssigningAuthority,
-                        code: code
+                        code: sourceAssigningAuthorityCodes[0]
                     }));
                 }
+            } else {
+                sourceAssigningAuthorityCodes = Array.from(new Set(sourceAssigningAuthorityCodes));
             }
-            sourceAssigningAuthorityCodes = Array.from(new Set(sourceAssigningAuthorityCodes));
             if (sourceAssigningAuthorityCodes.length > 0) {
                 const sourceAssigningAuthorityCode = sourceAssigningAuthorityCodes[0];
                 if (resource._sourceAssigningAuthority !== sourceAssigningAuthorityCode) {

--- a/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixMultipleSourceAssigningAuthority.test.js
+++ b/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixMultipleSourceAssigningAuthority.test.js
@@ -4,8 +4,6 @@ const practitioner2Resource = require('./fixtures/Practitioner/practitioner2.jso
 const practitionerrole1Resource = require('./fixtures/Practitioner/practitionerrole1.json');
 const practitionerrole2Resource = require('./fixtures/Practitioner/practitionerrole2.json');
 const Practitioner1HistoryResource = require('./fixtures/Practitioner/practitioner1_history.json');
-const patient1Resource = require('./fixtures/Patient/patient1.json');
-const patient1HistoryResource = require('./fixtures/Patient/patient1_history.json');
 
 
 // expected
@@ -14,16 +12,12 @@ const expectedPractitioner2InDatabaseBeforeRun = require('./fixtures/expected/ex
 const expectedPractitionerRole1InDatabaseBeforeRun = require('./fixtures/expected/expected_practitionerrole_1_in_database_before_run.json');
 const expectedPractitionerRole2InDatabaseBeforeRun = require('./fixtures/expected/expected_practitionerrole_2_in_database_before_run.json');
 const expectedPractitioner1HistoryInDatabaseBeforeRun = require('./fixtures/expected/expected_practitioner1_hisory_in_database_before_run.json');
-const expectedPatient1InDatabaseBeforeRun = require('./fixtures/expected/expected_patient_1_in_database_before_run.json');
-const expectedPatient1HistoryInDatabaseBeforeRun = require('./fixtures/expected/expected_patient1_history_in_database_before_run.json');
 
 const expectedPractitioner1DatabaseAfterRun = require('./fixtures/expected/expected_practitioner1.json');
 const expectedPractitioner2DatabaseAfterRun = require('./fixtures/expected/expected_practitioner2.json');
 const expectedPractitionerRole1DatabaseAfterRun = require('./fixtures/expected/expected_practitionerrole1.json');
 const expectedPractitionerRole2DatabaseAfterRun = require('./fixtures/expected/expected_practitionerrole2.json');
 const expectedPractitioner1HistoryDatabaseAfterRun = require('./fixtures/expected/expected_practitioner1_hisory.json');
-const expectedPatient1DatabaseAfterRun = require('./fixtures/expected/expected_patient1.json');
-const expectedPatient1HistoryDatabaseAfterRun = require('./fixtures/expected/expected_patient1_history.json');
 
 const { FixMultipleSourceAssigningAuthorityHistoryRunner } = require('../../../../admin/runners/fixMultipleSourceAssigningAuthorityHistoryRunner');
 
@@ -273,118 +267,6 @@ describe('Fix Multiple Source Assigning Authority Tests', () => {
             expect(practitioner1History).toBeDefined();
             delete practitioner1History._id;
             expect(practitioner1History).toStrictEqual(expectedPractitioner1HistoryDatabaseAfterRun);
-        });
-    });
-
-    describe('Patient fixMultipleSourceAssigningAuthority Tests', () => {
-        test('fixMultipleSourceAssigningAuthority works for patients', async () => {
-            // eslint-disable-next-line no-unused-vars
-            const request = await createTestRequest((c) => {
-                c.register('configManager', () => new MockConfigManagerWithoutGlobalId());
-                return c;
-            });
-            const container = getTestContainer();
-            /**
-             * @type {PostRequestProcessor}
-             */
-            // eslint-disable-next-line no-unused-vars
-            const postRequestProcessor = container.postRequestProcessor;
-
-            // insert directly into database instead of going through merge() so we simulate old records
-            /**
-             * @type {MongoDatabaseManager}
-             */
-            const mongoDatabaseManager = container.mongoDatabaseManager;
-            let patientCollection = await setupDatabaseAsync(
-                mongoDatabaseManager, patient1Resource, expectedPatient1InDatabaseBeforeRun
-            );
-
-            // run admin runner
-
-            let collections = ['Patient_4_0_0'];
-            const batchSize = 10000;
-
-            container.register('fixMultipleSourceAssigningAuthorityRunner', (c) => new FixMultipleSourceAssigningAuthorityRunner(
-                    {
-                        mongoCollectionManager: c.mongoCollectionManager,
-                        collections: collections,
-                        batchSize,
-                        useAuditDatabase: false,
-                        adminLogger: new AdminLogger(),
-                        mongoDatabaseManager: c.mongoDatabaseManager,
-                        preSaveManager: c.preSaveManager,
-                        filterRecords: true
-                    }
-                )
-            );
-
-            /**
-             * @type {FixMultipleSourceAssigningAuthorityRunner}
-             */
-            const fixMultipleSourceAssigningAuthorityRunner = container.fixMultipleSourceAssigningAuthorityRunner;
-            assertTypeEquals(fixMultipleSourceAssigningAuthorityRunner, FixMultipleSourceAssigningAuthorityRunner);
-            await fixMultipleSourceAssigningAuthorityRunner.processAsync();
-
-            // Check patient 1
-            const patient1 = await patientCollection.findOne({id: patient1Resource.id});
-            expect(patient1).toBeDefined();
-            delete patient1._id;
-            expectedPatient1DatabaseAfterRun.meta.lastUpdated = patient1.meta.lastUpdated;
-            expect(patient1).toStrictEqual(expectedPatient1DatabaseAfterRun);
-        });
-        test('fixMultipleSourceAssigningAuthorityHistory works for patient', async () => {
-            // eslint-disable-next-line no-unused-vars
-            const request = await createTestRequest((c) => {
-                c.register('configManager', () => new MockConfigManagerWithoutGlobalId());
-                return c;
-            });
-            const container = getTestContainer();
-            /**
-             * @type {PostRequestProcessor}
-             */
-                // eslint-disable-next-line no-unused-vars
-            const postRequestProcessor = container.postRequestProcessor;
-
-            // insert directly into database instead of going through merge() so we simulate old records
-            /**
-             * @type {MongoDatabaseManager}
-             */
-            const mongoDatabaseManager = container.mongoDatabaseManager;
-            const patientHistoryCollection = await setupHistoryDatabaseAsync(
-                mongoDatabaseManager,
-                patient1HistoryResource,
-                expectedPatient1HistoryInDatabaseBeforeRun
-            );
-
-            // run admin runner
-
-            const collections = ['Patient_4_0_0_History'];
-            const batchSize = 10000;
-
-            container.register('fixMultipleSourceAssigningAuthorityHistoryRunner', (c) => new FixMultipleSourceAssigningAuthorityHistoryRunner(
-                    {
-                        mongoCollectionManager: c.mongoCollectionManager,
-                        collections: collections,
-                        batchSize,
-                        adminLogger: new AdminLogger(),
-                        mongoDatabaseManager: c.mongoDatabaseManager,
-                        preSaveManager: c.preSaveManager
-                    }
-                )
-            );
-
-            /**
-             * @type {FixHistoryRunner}
-             */
-            const fixMultipleSourceAssigningAuthorityHistoryRunner = container.fixMultipleSourceAssigningAuthorityHistoryRunner;
-            assertTypeEquals(fixMultipleSourceAssigningAuthorityHistoryRunner, FixMultipleSourceAssigningAuthorityHistoryRunner);
-            await fixMultipleSourceAssigningAuthorityHistoryRunner.processAsync();
-
-            // Check patient 1 history
-            const patient1History = await patientHistoryCollection.findOne({id: patient1HistoryResource.id});
-            expect(patient1History).toBeDefined();
-            delete patient1History._id;
-            expect(patient1History).toStrictEqual(expectedPatient1HistoryDatabaseAfterRun);
         });
     });
 });

--- a/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixMultipleSourceAssigningAuthority.test.js
+++ b/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixMultipleSourceAssigningAuthority.test.js
@@ -4,6 +4,8 @@ const practitioner2Resource = require('./fixtures/Practitioner/practitioner2.jso
 const practitionerrole1Resource = require('./fixtures/Practitioner/practitionerrole1.json');
 const practitionerrole2Resource = require('./fixtures/Practitioner/practitionerrole2.json');
 const Practitioner1HistoryResource = require('./fixtures/Practitioner/practitioner1_history.json');
+const patient1Resource = require('./fixtures/Patient/patient1.json');
+const patient1HistoryResource = require('./fixtures/Patient/patient1_history.json');
 
 
 // expected
@@ -12,12 +14,17 @@ const expectedPractitioner2InDatabaseBeforeRun = require('./fixtures/expected/ex
 const expectedPractitionerRole1InDatabaseBeforeRun = require('./fixtures/expected/expected_practitionerrole_1_in_database_before_run.json');
 const expectedPractitionerRole2InDatabaseBeforeRun = require('./fixtures/expected/expected_practitionerrole_2_in_database_before_run.json');
 const expectedPractitioner1HistoryInDatabaseBeforeRun = require('./fixtures/expected/expected_practitioner1_hisory_in_database_before_run.json');
+const expectedPatient1InDatabaseBeforeRun = require('./fixtures/expected/expected_patient_1_in_database_before_run.json');
+const expectedPatient1HistoryInDatabaseBeforeRun = require('./fixtures/expected/expected_patient1_history_in_database_before_run.json');
 
 const expectedPractitioner1DatabaseAfterRun = require('./fixtures/expected/expected_practitioner1.json');
 const expectedPractitioner2DatabaseAfterRun = require('./fixtures/expected/expected_practitioner2.json');
 const expectedPractitionerRole1DatabaseAfterRun = require('./fixtures/expected/expected_practitionerrole1.json');
 const expectedPractitionerRole2DatabaseAfterRun = require('./fixtures/expected/expected_practitionerrole2.json');
 const expectedPractitioner1HistoryDatabaseAfterRun = require('./fixtures/expected/expected_practitioner1_hisory.json');
+const expectedPatient1DatabaseAfterRun = require('./fixtures/expected/expected_patient1.json');
+const expectedPatient1HistoryDatabaseAfterRun = require('./fixtures/expected/expected_patient1_history.json');
+
 const { FixMultipleSourceAssigningAuthorityHistoryRunner } = require('../../../../admin/runners/fixMultipleSourceAssigningAuthorityHistoryRunner');
 
 const { FixReferenceSourceAssigningAuthorityRunner } = require('../../../../admin/runners/fixReferenceSourceAssigningAuthorityRunner');
@@ -84,7 +91,7 @@ async function setupHistoryDatabaseAsync(mongoDatabaseManager, incomingResource,
     return collection;
 }
 
-describe('Practitioner Tests', () => {
+describe('Fix Multiple Source Assigning Authority Tests', () => {
     beforeEach(async () => {
         await commonBeforeEach();
     });
@@ -266,6 +273,118 @@ describe('Practitioner Tests', () => {
             expect(practitioner1History).toBeDefined();
             delete practitioner1History._id;
             expect(practitioner1History).toStrictEqual(expectedPractitioner1HistoryDatabaseAfterRun);
+        });
+    });
+
+    describe('Patient fixMultipleSourceAssigningAuthority Tests', () => {
+        test('fixMultipleSourceAssigningAuthority works for patients', async () => {
+            // eslint-disable-next-line no-unused-vars
+            const request = await createTestRequest((c) => {
+                c.register('configManager', () => new MockConfigManagerWithoutGlobalId());
+                return c;
+            });
+            const container = getTestContainer();
+            /**
+             * @type {PostRequestProcessor}
+             */
+            // eslint-disable-next-line no-unused-vars
+            const postRequestProcessor = container.postRequestProcessor;
+
+            // insert directly into database instead of going through merge() so we simulate old records
+            /**
+             * @type {MongoDatabaseManager}
+             */
+            const mongoDatabaseManager = container.mongoDatabaseManager;
+            let patientCollection = await setupDatabaseAsync(
+                mongoDatabaseManager, patient1Resource, expectedPatient1InDatabaseBeforeRun
+            );
+
+            // run admin runner
+
+            let collections = ['Patient_4_0_0'];
+            const batchSize = 10000;
+
+            container.register('fixMultipleSourceAssigningAuthorityRunner', (c) => new FixMultipleSourceAssigningAuthorityRunner(
+                    {
+                        mongoCollectionManager: c.mongoCollectionManager,
+                        collections: collections,
+                        batchSize,
+                        useAuditDatabase: false,
+                        adminLogger: new AdminLogger(),
+                        mongoDatabaseManager: c.mongoDatabaseManager,
+                        preSaveManager: c.preSaveManager,
+                        filterRecords: true
+                    }
+                )
+            );
+
+            /**
+             * @type {FixMultipleSourceAssigningAuthorityRunner}
+             */
+            const fixMultipleSourceAssigningAuthorityRunner = container.fixMultipleSourceAssigningAuthorityRunner;
+            assertTypeEquals(fixMultipleSourceAssigningAuthorityRunner, FixMultipleSourceAssigningAuthorityRunner);
+            await fixMultipleSourceAssigningAuthorityRunner.processAsync();
+
+            // Check patient 1
+            const patient1 = await patientCollection.findOne({id: patient1Resource.id});
+            expect(patient1).toBeDefined();
+            delete patient1._id;
+            expectedPatient1DatabaseAfterRun.meta.lastUpdated = patient1.meta.lastUpdated;
+            expect(patient1).toStrictEqual(expectedPatient1DatabaseAfterRun);
+        });
+        test('fixMultipleSourceAssigningAuthorityHistory works for patient', async () => {
+            // eslint-disable-next-line no-unused-vars
+            const request = await createTestRequest((c) => {
+                c.register('configManager', () => new MockConfigManagerWithoutGlobalId());
+                return c;
+            });
+            const container = getTestContainer();
+            /**
+             * @type {PostRequestProcessor}
+             */
+                // eslint-disable-next-line no-unused-vars
+            const postRequestProcessor = container.postRequestProcessor;
+
+            // insert directly into database instead of going through merge() so we simulate old records
+            /**
+             * @type {MongoDatabaseManager}
+             */
+            const mongoDatabaseManager = container.mongoDatabaseManager;
+            const patientHistoryCollection = await setupHistoryDatabaseAsync(
+                mongoDatabaseManager,
+                patient1HistoryResource,
+                expectedPatient1HistoryInDatabaseBeforeRun
+            );
+
+            // run admin runner
+
+            const collections = ['Patient_4_0_0_History'];
+            const batchSize = 10000;
+
+            container.register('fixMultipleSourceAssigningAuthorityHistoryRunner', (c) => new FixMultipleSourceAssigningAuthorityHistoryRunner(
+                    {
+                        mongoCollectionManager: c.mongoCollectionManager,
+                        collections: collections,
+                        batchSize,
+                        adminLogger: new AdminLogger(),
+                        mongoDatabaseManager: c.mongoDatabaseManager,
+                        preSaveManager: c.preSaveManager
+                    }
+                )
+            );
+
+            /**
+             * @type {FixHistoryRunner}
+             */
+            const fixMultipleSourceAssigningAuthorityHistoryRunner = container.fixMultipleSourceAssigningAuthorityHistoryRunner;
+            assertTypeEquals(fixMultipleSourceAssigningAuthorityHistoryRunner, FixMultipleSourceAssigningAuthorityHistoryRunner);
+            await fixMultipleSourceAssigningAuthorityHistoryRunner.processAsync();
+
+            // Check patient 1 history
+            const patient1History = await patientHistoryCollection.findOne({id: patient1HistoryResource.id});
+            expect(patient1History).toBeDefined();
+            delete patient1History._id;
+            expect(patient1History).toStrictEqual(expectedPatient1HistoryDatabaseAfterRun);
         });
     });
 });

--- a/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixMultipleSourceAssigningAuthorityPatient.test.js
+++ b/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixMultipleSourceAssigningAuthorityPatient.test.js
@@ -1,0 +1,198 @@
+// test file
+const patient1Resource = require('./fixtures/Patient/patient1.json');
+const patient1HistoryResource = require('./fixtures/Patient/patient1_history.json');
+
+
+// expected
+const expectedPatient1InDatabaseBeforeRun = require('./fixtures/expected/expected_patient_1_in_database_before_run.json');
+const expectedPatient1HistoryInDatabaseBeforeRun = require('./fixtures/expected/expected_patient1_history_in_database_before_run.json');
+
+const expectedPatient1DatabaseAfterRun = require('./fixtures/expected/expected_patient1.json');
+const expectedPatient1HistoryDatabaseAfterRun = require('./fixtures/expected/expected_patient1_history.json');
+
+const { FixMultipleSourceAssigningAuthorityHistoryRunner } = require('../../../../admin/runners/fixMultipleSourceAssigningAuthorityHistoryRunner');
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    createTestRequest,
+    getTestContainer,
+} = require('../../../common');
+const {describe, beforeEach, afterEach, test} = require('@jest/globals');
+const {AdminLogger} = require('../../../../admin/adminLogger');
+const {ConfigManager} = require('../../../../utils/configManager');
+const {FixMultipleSourceAssigningAuthorityRunner} = require('../../../../admin/runners/fixMultipleSourceAssigningAuthorityRunner');
+const {assertTypeEquals} = require('../../../../utils/assertType');
+
+class MockConfigManagerWithoutGlobalId extends ConfigManager {
+    get enableGlobalIdSupport() {
+        return false;
+    }
+
+    get enableReturnBundle() {
+        return true;
+    }
+}
+
+async function setupDatabaseAsync(mongoDatabaseManager, incomingResource, expectedResourceInDatabase) {
+    const fhirDb = await mongoDatabaseManager.getClientDbAsync();
+
+    const collection = fhirDb.collection(`${incomingResource.resourceType}_4_0_0`);
+    await collection.insertOne(incomingResource);
+
+    // ACT & ASSERT
+    // check that two entries were stored in the database
+    /**
+     * @type {import('mongodb').WithId<import('mongodb').Document> | null}
+     */
+    const resource = await collection.findOne({id: incomingResource.id});
+
+    delete resource._id;
+
+    incomingResource.meta.lastUpdated = resource.meta.lastUpdated;
+
+    expect(resource).toStrictEqual(expectedResourceInDatabase);
+    return collection;
+}
+
+async function setupHistoryDatabaseAsync(mongoDatabaseManager, incomingResource, expectedResourceInDatabase) {
+    const fhirDb = await mongoDatabaseManager.getClientDbAsync();
+
+    const collection = fhirDb.collection(`${incomingResource.resource.resourceType}_4_0_0_History`);
+    await collection.insertOne(incomingResource);
+
+    // ACT & ASSERT
+    // check that two entries were stored in the database
+    /**
+     * @type {import('mongodb').WithId<import('mongodb').Document> | null}
+     */
+    const resource = await collection.findOne({id: incomingResource.id});
+
+    delete resource._id;
+
+    expect(resource).toStrictEqual(expectedResourceInDatabase);
+    return collection;
+}
+
+describe('Fix Multiple Source Assigning Authority Tests', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    describe('fixMultipleSourceAssigningAuthority Tests', () => {
+        test('fixMultipleSourceAssigningAuthority works for patients', async () => {
+            // eslint-disable-next-line no-unused-vars
+            const request = await createTestRequest((c) => {
+                c.register('configManager', () => new MockConfigManagerWithoutGlobalId());
+                return c;
+            });
+            const container = getTestContainer();
+            /**
+             * @type {PostRequestProcessor}
+             */
+            // eslint-disable-next-line no-unused-vars
+            const postRequestProcessor = container.postRequestProcessor;
+
+            // insert directly into database instead of going through merge() so we simulate old records
+            /**
+             * @type {MongoDatabaseManager}
+             */
+            const mongoDatabaseManager = container.mongoDatabaseManager;
+            let patientCollection = await setupDatabaseAsync(
+                mongoDatabaseManager, patient1Resource, expectedPatient1InDatabaseBeforeRun
+            );
+
+            // run admin runner
+
+            let collections = ['Patient_4_0_0'];
+            const batchSize = 10000;
+
+            delete container['fixMultipleSourceAssigningAuthorityRunner'];
+            container.register('fixMultipleSourceAssigningAuthorityRunner', (c) => new FixMultipleSourceAssigningAuthorityRunner(
+                    {
+                        mongoCollectionManager: c.mongoCollectionManager,
+                        collections: collections,
+                        batchSize,
+                        useAuditDatabase: false,
+                        adminLogger: new AdminLogger(),
+                        mongoDatabaseManager: c.mongoDatabaseManager,
+                        preSaveManager: c.preSaveManager,
+                        filterRecords: true
+                    }
+                )
+            );
+
+            /**
+             * @type {FixMultipleSourceAssigningAuthorityRunner}
+             */
+            const fixMultipleSourceAssigningAuthorityRunner = container.fixMultipleSourceAssigningAuthorityRunner;
+            assertTypeEquals(fixMultipleSourceAssigningAuthorityRunner, FixMultipleSourceAssigningAuthorityRunner);
+            await fixMultipleSourceAssigningAuthorityRunner.processAsync();
+
+            // Check patient 1
+            const patient1 = await patientCollection.findOne({id: patient1Resource.id});
+            expect(patient1).toBeDefined();
+            delete patient1._id;
+            expectedPatient1DatabaseAfterRun.meta.lastUpdated = patient1.meta.lastUpdated;
+            expect(patient1).toStrictEqual(expectedPatient1DatabaseAfterRun);
+        });
+        test('fixMultipleSourceAssigningAuthorityHistory works for patient', async () => {
+            // eslint-disable-next-line no-unused-vars
+            const request = await createTestRequest((c) => {
+                c.register('configManager', () => new MockConfigManagerWithoutGlobalId());
+                return c;
+            });
+            const container = getTestContainer();
+            /**
+             * @type {PostRequestProcessor}
+             */
+                // eslint-disable-next-line no-unused-vars
+            const postRequestProcessor = container.postRequestProcessor;
+
+            // insert directly into database instead of going through merge() so we simulate old records
+            /**
+             * @type {MongoDatabaseManager}
+             */
+            const mongoDatabaseManager = container.mongoDatabaseManager;
+            const patientHistoryCollection = await setupHistoryDatabaseAsync(
+                mongoDatabaseManager,
+                patient1HistoryResource,
+                expectedPatient1HistoryInDatabaseBeforeRun
+            );
+
+            // run admin runner
+
+            const collections = ['Patient_4_0_0_History'];
+            const batchSize = 10000;
+            delete container.fixMultipleSourceAssigningAuthorityRunner;
+            container.register('fixMultipleSourceAssigningAuthorityHistoryRunner', (c) => new FixMultipleSourceAssigningAuthorityHistoryRunner(
+                    {
+                        mongoCollectionManager: c.mongoCollectionManager,
+                        collections: collections,
+                        batchSize,
+                        adminLogger: new AdminLogger(),
+                        mongoDatabaseManager: c.mongoDatabaseManager,
+                        preSaveManager: c.preSaveManager
+                    }
+                )
+            );
+
+            /**
+             * @type {FixHistoryRunner}
+             */
+            const fixMultipleSourceAssigningAuthorityHistoryRunner = container.fixMultipleSourceAssigningAuthorityHistoryRunner;
+            assertTypeEquals(fixMultipleSourceAssigningAuthorityHistoryRunner, FixMultipleSourceAssigningAuthorityHistoryRunner);
+            await fixMultipleSourceAssigningAuthorityHistoryRunner.processAsync();
+
+            // Check patient 1 history
+            const patient1History = await patientHistoryCollection.findOne({id: patient1HistoryResource.id});
+            expect(patient1History).toBeDefined();
+            delete patient1History._id;
+            expect(patient1History).toStrictEqual(expectedPatient1HistoryDatabaseAfterRun);
+        });
+    });
+});

--- a/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixtures/Patient/patient1.json
+++ b/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixtures/Patient/patient1.json
@@ -1,0 +1,112 @@
+{
+  "_id": "62967cee03c5d07d317230ae",
+  "resourceType": "Patient",
+  "id": "VAEagle-123456789",
+  "meta": {
+    "versionId": "23",
+    "lastUpdated": "2023-04-25T14:56:11.000Z",
+    "source": "https://www.vaeagle.com/boonchapman/eligibility",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "virginiaeagle"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "virginiaeagle"
+      },
+      {
+        "system": "https://www.icanbwell.com/vendor",
+        "code": "boon-chapman"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "boon-chapman"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "lnf"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "lnf"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "virginiaeagle"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "lnf"
+      }
+    ]
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MB"
+          }
+        ],
+        "text": "Member Number"
+      },
+      "system": "https://www.boonchapman.com/",
+      "value": "123456789"
+    },
+    {
+      "id": "sourceId",
+      "system": "https://www.icanbwell.com/sourceId",
+      "value": "VAEagle-123456789"
+    },
+    {
+      "id": "uuid",
+      "system": "https://www.icanbwell.com/uuid",
+      "value": "29763599-2e06-5020-bd7c-1dc5fa1f6daf"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "id": "amp-0",
+      "family": "Doe",
+      "given": [
+        "John",
+        "M"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "id": "amp-0",
+      "system": "phone"
+    },
+    {
+      "id": "amp-1",
+      "system": "phone"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "2001-07-14",
+  "address": [
+    {
+      "id": "amp-0",
+      "line": [
+        "1 main st."
+      ],
+      "city": "main city",
+      "state": "VA",
+      "postalCode": "22407"
+    }
+  ],
+  "_access": {
+    "virginiaeagle": 1,
+    "boon-chapman": 1,
+    "lnf": 1
+  },
+  "_sourceAssigningAuthority": "virginiaeagle",
+  "_uuid": "29763599-2e06-5020-bd7c-1dc5fa1f6daf",
+  "_sourceId": "VAEagle-123456789"
+}

--- a/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixtures/Patient/patient1_history.json
+++ b/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixtures/Patient/patient1_history.json
@@ -1,0 +1,133 @@
+{
+  "_id": "6447eb7ec534ae7b40a21fe2",
+  "id": "29763599-2e06-5020-bd7c-1dc5fa1f6daf",
+  "resource": {
+    "resourceType": "Patient",
+    "id": "VAEagle-123456789",
+    "meta": {
+      "versionId": "23",
+      "lastUpdated": "2023-04-25T14:56:11.000Z",
+      "source": "https://www.vaeagle.com/boonchapman/eligibility",
+      "security": [
+        {
+          "system": "https://www.icanbwell.com/owner",
+          "code": "virginiaeagle"
+        },
+        {
+          "system": "https://www.icanbwell.com/access",
+          "code": "virginiaeagle"
+        },
+        {
+          "system": "https://www.icanbwell.com/vendor",
+          "code": "boon-chapman"
+        },
+        {
+          "system": "https://www.icanbwell.com/access",
+          "code": "boon-chapman"
+        },
+        {
+          "system": "https://www.icanbwell.com/owner",
+          "code": "lnf"
+        },
+        {
+          "system": "https://www.icanbwell.com/access",
+          "code": "lnf"
+        },
+        {
+          "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+          "code": "virginiaeagle"
+        },
+        {
+          "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+          "code": "lnf"
+        }
+      ]
+    },
+    "identifier": [
+      {
+        "use": "usual",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+              "code": "MB"
+            }
+          ],
+          "text": "Member Number"
+        },
+        "system": "https://www.boonchapman.com/",
+        "value": "123456789"
+      },
+      {
+        "id": "sourceId",
+        "system": "https://www.icanbwell.com/sourceId",
+        "value": "VAEagle-123456789"
+      },
+      {
+        "id": "uuid",
+        "system": "https://www.icanbwell.com/uuid",
+        "value": "29763599-2e06-5020-bd7c-1dc5fa1f6daf"
+      }
+    ],
+    "active": true,
+    "name": [
+      {
+        "id": "amp-0",
+        "family": "Doe",
+        "given": [
+          "John",
+          "M"
+        ]
+      }
+    ],
+    "telecom": [
+      {
+        "id": "amp-0",
+        "system": "phone"
+      },
+      {
+        "id": "amp-1",
+        "system": "phone"
+      }
+    ],
+    "gender": "male",
+    "birthDate": "2001-07-14",
+    "address": [
+      {
+        "id": "amp-0",
+        "line": [
+          "1 main st."
+        ],
+        "city": "main city",
+        "state": "VA",
+        "postalCode": "22407"
+      }
+    ],
+    "_access": {
+      "virginiaeagle": 1,
+      "boon-chapman": 1,
+      "lnf": 1
+    },
+    "_sourceAssigningAuthority": "virginiaeagle",
+    "_uuid": "29763599-2e06-5020-bd7c-1dc5fa1f6daf",
+    "_sourceId": "VAEagle-123456789"
+  },
+  "request": {
+    "id": "a26883dc-2d88-4ed3-84f9-86a2dd28af3e",
+    "method": "POST",
+    "url": "/4_0_0/Patient/VAEagle-123456789"
+  },
+  "response": {
+    "status": "200",
+    "outcome": {
+      "resourceType": "OperationOutcome",
+      "issue": [
+        {
+          "severity": "information",
+          "code": "informational",
+          "diagnostics": "{\"op\":\"replace\",\"path\":\"/active\",\"value\":true}"
+        }
+      ]
+    }
+  }
+}

--- a/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixtures/expected/expected_patient1.json
+++ b/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixtures/expected/expected_patient1.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "Patient",
+  "id": "VAEagle-123456789",
+  "meta": {
+    "versionId": "23",
+    "lastUpdated": "2023-04-25T14:56:11.000Z",
+    "source": "https://www.vaeagle.com/boonchapman/eligibility",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "virginiaeagle"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "virginiaeagle"
+      },
+      {
+        "system": "https://www.icanbwell.com/vendor",
+        "code": "boon-chapman"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "boon-chapman"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "lnf"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "lnf"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "virginiaeagle"
+      }
+    ]
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MB"
+          }
+        ],
+        "text": "Member Number"
+      },
+      "system": "https://www.boonchapman.com/",
+      "value": "123456789"
+    },
+    {
+      "id": "sourceId",
+      "system": "https://www.icanbwell.com/sourceId",
+      "value": "VAEagle-123456789"
+    },
+    {
+      "id": "uuid",
+      "system": "https://www.icanbwell.com/uuid",
+      "value": "29763599-2e06-5020-bd7c-1dc5fa1f6daf"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "id": "amp-0",
+      "family": "Doe",
+      "given": [
+        "John",
+        "M"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "id": "amp-0",
+      "system": "phone"
+    },
+    {
+      "id": "amp-1",
+      "system": "phone"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "2001-07-14",
+  "address": [
+    {
+      "id": "amp-0",
+      "line": [
+        "1 main st."
+      ],
+      "city": "main city",
+      "state": "VA",
+      "postalCode": "22407"
+    }
+  ],
+  "_access": {
+    "virginiaeagle": 1,
+    "boon-chapman": 1,
+    "lnf": 1
+  },
+  "_sourceAssigningAuthority": "virginiaeagle",
+  "_uuid": "29763599-2e06-5020-bd7c-1dc5fa1f6daf",
+  "_sourceId": "VAEagle-123456789"
+}

--- a/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixtures/expected/expected_patient1_history.json
+++ b/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixtures/expected/expected_patient1_history.json
@@ -1,0 +1,128 @@
+{
+  "id": "29763599-2e06-5020-bd7c-1dc5fa1f6daf",
+  "resource": {
+    "resourceType": "Patient",
+    "id": "VAEagle-123456789",
+    "meta": {
+      "versionId": "23",
+      "lastUpdated": "2023-04-25T14:56:11.000Z",
+      "source": "https://www.vaeagle.com/boonchapman/eligibility",
+      "security": [
+        {
+          "system": "https://www.icanbwell.com/owner",
+          "code": "virginiaeagle"
+        },
+        {
+          "system": "https://www.icanbwell.com/access",
+          "code": "virginiaeagle"
+        },
+        {
+          "system": "https://www.icanbwell.com/vendor",
+          "code": "boon-chapman"
+        },
+        {
+          "system": "https://www.icanbwell.com/access",
+          "code": "boon-chapman"
+        },
+        {
+          "system": "https://www.icanbwell.com/owner",
+          "code": "lnf"
+        },
+        {
+          "system": "https://www.icanbwell.com/access",
+          "code": "lnf"
+        },
+        {
+          "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+          "code": "virginiaeagle"
+        }
+      ]
+    },
+    "identifier": [
+      {
+        "use": "usual",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+              "code": "MB"
+            }
+          ],
+          "text": "Member Number"
+        },
+        "system": "https://www.boonchapman.com/",
+        "value": "123456789"
+      },
+      {
+        "id": "sourceId",
+        "system": "https://www.icanbwell.com/sourceId",
+        "value": "VAEagle-123456789"
+      },
+      {
+        "id": "uuid",
+        "system": "https://www.icanbwell.com/uuid",
+        "value": "29763599-2e06-5020-bd7c-1dc5fa1f6daf"
+      }
+    ],
+    "active": true,
+    "name": [
+      {
+        "id": "amp-0",
+        "family": "Doe",
+        "given": [
+          "John",
+          "M"
+        ]
+      }
+    ],
+    "telecom": [
+      {
+        "id": "amp-0",
+        "system": "phone"
+      },
+      {
+        "id": "amp-1",
+        "system": "phone"
+      }
+    ],
+    "gender": "male",
+    "birthDate": "2001-07-14",
+    "address": [
+      {
+        "id": "amp-0",
+        "line": [
+          "1 main st."
+        ],
+        "city": "main city",
+        "state": "VA",
+        "postalCode": "22407"
+      }
+    ],
+    "_access": {
+      "virginiaeagle": 1,
+      "boon-chapman": 1,
+      "lnf": 1
+    },
+    "_sourceAssigningAuthority": "virginiaeagle",
+    "_uuid": "29763599-2e06-5020-bd7c-1dc5fa1f6daf",
+    "_sourceId": "VAEagle-123456789"
+  },
+  "request": {
+    "id": "a26883dc-2d88-4ed3-84f9-86a2dd28af3e",
+    "method": "POST",
+    "url": "/4_0_0/Patient/VAEagle-123456789"
+  },
+  "response": {
+    "status": "200",
+    "outcome": {
+      "resourceType": "OperationOutcome",
+      "issue": [
+        {
+          "severity": "information",
+          "code": "informational",
+          "diagnostics": "{\"op\":\"replace\",\"path\":\"/active\",\"value\":true}"
+        }
+      ]
+    }
+  }
+}

--- a/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixtures/expected/expected_patient1_history_in_database_before_run.json
+++ b/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixtures/expected/expected_patient1_history_in_database_before_run.json
@@ -1,0 +1,132 @@
+{
+  "id": "29763599-2e06-5020-bd7c-1dc5fa1f6daf",
+  "resource": {
+    "resourceType": "Patient",
+    "id": "VAEagle-123456789",
+    "meta": {
+      "versionId": "23",
+      "lastUpdated": "2023-04-25T14:56:11.000Z",
+      "source": "https://www.vaeagle.com/boonchapman/eligibility",
+      "security": [
+        {
+          "system": "https://www.icanbwell.com/owner",
+          "code": "virginiaeagle"
+        },
+        {
+          "system": "https://www.icanbwell.com/access",
+          "code": "virginiaeagle"
+        },
+        {
+          "system": "https://www.icanbwell.com/vendor",
+          "code": "boon-chapman"
+        },
+        {
+          "system": "https://www.icanbwell.com/access",
+          "code": "boon-chapman"
+        },
+        {
+          "system": "https://www.icanbwell.com/owner",
+          "code": "lnf"
+        },
+        {
+          "system": "https://www.icanbwell.com/access",
+          "code": "lnf"
+        },
+        {
+          "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+          "code": "virginiaeagle"
+        },
+        {
+          "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+          "code": "lnf"
+        }
+      ]
+    },
+    "identifier": [
+      {
+        "use": "usual",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+              "code": "MB"
+            }
+          ],
+          "text": "Member Number"
+        },
+        "system": "https://www.boonchapman.com/",
+        "value": "123456789"
+      },
+      {
+        "id": "sourceId",
+        "system": "https://www.icanbwell.com/sourceId",
+        "value": "VAEagle-123456789"
+      },
+      {
+        "id": "uuid",
+        "system": "https://www.icanbwell.com/uuid",
+        "value": "29763599-2e06-5020-bd7c-1dc5fa1f6daf"
+      }
+    ],
+    "active": true,
+    "name": [
+      {
+        "id": "amp-0",
+        "family": "Doe",
+        "given": [
+          "John",
+          "M"
+        ]
+      }
+    ],
+    "telecom": [
+      {
+        "id": "amp-0",
+        "system": "phone"
+      },
+      {
+        "id": "amp-1",
+        "system": "phone"
+      }
+    ],
+    "gender": "male",
+    "birthDate": "2001-07-14",
+    "address": [
+      {
+        "id": "amp-0",
+        "line": [
+          "1 main st."
+        ],
+        "city": "main city",
+        "state": "VA",
+        "postalCode": "22407"
+      }
+    ],
+    "_access": {
+      "virginiaeagle": 1,
+      "boon-chapman": 1,
+      "lnf": 1
+    },
+    "_sourceAssigningAuthority": "virginiaeagle",
+    "_uuid": "29763599-2e06-5020-bd7c-1dc5fa1f6daf",
+    "_sourceId": "VAEagle-123456789"
+  },
+  "request": {
+    "id": "a26883dc-2d88-4ed3-84f9-86a2dd28af3e",
+    "method": "POST",
+    "url": "/4_0_0/Patient/VAEagle-123456789"
+  },
+  "response": {
+    "status": "200",
+    "outcome": {
+      "resourceType": "OperationOutcome",
+      "issue": [
+        {
+          "severity": "information",
+          "code": "informational",
+          "diagnostics": "{\"op\":\"replace\",\"path\":\"/active\",\"value\":true}"
+        }
+      ]
+    }
+  }
+}

--- a/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixtures/expected/expected_patient_1_in_database_before_run.json
+++ b/src/tests/admin/runners/fixMultipleSourceAssigningAuthority/fixtures/expected/expected_patient_1_in_database_before_run.json
@@ -1,0 +1,111 @@
+{
+  "resourceType": "Patient",
+  "id": "VAEagle-123456789",
+  "meta": {
+    "versionId": "23",
+    "lastUpdated": "2023-04-25T14:56:11.000Z",
+    "source": "https://www.vaeagle.com/boonchapman/eligibility",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "virginiaeagle"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "virginiaeagle"
+      },
+      {
+        "system": "https://www.icanbwell.com/vendor",
+        "code": "boon-chapman"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "boon-chapman"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "lnf"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "lnf"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "virginiaeagle"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "lnf"
+      }
+    ]
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MB"
+          }
+        ],
+        "text": "Member Number"
+      },
+      "system": "https://www.boonchapman.com/",
+      "value": "123456789"
+    },
+    {
+      "id": "sourceId",
+      "system": "https://www.icanbwell.com/sourceId",
+      "value": "VAEagle-123456789"
+    },
+    {
+      "id": "uuid",
+      "system": "https://www.icanbwell.com/uuid",
+      "value": "29763599-2e06-5020-bd7c-1dc5fa1f6daf"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "id": "amp-0",
+      "family": "Doe",
+      "given": [
+        "John",
+        "M"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "id": "amp-0",
+      "system": "phone"
+    },
+    {
+      "id": "amp-1",
+      "system": "phone"
+    }
+  ],
+  "gender": "male",
+  "birthDate": "2001-07-14",
+  "address": [
+    {
+      "id": "amp-0",
+      "line": [
+        "1 main st."
+      ],
+      "city": "main city",
+      "state": "VA",
+      "postalCode": "22407"
+    }
+  ],
+  "_access": {
+    "virginiaeagle": 1,
+    "boon-chapman": 1,
+    "lnf": 1
+  },
+  "_sourceAssigningAuthority": "virginiaeagle",
+  "_uuid": "29763599-2e06-5020-bd7c-1dc5fa1f6daf",
+  "_sourceId": "VAEagle-123456789"
+}


### PR DESCRIPTION
1. Fix main collection: `node src/admin/scripts/fixMultipleSourceAssigningAuthority.js --batchSize=10000 --filterRecords`
2. Fix references in other collections: `node src/admin/scripts/fixReferenceSourceAssigningAuthority.js--batchSize=10000 --after <AFTER_DATE>` Choose AFTER_DATE as the start date of the script in step 1.
3. Fix history: `node src/admin/scripts/fixMultipleSourceAssigningAuthorityHistory.js --collections=all --batchSize=10000` 