### PR TITLE
Revert "Revert "EFS-303 Created insertOneAuditEventAsync to insert audit event""

### DIFF
--- a/src/dataLayer/databaseBulkInserter.js
+++ b/src/dataLayer/databaseBulkInserter.js
@@ -266,7 +266,7 @@ class DatabaseBulkInserter extends EventEmitter {
     }
 
     /**
-     * Inserts item into collection
+     * Inserts item into collection if item doesn't exists else updates the item
      * @param {string} requestId
      * @param {string} resourceType
      * @param {Resource} doc
@@ -338,6 +338,69 @@ class DatabaseBulkInserter extends EventEmitter {
                     patches: null
                 });
             }
+            if (doc._id) {
+                await this.errorReporter.reportMessageAsync({
+                    source: 'DatabaseBulkInserter.insertOneAsync',
+                    message: '_id still present',
+                    args: {
+                        doc: doc
+                    }
+                });
+                logInfo('_id still present', {args: {
+                    source: 'DatabaseBulkInserter.insertOneAsync',
+                    doc: doc
+                }});
+            }
+        } catch (e) {
+            throw new RethrownError({
+                error: e
+            });
+        }
+    }
+
+    /**
+     * Inserts item into collection without checking if item exists
+     * @param {string} requestId
+     * @param {string} resourceType
+     * @param {Resource} doc
+     * @returns {Promise<void>}
+     */
+    async insertOnlyAsync({requestId, resourceType, doc}) {
+        try {
+            assertTypeEquals(doc, Resource);
+            if (!doc.meta) {
+                doc.meta = new Meta({});
+            }
+            if (!doc.meta.versionId || isNaN(parseInt(doc.meta.versionId))) {
+                doc.meta.versionId = '1';
+            }
+            doc = await this.preSaveManager.preSaveAsync(doc);
+
+            assertIsValid(doc._uuid, `No uuid found for ${doc.resourceType}/${doc.id}`);
+            /**
+             * @type {Map<string, BulkInsertUpdateEntry[]>}
+             */
+            const operationsByResourceTypeMap = this.getOperationsByResourceTypeMap({requestId});
+            await logVerboseAsync({
+                source: 'DatabaseBulkInserter.insertOneAsync',
+                args:
+                    {
+                        message: 'start',
+                        bufferLength: operationsByResourceTypeMap.size
+                    }
+            });
+
+            this.addOperationForResourceType({
+                requestId,
+                resourceType,
+                resource: doc,
+                operation: {
+                    insertOne: {
+                        document: doc.toJSONInternal()
+                    }
+                },
+                operationType: 'insert',
+            });
             if (doc._id) {
                 await this.errorReporter.reportMessageAsync({
                     source: 'DatabaseBulkInserter.insertOneAsync',

--- a/src/utils/auditLogger.js
+++ b/src/utils/auditLogger.js
@@ -212,7 +212,7 @@ class AuditLogger {
          */
         const resourceType = 'AuditEvent';
         for (const /** @type {Resource} */ doc of this.queue) {
-            await this.databaseBulkInserter.insertOneAsync({requestId, resourceType, doc});
+            await this.databaseBulkInserter.insertOnlyAsync({requestId, resourceType, doc});
         }
         this.queue = [];
         /**

--- a/src/utils/auditLogger.js
+++ b/src/utils/auditLogger.js
@@ -21,6 +21,8 @@ const AuditEventAgent = require('../fhir/classes/4_0_0/backbone_elements/auditEv
 const AuditEventSource = require('../fhir/classes/4_0_0/backbone_elements/auditEventSource');
 const AuditEventEntity = require('../fhir/classes/4_0_0/backbone_elements/auditEventEntity');
 const AuditEventNetwork = require('../fhir/classes/4_0_0/backbone_elements/auditEventNetwork');
+const Mutex = require('async-mutex').Mutex;
+const mutex = new Mutex();
 
 class AuditLogger {
     /**
@@ -210,44 +212,46 @@ class AuditLogger {
          * Audit entries are always of resource type AuditEvent
          * @type {string}
          */
-        const resourceType = 'AuditEvent';
-        for (const /** @type {Resource} */ doc of this.queue) {
-            await this.databaseBulkInserter.insertOnlyAsync({requestId, resourceType, doc});
-        }
-        this.queue = [];
-        /**
-         * @type {MergeResultEntry[]}
-         */
-        const mergeResults = await this.databaseBulkInserter.executeAsync(
-            {
-                requestId, currentDate, base_version: this.base_version,
-                method
+        await mutex.runExclusive(async () => {
+            const resourceType = 'AuditEvent';
+            for (const /** @type {Resource} */ doc of this.queue) {
+                await this.databaseBulkInserter.insertOnlyAsync({requestId, resourceType, doc});
             }
-        );
-        /**
-         * @type {MergeResultEntry[]}
-         */
-        const mergeResultErrors = mergeResults.filter(m => m.issue);
-        if (mergeResultErrors.length > 0) {
-            logError('Error creating audit entries', {
-                error: mergeResultErrors,
-                source: 'flushAsync',
-                args: {
-                    requestId: requestId,
-                    errors: mergeResultErrors
-                }
-            });
-            await this.errorReporter.reportErrorAsync(
+            this.queue = [];
+            /**
+             * @type {MergeResultEntry[]}
+             */
+            const mergeResults = await this.databaseBulkInserter.executeAsync(
                 {
+                    requestId, currentDate, base_version: this.base_version,
+                    method
+                }
+            );
+            /**
+             * @type {MergeResultEntry[]}
+             */
+            const mergeResultErrors = mergeResults.filter(m => m.issue);
+            if (mergeResultErrors.length > 0) {
+                logError('Error creating audit entries', {
+                    error: mergeResultErrors,
                     source: 'flushAsync',
-                    message: `Error creating audit entries: ${JSON.stringify(mergeResultErrors, getCircularReplacer())}`,
                     args: {
                         request: {id: requestId},
                         errors: mergeResultErrors
                     }
-                }
-            );
-        }
+                });
+                await this.errorReporter.reportErrorAsync(
+                    {
+                        source: 'flushAsync',
+                        message: `Error creating audit entries: ${JSON.stringify(mergeResultErrors, getCircularReplacer())}`,
+                        args: {
+                            requestId: requestId,
+                            errors: mergeResultErrors
+                        }
+                    }
+                );
+            }
+        });
     }
 }
 


### PR DESCRIPTION
Reverts icanbwell/fhir-server#1018

Problem:
References of the main resources are resolved in parallel. Even the AuditEvents generated by those referenced resources are added to the same map for the current request. When AuditEvent of one resource type is getting executed, the AuditEvent of another resource type is also being executed to be put into the DB. Since the current AuditEvent does not cleared before the execution of the other AuditEvent, same AuditEvent can be part of both the DB operations.

Solution:
Use lock to flush AuditEvents one at a time i.e insertion of DB operation into the map, its execution and clearing the map should be done one at a time.
Added mutex.runExclusive() to flushAsync() function.