### PR TITLE
EFS-541 Made owner tag compulsory for update endpoint

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -8,6 +8,6 @@
     </option>
   </component>
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -472,7 +472,8 @@ const createContainer = function () {
                 resourceMerger: c.resourceMerger,
                 configManager: c.configManager,
                 databaseAttachmentManager: c.databaseAttachmentManager,
-                bwellPersonFinder: c.bwellPersonFinder
+                bwellPersonFinder: c.bwellPersonFinder,
+                preSaveManager: c.preSaveManager
             }
         )
     );

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -473,7 +473,7 @@ const createContainer = function () {
                 configManager: c.configManager,
                 databaseAttachmentManager: c.databaseAttachmentManager,
                 bwellPersonFinder: c.bwellPersonFinder,
-                preSaveManager: c.preSaveManager
+                searchManager: c.searchManager
             }
         )
     );
@@ -563,7 +563,8 @@ const createContainer = function () {
             databaseBulkInserter: c.databaseBulkInserter,
             databaseAttachmentManager: c.databaseAttachmentManager,
             configManager: c.configManager,
-            bwellPersonFinder: c.bwellPersonFinder
+            bwellPersonFinder: c.bwellPersonFinder,
+            searchManager: c.searchManager
         }
     ));
     container.register('validateOperation', (c) => new ValidateOperation(

--- a/src/operations/patch/patch.js
+++ b/src/operations/patch/patch.js
@@ -3,7 +3,6 @@
 const {BadRequestError, NotFoundError} = require('../../utils/httpErrors');
 const {validate, applyPatch, compare} = require('fast-json-patch');
 const moment = require('moment-timezone');
-const { FieldMapper } = require('../query/filters/fieldMapper');
 const {assertTypeEquals, assertIsValid} = require('../../utils/assertType');
 const {DatabaseQueryFactory} = require('../../dataLayer/databaseQueryFactory');
 const {PostRequestProcessor} = require('../../utils/postRequestProcessor');
@@ -19,6 +18,9 @@ const {ConfigManager} = require('../../utils/configManager');
 const {DELETE, RETRIEVE} = require('../../constants').GRIDFS;
 const { BwellPersonFinder } = require('../../utils/bwellPersonFinder');
 const {PostSaveProcessor} = require('../../dataLayer/postSaveProcessor');
+const { isTrue } = require('../../utils/isTrue');
+const { SecurityTagSystem } = require('../../utils/securityTagSystem');
+const { SearchManager } = require('../search/searchManager');
 
 class PatchOperation {
     /**
@@ -32,6 +34,7 @@ class PatchOperation {
      * @param {DatabaseAttachmentManager} databaseAttachmentManager
      * @param {ConfigManager} configManager
      * @param {BwellPersonFinder} bwellPersonFinder
+     * @param {SearchManager} searchManager
      */
     constructor(
         {
@@ -43,7 +46,8 @@ class PatchOperation {
             databaseBulkInserter,
             databaseAttachmentManager,
             configManager,
-            bwellPersonFinder
+            bwellPersonFinder,
+            searchManager
         }
     ) {
         /**
@@ -93,6 +97,12 @@ class PatchOperation {
          */
         this.bwellPersonFinder = bwellPersonFinder;
         assertTypeEquals(bwellPersonFinder, BwellPersonFinder);
+
+        /**
+         * @type {SearchManager}
+         */
+        this.searchManager = searchManager;
+        assertTypeEquals(searchManager, SearchManager);
     }
 
     /**
@@ -107,12 +117,23 @@ class PatchOperation {
         assertIsValid(resourceType !== undefined);
         assertTypeEquals(parsedArgs, ParsedArgs);
         const currentOperationName = 'patch';
+        const extraInfo = {
+            currentOperationName: currentOperationName
+        };
         const {
             requestId,
             method,
             body: patchContent,
             /** @type {import('content-type').ContentType} */ contentTypeFromHeader,
-            /**@type {string} */ userRequestId
+            /**@type {string} */ userRequestId,
+            user,
+            scope,
+            /** @type {string[]} */
+            patientIdsFromJwtToken,
+            /** @type {boolean} */
+            isUser,
+            /** @type {string} */
+            personIdFromJwtToken,
         } = requestInfo;
 
         // currently we only support JSONPatch
@@ -156,16 +177,59 @@ class PatchOperation {
              * @type {Resource}
              */
             let foundResource;
-            try {
-                const databaseQueryManager = this.databaseQueryFactory.createQuery(
-                    {resourceType, base_version}
-                );
-                const idFieldMapper = new FieldMapper({useHistoryTable: false});
-                const idField = idFieldMapper.getFieldName('id', id.toString());
-                foundResource = await databaseQueryManager.findOneAsync({query: {[idField]: id.toString()}});
-            } catch (e) {
+            /**
+             * @type {boolean}
+             */
+            const useAccessIndex = (this.configManager.useAccessIndex || isTrue(parsedArgs['_useAccessIndex']));
+
+            /**
+             * @type {{base_version, columns: Set, query: import('mongodb').Document}}
+             */
+            const {
+                /** @type {import('mongodb').Document}**/
+                query,
+                // /** @type {Set} **/
+                // columns
+            } = await this.searchManager.constructQueryAsync({
+                user,
+                scope,
+                isUser,
+                patientIdsFromJwtToken,
+                resourceType,
+                useAccessIndex,
+                personIdFromJwtToken,
+                parsedArgs,
+            });
+            const databaseQueryManager = this.databaseQueryFactory.createQuery(
+                { resourceType, base_version },
+            );
+            /**
+             * @type {DatabasePartitionedCursor}
+             */
+            let cursor = await databaseQueryManager.findAsync({ query: query, extraInfo });
+            /**
+             * @type {[Resource] | null}
+             */
+            let resources = await cursor.toArrayAsync();
+
+            if (resources.length > 1) {
+                const sourceAssigningAuthorities = resources.flatMap(
+                    r => r.meta && r.meta.security ?
+                        r.meta.security
+                            .filter(tag => tag.system === SecurityTagSystem.sourceAssigningAuthority)
+                            .map(tag => tag.code)
+                        : [],
+                ).sort();
+                throw new BadRequestError(new Error(
+                    `Multiple resources found with id ${id}.  ` +
+                    'Please either specify the owner/sourceAssigningAuthority tag: ' +
+                    sourceAssigningAuthorities.map(sa => `${id}|${sa}`).join(' or ') +
+                    ' OR use uuid to query.',
+                ));
+            } else if (resources.length === 0) {
                 throw new NotFoundError(new Error(`Resource not found: ${resourceType}/${id}`));
             }
+            foundResource = resources[0];
             if (!foundResource) {
                 throw new NotFoundError('Resource not found');
             }

--- a/src/operations/patch/patch.js
+++ b/src/operations/patch/patch.js
@@ -127,7 +127,7 @@ class PatchOperation {
             /** @type {import('content-type').ContentType} */ contentTypeFromHeader,
             /**@type {string} */ userRequestId,
             user,
-            scope,
+            /**@type {string | null} */ scope,
             /** @type {string[]} */
             patientIdsFromJwtToken,
             /** @type {boolean} */

--- a/src/operations/update/update.js
+++ b/src/operations/update/update.js
@@ -1,6 +1,5 @@
 const moment = require('moment-timezone');
 const sendToS3 = require('../../utils/aws-s3');
-const { FieldMapper } = require('../query/filters/fieldMapper');
 const {NotValidatedError, ForbiddenError, BadRequestError} = require('../../utils/httpErrors');
 const {validationsFailedCounter} = require('../../utils/prometheus.utils');
 const {assertTypeEquals, assertIsValid} = require('../../utils/assertType');
@@ -21,7 +20,9 @@ const {FhirResourceCreator} = require('../../fhir/fhirResourceCreator');
 const {DatabaseAttachmentManager} = require('../../dataLayer/databaseAttachmentManager');
 const { BwellPersonFinder } = require('../../utils/bwellPersonFinder');
 const {PostSaveProcessor} = require('../../dataLayer/postSaveProcessor');
-const { PreSaveManager } = require('../../preSaveHandlers/preSave');
+const { isTrue } = require('../../utils/isTrue');
+const { SearchManager } = require('../search/searchManager');
+const { IdParser } = require('../../utils/idParser');
 const {RETRIEVE} = require('../../constants').GRIDFS;
 
 /**
@@ -43,7 +44,7 @@ class UpdateOperation {
      * @param {ConfigManager} configManager
      * @param {DatabaseAttachmentManager} databaseAttachmentManager
      * @param {BwellPersonFinder} bwellPersonFinder
-     * @param {PreSaveManager} preSaveManager
+     * @param {SearchManager} searchManager
      */
     constructor(
         {
@@ -60,7 +61,7 @@ class UpdateOperation {
             configManager,
             databaseAttachmentManager,
             bwellPersonFinder,
-            preSaveManager
+            searchManager
         }
     ) {
         /**
@@ -134,10 +135,10 @@ class UpdateOperation {
         assertTypeEquals(bwellPersonFinder, BwellPersonFinder);
 
         /**
-         * @type {PreSaveManager}
+         * @type {SearchManager}
          */
-        this.preSaveManager = preSaveManager;
-        assertTypeEquals(preSaveManager, PreSaveManager);
+        this.searchManager = searchManager;
+        assertTypeEquals(searchManager, SearchManager);
     }
 
     /**
@@ -153,6 +154,9 @@ class UpdateOperation {
         assertTypeEquals(parsedArgs, ParsedArgs);
 
         const currentOperationName = 'update';
+        const extraInfo = {
+            currentOperationName: currentOperationName
+        };
         // Query our collection for this observation
         /**
          * @type {number}
@@ -165,7 +169,13 @@ class UpdateOperation {
             body, /** @type {string|null} */
             requestId, /** @type {string} */
             method,
-            /**@type {string} */ userRequestId
+            /**@type {string} */ userRequestId,
+            /** @type {string[]} */
+            patientIdsFromJwtToken,
+            /** @type {boolean} */
+            isUser,
+            /** @type {string} */
+            personIdFromJwtToken,
         } = requestInfo;
 
         await this.scopesValidator.verifyHasValidScopesAsync(
@@ -188,7 +198,8 @@ class UpdateOperation {
         let resource_incoming_json = body;
         let {base_version, id} = parsedArgs;
 
-        resource_incoming_json.id = id;
+        const { id: rawId } = IdParser.parse(id);
+        resource_incoming_json.id = rawId;
 
         if (this.configManager.logAllSaves) {
             await sendToS3('logs',
@@ -207,7 +218,7 @@ class UpdateOperation {
 
         if (this.configManager.validateSchema || parsedArgs['_validate']) {
             // Truncate id to 64 so it passes the validator since we support more than 64 internally
-            resource_incoming_json.id = id.slice(0, 64);
+            resource_incoming_json.id = rawId.slice(0, 64);
             /**
              * @type {OperationOutcome|null}
              */
@@ -242,17 +253,63 @@ class UpdateOperation {
 
 
         try {
+            /**
+             * @type {boolean}
+             */
+            const useAccessIndex = (this.configManager.useAccessIndex || isTrue(parsedArgs['_useAccessIndex']));
+
+            /**
+             * @type {{base_version, columns: Set, query: import('mongodb').Document}}
+             */
+            const {
+                /** @type {import('mongodb').Document}**/
+                query,
+                // /** @type {Set} **/
+                // columns
+            } = await this.searchManager.constructQueryAsync({
+                user,
+                scope,
+                isUser,
+                patientIdsFromJwtToken,
+                resourceType,
+                useAccessIndex,
+                personIdFromJwtToken,
+                parsedArgs
+            });
+
             // Get current record
             const databaseQueryManager = this.databaseQueryFactory.createQuery(
                 {resourceType, base_version}
             );
-            const idFieldMapper = new FieldMapper({useHistoryTable: false});
-            const idField = idFieldMapper.getFieldName('id', id.toString());
 
+            /**
+             * @type {DatabasePartitionedCursor}
+             */
+            let cursor = await databaseQueryManager.findAsync({ query: query, extraInfo });
+            /**
+             * @type {[Resource] | null}
+             */
+            let resources = await cursor.toArrayAsync();
+
+            if (resources.length > 1) {
+                const sourceAssigningAuthorities = resources.flatMap(
+                    r => r.meta && r.meta.security ?
+                        r.meta.security
+                            .filter(tag => tag.system === SecurityTagSystem.sourceAssigningAuthority)
+                            .map(tag => tag.code)
+                        : [],
+                ).sort();
+                throw new BadRequestError(new Error(
+                    `Multiple resources found with id ${id}.  ` +
+                    'Please either specify the owner/sourceAssigningAuthority tag: ' +
+                    sourceAssigningAuthorities.map(sa => `${id}|${sa}`).join(' or ') +
+                    ' OR use uuid to query.',
+                ));
+            }
             /**
              * @type {Resource | null}
              */
-            let data = await databaseQueryManager.findOneAsync({query: {[idField]: id.toString()}});
+            let data = resources[0];
             /**
              * @type {Resource|null}
              */

--- a/src/tests/patch/patch/fixtures/ActivityDefinition/activitydefinition4.json
+++ b/src/tests/patch/patch/fixtures/ActivityDefinition/activitydefinition4.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "ActivityDefinition",
+  "id": "sameid",
+  "meta": {
+    "source": "bwell",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "bwell"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "bwell"
+      }
+    ]
+  },
+  "name": "TEST1",
+  "approvalDate": "2022-09-12",
+  "library": [
+    "http://fhir.staging.icanbwell.com/4_0_0/Library/DIABETESTYPE2-ClinicalGrouping"
+  ]
+}

--- a/src/tests/patch/patch/fixtures/ActivityDefinition/activitydefinition5.json
+++ b/src/tests/patch/patch/fixtures/ActivityDefinition/activitydefinition5.json
@@ -1,0 +1,26 @@
+{
+  "resourceType": "ActivityDefinition",
+  "id": "sameid",
+  "meta": {
+    "source": "bwell",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "medstar"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "bwell"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "medstar"
+      }
+    ]
+  },
+  "name": "TEST2",
+  "approvalDate": "2022-09-12",
+  "library": [
+    "http://fhir.staging.icanbwell.com/4_0_0/Library/DIABETESTYPE2-ClinicalGrouping"
+  ]
+}

--- a/src/tests/patch/patch/fixtures/expected/expected_ActivityDefinition5.json
+++ b/src/tests/patch/patch/fixtures/expected/expected_ActivityDefinition5.json
@@ -1,0 +1,44 @@
+{
+  "resourceType": "ActivityDefinition",
+  "id": "sameid",
+  "meta": {
+    "versionId": "2",
+    "lastUpdated": "2023-08-29T09:27:35.000Z",
+    "source": "bwell",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "medstar"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "bwell"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "medstar"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "medstar"
+      }
+    ]
+  },
+  "identifier": [
+    {
+      "id": "sourceId",
+      "system": "https://www.icanbwell.com/sourceId",
+      "value": "sameid"
+    },
+    {
+      "id": "uuid",
+      "system": "https://www.icanbwell.com/uuid",
+      "value": "8a635bee-94ea-548b-a1f3-1e4ad96ae350"
+    }
+  ],
+  "name": "TEST3",
+  "approvalDate": "2022-09-12",
+  "library": [
+    "http://fhir.staging.icanbwell.com/4_0_0/Library/DIABETESTYPE2-ClinicalGrouping"
+  ]
+}

--- a/src/tests/patch/patch/fixtures/expected/expected_ActivityDefinitionBwell.json
+++ b/src/tests/patch/patch/fixtures/expected/expected_ActivityDefinitionBwell.json
@@ -1,0 +1,93 @@
+{
+  "entry": [
+    {
+      "resource": {
+        "approvalDate": "2022-09-12",
+        "id": "sameid",
+        "identifier": [
+          {
+            "id": "sourceId",
+            "system": "https://www.icanbwell.com/sourceId",
+            "value": "sameid"
+          },
+          {
+            "id": "uuid",
+            "system": "https://www.icanbwell.com/uuid",
+            "value": "8a635bee-94ea-548b-a1f3-1e4ad96ae350"
+          }
+        ],
+        "library": [
+          "http://fhir.staging.icanbwell.com/4_0_0/Library/DIABETESTYPE2-ClinicalGrouping"
+        ],
+        "meta": {
+          "security": [
+            {
+              "code": "medstar",
+              "system": "https://www.icanbwell.com/owner"
+            },
+            {
+              "code": "bwell",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "medstar",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "medstar",
+              "system": "https://www.icanbwell.com/sourceAssigningAuthority"
+            }
+          ],
+          "source": "bwell",
+          "versionId": "2"
+        },
+        "name": "TEST3",
+        "resourceType": "ActivityDefinition"
+      }
+    },
+    {
+      "resource": {
+        "approvalDate": "2022-09-12",
+        "id": "sameid",
+        "identifier": [
+          {
+            "id": "sourceId",
+            "system": "https://www.icanbwell.com/sourceId",
+            "value": "sameid"
+          },
+          {
+            "id": "uuid",
+            "system": "https://www.icanbwell.com/uuid",
+            "value": "68fc821f-d948-5342-945b-adb82516e7df"
+          }
+        ],
+        "library": [
+          "http://fhir.staging.icanbwell.com/4_0_0/Library/DIABETESTYPE2-ClinicalGrouping"
+        ],
+        "meta": {
+          "security": [
+            {
+              "code": "bwell",
+              "system": "https://www.icanbwell.com/owner"
+            },
+            {
+              "code": "bwell",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "bwell",
+              "system": "https://www.icanbwell.com/sourceAssigningAuthority"
+            }
+          ],
+          "source": "bwell",
+          "versionId": "1"
+        },
+        "name": "TEST1",
+        "resourceType": "ActivityDefinition"
+      }
+    }
+  ],
+  "resourceType": "Bundle",
+  "total": 0,
+  "type": "searchset"
+}

--- a/src/tests/patch/patch/fixtures/expected/expected_ActivityDefinitionMedstar.json
+++ b/src/tests/patch/patch/fixtures/expected/expected_ActivityDefinitionMedstar.json
@@ -1,0 +1,52 @@
+{
+  "entry": [
+    {
+      "resource": {
+        "approvalDate": "2022-09-12",
+        "id": "sameid",
+        "identifier": [
+          {
+            "id": "sourceId",
+            "system": "https://www.icanbwell.com/sourceId",
+            "value": "sameid"
+          },
+          {
+            "id": "uuid",
+            "system": "https://www.icanbwell.com/uuid",
+            "value": "8a635bee-94ea-548b-a1f3-1e4ad96ae350"
+          }
+        ],
+        "library": [
+          "http://fhir.staging.icanbwell.com/4_0_0/Library/DIABETESTYPE2-ClinicalGrouping"
+        ],
+        "meta": {
+          "security": [
+            {
+              "code": "medstar",
+              "system": "https://www.icanbwell.com/owner"
+            },
+            {
+              "code": "bwell",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "medstar",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "medstar",
+              "system": "https://www.icanbwell.com/sourceAssigningAuthority"
+            }
+          ],
+          "source": "bwell",
+          "versionId": "2"
+        },
+        "name": "TEST3",
+        "resourceType": "ActivityDefinition"
+      }
+    }
+  ],
+  "resourceType": "Bundle",
+  "total": 0,
+  "type": "searchset"
+}

--- a/src/tests/patch/patch/fixtures/expected/expected_error_with_multiple_documents.json
+++ b/src/tests/patch/patch/fixtures/expected/expected_error_with_multiple_documents.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "OperationOutcome",
+  "issue": [
+    {
+      "severity": "error",
+      "code": "invalid",
+      "details": {
+        "text": "Multiple resources found with id sameid.  Please either specify the owner/sourceAssigningAuthority tag: sameid|bwell or sameid|medstar OR use uuid to query."
+      },
+      "diagnostics": "Error: Multiple resources found with id sameid.  Please either specify the owner/sourceAssigningAuthority tag: sameid|bwell or sameid|medstar OR use uuid to query."
+    }
+  ]
+}

--- a/src/tests/patch/patch/fixtures/patches/patch3.json
+++ b/src/tests/patch/patch/fixtures/patches/patch3.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/name",
+    "value": "TEST3"
+  }
+]

--- a/src/tests/patch/patch/patch.test.js
+++ b/src/tests/patch/patch/patch.test.js
@@ -1,13 +1,31 @@
 // test file
 const person1Resource = require('./fixtures/Person/person1.json');
+const activitydefinition4Resource = require('./fixtures/ActivityDefinition/activitydefinition4.json');
+const activitydefinition5Resource = require('./fixtures/ActivityDefinition/activitydefinition5.json');
 
 // expected
 const expectedPersonResources = require('./fixtures/expected/expected_person.json');
 const patch1 = require('./fixtures/patches/patch1.json');
 const patch2 = require('./fixtures/patches/patch2.json');
+const patch3 = require('./fixtures/patches/patch3.json');
 
 const {commonBeforeEach, commonAfterEach, getHeaders, createTestRequest, getHeadersJsonPatch} = require('../../common');
 const { describe, beforeEach, afterEach, test } = require('@jest/globals');
+const expectedActivityDefinition5Resource = require('./fixtures/expected/expected_ActivityDefinition5.json');
+const expectedActivityDefinitionMedstarResources = require('./fixtures/expected/expected_ActivityDefinitionMedstar.json');
+const expectedActivityDefinitionBwellResources = require('./fixtures/expected/expected_ActivityDefinitionBwell.json');
+const expectedErrorWithMultipleDocuments = require('./fixtures/expected/expected_error_with_multiple_documents.json');
+const { ConfigManager } = require('../../../utils/configManager');
+
+class MockConfigManager extends ConfigManager {
+    get enableGlobalIdSupport() {
+        return true;
+    }
+
+    get enableReturnBundle() {
+        return true;
+    }
+}
 
 describe('Person Tests', () => {
     beforeEach(async () => {
@@ -102,6 +120,82 @@ describe('Person Tests', () => {
                 ],
                 'resourceType': 'OperationOutcome',
             });
+        });
+
+        test('patch response works when multiple documents with same id are present when accessed from different scopes', async () => {
+            const request = await createTestRequest((c) => {
+                c.register('configManager', () => new MockConfigManager());
+                return c;
+            });
+            const allAccessHeaders = getHeaders('user/*.read user/*.write access/bwell.* access/medstar.*');
+            let resp = await request
+                .post('/4_0_0/ActivityDefinition/$merge')
+                .send(activitydefinition5Resource)
+                .set(allAccessHeaders)
+                .expect(200);
+
+            resp = await request
+                .post('/4_0_0/ActivityDefinition/$merge')
+                .send(activitydefinition4Resource)
+                .set(allAccessHeaders)
+                .expect(200);
+
+            const medstarHeaders = getHeadersJsonPatch('user/*.read user/*.write access/medstar.*');
+            const bwellHeaders = getHeadersJsonPatch('user/*.read user/*.write access/bwell.*');
+            resp = await request
+                .patch('/4_0_0/ActivityDefinition/sameid')
+                .send(patch3)
+                .set(medstarHeaders)
+                .expect(200);
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResponse(expectedActivityDefinition5Resource);
+
+            resp = await request
+                .get('/4_0_0/ActivityDefinition/?_bundle=1')
+                .set(medstarHeaders);
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResponse(expectedActivityDefinitionMedstarResources);
+
+            resp = await request
+                .get('/4_0_0/ActivityDefinition/?_bundle=1')
+                .set(bwellHeaders);
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResponse(expectedActivityDefinitionBwellResources);
+        });
+
+        test('patch response throws validation error when multiple documents with same id are present when accessed from same scopes', async () => {
+            const request = await createTestRequest((c) => {
+                c.register('configManager', () => new MockConfigManager());
+                return c;
+            });
+            const allAccessHeaders = getHeaders('user/*.read user/*.write access/bwell.* access/medstar.*');
+            const allAccessPatchHeaders = getHeadersJsonPatch('user/*.read user/*.write access/bwell.* access/medstar.*');
+            let resp = await request
+                .post('/4_0_0/ActivityDefinition/$merge')
+                .send(activitydefinition5Resource)
+                .set(allAccessHeaders)
+                .expect(200);
+
+            resp = await request
+                .post('/4_0_0/ActivityDefinition/$merge')
+                .send(activitydefinition4Resource)
+                .set(allAccessHeaders)
+                .expect(200);
+
+            resp = await request
+                .patch('/4_0_0/ActivityDefinition/sameid')
+                .send(patch3)
+                .set(allAccessPatchHeaders)
+                .expect(400);
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResponse(expectedErrorWithMultipleDocuments);
+
+            resp = await request
+                .patch('/4_0_0/ActivityDefinition/sameid|medstar')
+                .send(patch3)
+                .set(allAccessPatchHeaders);
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResponse(expectedActivityDefinition5Resource);
         });
     });
 });

--- a/src/tests/patient/search_with_patient_filtering/search_with_patient_filtering.test.js
+++ b/src/tests/patient/search_with_patient_filtering/search_with_patient_filtering.test.js
@@ -134,7 +134,7 @@ describe('patient Tests', () => {
         expect(resp).toHaveStatusCode(201);
 
         resp = await request
-            .put('/4_0_0/AllergyIntolerance/patient-123-c-allergy-intolerance')
+            .put('/4_0_0/AllergyIntolerance/patient-123-a-allergy-intolerance')
             .send(allergy3Resource)
             .set(getHeaders());
         // noinspection JSUnresolvedFunction
@@ -155,7 +155,7 @@ describe('patient Tests', () => {
         expect(resp).toHaveStatusCode(201);
 
         resp = await request
-            .put('/4_0_0/Condition/patient-123-c-condition')
+            .put('/4_0_0/Condition/patient-123-a-condition')
             .send(condition3Resource)
             .set(getHeaders());
         // noinspection JSUnresolvedFunction

--- a/src/tests/update/put_response/fixtures/ActivityDefinition/activitydefinition4.json
+++ b/src/tests/update/put_response/fixtures/ActivityDefinition/activitydefinition4.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "ActivityDefinition",
+  "id": "sameid",
+  "meta": {
+    "source": "bwell",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "bwell"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "bwell"
+      }
+    ]
+  },
+  "name": "TEST1",
+  "approvalDate": "2022-09-12",
+  "library": [
+    "http://fhir.staging.icanbwell.com/4_0_0/Library/DIABETESTYPE2-ClinicalGrouping"
+  ]
+}

--- a/src/tests/update/put_response/fixtures/ActivityDefinition/activitydefinition5.json
+++ b/src/tests/update/put_response/fixtures/ActivityDefinition/activitydefinition5.json
@@ -1,0 +1,26 @@
+{
+  "resourceType": "ActivityDefinition",
+  "id": "sameid",
+  "meta": {
+    "source": "bwell",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "medstar"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "bwell"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "medstar"
+      }
+    ]
+  },
+  "name": "TEST2",
+  "approvalDate": "2022-09-12",
+  "library": [
+    "http://fhir.staging.icanbwell.com/4_0_0/Library/DIABETESTYPE2-ClinicalGrouping"
+  ]
+}

