### PR TITLE
EFS-652 Removed explicit duplicate SIGTERM handler

### DIFF
--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -38,9 +38,3 @@ process.on('exit', function (code) {
         logInfo(stack, {});
     }
 });
-
-process.on('SIGTERM', () => {
-    console.log('Received SIGTERM signal. Shutting down gracefully...');
-    // Perform any necessary cleanup or finalization steps
-    process.exit(0); // Terminate the process with exit code 0 (success)
-});


### PR DESCRIPTION
- While working on EFS-378, We have integrated Terminus for graceful shutdown and we don’t need this explicit SIGTERM handler anymore. But somehow it was re-introduced by Imran changes.
- https://github.com/icanbwell/fhir-server/pull/1145/files#diff-519678aa4b49c6489b5992f218f138bd96c60e7068003ce00ae497caec9a6935R41-R46