### PR TITLE
EFS-283 Update fixRefences script to update the authority and uuid correctly when cache not used

### DIFF
--- a/src/admin/runners/fixReferenceSourceAssigningAuthorityRunner.js
+++ b/src/admin/runners/fixReferenceSourceAssigningAuthorityRunner.js
@@ -383,13 +383,20 @@ class FixReferenceSourceAssigningAuthorityRunner extends BaseBulkOperationRunner
                             }
                         );
                         reference._sourceAssigningAuthority = doc._sourceAssigningAuthority;
-                        reference._uuid = generateUUIDv5(`${id}|${reference._sourceAssigningAuthority}`);
+                        const newUUID = generateUUIDv5(`${id}|${reference._sourceAssigningAuthority}`);
+                        reference._uuid = `${resourceType}/${newUUID}`;
                         if (reference.extension) {
                             const uuidExtension = reference.extension.find(e => e.id === 'uuid');
                             if (uuidExtension) {
                                 uuidExtension.valueString = reference._uuid;
                             }
+                            const sourceAssigningAuthorityExtension = reference.extension.find(
+                                e => e.id === 'sourceAssigningAuthority');
+                            if (sourceAssigningAuthorityExtension) {
+                                sourceAssigningAuthorityExtension.valueString = reference._sourceAssigningAuthority;
+                            }
                         }
+
                         if (!cache.has(reference._uuid)) {
                             cache.set(reference._uuid, {
                                 _uuid: reference._uuid,


### PR DESCRIPTION
The script will work fine when --preloadCollections parameter is used. But when --preloadCollections is not used, the part of code that sets the references's UUID and authority has issue. UUID is set without the resource type prefix and the authority is not set at all. FIxed that in this PR.