--- a/src/tests/update/put_response/fixtures/expected/expected_ActivityDefinition5.json
+++ b/src/tests/update/put_response/fixtures/expected/expected_ActivityDefinition5.json
@@ -1,0 +1,44 @@
+{
+  "resourceType": "ActivityDefinition",
+  "id": "sameid",
+  "meta": {
+    "versionId": "2",
+    "lastUpdated": "2023-08-29T09:27:35.000Z",
+    "source": "bwell",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "medstar"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "bwell"
+      },
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "medstar"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "medstar"
+      }
+    ]
+  },
+  "identifier": [
+    {
+      "id": "sourceId",
+      "system": "https://www.icanbwell.com/sourceId",
+      "value": "sameid"
+    },
+    {
+      "id": "uuid",
+      "system": "https://www.icanbwell.com/uuid",
+      "value": "8a635bee-94ea-548b-a1f3-1e4ad96ae350"
+    }
+  ],
+  "name": "TEST3",
+  "approvalDate": "2022-09-12",
+  "library": [
+    "http://fhir.staging.icanbwell.com/4_0_0/Library/DIABETESTYPE2-ClinicalGrouping"
+  ]
+}

--- a/src/tests/update/put_response/fixtures/expected/expected_ActivityDefinitionBwell.json
+++ b/src/tests/update/put_response/fixtures/expected/expected_ActivityDefinitionBwell.json
@@ -1,0 +1,93 @@
+{
+  "entry": [
+    {
+      "resource": {
+        "approvalDate": "2022-09-12",
+        "id": "sameid",
+        "identifier": [
+          {
+            "id": "sourceId",
+            "system": "https://www.icanbwell.com/sourceId",
+            "value": "sameid"
+          },
+          {
+            "id": "uuid",
+            "system": "https://www.icanbwell.com/uuid",
+            "value": "8a635bee-94ea-548b-a1f3-1e4ad96ae350"
+          }
+        ],
+        "library": [
+          "http://fhir.staging.icanbwell.com/4_0_0/Library/DIABETESTYPE2-ClinicalGrouping"
+        ],
+        "meta": {
+          "security": [
+            {
+              "code": "medstar",
+              "system": "https://www.icanbwell.com/owner"
+            },
+            {
+              "code": "bwell",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "medstar",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "medstar",
+              "system": "https://www.icanbwell.com/sourceAssigningAuthority"
+            }
+          ],
+          "source": "bwell",
+          "versionId": "2"
+        },
+        "name": "TEST3",
+        "resourceType": "ActivityDefinition"
+      }
+    },
+    {
+      "resource": {
+        "approvalDate": "2022-09-12",
+        "id": "sameid",
+        "identifier": [
+          {
+            "id": "sourceId",
+            "system": "https://www.icanbwell.com/sourceId",
+            "value": "sameid"
+          },
+          {
+            "id": "uuid",
+            "system": "https://www.icanbwell.com/uuid",
+            "value": "68fc821f-d948-5342-945b-adb82516e7df"
+          }
+        ],
+        "library": [
+          "http://fhir.staging.icanbwell.com/4_0_0/Library/DIABETESTYPE2-ClinicalGrouping"
+        ],
+        "meta": {
+          "security": [
+            {
+              "code": "bwell",
+              "system": "https://www.icanbwell.com/owner"
+            },
+            {
+              "code": "bwell",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "bwell",
+              "system": "https://www.icanbwell.com/sourceAssigningAuthority"
+            }
+          ],
+          "source": "bwell",
+          "versionId": "1"
+        },
+        "name": "TEST1",
+        "resourceType": "ActivityDefinition"
+      }
+    }
+  ],
+  "resourceType": "Bundle",
+  "total": 0,
+  "type": "searchset"
+}

