### PR TITLE
EFS-574 Update Error message in  endpoint, mention the path of profie that was not able to fetch

### DIFF
--- a/src/admin/personMatchManager.js
+++ b/src/admin/personMatchManager.js
@@ -24,6 +24,9 @@ class PersonMatchManager {
         this.databaseQueryFactory = databaseQueryFactory;
         assertTypeEquals(databaseQueryFactory, DatabaseQueryFactory);
 
+        /**
+         * @type {ConfigManager}
+         */
         this.configManager = configManager;
         assertTypeEquals(configManager, ConfigManager);
     }
@@ -140,7 +143,8 @@ class PersonMatchManager {
             const res = await superagent
                 .post(url)
                 .send(parameters)
-                .set(header);
+                .set(header)
+                .timeout(this.configManager.requestTimeoutMs);
             const json = res.body;
             logInfo('', {json});
             return json;

--- a/src/operations/common/resourceValidator.js
+++ b/src/operations/common/resourceValidator.js
@@ -248,7 +248,7 @@ class ResourceValidator {
                             // handle 404 error
                             throw new BadRequestError(
                                 new Error(
-                                    `Unable to fetch profile details for resource at ${resourceToValidateJson.resourceType}.meta.profile[${i}] = '${profile}'`
+                                    `Unable to fetch profile details for resource at ${resourceToValidateJson.resourceType}.meta.profile[${i}] = '${metaProfile}'`
                                 )
                             );
                         } else {

--- a/src/routeHandlers/smartConfiguration.js
+++ b/src/routeHandlers/smartConfiguration.js
@@ -4,15 +4,18 @@
 
 const env = require('var');
 const superagent = require('superagent');
-
+const requestTimeout = (parseInt(env.EXTERNAL_REQUEST_TIMEOUT_SEC) || 30) * 1000;
 module.exports.handleSmartConfiguration = async (req, res) => {
     if (env.AUTH_CONFIGURATION_URI) {
         /**
          * @type {*}
          */
-        const response = await superagent.get(env.AUTH_CONFIGURATION_URI).set({
-            Accept: 'application/json',
-        });
+        const response = await superagent
+            .get(env.AUTH_CONFIGURATION_URI)
+            .set({
+                Accept: 'application/json',
+            })
+            .timeout(requestTimeout);
         /**
          * @type {Object}
          */

--- a/src/strategies/jwt.bearer.strategy.js
+++ b/src/strategies/jwt.bearer.strategy.js
@@ -11,6 +11,7 @@ const {isTrue} = require('../utils/isTrue');
 const async = require('async');
 const superagent = require('superagent');
 const {Issuer} = require('openid-client');
+const requestTimeout = (parseInt(env.EXTERNAL_REQUEST_TIMEOUT_SEC) || 30) * 1000;
 
 const requiredJWTFields = [
     // 'custom:clientFhirPersonId',
@@ -28,9 +29,12 @@ const getExternalJwksByUrlAsync = async (jwksUrl) => {
     /**
      * @type {*}
      */
-    const res = await superagent.get(jwksUrl).set({
-        'Accept': 'application/json'
-    });
+    const res = await superagent
+        .get(jwksUrl)
+        .set({
+            Accept: 'application/json',
+        })
+        .timeout(requestTimeout);
     /**
      * @type {Object}
      */

--- a/src/tests/validate/remote_server/expected/404_from_profile_url.json
+++ b/src/tests/validate/remote_server/expected/404_from_profile_url.json
@@ -5,9 +5,9 @@
       "severity": "error",
       "code": "invalid",
       "details": {
-        "text": "Unable to fetch profile details from http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+        "text": "Unable to fetch profile details from passed param profile = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner'"
       },
-      "diagnostics": "Error: Unable to fetch profile details from http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+      "diagnostics": "Error: Unable to fetch profile details from passed param profile = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner'"
     }
   ]
 }

--- a/src/tests/validate/remote_server/expected/404_from_profile_url_indside_resource.json
+++ b/src/tests/validate/remote_server/expected/404_from_profile_url_indside_resource.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "OperationOutcome",
+  "issue": [
+    {
+      "severity": "error",
+      "code": "invalid",
+      "details": {
+        "text": "Unable to fetch profile details for resource at Practitioner.meta.profile[0] = 'http://hl7.org/fhir/us/core/StructureDefinition/invalid'"
+      },
+      "diagnostics": "Error: Unable to fetch profile details for resource at Practitioner.meta.profile[0] = 'http://hl7.org/fhir/us/core/StructureDefinition/invalid'"
+    }
+  ]
+}

--- a/src/tests/validate/remote_server/fixtures/invalid_practitioner_1.json
+++ b/src/tests/validate/remote_server/fixtures/invalid_practitioner_1.json
@@ -1,0 +1,47 @@
+{
+  "resourceType": "Practitioner",
+  "id": "4657",
+  "meta": {
+    "source": "http://fhir",
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/invalid"
+    ],
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "medstar"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "medstar"
+      }
+    ]
+  },
+  "active": true,
+  "name": [
+    {
+      "use": "usual",
+      "family": "AL-ANI MBBS",
+      "given": [
+        "AWSSE"
+      ]
+    }
+  ],
+  "telecom": [],
+  "address": [
+    {
+      "use": "work",
+      "type": "physical",
+      "text": "MedStar Adult Medicine at MUMH",
+      "line": [
+        "33RD STREET PROFESSIONAL BLDG,G",
+        "200 EAST 33RD STREET"
+      ],
+      "city": "BALTIMORE",
+      "state": "MD",
+      "postalCode": "21218",
+      "country": "USA"
+    }
+  ],
+  "gender": "unknown"
+}

