### PR TITLE
EA-1945 Caches combinedDataElementMap variable

### DIFF
--- a/src/fhir/fhirTypesManager.js
+++ b/src/fhir/fhirTypesManager.js
@@ -9,6 +9,8 @@ const customDataElementsMap = new Map([
     ]
 ]);
 
+const combinedDataElementsMap = new Map([...dataElementMap, ...customDataElementsMap]);
+
 class FhirTypesManager {
     /**
      * gets type of field in resource
@@ -21,7 +23,6 @@ class FhirTypesManager {
      */
     getTypeForField ({ resourceType, field }) {
         const resourceAndField = `${resourceType}.${field}`;
-        const combinedDataElementsMap = new Map([...dataElementMap, ...customDataElementsMap]);
         const dataType = combinedDataElementsMap.get(resourceAndField);
         return dataType && dataType.code;
     }


### PR DESCRIPTION
## What

This function is [called during arg parsing](https://github.com/icanbwell/fhir-server/blob/main/src/operations/query/r4ArgsParser.js#L161) and seems to be a large bottleneck. See below:

<img width="2980" alt="graph-query-zoomed" src="https://github.com/user-attachments/assets/d072ffaa-ae76-455e-ab9e-5990c5185172" />

As you can see, this function can take up to 13ms to run. 

If you take a look at getTypeForField ([here](https://github.com/icanbwell/fhir-server/blob/main/src/fhir/fhirTypesManager.js#L22)), you can see that its creating a new array by spreading two other arrays like so. Notice that every time this function is called, 2 or 3 garbage collections happen (the yellow squares under the getTypeForField call).

dataElementMap is the result of Object.entries of [this file](https://github.com/icanbwell/fhir-server/blob/main/src/fhir/generator/json/fhir-generated.field-types.json).

For reference, that file is over 38,000 lines long and dataElementMap has a length of 7615. 

That means that every time FhirTypesManager.getTypeForField a new array of 7615 items is created (which is actually 7616 arrays total) and then a Map is created from that array. This is absolutely ridiculous and another example of the performance consequences that can arise from lack of attention to detail. 

This simply moves the creation of this map to the root of the file so its created once and not every time this function is called