--- a/src/tests/update/put_response/fixtures/expected/expected_ActivityDefinitionMedstar.json
+++ b/src/tests/update/put_response/fixtures/expected/expected_ActivityDefinitionMedstar.json
@@ -1,0 +1,52 @@
+{
+  "entry": [
+    {
+      "resource": {
+        "approvalDate": "2022-09-12",
+        "id": "sameid",
+        "identifier": [
+          {
+            "id": "sourceId",
+            "system": "https://www.icanbwell.com/sourceId",
+            "value": "sameid"
+          },
+          {
+            "id": "uuid",
+            "system": "https://www.icanbwell.com/uuid",
+            "value": "8a635bee-94ea-548b-a1f3-1e4ad96ae350"
+          }
+        ],
+        "library": [
+          "http://fhir.staging.icanbwell.com/4_0_0/Library/DIABETESTYPE2-ClinicalGrouping"
+        ],
+        "meta": {
+          "security": [
+            {
+              "code": "medstar",
+              "system": "https://www.icanbwell.com/owner"
+            },
+            {
+              "code": "bwell",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "medstar",
+              "system": "https://www.icanbwell.com/access"
+            },
+            {
+              "code": "medstar",
+              "system": "https://www.icanbwell.com/sourceAssigningAuthority"
+            }
+          ],
+          "source": "bwell",
+          "versionId": "2"
+        },
+        "name": "TEST3",
+        "resourceType": "ActivityDefinition"
+      }
+    }
+  ],
+  "resourceType": "Bundle",
+  "total": 0,
+  "type": "searchset"
+}