--- a/src/tests/validate/remote_server/practitioner_remote_server_by_id.validate.test.js
+++ b/src/tests/validate/remote_server/practitioner_remote_server_by_id.validate.test.js
@@ -17,8 +17,11 @@ const expectedValidPractitionerResponseWithProfile = require('./expected/valid_p
 const deepcopy = require('deepcopy');
 const {SecurityTagSystem} = require('../../../utils/securityTagSystem');
 const invalidPractitionerResource = require('./fixtures/invalid_practitioner.json');
+const invalidPractitionerResource1 = require('./fixtures/invalid_practitioner_1.json');
+
 const expectedInvalidPractitionerResponse = require('./expected/invalid_practitioner_response.json');
 const expected404FromProfile = require('./expected/404_from_profile_url.json');
+const expected404FromProfileInsideResource = require('./expected/404_from_profile_url_indside_resource.json');
 
 const fhirValidationUrl = 'http://foo/fhir';
 
@@ -497,6 +500,93 @@ describe('Practitioner Update Tests', () => {
             expect(getProfileScope.isDone()).toBeTruthy();
             expect(uploadProfileScope.isDone()).toBeFalsy();
             expect(validationScope.isDone()).toBeFalsy();
+        });
+
+        test('should throw bad request for profile present inside resource', async () => {
+            const request = await createTestRequest((c) => {
+                c.register('configManager', () => new MockConfigManager());
+                return c;
+            });
+
+            // http://foo/fhir/StructureDefinition
+            const uploadProfileScope = nock(`${fhirValidationUrl}`, {
+                reqheaders: {
+                    'accept-encoding': 'gzip, deflate',
+                    'accept': 'application/json',
+                    'content-type': 'application/fhir+json',
+                },
+            })
+                .post('/StructureDefinition', body => body.id === 'us-core-practitioner')
+                .reply(200, {});
+
+            const validationScope = nock(`${fhirValidationUrl}`, {
+                reqheaders: {
+                    'accept-encoding': 'gzip, deflate',
+                    'accept': 'application/json',
+                    'content-type': 'application/fhir+json'
+                },
+            })
+                .post(
+                    '/Practitioner/$validate?profile=http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner',
+                    body => body.resourceType === 'Practitioner' && body.id === '4657'
+                )
+                .reply(200, {
+                        'resourceType': 'OperationOutcome',
+                        'issue': [
+                            {
+                                'severity': 'error',
+                                'code': 'processing',
+                                'details': {
+                                    'coding': [
+                                        {
+                                            'system': 'http://hl7.org/fhir/java-core-messageId',
+                                            'code': 'VALIDATION_VAL_PROFILE_UNKNOWN_NOT_POLICY'
+                                        }
+                                    ]
+                                },
+                                'diagnostics': "Profile reference 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient' has not been checked because it is unknown, and the validator is set to not fetch unknown profiles",
+                                'location': [
+                                    'Patient.meta.profile[0]',
+                                    'Line 1, Col 2'
+                                ]
+                            }
+                        ]
+                    }
+                );
+
+            let resp = await request
+                .get('/4_0_0/Practitioner')
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResourceCount(0);
+
+            resp = await request
+                .post('/4_0_0/Practitioner/$merge')
+                .send(invalidPractitionerResource1)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            // http://hl7.org/fhir/us/core/StructureDefinition/invalid
+            const getProfileScopeInternal = nock('http://hl7.org')
+                .get('/fhir/us/core/StructureDefinition/invalid')
+                .reply(404, {
+                    msg: 'URL Not found'
+                });
+
+            resp = await request
+            .get('/4_0_0/Practitioner/4657/$validate')
+            .set(getHeaders());
+
+            expect(getProfileScopeInternal.isDone()).toBeTruthy();
+            expect(uploadProfileScope.isDone()).toBeFalsy();
+            expect(validationScope.isDone()).toBeFalsy();
+
+            expect(resp).toHaveResponse(expected404FromProfileInsideResource,
+                resource => {
+                    delete resource.details; // has lastUpdated
+                    return resource;
+                });
         });
     });
 });

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -501,6 +501,14 @@ class ConfigManager {
     get payloadLimit() {
         return env.PAYLOAD_LIMIT || '50mb';
     }
+
+    /**
+     * returns the request timeout in ms
+     * @returns {number}
+     */
+    get requestTimeoutMs() {
+        return (parseInt(env.EXTERNAL_REQUEST_TIMEOUT_SEC) || 30) * 1000;
+    }
 }
 
 module.exports = {

--- a/src/utils/digestAuth.js
+++ b/src/utils/digestAuth.js
@@ -1,4 +1,5 @@
 const superagent = require('superagent');
+const env = require('var');
 const urlLib = require('url');
 const crypto = require('crypto');
 
@@ -25,6 +26,10 @@ class RequestWithDigestAuth {
         this.username = username;
         this.count = 0;
         this.retry = retry ?? 1;
+        /**
+         * @type {number}
+         */
+        this.requestTimeout = (parseInt(env.EXTERNAL_REQUEST_TIMEOUT_SEC) || 30) * 1000;
     }
 
     /**
@@ -117,7 +122,7 @@ class RequestWithDigestAuth {
                 request.query(query);
             }
 
-            const response = await request.send(data);
+            const response = await request.send(data).timeout(this.requestTimeout);
             return response;
         }
     }

--- a/src/utils/remoteFhirValidator.js
+++ b/src/utils/remoteFhirValidator.js
@@ -19,6 +19,9 @@ class RemoteFhirValidator {
             profileUrlMapper
         }
     ) {
+        /**
+         * @type {ConfigManager}
+         */
         this.configManager = configManager;
         assertTypeEquals(configManager, ConfigManager);
 
@@ -39,7 +42,8 @@ class RemoteFhirValidator {
         const originalUrl = this.profileUrlMapper.getOriginalUrl(url);
         const response = await request
             .get(originalUrl.toString())
-            .set('Accept', 'application/json');
+            .set('Accept', 'application/json')
+            .timeout(this.configManager.requestTimeoutMs);
         return response.body;
     }
 

--- a/src/utils/remoteFhirValidator.js
+++ b/src/utils/remoteFhirValidator.js
@@ -6,7 +6,6 @@ const {ConfigManager} = require('./configManager');
 const {logInfo} = require('../operations/common/logging');
 const request = require('superagent');
 const { ProfileUrlMapper } = require('./profileMapper');
-const { BadRequestError} = require('./httpErrors');
 
 class RemoteFhirValidator {
     /**
@@ -38,24 +37,10 @@ class RemoteFhirValidator {
     async fetchProfileAsync({url}) {
         assertIsValid(url, 'url must be specified');
         const originalUrl = this.profileUrlMapper.getOriginalUrl(url);
-        try {
-            const response = await request
-                .get(originalUrl.toString())
-                .set('Accept', 'application/json');
-            return response.body;
-        } catch (error) {
-            if (error.response && error.response.status === 404) {
-                // handle 404 error
-                throw new BadRequestError(
-                    new Error(
-                        `Unable to fetch profile details from ${url}`
-                    )
-                );
-            } else {
-                throw error;
-            }
-        }
-
+        const response = await request
+            .get(originalUrl.toString())
+            .set('Accept', 'application/json');
+        return response.body;
     }
 
     /**


### PR DESCRIPTION
1. Update the error message when we receive 404 while fetching the profile, pass the profile path to make the message unambiguous
2. Add request timeout for superagent