### PR TITLE
EFS-433 Disabling the deprecated keepAlive option in mongoConfig options

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -25,7 +25,7 @@ mongoUrl = encodeURI(mongoUrl);
  */
 const options = {
     appName: 'fhir',
-    keepAlive: true,
+    // keepAlive: true,
     connectTimeoutMS: env.MONGO_CONNECT_TIMEOUT ? parseInt(env.MONGO_CONNECT_TIMEOUT) : 60 * 60 * 1000,
     socketTimeoutMS: env.MONGO_SOCKET_TIMEOUT ? parseInt(env.MONGO_SOCKET_TIMEOUT) : 60 * 60 * 1000,
     retryReads: true,

--- a/src/config.js
+++ b/src/config.js
@@ -25,7 +25,6 @@ mongoUrl = encodeURI(mongoUrl);
  */
 const options = {
     appName: 'fhir',
-    // keepAlive: true,
     connectTimeoutMS: env.MONGO_CONNECT_TIMEOUT ? parseInt(env.MONGO_CONNECT_TIMEOUT) : 60 * 60 * 1000,
     socketTimeoutMS: env.MONGO_SOCKET_TIMEOUT ? parseInt(env.MONGO_SOCKET_TIMEOUT) : 60 * 60 * 1000,
     retryReads: true,


### PR DESCRIPTION
KeepAlive option is deprecated and no longer configurable. As per docs, it will be true by default.
For more info about this, check: https://github.com/mongodb/node-mongodb-native/pull/3621