--- a/src/tests/update/put_response/fixtures/expected/expected_error_with_multiple_documents.json
+++ b/src/tests/update/put_response/fixtures/expected/expected_error_with_multiple_documents.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "OperationOutcome",
+  "issue": [
+    {
+      "severity": "error",
+      "code": "invalid",
+      "details": {
+        "text": "Multiple resources found with id sameid.  Please either specify the owner/sourceAssigningAuthority tag: sameid|bwell or sameid|medstar OR use uuid to query."
+      },
+      "diagnostics": "Error: Multiple resources found with id sameid.  Please either specify the owner/sourceAssigningAuthority tag: sameid|bwell or sameid|medstar OR use uuid to query."
+    }
+  ]
+}

--- a/src/tests/update/put_response/fixtures/expected/expected_error_without_owner.json
+++ b/src/tests/update/put_response/fixtures/expected/expected_error_without_owner.json
@@ -1,0 +1,13 @@
+{
+    "issue": [
+        {
+            "code": "invalid",
+            "details": {
+                "text": "Resource ActivityDefinition/ab2d17e3-3996-487c-bf81-cbe31abde0be is missing a security access tag with system: https://www.icanbwell.com/owner"
+            },
+            "diagnostics": "Error: Resource ActivityDefinition/ab2d17e3-3996-487c-bf81-cbe31abde0be is missing a security access tag with system: https://www.icanbwell.com/owner",
+            "severity": "error"
+        }
+    ],
+    "resourceType": "OperationOutcome"
+}

--- a/src/tests/update/put_response/put_sourceAssigningAuthority.test.js
+++ b/src/tests/update/put_response/put_sourceAssigningAuthority.test.js
@@ -3,8 +3,10 @@ const activitydefinition1Resource = require('./fixtures/ActivityDefinition/activ
 
 // expected
 const expectedActivityDefinitionResources = require('./fixtures/expected/expected_ActivityDefinition1.json');
+const expectedErrorWithoutOwner = require('./fixtures/expected/expected_error_without_owner.json');
 
 const {commonBeforeEach, commonAfterEach, getHeaders, createTestRequest} = require('../../common');
+const { SecurityTagSystem } = require('../../../utils/securityTagSystem');
 
 describe('ActivityDefinition Tests', () => {
     beforeEach(async () => {
@@ -47,6 +49,30 @@ describe('ActivityDefinition Tests', () => {
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
             expect(resp).toHaveResponse(expectedActivityDefinitionResources);
+        });
+
+        test('put_response works without owner tag', async () => {
+            const request = await createTestRequest();
+            // Case when meta.source doesn't exist
+            let resp = await request
+                .post('/4_0_0/ActivityDefinition/$merge')
+                .send(activitydefinition1Resource)
+                .set(getHeaders())
+                .expect(200);
+
+            activitydefinition1Resource.name = 'TEST1';
+
+            activitydefinition1Resource.meta.security = activitydefinition1Resource.meta.security.filter(
+                s => s.system !== SecurityTagSystem.owner
+            );
+
+            resp = await request
+                .put('/4_0_0/ActivityDefinition/ab2d17e3-3996-487c-bf81-cbe31abde0be')
+                .send(activitydefinition1Resource)
+                .set(getHeaders())
+                .expect(400);
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResponse(expectedErrorWithoutOwner);
         });
     });
 });


### PR DESCRIPTION
1. Consider access tags in the scope to filter the documents.
2. Consider the id and sourceassigningauthority to filter the documents.
3. Test cases.