### PR TITLE
Update fhir to csv package

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,11 @@ Use `/health` as the url for health check in Kubernetes or other systems
 
 The FHIR server can optionally send change events to a Kafka queue:
 [Change Events](changeEvents.md)
+
+## Download Patient (or Person or Practioner) Summary
+This b.well FHIR server supports the $summary operation for the Patient, Person, and Practitioner resources. This operation allows you to retrieve a summary of a patient's information in a single request.
+[download_summary.md](download_summary.md)
+
+## Download Search Results as Microsoft Excel file
+In addition to receiving search results in JSON format, you can also download the search results in Microsoft Excel format. To do this, you can use the following URL:
+[download_results.md](download_results.md)

--- a/download_results.md
+++ b/download_results.md
@@ -1,0 +1,24 @@
+# Download Search Results as Microsoft Excel file
+
+In addition to receiving search results in JSON format, you can also download the search results in Microsoft Excel format. To do this, you can use the following URL:
+
+```
+GET https://api.bwellhealth.com/fhir/Patient/$search?_format=application/vnd.ms-excel
+```
+or you can pass the Accept header as `application/vnd.ms-excel`:
+
+```
+GET https://api.bwellhealth.com/fhir/Patient/$search
+Accept: application/vnd.ms-excel
+```
+This will return a single Microsoft Excel file containing the search results. The Excel file will contain multiple sheets, each representing a different resource type associated with the search criteria.
+
+
+This works for any search in the FHIR not just for Patient.
+
+
+NOTE: This uses the fhir-to-csv library (https://github.com/icanbwell/fhir-to-csv) to convert the FHIR resources to CSV format. The library is designed to handle the conversion of FHIR resources to Excel format, and it supports various resource types and their associated fields.
+
+## Google Sheets or Apple Numbers
+You can open the Microsoft Excel file in Google Sheets or Apple Numbers. The file is compatible with these applications, and you can view and edit the data as needed.
+

--- a/download_summary.md
+++ b/download_summary.md
@@ -1,0 +1,38 @@
+# Download Patient (or Person or Practioner) Summary
+
+This b.well FHIR server supports the $summary operation for the Patient, Person, and Practitioner resources. This operation allows you to retrieve a summary of a patient's information in a single request in either CSV or Microsoft Excel format.
+
+## Download as CSV
+To download a summary of a patient in CSV format, you can use the following URL:
+
+```
+GET https://api.bwellhealth.com/fhir/Patient/{id}/$summary?_format=text/csv
+```
+or you can pass the Accept header as `text/csv`:
+
+```
+GET https://api.bwellhealth.com/fhir/Patient/{id}/$summary
+Accept: text/csv
+```
+This will return a Zip file containing the CSV files for the patient. The Zip file will contain multiple CSV files, each representing a different resource type associated with the patient.
+
+## Download as Microsoft Excel file
+To download a summary of a patient in Microsoft Excel format, you can use the following URL:
+
+```
+GET https://api.bwellhealth.com/fhir/Patient/{id}/$summary?_format=application/vnd.ms-excel
+```
+or you can pass the Accept header as `application/application/vnd.ms-excel`:
+
+```
+GET https://api.bwellhealth.com/fhir/Patient/{id}/$summary
+Accept: application/application/vnd.ms-excel
+```
+This will return a single Microsoft Excel file containing the summary of the patient. The Excel file will contain multiple sheets, each representing a different resource type associated with the patient.
+
+
+NOTE: This uses the fhir-to-csv library (https://github.com/icanbwell/fhir-to-csv) to convert the FHIR resources to CSV format. The library is designed to handle the conversion of FHIR resources to Excel format, and it supports various resource types and their associated fields.
+
+## Google Sheets or Apple Numbers
+You can open the Microsoft Excel file in Google Sheets or Apple Numbers. The file is compatible with these applications, and you can view and edit the data as needed.
+

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@graphql-tools/graphql-file-loader": "^8.0.1",
     "@graphql-tools/load-files": "^7.0.0",
     "@graphql-tools/merge": "^9.0.4",
-    "@imranq2/fhir-to-csv": "^1.0.12",
+    "@imranq2/fhir-to-csv": "^1.0.13",
     "@json2csv/node": "^7.0.6",
     "@json2csv/plainjs": "^7.0.6",
     "@json2csv/transforms": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@graphql-tools/graphql-file-loader": "^8.0.1",
     "@graphql-tools/load-files": "^7.0.0",
     "@graphql-tools/merge": "^9.0.4",
-    "@imranq2/fhir-to-csv": "^1.0.9",
+    "@imranq2/fhir-to-csv": "^1.0.10",
     "@json2csv/node": "^7.0.6",
     "@json2csv/plainjs": "^7.0.6",
     "@json2csv/transforms": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@graphql-tools/graphql-file-loader": "^8.0.1",
     "@graphql-tools/load-files": "^7.0.0",
     "@graphql-tools/merge": "^9.0.4",
-    "@imranq2/fhir-to-csv": "^1.0.13",
+    "@imranq2/fhir-to-csv": "^1.0.15",
     "@json2csv/node": "^7.0.6",
     "@json2csv/plainjs": "^7.0.6",
     "@json2csv/transforms": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "xss": "^1.0.15",
     "yargs": "^17.7.2",
     "zlib": "^1.0.5",
-    "xlsx": "^0.18.5",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "jszip": "^3.10.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@graphql-tools/graphql-file-loader": "^8.0.1",
     "@graphql-tools/load-files": "^7.0.0",
     "@graphql-tools/merge": "^9.0.4",
-    "@imranq2/fhir-to-csv": "^1.0.7",
+    "@imranq2/fhir-to-csv": "^1.0.8",
     "@json2csv/node": "^7.0.6",
     "@json2csv/plainjs": "^7.0.6",
     "@json2csv/transforms": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@graphql-tools/graphql-file-loader": "^8.0.1",
     "@graphql-tools/load-files": "^7.0.0",
     "@graphql-tools/merge": "^9.0.4",
-    "@imranq2/fhir-to-csv": "^1.0.10",
+    "@imranq2/fhir-to-csv": "^1.0.11",
     "@json2csv/node": "^7.0.6",
     "@json2csv/plainjs": "^7.0.6",
     "@json2csv/transforms": "^7.0.6",
@@ -186,7 +186,7 @@
     "yargs": "^17.7.2",
     "zlib": "^1.0.5",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-    "jszip": "^3.10.1"
+    "fflate": "^0.8.2"
   },
   "devDependencies": {
     "@babel/core": "^7.24.6",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@graphql-tools/graphql-file-loader": "^8.0.1",
     "@graphql-tools/load-files": "^7.0.0",
     "@graphql-tools/merge": "^9.0.4",
-    "@imranq2/fhir-to-csv": "^1.0.11",
+    "@imranq2/fhir-to-csv": "^1.0.12",
     "@json2csv/node": "^7.0.6",
     "@json2csv/plainjs": "^7.0.6",
     "@json2csv/transforms": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@graphql-tools/graphql-file-loader": "^8.0.1",
     "@graphql-tools/load-files": "^7.0.0",
     "@graphql-tools/merge": "^9.0.4",
-    "@imranq2/fhir-to-csv": "^1.0.8",
+    "@imranq2/fhir-to-csv": "^1.0.9",
     "@json2csv/node": "^7.0.6",
     "@json2csv/plainjs": "^7.0.6",
     "@json2csv/transforms": "^7.0.6",

--- a/src/converters/baseBundleConverter.js
+++ b/src/converters/baseBundleConverter.js
@@ -7,6 +7,15 @@ class BaseBundleConverter{
     convert({bundle}) {
         throw new Error("convert method not implemented");
     }
+
+    /**
+     * convert
+     * @param {Object[]} resources
+     * @return {Buffer}
+     */
+    convertResources({resources}) {
+        throw new Error("convert method not implemented");
+    }
 }
 
 module.exports = {

--- a/src/converters/baseBundleConverter.js
+++ b/src/converters/baseBundleConverter.js
@@ -2,6 +2,7 @@ class BaseBundleConverter{
     /**
      * convert
      * @param {Bundle} bundle
+     * @return {Promise<Buffer>}
      */
     convert({bundle}) {
         throw new Error("convert method not implemented");

--- a/src/converters/baseBundleConverter.js
+++ b/src/converters/baseBundleConverter.js
@@ -1,8 +1,8 @@
 class BaseBundleConverter{
     /**
      * convert
-     * @param {Bundle} bundle
-     * @return {Promise<Buffer>}
+     * @param {Object} bundle
+     * @return {Buffer}
      */
     convert({bundle}) {
         throw new Error("convert method not implemented");

--- a/src/converters/bundleToCsvConverter.js
+++ b/src/converters/bundleToCsvConverter.js
@@ -1,5 +1,5 @@
 const {BaseBundleConverter} = require("./baseBundleConverter");
-const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/converters/fhir_bundle_converter");
+const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/fhir_bundle_converter");
 
 class BundleToCsvConverter extends BaseBundleConverter {
     /**

--- a/src/converters/bundleToCsvConverter.js
+++ b/src/converters/bundleToCsvConverter.js
@@ -4,10 +4,10 @@ const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/fhir_bundle_conv
 class BundleToCsvConverter extends BaseBundleConverter {
     /**
      * convert
-     * @param {Bundle} bundle
-     * @return {Promise<Buffer>}
+     * @param {Object} bundle
+     * @return {Buffer}
      */
-    async convert({bundle}) {
+    convert({bundle}) {
         if (!bundle) {
             throw new Error("Bundle is not set");
         }
@@ -16,11 +16,12 @@ class BundleToCsvConverter extends BaseBundleConverter {
          * @type {FHIRBundleConverter}
          */
         const converter = new FHIRBundleConverter();
-        const extractedData = await converter.convertToDictionaries(bundle);
+
+        const extractedData = converter.convertToDictionaries(bundle);
         /**
          * @type {Buffer<ArrayBufferLike>}
          */
-        const zipBuffer = await converter.convertToCSVZipped(
+        const zipBuffer = converter.convertToCSVZipped(
             extractedData
         );
         return zipBuffer;

--- a/src/converters/bundleToCsvConverter.js
+++ b/src/converters/bundleToCsvConverter.js
@@ -17,7 +17,28 @@ class BundleToCsvConverter extends BaseBundleConverter {
          */
         const converter = new FHIRBundleConverter();
 
-        const extractedData = converter.convertToDictionaries(bundle);
+        const extractedData = converter.convertBundleToDictionaries(bundle);
+        /**
+         * @type {Buffer<ArrayBufferLike>}
+         */
+        const zipBuffer = converter.convertToCSVZipped(
+            extractedData
+        );
+        return zipBuffer;
+    }
+
+    /**
+     * convert
+     * @param {Object[]} resources
+     * @return {Buffer}
+     */
+    convertResources({resources}) {
+        /**
+         * @type {FHIRBundleConverter}
+         */
+        const converter = new FHIRBundleConverter();
+
+        const extractedData = converter.convertResourcesToDictionaries(resources);
         /**
          * @type {Buffer<ArrayBufferLike>}
          */

--- a/src/converters/bundleToExcelConverter.js
+++ b/src/converters/bundleToExcelConverter.js
@@ -16,7 +16,27 @@ class BundleToExcelConverter extends BaseBundleConverter {
          * @type {FHIRBundleConverter}
          */
         const converter = new FHIRBundleConverter();
-        const extractedData = converter.convertToDictionaries(bundle);
+        const extractedData = converter.convertBundleToDictionaries(bundle);
+        /**
+         * @type {Buffer<ArrayBufferLike>}
+         */
+        const excelBuffer = converter.convertToExcel(
+            extractedData
+        );
+        return excelBuffer;
+    }
+
+    /**
+     * convert
+     * @param {Object[]} resources
+     * @return {Buffer}
+     */
+    convertResources({resources}) {
+        /**
+         * @type {FHIRBundleConverter}
+         */
+        const converter = new FHIRBundleConverter();
+        const extractedData = converter.convertResourcesToDictionaries(resources);
         /**
          * @type {Buffer<ArrayBufferLike>}
          */

--- a/src/converters/bundleToExcelConverter.js
+++ b/src/converters/bundleToExcelConverter.js
@@ -4,10 +4,10 @@ const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/fhir_bundle_conv
 class BundleToExcelConverter extends BaseBundleConverter {
     /**
      * convert
-     * @param {Bundle} bundle
-     * @return {Promise<Buffer>}
+     * @param {Object} bundle
+     * @return {Buffer}
      */
-    async convert({bundle}) {
+    convert({bundle}) {
         if (!bundle) {
             throw new Error("Bundle is not set");
         }
@@ -16,11 +16,11 @@ class BundleToExcelConverter extends BaseBundleConverter {
          * @type {FHIRBundleConverter}
          */
         const converter = new FHIRBundleConverter();
-        const extractedData = await converter.convertToDictionaries(bundle);
+        const extractedData = converter.convertToDictionaries(bundle);
         /**
          * @type {Buffer<ArrayBufferLike>}
          */
-        const excelBuffer = await converter.convertToExcel(
+        const excelBuffer = converter.convertToExcel(
             extractedData
         );
         return excelBuffer;

--- a/src/converters/bundleToExcelConverter.js
+++ b/src/converters/bundleToExcelConverter.js
@@ -1,5 +1,5 @@
 const {BaseBundleConverter} = require("./baseBundleConverter");
-const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/converters/fhir_bundle_converter");
+const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/fhir_bundle_converter");
 
 class BundleToExcelConverter extends BaseBundleConverter {
     /**

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -693,8 +693,7 @@ const createContainer = function () {
             graphOperation: c.graphOperation,
             fhirLoggingManager: c.fhirLoggingManager,
             scopesValidator: c.scopesValidator,
-            configManager: c.configManager,
-            summaryHelper: c.summaryHelper
+            configManager: c.configManager
         }
     ));
 

--- a/src/graphs/practitioner/summary.json
+++ b/src/graphs/practitioner/summary.json
@@ -1,0 +1,61 @@
+{
+    "resourceType": "GraphDefinition",
+    "id": "o",
+    "name": "provider_everything",
+    "status": "active",
+    "start": "Practitioner",
+    "link": [
+        {
+            "description": "Practitioner Roles for this Practitioner",
+            "target": [
+                {
+                    "type": "PractitionerRole",
+                    "params": "practitioner={ref}",
+                    "link": [
+                        {
+                            "path": "organization",
+                            "target": [
+                                {
+                                    "type": "Organization"
+                                }
+                            ]
+                        },
+                        {
+                            "path": "location[x]",
+                            "target": [
+                                {
+                                    "type": "Location"
+                                }
+                            ]
+                        },
+                        {
+                            "path": "healthcareService[x]",
+                            "target": [
+                                {
+                                    "type": "HealthcareService"
+                                }
+                            ]
+                        },
+                        {
+                            "path": "extension.extension:url=plan",
+                            "target": [
+                                {
+                                    "link": [
+                                        {
+                                            "path": "valueReference",
+                                            "target": [
+                                                {
+                                                    "type": "InsurancePlan"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/operations/search/searchManager.js
+++ b/src/operations/search/searchManager.js
@@ -966,6 +966,7 @@ class SearchManager {
      * @param {string} defaultSortId
      * @param {boolean} getRaw
      * @param {boolean} useFastSerializer
+     * @param {Object} params
      * @returns {Promise<string[]>} ids of resources streamed
      */
     async streamResourcesFromCursorAsync (

--- a/src/operations/streaming/resourceWriters/fhirResourceExcelWriter.js
+++ b/src/operations/streaming/resourceWriters/fhirResourceExcelWriter.js
@@ -1,0 +1,175 @@
+const {convertErrorToOperationOutcome} = require('../../../utils/convertErrorToOperationOutcome');
+const {logInfo, logError} = require('../../common/logging');
+const {FhirResourceWriterBase} = require('./fhirResourceWriterBase');
+const {getCircularReplacer} = require('../../../utils/getCircularReplacer');
+const {assertTypeEquals} = require('../../../utils/assertType');
+const {ConfigManager} = require('../../../utils/configManager');
+const {captureException} = require('../../common/sentry');
+const {FhirResourceSerializer} = require('../../../fhir/fhirResourceSerializer');
+const {removeUnderscoreProps} = require('../../../utils/removeUnderscoreProps');
+const {fhirContentTypes} = require("../../../utils/contentTypes");
+const {BundleToExcelConverter} = require("../../../converters/bundleToExcelConverter");
+
+class FhirResourceExcelWriter extends FhirResourceWriterBase {
+    /**
+     * Streams the incoming data as json
+     *
+     * @param {AbortSignal} signal
+     * @param {string} contentType
+     * @param {number} highWaterMark
+     * @param {ConfigManager} configManager
+     * @param {import('http').ServerResponse} response
+     * @param {Boolean} rawResources
+     * @param {Boolean} useFastSerializer
+     */
+    constructor({
+                    signal,
+                    contentType,
+                    highWaterMark,
+                    configManager,
+                    response,
+                    rawResources = false,
+                    useFastSerializer = false
+                }) {
+        super({objectMode: true, contentType, highWaterMark, response, rawResources, useFastSerializer});
+        /**
+         * @type {AbortSignal}
+         * @private
+         */
+        this._signal = signal;
+
+        /**
+         * @type {ConfigManager}
+         */
+        this.configManager = configManager;
+        assertTypeEquals(configManager, ConfigManager);
+
+        /**
+         *  list of json resources
+         * @type {Object[]}
+         */
+        this.json_resources = [];
+    }
+
+    /**
+     * transforms a chunk
+     * @param {Resource} chunk
+     * @param {import('stream').BufferEncoding} encoding
+     * @param {import('stream').TransformCallBack} callback
+     * @private
+     */
+    _transform(chunk, encoding, callback) {
+        if (this._signal.aborted) {
+            callback();
+            return;
+        }
+        try {
+            if (chunk !== null && chunk !== undefined) {
+                /**
+                 * @type {Resource|Object}
+                 */
+                let myChunk = chunk;
+                if (this.configManager.logStreamSteps) {
+                    logInfo(`FhirResourceExcelWriter: _transform ${chunk.id}`, {});
+                }
+                if (this.rawResources) {
+                    if (this.useFastSerializer) {
+                        myChunk = FhirResourceSerializer.serialize(chunk);
+                    } else {
+                        removeUnderscoreProps(myChunk);
+                    }
+                    const resourceJson = JSON.stringify(chunk, getCircularReplacer());
+                } else {
+                    myChunk = chunk.toJSON();
+                }
+                this.json_resources.push(myChunk);
+            }
+        } catch (e) {
+            logError(`FhirResourceExcelWriter _transform: error: ${e.message}`, {
+                error: e,
+                source: 'FhirResourceExcelWriter._transform',
+                args: {
+                    stack: e.stack,
+                    message: e.message
+                }
+            });
+            // as we are not propagating this error, send this to sentry
+            captureException(e);
+            const operationOutcome = convertErrorToOperationOutcome({
+                error: {
+                    ...e,
+                    message: `Error occurred while streaming response for chunk: ${chunk?.id}`
+                }
+            });
+            this.writeOperationOutcome({operationOutcome, encoding});
+        }
+        callback();
+    }
+
+    /**
+     * @param {import('stream').TransformCallBack} callback
+     * @private
+     */
+    _flush(callback) {
+        if (this.configManager.logStreamSteps) {
+            logInfo('FhirResourceExcelWriter: _flush', {});
+        }
+        // now convert to Excel and write it out
+        const contentType = fhirContentTypes.excel;
+        this.response.setHeader('Content-Type', contentType);
+        this.response.setHeader('X-Request-ID', String(this.requestId));
+
+        const filename = (this._bundle.id || String(this.RequestId)) + '.xlsx';
+        this.response.setHeader(
+            'Content-Disposition',
+            `attachment; filename="${filename}"`
+        );
+        this.response.setHeader('Access-Control-Expose-Headers', 'Content-Disposition');
+        /**
+         * @type {Bundle}
+         */
+        const bundle_copy = this._bundle.clone();
+        bundle_copy.entry = this._bundle_entries;
+        /**
+         * @type {Object}
+         */
+        const bundle = bundle_copy.toJSON();
+
+        /**
+         * @type {BundleToExcelConverter}
+         */
+        const exporter = new BundleToExcelConverter();
+        /**
+         * @type {Buffer}
+         */
+        const excelBuffer = exporter.convert(
+            {
+                bundle
+            }
+        );
+        // write the buffer to the response
+        this.push(excelBuffer);
+        this.push(null);
+        callback();
+    }
+
+    /**
+     * writes an OperationOutcome
+     * @param {OperationOutcome} operationOutcome
+     * @param {import('stream').BufferEncoding|null} [encoding]
+     */
+    writeOperationOutcome({operationOutcome, encoding}) {
+        // this is an unexpected error so set statuscode 500
+        this.response.statusCode = 500;
+        const operationOutcomeJson = JSON.stringify(operationOutcome.toJSON());
+        this.push(operationOutcomeJson + '\n', encoding);
+    }
+
+    getContentType() {
+        return this._contentType;
+    }
+}
+
+module.exports = {
+    FhirResourceExcelWriter
+};

--- a/src/operations/streaming/resourceWriters/fhirResourceExcelWriter.js
+++ b/src/operations/streaming/resourceWriters/fhirResourceExcelWriter.js
@@ -1,13 +1,11 @@
 const {convertErrorToOperationOutcome} = require('../../../utils/convertErrorToOperationOutcome');
 const {logInfo, logError} = require('../../common/logging');
 const {FhirResourceWriterBase} = require('./fhirResourceWriterBase');
-const {getCircularReplacer} = require('../../../utils/getCircularReplacer');
 const {assertTypeEquals} = require('../../../utils/assertType');
 const {ConfigManager} = require('../../../utils/configManager');
 const {captureException} = require('../../common/sentry');
 const {FhirResourceSerializer} = require('../../../fhir/fhirResourceSerializer');
 const {removeUnderscoreProps} = require('../../../utils/removeUnderscoreProps');
-const {fhirContentTypes} = require("../../../utils/contentTypes");
 const {BundleToExcelConverter} = require("../../../converters/bundleToExcelConverter");
 const {generateUUID} = require("../../../utils/uid.util");
 const {BufferToChunkTransferResponse} = require("../../../utils/buffer_to_chunk_transfer_response");
@@ -51,6 +49,11 @@ class FhirResourceExcelWriter extends FhirResourceWriterBase {
          * @type {Object[]}
          */
         this.json_resources = [];
+
+        /**
+         * @type {string}
+        */
+        this.requestId = this.response.req.id
     }
 
     /**
@@ -80,7 +83,6 @@ class FhirResourceExcelWriter extends FhirResourceWriterBase {
                     } else {
                         removeUnderscoreProps(myChunk);
                     }
-                    const resourceJson = JSON.stringify(chunk, getCircularReplacer());
                 } else {
                     myChunk = chunk.toJSON();
                 }
@@ -122,7 +124,7 @@ class FhirResourceExcelWriter extends FhirResourceWriterBase {
             this.response.setHeader('Content-Type', this.getContentType());
             this.response.setHeader('X-Request-ID', String(this.requestId));
 
-            const filename = (this.RequestId ? String(this.RequestId) : generateUUID()) + '.xlsx';
+            const filename = (this.requestId ? String(this.requestId) : generateUUID()) + '.xlsx';
             this.response.setHeader(
                 'Content-Disposition',
                 `attachment; filename="${filename}"`

--- a/src/operations/streaming/resourceWriters/fhirResourceWriterFactory.js
+++ b/src/operations/streaming/resourceWriters/fhirResourceWriterFactory.js
@@ -1,10 +1,11 @@
-const { hasNdJsonContentType, fhirContentTypes } = require('../../../utils/contentTypes');
+const { hasNdJsonContentType, fhirContentTypes, hasExcelContentType} = require('../../../utils/contentTypes');
 const { FhirResourceNdJsonWriter } = require('./fhirResourceNdJsonWriter');
 const { FhirResourceCsvWriter } = require('./fhirResourceCsvWriter');
 const { FhirResourceWriter } = require('./fhirResourceWriter');
 const { assertTypeEquals } = require('../../../utils/assertType');
 const { ConfigManager } = require('../../../utils/configManager');
 const { FhirBundleWriter } = require('./fhirBundleWriter');
+const {FhirResourceExcelWriter} = require("./fhirResourceExcelWriter");
 
 class FhirResourceWriterFactory {
     /**
@@ -103,6 +104,17 @@ class FhirResourceWriterFactory {
                     useFastSerializer
                 });
             }
+            if (hasExcelContentType(format)){
+                return new FhirResourceExcelWriter({
+                    signal,
+                    contentType: fhirContentTypes.excel,
+                    highWaterMark,
+                    configManager,
+                    response,
+                    rawResources,
+                    useFastSerializer
+                });
+            }
             if (format === fhirContentTypes.tsv) {
                 return new FhirResourceCsvWriter({
                     signal,
@@ -169,6 +181,17 @@ class FhirResourceWriterFactory {
                 contentType: fhirContentTypes.csv,
                 highWaterMark,
                 configManager,
+                rawResources,
+                useFastSerializer
+            });
+        }
+        if (accepts.includes(fhirContentTypes.excel)) {
+            return new FhirResourceExcelWriter({
+                signal,
+                contentType: fhirContentTypes.excel,
+                highWaterMark,
+                configManager,
+                response,
                 rawResources,
                 useFastSerializer
             });

--- a/src/operations/summary/summary.js
+++ b/src/operations/summary/summary.js
@@ -13,6 +13,7 @@ const {QueryParameterValue} = require('../query/queryParameterValue');
 const {EverythingOperation} = require("../everything/everything");
 const patientSummaryGraph = require("../../graphs/patient/summary.json");
 const personSummaryGraph = require("../../graphs/person/summary.json");
+const practitionerSummaryGraph = require("../../graphs/practitioner/summary.json");
 
 class SummaryOperation {
     /**
@@ -169,6 +170,10 @@ class SummaryOperation {
                 }
                 case 'Patient': {
                     parsedArgs.resource = patientSummaryGraph;
+                    break;
+                }
+                case 'Practitioner': {
+                    parsedArgs.resource = practitionerSummaryGraph;
                     break;
                 }
                 default:

--- a/src/operations/summary/summary.js
+++ b/src/operations/summary/summary.js
@@ -162,7 +162,7 @@ class SummaryOperation {
                 parsedArgs.resourceFilterList = resourceFilterList;
             }
 
-            // Grab an instance of our DB and collection
+            // if an id was passed and we have a graph for that id then use that
             switch (resourceType) {
                 case 'Person': {
                     parsedArgs.resource = personSummaryGraph;

--- a/src/operations/summary/summary.js
+++ b/src/operations/summary/summary.js
@@ -3,14 +3,9 @@ const {ScopesValidator} = require('../security/scopesValidator');
 const {assertTypeEquals, assertIsValid} = require('../../utils/assertType');
 const {FhirLoggingManager} = require('../common/fhirLoggingManager');
 const {ParsedArgs} = require('../query/parsedArgs');
-const deepcopy = require('deepcopy');
 const {isTrue} = require('../../utils/isTrue');
 const {ConfigManager} = require('../../utils/configManager');
 const {ForbiddenError} = require('../../utils/httpErrors');
-const {isFalseWithFallback} = require('../../utils/isFalse');
-const {ParsedArgsItem} = require('../query/parsedArgsItem');
-const {QueryParameterValue} = require('../query/queryParameterValue');
-const {EverythingOperation} = require("../everything/everything");
 const patientSummaryGraph = require("../../graphs/patient/summary.json");
 const personSummaryGraph = require("../../graphs/person/summary.json");
 const practitionerSummaryGraph = require("../../graphs/practitioner/summary.json");
@@ -134,14 +129,6 @@ class SummaryOperation {
             throw forbiddenError;
         }
 
-        /**
-         * @param {boolean}
-         */
-        let useSummaryHelperForPatient =
-            resourceType === 'Patient' &&
-            requestInfo.method.toLowerCase() !== 'delete' &&
-            this.configManager.disableGraphInSummaryOp;
-
         await this.scopesValidator.verifyHasValidScopesAsync({
             requestInfo,
             parsedArgs,
@@ -192,8 +179,7 @@ class SummaryOperation {
                 resourceType,
                 responseStreamer,
                 supportLegacyId,
-                includeNonClinicalResources: isTrue(parsedArgs._includeNonClinicalResources),
-                getRaw: this.configManager.getRawSummaryOpBundle
+                includeNonClinicalResources: isTrue(parsedArgs._includeNonClinicalResources)
             });
 
             await this.fhirLoggingManager.logOperationSuccessAsync({

--- a/src/tests/practitioner/search_by_multiple_ids_csv/search_by_multiple_ids.excel.test.js
+++ b/src/tests/practitioner/search_by_multiple_ids_csv/search_by_multiple_ids.excel.test.js
@@ -1,0 +1,124 @@
+// provider file
+const practitionerResource = require('./fixtures/practitioner/practitioner.json');
+const practitionerResource2 = require('./fixtures/practitioner/practitioner2.json');
+const practitionerResource3 = require('./fixtures/practitioner/practitioner3.json');
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    createTestRequest, getHeadersCsv, getHeadersCsvFormUrlEncoded, getHtmlHeaders
+} = require('../../common');
+const {describe, beforeEach, afterEach, test, expect} = require('@jest/globals');
+const path = require('path');
+const fs = require('fs');
+const {fhirContentTypes} = require('../../../utils/contentTypes');
+const {ConfigManager} = require('../../../utils/configManager');
+const XLSX = require("xlsx");
+
+class MockConfigManagerDefaultSortId extends ConfigManager {
+    get streamResponse() {
+        return true;
+    }
+}
+
+describe('search by multiple ids Excel', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    describe('Practitioner Search By Multiple Ids Excel Tests', () => {
+        test('search by multiple id works with _format Excel from browser', async () => {
+            const request = await createTestRequest((c) => {
+                c.register('configManager', () => new MockConfigManagerDefaultSortId());
+                return c;
+            });
+            /**
+             * @type {Response}
+             */
+            let resp = await request
+                .get(`/4_0_0/Practitioner?_format=${fhirContentTypes.excel}`)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResourceCount(0);
+
+            resp = await request
+                .post('/4_0_0/Practitioner/1679033641/$merge')
+                .send(practitionerResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .post('/4_0_0/Practitioner/0/$merge')
+                .send(practitionerResource2)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .post('/4_0_0/Practitioner/1/$merge')
+                .send(practitionerResource3)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .get(`/4_0_0/Practitioner?_format=${fhirContentTypes.excel}`)
+                .set(getHeaders())
+                .responseType('blob'); // Important for binary data;
+            expect(resp.headers['content-type']).toBe(fhirContentTypes.excel);
+            expect(resp.headers['content-disposition']).toBeDefined();
+
+            // Generate unique filename
+            // get folder containing this test
+            const tempFolder = __dirname + '/temp';
+            // if subfolder temp from current folder exists then delete it
+            if (fs.existsSync(tempFolder)) {
+                fs.rmSync(tempFolder, {recursive: true, force: true});
+            }
+            // if subfolder temp from current folder does not exist then create it
+            if (!fs.existsSync(tempFolder)) {
+                fs.mkdirSync(tempFolder);
+            }
+            const filename = `export_${new Date().toISOString().replace(/:/g, '-')}.xlsx`;
+            const filepath = tempFolder + '/' + filename;
+            // Write the response body to a file
+            fs.writeFileSync(filepath, resp.body);
+
+            // Optional: Check file size
+            const stats = fs.statSync(filepath);
+            expect(stats.size).toBeGreaterThan(0);
+
+            const workbook = XLSX.read(resp.body);
+
+            // Detailed file inspection
+            /**
+             * @type {str}
+             */
+            for (const sheetName of workbook.SheetNames) {
+                const sheetData = XLSX.utils.sheet_to_json(workbook.Sheets[sheetName], {header: 1});
+
+                expect(sheetData.length).toBeGreaterThan(0);
+            }
+
+            // Check for specific resource type CSVs
+            const expectedResourceTypes = ['Practitioner']; // Adjust as needed
+            expectedResourceTypes.forEach(resourceType => {
+                /**
+                 * @type {string[]}
+                 */
+                const sheetNames = workbook.SheetNames;
+                const matchingFile = sheetNames.find(filename =>
+                    filename.toLowerCase().includes(resourceType.toLowerCase())
+                );
+                expect(matchingFile).toBeTruthy();
+            });
+
+        });
+    });
+});

--- a/src/tests/practitioner/search_by_multiple_ids_csv/search_by_multiple_ids.excel.test.js
+++ b/src/tests/practitioner/search_by_multiple_ids_csv/search_by_multiple_ids.excel.test.js
@@ -7,10 +7,9 @@ const {
     commonBeforeEach,
     commonAfterEach,
     getHeaders,
-    createTestRequest, getHeadersCsv, getHeadersCsvFormUrlEncoded, getHtmlHeaders
+    createTestRequest
 } = require('../../common');
 const {describe, beforeEach, afterEach, test, expect} = require('@jest/globals');
-const path = require('path');
 const fs = require('fs');
 const {fhirContentTypes} = require('../../../utils/contentTypes');
 const {ConfigManager} = require('../../../utils/configManager');

--- a/src/tests/practitioner/search_by_multiple_ids_csv/search_by_multiple_ids_csv.test.js
+++ b/src/tests/practitioner/search_by_multiple_ids_csv/search_by_multiple_ids_csv.test.js
@@ -9,14 +9,14 @@ const {
     getHeaders,
     createTestRequest, getHeadersCsv, getHeadersCsvFormUrlEncoded, getHtmlHeaders
 } = require('../../common');
-const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+const {describe, beforeEach, afterEach, test, expect} = require('@jest/globals');
 const path = require('path');
 const fs = require('fs');
-const { fhirContentTypes } = require('../../../utils/contentTypes');
-const { ConfigManager } = require('../../../utils/configManager');
+const {fhirContentTypes} = require('../../../utils/contentTypes');
+const {ConfigManager} = require('../../../utils/configManager');
 
 class MockConfigManagerDefaultSortId extends ConfigManager {
-    get streamResponse () {
+    get streamResponse() {
         return true;
     }
 }
@@ -47,14 +47,14 @@ describe('search by multiple ids csv', () => {
                 .send(practitionerResource)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/0/$merge')
                 .send(practitionerResource2)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .get('/4_0_0/Practitioner?_streamResponse=1')
@@ -88,21 +88,21 @@ describe('search by multiple ids csv', () => {
                 .send(practitionerResource)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/0/$merge')
                 .send(practitionerResource2)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/1/$merge')
                 .send(practitionerResource3)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .get('/4_0_0/Practitioner?_streamResponse=1')
@@ -136,21 +136,21 @@ describe('search by multiple ids csv', () => {
                 .send(practitionerResource)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/0/$merge')
                 .send(practitionerResource2)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/1/$merge')
                 .send(practitionerResource3)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .get(`/4_0_0/Practitioner?_format=${fhirContentTypes.csv}`)
@@ -168,7 +168,7 @@ describe('search by multiple ids csv', () => {
             // noinspection JSUnresolvedFunction
             expect(resp).toHaveResponse(expectedPractitionerCsv);
         });
-        test('search by multiple id works with _format parameter from browser', async () => {
+        test('search by multiple id works with _format csv from browser', async () => {
             const request = await createTestRequest((c) => {
                 c.register('configManager', () => new MockConfigManagerDefaultSortId());
                 return c;
@@ -184,21 +184,21 @@ describe('search by multiple ids csv', () => {
                 .send(practitionerResource)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/0/$merge')
                 .send(practitionerResource2)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/1/$merge')
                 .send(practitionerResource3)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .get(`/4_0_0/Practitioner?_format=${fhirContentTypes.csv}`)
@@ -216,6 +216,50 @@ describe('search by multiple ids csv', () => {
             // noinspection JSUnresolvedFunction
             expect(resp).toHaveResponse(expectedPractitionerCsv);
         });
+        test('search by multiple id works with _format Excel from browser', async () => {
+            const request = await createTestRequest((c) => {
+                c.register('configManager', () => new MockConfigManagerDefaultSortId());
+                return c;
+            });
+            /**
+             * @type {Response}
+             */
+            let resp = await request
+                .get(`/4_0_0/Practitioner?_format=${fhirContentTypes.excel}`)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResourceCount(0);
+
+            resp = await request
+                .post('/4_0_0/Practitioner/1679033641/$merge')
+                .send(practitionerResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .post('/4_0_0/Practitioner/0/$merge')
+                .send(practitionerResource2)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .post('/4_0_0/Practitioner/1/$merge')
+                .send(practitionerResource3)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .get(`/4_0_0/Practitioner?_format=${fhirContentTypes.excel}`)
+                .set(getHeaders());
+            expect(resp.headers['content-type']).toBe(fhirContentTypes.excel);
+            expect(resp.headers['content-disposition']).toBeDefined();
+            // Write the response body to a file
+            const filePath = path.resolve(__dirname, 'response.xlsx');
+            fs.writeFileSync(filePath, resp.body);
+        });
         test('search by multiple id works with selected elements', async () => {
             const request = await createTestRequest((c) => {
                 c.register('configManager', () => new MockConfigManagerDefaultSortId());
@@ -232,21 +276,21 @@ describe('search by multiple ids csv', () => {
                 .send(practitionerResource)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/0/$merge')
                 .send(practitionerResource2)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/1/$merge')
                 .send(practitionerResource3)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .get('/4_0_0/Practitioner?_streamResponse=1')
@@ -274,21 +318,21 @@ describe('search by multiple ids csv', () => {
                 .send(practitionerResource)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/0/$merge')
                 .send(practitionerResource2)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/1/$merge')
                 .send(practitionerResource3)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             const expectedPractitionerCsv = fs.readFileSync(
                 path.resolve(__dirname, './fixtures/expected/expected_practitioner.csv'),
@@ -297,7 +341,7 @@ describe('search by multiple ids csv', () => {
 
             resp = await request
                 .post('/4_0_0/Practitioner/_search?_sort=id&_streamResponse=1')
-                .send({ resourceType: 'Parameters', parameter: [{ name: 'id', valueString: '0,1679033641' }] })
+                .send({resourceType: 'Parameters', parameter: [{name: 'id', valueString: '0,1679033641'}]})
                 .set(getHeadersCsv());
             // noinspection JSUnresolvedFunction
             expect(resp).toHaveResponse(expectedPractitionerCsv);
@@ -312,21 +356,21 @@ describe('search by multiple ids csv', () => {
                 .send(practitionerResource)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/0/$merge')
                 .send(practitionerResource2)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/1/$merge')
                 .send(practitionerResource3)
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
+            expect(resp).toHaveMergeResponse({created: true});
 
             resp = await request
                 .post('/4_0_0/Practitioner/_search?_sort=id&_streamResponse=1')

--- a/src/tests/practitioner/search_by_multiple_ids_csv/search_by_multiple_ids_csv.test.js
+++ b/src/tests/practitioner/search_by_multiple_ids_csv/search_by_multiple_ids_csv.test.js
@@ -216,64 +216,6 @@ describe('search by multiple ids csv', () => {
             // noinspection JSUnresolvedFunction
             expect(resp).toHaveResponse(expectedPractitionerCsv);
         });
-        test('search by multiple id works with _format Excel from browser', async () => {
-            const request = await createTestRequest((c) => {
-                c.register('configManager', () => new MockConfigManagerDefaultSortId());
-                return c;
-            });
-            /**
-             * @type {Response}
-             */
-            let resp = await request
-                .get(`/4_0_0/Practitioner?_format=${fhirContentTypes.excel}`)
-                .set(getHeaders());
-            // noinspection JSUnresolvedFunction
-            expect(resp).toHaveResourceCount(0);
-
-            resp = await request
-                .post('/4_0_0/Practitioner/1679033641/$merge')
-                .send(practitionerResource)
-                .set(getHeaders());
-            // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({created: true});
-
-            resp = await request
-                .post('/4_0_0/Practitioner/0/$merge')
-                .send(practitionerResource2)
-                .set(getHeaders());
-            // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({created: true});
-
-            resp = await request
-                .post('/4_0_0/Practitioner/1/$merge')
-                .send(practitionerResource3)
-                .set(getHeaders());
-            // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({created: true});
-
-            resp = await request
-                .get(`/4_0_0/Practitioner?_format=${fhirContentTypes.excel}`)
-                .set(getHeaders())
-                .responseType('blob'); // Important for binary data;
-            expect(resp.headers['content-type']).toBe(fhirContentTypes.excel);
-            expect(resp.headers['content-disposition']).toBeDefined();
-
-            // Generate unique filename
-            // get folder containing this test
-            const tempFolder = __dirname + '/temp';
-            // if subfolder temp from current folder exists then delete it
-            if (fs.existsSync(tempFolder)) {
-                fs.rmSync(tempFolder, {recursive: true, force: true});
-            }
-            // if subfolder temp from current folder does not exist then create it
-            if (!fs.existsSync(tempFolder)) {
-                fs.mkdirSync(tempFolder);
-            }
-            const filename = `export_${new Date().toISOString().replace(/:/g, '-')}.xlsx`;
-            const filepath = tempFolder + '/' + filename;
-            // Write the response body to a file
-            fs.writeFileSync(filepath, resp.body);
-        });
         test('search by multiple id works with selected elements', async () => {
             const request = await createTestRequest((c) => {
                 c.register('configManager', () => new MockConfigManagerDefaultSortId());

--- a/src/tests/practitioner/search_by_multiple_ids_csv/search_by_multiple_ids_csv.test.js
+++ b/src/tests/practitioner/search_by_multiple_ids_csv/search_by_multiple_ids_csv.test.js
@@ -253,12 +253,26 @@ describe('search by multiple ids csv', () => {
 
             resp = await request
                 .get(`/4_0_0/Practitioner?_format=${fhirContentTypes.excel}`)
-                .set(getHeaders());
+                .set(getHeaders())
+                .responseType('blob'); // Important for binary data;
             expect(resp.headers['content-type']).toBe(fhirContentTypes.excel);
             expect(resp.headers['content-disposition']).toBeDefined();
+
+            // Generate unique filename
+            // get folder containing this test
+            const tempFolder = __dirname + '/temp';
+            // if subfolder temp from current folder exists then delete it
+            if (fs.existsSync(tempFolder)) {
+                fs.rmSync(tempFolder, {recursive: true, force: true});
+            }
+            // if subfolder temp from current folder does not exist then create it
+            if (!fs.existsSync(tempFolder)) {
+                fs.mkdirSync(tempFolder);
+            }
+            const filename = `export_${new Date().toISOString().replace(/:/g, '-')}.xlsx`;
+            const filepath = tempFolder + '/' + filename;
             // Write the response body to a file
-            const filePath = path.resolve(__dirname, 'response.xlsx');
-            fs.writeFileSync(filePath, resp.body);
+            fs.writeFileSync(filepath, resp.body);
         });
         test('search by multiple id works with selected elements', async () => {
             const request = await createTestRequest((c) => {

--- a/src/tests/summary/person_or_patient/person_or_patient.csv.test.js
+++ b/src/tests/summary/person_or_patient/person_or_patient.csv.test.js
@@ -35,7 +35,7 @@ const expectedPerson1ContainedResources = require('./fixtures/expected/expected_
 const expectedPatientResources = require('./fixtures/expected/expected_Patient.json');
 const expectedPatientResourcesType = require('./fixtures/expected/expected_Patient_type.json');
 const expectedPatientContainedResources = require('./fixtures/expected/expected_Patient_contained.json');
-var JSZip = require("jszip");
+const {unzipSync, strFromU8} = require('fflate');
 
 const {
     commonBeforeEach,
@@ -213,10 +213,10 @@ describe('Person and Patient $summary Tests', () => {
             const stats = fs.statSync(filepath);
             expect(stats.size).toBeGreaterThan(0);
 
-            // Convert response to JSZip for detailed inspection
-            const zip = await JSZip.loadAsync(resp.body);
+            // Convert response to fflate for detailed inspection
+            const zipContent = unzipSync(new Uint8Array(resp.body));
 
-            const fileNames = Object.keys(zip.files);
+            const fileNames = Object.keys(zipContent);
             console.log('Zip file contents:', fileNames); // Diagnostic logging
 
             // Check for files in the zip
@@ -224,17 +224,12 @@ describe('Person and Patient $summary Tests', () => {
 
             // Detailed file inspection
             for (const fileName of fileNames) {
-                const file = zip.files[fileName];
+                const fileContent = strFromU8(zipContent[fileName]);
 
-                // Verify each file
-                expect(file).toBeDefined();
-                expect(file.name).toMatch(/\.csv$/); // Ensure CSV files
-
-                // Optional: Read file content
-                const fileContent = await file.async('string');
                 expect(fileContent).toBeTruthy();
                 expect(fileContent.trim().length).toBeGreaterThan(0);
             }
+
 
             // Check for specific resource type CSVs
             const expectedResourceTypes = ['Patient', 'Observation']; // Adjust as needed
@@ -400,10 +395,10 @@ describe('Person and Patient $summary Tests', () => {
             const stats = fs.statSync(filepath);
             expect(stats.size).toBeGreaterThan(0);
 
-            // Convert response to JSZip for detailed inspection
-            const zip = await JSZip.loadAsync(resp.body);
+            // Convert response to fflate for detailed inspection
+            const zipContent = unzipSync(new Uint8Array(resp.body));
 
-            const fileNames = Object.keys(zip.files);
+            const fileNames = Object.keys(zipContent);
             console.log('Zip file contents:', fileNames); // Diagnostic logging
 
             // Check for files in the zip
@@ -411,14 +406,8 @@ describe('Person and Patient $summary Tests', () => {
 
             // Detailed file inspection
             for (const fileName of fileNames) {
-                const file = zip.files[fileName];
+                const fileContent = strFromU8(zipContent[fileName]);
 
-                // Verify each file
-                expect(file).toBeDefined();
-                expect(file.name).toMatch(/\.csv$/); // Ensure CSV files
-
-                // Optional: Read file content
-                const fileContent = await file.async('string');
                 expect(fileContent).toBeTruthy();
                 expect(fileContent.trim().length).toBeGreaterThan(0);
             }
@@ -587,10 +576,10 @@ describe('Person and Patient $summary Tests', () => {
             const stats = fs.statSync(filepath);
             expect(stats.size).toBeGreaterThan(0);
 
-            // Convert response to JSZip for detailed inspection
-            const zip = await JSZip.loadAsync(resp.body);
+            // Convert response to fflate for detailed inspection
+            const zipContent = unzipSync(new Uint8Array(resp.body));
 
-            const fileNames = Object.keys(zip.files);
+            const fileNames = Object.keys(zipContent);
             console.log('Zip file contents:', fileNames); // Diagnostic logging
 
             // Check for files in the zip
@@ -598,17 +587,12 @@ describe('Person and Patient $summary Tests', () => {
 
             // Detailed file inspection
             for (const fileName of fileNames) {
-                const file = zip.files[fileName];
+                const fileContent = strFromU8(zipContent[fileName]);
 
-                // Verify each file
-                expect(file).toBeDefined();
-                expect(file.name).toMatch(/\.csv$/); // Ensure CSV files
-
-                // Optional: Read file content
-                const fileContent = await file.async('string');
                 expect(fileContent).toBeTruthy();
                 expect(fileContent.trim().length).toBeGreaterThan(0);
             }
+
 
             // Check for specific resource type CSVs
             const expectedResourceTypes = ['Patient', 'Observation']; // Adjust as needed

--- a/src/tests/summary/person_or_patient/person_or_patient.excel.test.js
+++ b/src/tests/summary/person_or_patient/person_or_patient.excel.test.js
@@ -380,7 +380,8 @@ describe('Person and Patient $summary Tests with Excel content', () => {
             if (!fs.existsSync(tempFolder)) {
                 fs.mkdirSync(tempFolder);
             }
-            const filename = `export_${new Date().toISOString().replace(/:/g, '-')}.xlsx`;
+            const filenameMatch = resp.headers['content-disposition'].split('filename=')[1];
+            const filename = filenameMatch.split(';')[0].trim().replace(/"/g, '');
             const filepath = tempFolder + '/' + filename;
 
             // Write file
@@ -548,6 +549,9 @@ describe('Person and Patient $summary Tests with Excel content', () => {
             expect(resp.headers['content-type']).toBe(fhirContentTypes.excel);
             expect(resp.headers['content-disposition']).toMatch(/attachment; filename=.+\.xlsx/);
 
+            const filenameMatch = resp.headers['content-disposition'].split('filename=')[1];
+            const filename = filenameMatch.split(';')[0].trim().replace(/"/g, '');
+
             // Generate unique filename
             // get folder containing this test
             const tempFolder = __dirname + '/temp';
@@ -559,7 +563,6 @@ describe('Person and Patient $summary Tests with Excel content', () => {
             if (!fs.existsSync(tempFolder)) {
                 fs.mkdirSync(tempFolder);
             }
-            const filename = `export_${new Date().toISOString().replace(/:/g, '-')}.xlsx`;
             const filepath = tempFolder + '/' + filename;
 
             // Write file

--- a/src/tests/summary/person_or_patient/person_or_patient.excel.test.js
+++ b/src/tests/summary/person_or_patient/person_or_patient.excel.test.js
@@ -35,8 +35,7 @@ const expectedPerson1ContainedResources = require('./fixtures/expected/expected_
 const expectedPatientResources = require('./fixtures/expected/expected_Patient.json');
 const expectedPatientResourcesType = require('./fixtures/expected/expected_Patient_type.json');
 const expectedPatientContainedResources = require('./fixtures/expected/expected_Patient_contained.json');
-var JSZip = require("jszip");
-var XLSX = require("xlsx");
+const XLSX = require("xlsx");
 
 const {
     commonBeforeEach,

--- a/src/tests/summary/practitioner/fixtures/practitioner/organization.json
+++ b/src/tests/summary/practitioner/fixtures/practitioner/organization.json
@@ -1,0 +1,32 @@
+{
+  "resourceType": "Organization",
+  "id": "123456",
+  "meta": {
+    "versionId": "1",
+    "source": "client",
+    "lastUpdated": "2021-01-14T23:42:00+00:00",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      }
+    ]
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+          "code": "prov",
+          "display": "Healthcare Provider"
+        }
+      ],
+      "text": "Healthcare Organization"
+    }
+  ],
+  "name": "Client Medical Group"
+}

--- a/src/tests/summary/practitioner/fixtures/practitioner/practitioner.json
+++ b/src/tests/summary/practitioner/fixtures/practitioner/practitioner.json
@@ -1,0 +1,121 @@
+{
+  "resourceType": "Practitioner",
+  "meta": {
+    "versionId": "1",
+    "source": "client",
+    "lastUpdated": "2021-01-14T23:42:00+00:00",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      }
+    ]
+  },
+  "id": "1679033641",
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "PRN"
+          }
+        ]
+      },
+      "system": "http://clienthealth.org",
+      "value": "4657"
+    },
+    {
+      "use": "official",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NPI"
+          }
+        ]
+      },
+      "system": "http://hl7.org/fhir/sid/us-npi",
+      "value": "1679033641"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "use": "usual",
+      "text": "SAMER S. NAJJAR  MD",
+      "family": "NAJJAR  MD",
+      "given": [
+        "SAMER S."
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "email",
+      "use": "work",
+      "value": "foo@foo.com"
+    }
+  ],
+  "gender": "unknown",
+  "qualification": [
+    {
+      "code": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/ValueSet/v2-2.7-030",
+            "code": "MD"
+          }
+        ]
+      },
+      "issuer": {
+        "reference": "Organization/123456"
+      }
+    },
+    {
+      "code": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/ValueSet/v2-2.7-030",
+            "code": "MD"
+          }
+        ]
+      },
+      "period": {
+        "start": "1960-01-01",
+        "end": "2021-12-11"
+      },
+      "issuer": {
+        "reference": "Organization/123456"
+      }
+    },
+    {
+      "code": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/ValueSet/v2-2.7-030",
+            "code": "MD"
+          }
+        ]
+      },
+      "issuer": {
+        "display": "the person who issued it"
+      }
+    }
+  ],
+  "communication": [
+    {
+      "coding": [
+        {
+          "code": "en",
+          "system": "urn:ietf:bcp:47"
+        }
+      ]
+    }
+  ]
+}

--- a/src/tests/summary/practitioner/fixtures/practitioner/practitionerRole.json
+++ b/src/tests/summary/practitioner/fixtures/practitioner/practitionerRole.json
@@ -1,0 +1,75 @@
+{
+    "resourceType": "PractitionerRole",
+    "id": "1881603751",
+    "meta": {
+        "source": "http://clienthealth.org/provider",
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "client"
+            },
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "client"
+            }
+        ]
+    },
+    "extension": [
+        {
+            "id": "new-patients-1",
+            "extension": [
+                {
+                    "id": "acceptingpatients",
+                    "url": "acceptingPatients",
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "https://build.fhir.org/ig/HL7/davinci-pdex-plan-net/CodeSystem-AcceptingPatientsCS.html",
+                                "code": "existptonly"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "agerange",
+                    "url": "ageRange",
+                    "valueRange": {
+                        "low": {
+                            "value": 0.0,
+                            "unit": "years"
+                        },
+                        "high": {
+                            "unit": "years"
+                        }
+                    }
+                }
+            ],
+            "url": "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients"
+        }
+    ],
+    "active": true,
+    "practitioner": {
+        "reference": "Practitioner/1679033641"
+    },
+    "organization": {
+        "reference": "Organization/Client-Alias-ABC"
+    },
+    "code": [
+        {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/practitioner-role",
+                    "code": "doctor",
+                    "display": "Doctor"
+                }
+            ],
+            "text": "Doctor"
+        }
+    ],
+    "specialty": [],
+    "location": [
+        {
+            "reference": "Location/Client-Alias-ABC"
+        }
+    ]
+}

--- a/src/tests/summary/practitioner/fixtures/practitioner/practitionerRoleDifferentSecurityTag.json
+++ b/src/tests/summary/practitioner/fixtures/practitioner/practitionerRoleDifferentSecurityTag.json
@@ -1,0 +1,75 @@
+{
+    "resourceType": "PractitionerRole",
+    "id": "bad",
+    "meta": {
+        "source": "http://clienthealth.org/provider",
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "notclient"
+            },
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "client"
+            }
+        ]
+    },
+    "extension": [
+        {
+            "id": "new-patients-1",
+            "extension": [
+                {
+                    "id": "acceptingpatients",
+                    "url": "acceptingPatients",
+                    "valueCodeableConcept": {
+                        "coding": [
+                            {
+                                "system": "https://build.fhir.org/ig/HL7/davinci-pdex-plan-net/CodeSystem-AcceptingPatientsCS.html",
+                                "code": "existptonly"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "agerange",
+                    "url": "ageRange",
+                    "valueRange": {
+                        "low": {
+                            "value": 0.0,
+                            "unit": "years"
+                        },
+                        "high": {
+                            "unit": "years"
+                        }
+                    }
+                }
+            ],
+            "url": "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/newpatients"
+        }
+    ],
+    "active": true,
+    "practitioner": {
+        "reference": "Practitioner/1679033641"
+    },
+    "organization": {
+        "reference": "Organization/Client-Alias-ABC"
+    },
+    "code": [
+        {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/practitioner-role",
+                    "code": "doctor",
+                    "display": "Doctor"
+                }
+            ],
+            "text": "Doctor"
+        }
+    ],
+    "specialty": [],
+    "location": [
+        {
+            "reference": "Location/Client-Alias-ABC"
+        }
+    ]
+}

--- a/src/tests/summary/practitioner/practitioner.excel.test.js
+++ b/src/tests/summary/practitioner/practitioner.excel.test.js
@@ -10,10 +10,9 @@ const {
     commonAfterEach,
     getHeaders,
     createTestRequest,
-    getHeadersExcel,
-    getHeadersZip
+    getHeadersExcel
 } = require('../../common');
-const {describe, beforeEach, afterEach, test, expect, jest} = require('@jest/globals');
+const {describe, beforeEach, afterEach, test, expect} = require('@jest/globals');
 const fs = require("node:fs");
 const {fhirContentTypes} = require("../../../utils/contentTypes");
 

--- a/src/tests/summary/practitioner/practitioner.excel.test.js
+++ b/src/tests/summary/practitioner/practitioner.excel.test.js
@@ -1,0 +1,234 @@
+// test file
+const practitionerResource = require('./fixtures/practitioner/practitioner.json');
+const practitionerRoleResource = require('./fixtures/practitioner/practitionerRole.json');
+const practitionerRoleDifferentSecurityTagResource = require('./fixtures/practitioner/practitionerRoleDifferentSecurityTag.json');
+const organizationResource = require('./fixtures/practitioner/organization.json');
+const XLSX = require("xlsx");
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    createTestRequest,
+    getHeadersExcel,
+    getHeadersZip
+} = require('../../common');
+const {describe, beforeEach, afterEach, test, expect, jest} = require('@jest/globals');
+const fs = require("node:fs");
+const {fhirContentTypes} = require("../../../utils/contentTypes");
+
+describe('Practitioner $summary Tests with Excel content', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    describe('Practitioner $summary Tests', () => {
+        test('Practitioner $summary works with Accepts header', async () => {
+            const request = await createTestRequest();
+            // ARRANGE
+            let resp = await request
+                .get('/4_0_0/Practitioner')
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResourceCount(0);
+
+            resp = await request
+                .post('/4_0_0/Practitioner/1679033641/$merge')
+                .send(practitionerResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .post('/4_0_0/PractitionerRole/1/$merge')
+                .send(practitionerRoleResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .post('/4_0_0/PractitionerRole/1/$merge')
+                .send(practitionerRoleDifferentSecurityTagResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .post('/4_0_0/Organization/123456/$merge')
+                .send(organizationResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            // ACT & ASSERT
+            // First get patient everything
+            resp = await request
+                .get('/4_0_0/Practitioner/1679033641/$summary?_debug=true')
+                .set(getHeadersExcel())
+                .responseType('blob'); // Important for binary data
+
+            // Basic response checks
+            expect(resp.status).toBe(200);
+
+            // Content-Type checks
+            expect(resp.headers['content-type']).toBe(fhirContentTypes.excel);
+            expect(resp.headers['content-disposition']).toMatch(/attachment; filename=.+\.xlsx/);
+
+            // Generate unique filename
+            // get folder containing this test
+            const tempFolder = __dirname + '/temp';
+            // if subfolder temp from current folder exists then delete it
+            if (fs.existsSync(tempFolder)) {
+                fs.rmSync(tempFolder, {recursive: true, force: true});
+            }
+            // if subfolder temp from current folder does not exist then create it
+            if (!fs.existsSync(tempFolder)) {
+                fs.mkdirSync(tempFolder);
+            }
+            const filename = `export_${new Date().toISOString().replace(/:/g, '-')}.xlsx`;
+            const filepath = tempFolder + '/' + filename;
+
+            // Write file
+            fs.writeFileSync(filepath, resp.body);
+
+            // Optional: Verify file was written
+            expect(fs.existsSync(filepath)).toBe(true);
+
+            // Optional: Check file size
+            const stats = fs.statSync(filepath);
+            expect(stats.size).toBeGreaterThan(0);
+
+            const workbook = XLSX.read(resp.body);
+
+            // Detailed file inspection
+            /**
+             * @type {str}
+             */
+            for (const sheetName of workbook.SheetNames) {
+                const sheetData = XLSX.utils.sheet_to_json(workbook.Sheets[sheetName], {header: 1});
+
+                expect(sheetData.length).toBeGreaterThan(0);
+            }
+
+            // Check for specific resource type CSVs
+            const expectedResourceTypes = ['Practitioner', 'PractitionerRole']; // Adjust as needed
+            expectedResourceTypes.forEach(resourceType => {
+                /**
+                 * @type {string[]}
+                 */
+                const sheetNames = workbook.SheetNames;
+                console.info(`Found sheet names: ${sheetNames}`);
+                const matchingFile = sheetNames.find(filename =>
+                    filename.toLowerCase().includes(resourceType.toLowerCase())
+                );
+                expect(matchingFile).toBeTruthy();
+            });
+        });
+        test('Practitioner $summary works with _format', async () => {
+            const request = await createTestRequest();
+            // ARRANGE
+            // ARRANGE
+            let resp = await request
+                .get('/4_0_0/Practitioner')
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResourceCount(0);
+
+            resp = await request
+                .post('/4_0_0/Practitioner/1679033641/$merge')
+                .send(practitionerResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .post('/4_0_0/PractitionerRole/1/$merge')
+                .send(practitionerRoleResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .post('/4_0_0/PractitionerRole/1/$merge')
+                .send(practitionerRoleDifferentSecurityTagResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            resp = await request
+                .post('/4_0_0/Organization/123456/$merge')
+                .send(organizationResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({created: true});
+
+            // ACT & ASSERT
+            // First get patient everything
+            resp = await request
+                .get('/4_0_0/Practitioner/1679033641/$summary?_debug=true')
+                .set(getHeadersExcel())
+                .responseType('blob'); // Important for binary data
+
+            // Basic response checks
+            expect(resp.status).toBe(200);
+
+            // Content-Type checks
+            expect(resp.headers['content-type']).toBe(fhirContentTypes.excel);
+            expect(resp.headers['content-disposition']).toMatch(/attachment; filename=.+\.xlsx/);
+
+            // Generate unique filename
+            // get folder containing this test
+            const tempFolder = __dirname + '/temp';
+            // if subfolder temp from current folder exists then delete it
+            if (fs.existsSync(tempFolder)) {
+                fs.rmSync(tempFolder, {recursive: true, force: true});
+            }
+            // if subfolder temp from current folder does not exist then create it
+            if (!fs.existsSync(tempFolder)) {
+                fs.mkdirSync(tempFolder);
+            }
+            const filenameMatch = resp.headers['content-disposition'].split('filename=')[1];
+            const filename = filenameMatch.split(';')[0].trim().replace(/"/g, '');
+            const filepath = tempFolder + '/' + filename;
+
+            // Write file
+            fs.writeFileSync(filepath, resp.body);
+
+            // Optional: Verify file was written
+            expect(fs.existsSync(filepath)).toBe(true);
+
+            // Optional: Check file size
+            const stats = fs.statSync(filepath);
+            expect(stats.size).toBeGreaterThan(0);
+
+            const workbook = XLSX.read(resp.body);
+
+            // Detailed file inspection
+            /**
+             * @type {str}
+             */
+            for (const sheetName of workbook.SheetNames) {
+                const sheetData = XLSX.utils.sheet_to_json(workbook.Sheets[sheetName], {header: 1});
+
+                expect(sheetData.length).toBeGreaterThan(0);
+            }
+
+            // Check for specific resource type CSVs
+            const expectedResourceTypes = ['Practitioner', 'PractitionerRole']; // Adjust as needed
+            expectedResourceTypes.forEach(resourceType => {
+                /**
+                 * @type {string[]}
+                 */
+                const sheetNames = workbook.SheetNames;
+                const matchingFile = sheetNames.find(filename =>
+                    filename.toLowerCase().includes(resourceType.toLowerCase())
+                );
+                expect(matchingFile).toBeTruthy();
+            });
+        });
+    });
+});

--- a/src/tests/utils/fhirResponseCsvStreamer/fhirResponseCsvStreamer.test.js
+++ b/src/tests/utils/fhirResponseCsvStreamer/fhirResponseCsvStreamer.test.js
@@ -1,4 +1,4 @@
-const {FHIRBundleConverter} = require('@imranq2/fhir-to-csv/lib/converters/fhir_bundle_converter');
+const {FHIRBundleConverter} = require('@imranq2/fhir-to-csv/lib/fhir_bundle_converter');
 const {PassThrough} = require('stream');
 const {FhirResponseCsvStreamer} = require("../../../utils/fhirResponseCsvStreamer");
 const {describe, beforeEach, afterEach, test, expect, it} = require('@jest/globals');
@@ -6,7 +6,6 @@ const {jest} = require('@jest/globals');
 const Bundle = require("../../../fhir/classes/4_0_0/resources/bundle");
 const BundleEntry = require("../../../fhir/classes/4_0_0/backbone_elements/bundleEntry");
 const moment = require("moment-timezone");
-const {ExtractorRegistrar} = require("@imranq2/fhir-to-csv/lib/converters/register");
 const {fhirContentTypes} = require("../../../utils/contentTypes");
 
 describe('FhirResponseCsvStreamer', () => {

--- a/src/utils/buffer_to_chunk_transfer_response.js
+++ b/src/utils/buffer_to_chunk_transfer_response.js
@@ -7,9 +7,9 @@ class BufferToChunkTransferResponse {
      * @param {ServerResponse} response
      * @param {Buffer} buffer
      * @param {number} chunkSize
-     * @returns {Promise<void>}
+     * @returns {void}
      */
-    async sendLargeFileChunked({response, buffer, chunkSize = 64 * 1024}) {
+    sendLargeFileChunked({response, buffer, chunkSize = 64 * 1024}) {
         // Create a readable stream from the buffer
         /**
          * @type {module:stream.Stream.Readable | module:stream.internal.Readable}

--- a/src/utils/buffer_to_chunk_transfer_response.js
+++ b/src/utils/buffer_to_chunk_transfer_response.js
@@ -18,9 +18,9 @@ class BufferToChunkTransferResponse {
             read() {
                 // If buffer is not empty, push chunks
                 if (buffer.length > 0) {
-                    const chunk = buffer.slice(0, Math.min(chunkSize, buffer.length));
+                    const chunk = buffer.subarray(0, Math.min(chunkSize, buffer.length));
                     this.push(chunk);
-                    buffer = buffer.slice(chunk.length);
+                    buffer = buffer.subarray(chunk.length);
                 }
 
                 // Signal end of stream when buffer is exhausted

--- a/src/utils/buffer_to_chunk_transfer_response.js
+++ b/src/utils/buffer_to_chunk_transfer_response.js
@@ -1,5 +1,4 @@
 const {Readable} = require('stream');
-const {fhirContentTypes} = require("./contentTypes");
 
 class BufferToChunkTransferResponse {
     /**

--- a/src/utils/fhirResponseCsvStreamer.js
+++ b/src/utils/fhirResponseCsvStreamer.js
@@ -1,9 +1,8 @@
 const {FhirResourceSerializer} = require('../fhir/fhirResourceSerializer');
 const {BaseResponseStreamer} = require('./baseResponseStreamer');
 const {fhirContentTypes} = require('./contentTypes');
-const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/converters/fhir_bundle_converter");
-var JSZip = require("jszip");
-const {ExtractorRegistrar} = require("@imranq2/fhir-to-csv/lib/converters/register");
+const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/fhir_bundle_converter");
+const JSZip = require("jszip");
 const {BundleToExcelConverter} = require("../converters/bundleToExcelConverter");
 const {BundleToCsvConverter} = require("../converters/bundleToCsvConverter");
 const {BufferToChunkTransferResponse} = require("./buffer_to_chunk_transfer_response");
@@ -80,8 +79,6 @@ class FhirResponseCsvStreamer extends BaseResponseStreamer {
      */
     async endAsync() {
         try {
-            ExtractorRegistrar.registerAll();
-
             if (this._bundle !== undefined && (this._bundle.entry || this._bundle_entries.length > 0)) {
                 const filename = (this._bundle.id || String(this.RequestId)) + '.zip';
                 this.response.setHeader(

--- a/src/utils/fhirResponseCsvStreamer.js
+++ b/src/utils/fhirResponseCsvStreamer.js
@@ -85,10 +85,7 @@ class FhirResponseCsvStreamer extends BaseResponseStreamer {
                     `attachment; filename="${filename}"`
                 );
                 this.response.setHeader('Access-Control-Expose-Headers', 'Content-Disposition');
-                /**
-                 * @type {FHIRBundleConverter}
-                 */
-                const converter = new FHIRBundleConverter();
+
                 /**
                  * @type {Object}
                  */

--- a/src/utils/fhirResponseCsvStreamer.js
+++ b/src/utils/fhirResponseCsvStreamer.js
@@ -1,8 +1,5 @@
-const {FhirResourceSerializer} = require('../fhir/fhirResourceSerializer');
 const {BaseResponseStreamer} = require('./baseResponseStreamer');
 const {fhirContentTypes} = require('./contentTypes');
-const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/fhir_bundle_converter");
-const {BundleToExcelConverter} = require("../converters/bundleToExcelConverter");
 const {BundleToCsvConverter} = require("../converters/bundleToCsvConverter");
 const {BufferToChunkTransferResponse} = require("./buffer_to_chunk_transfer_response");
 
@@ -79,7 +76,7 @@ class FhirResponseCsvStreamer extends BaseResponseStreamer {
     async endAsync() {
         try {
             if (this._bundle !== undefined && (this._bundle.entry || this._bundle_entries.length > 0)) {
-                const filename = (this._bundle.id || String(this.RequestId)) + '.zip';
+                const filename = (this._bundle.id || String(this.requestId)) + '.zip';
                 this.response.setHeader(
                     'Content-Disposition',
                     `attachment; filename="${filename}"`

--- a/src/utils/fhirResponseCsvStreamer.js
+++ b/src/utils/fhirResponseCsvStreamer.js
@@ -113,7 +113,7 @@ class FhirResponseCsvStreamer extends BaseResponseStreamer {
                 /**
                  * @type {Buffer}
                  */
-                const csvBuffer = await exporter.convert(
+                const csvBuffer = exporter.convert(
                     {
                         bundle
                     }

--- a/src/utils/fhirResponseCsvStreamer.js
+++ b/src/utils/fhirResponseCsvStreamer.js
@@ -2,7 +2,6 @@ const {FhirResourceSerializer} = require('../fhir/fhirResourceSerializer');
 const {BaseResponseStreamer} = require('./baseResponseStreamer');
 const {fhirContentTypes} = require('./contentTypes');
 const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/fhir_bundle_converter");
-const JSZip = require("jszip");
 const {BundleToExcelConverter} = require("../converters/bundleToExcelConverter");
 const {BundleToCsvConverter} = require("../converters/bundleToCsvConverter");
 const {BufferToChunkTransferResponse} = require("./buffer_to_chunk_transfer_response");

--- a/src/utils/fhirResponseExcelStreamer.js
+++ b/src/utils/fhirResponseExcelStreamer.js
@@ -1,7 +1,5 @@
-const {FhirResourceSerializer} = require('../fhir/fhirResourceSerializer');
 const {BaseResponseStreamer} = require('./baseResponseStreamer');
 const {fhirContentTypes} = require('./contentTypes');
-const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/fhir_bundle_converter");
 const {BundleToExcelConverter} = require("../converters/bundleToExcelConverter");
 const {BufferToChunkTransferResponse} = require("./buffer_to_chunk_transfer_response");
 
@@ -78,7 +76,7 @@ class FhirResponseExcelStreamer extends BaseResponseStreamer {
     async endAsync() {
         try {
             if (this._bundle !== undefined && this._bundle_entries.length > 0) {
-                const filename = (this._bundle.id || String(this.RequestId)) + '.xlsx';
+                const filename = (this._bundle.id || String(this.requestId)) + '.xlsx';
                 this.response.setHeader(
                     'Content-Disposition',
                     `attachment; filename="${filename}"`

--- a/src/utils/fhirResponseExcelStreamer.js
+++ b/src/utils/fhirResponseExcelStreamer.js
@@ -112,7 +112,7 @@ class FhirResponseExcelStreamer extends BaseResponseStreamer {
                     throw new Error('Generated Excel buffer is empty');
                 }
 
-                await new BufferToChunkTransferResponse().sendLargeFileChunked(
+                new BufferToChunkTransferResponse().sendLargeFileChunked(
                     {
                         response: this.response,
                         buffer: excelBuffer,

--- a/src/utils/fhirResponseExcelStreamer.js
+++ b/src/utils/fhirResponseExcelStreamer.js
@@ -2,7 +2,6 @@ const {FhirResourceSerializer} = require('../fhir/fhirResourceSerializer');
 const {BaseResponseStreamer} = require('./baseResponseStreamer');
 const {fhirContentTypes} = require('./contentTypes');
 const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/fhir_bundle_converter");
-const JSZip = require("jszip");
 const {BundleToExcelConverter} = require("../converters/bundleToExcelConverter");
 const {BufferToChunkTransferResponse} = require("./buffer_to_chunk_transfer_response");
 

--- a/src/utils/fhirResponseExcelStreamer.js
+++ b/src/utils/fhirResponseExcelStreamer.js
@@ -1,9 +1,8 @@
 const {FhirResourceSerializer} = require('../fhir/fhirResourceSerializer');
 const {BaseResponseStreamer} = require('./baseResponseStreamer');
 const {fhirContentTypes} = require('./contentTypes');
-const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/converters/fhir_bundle_converter");
-var JSZip = require("jszip");
-const {ExtractorRegistrar} = require("@imranq2/fhir-to-csv/lib/converters/register");
+const {FHIRBundleConverter} = require("@imranq2/fhir-to-csv/lib/fhir_bundle_converter");
+const JSZip = require("jszip");
 const {BundleToExcelConverter} = require("../converters/bundleToExcelConverter");
 const {BufferToChunkTransferResponse} = require("./buffer_to_chunk_transfer_response");
 
@@ -79,8 +78,6 @@ class FhirResponseExcelStreamer extends BaseResponseStreamer {
      */
     async endAsync() {
         try {
-            ExtractorRegistrar.registerAll();
-
             if (this._bundle !== undefined && this._bundle_entries.length > 0) {
                 const filename = (this._bundle.id || String(this.RequestId)) + '.xlsx';
                 this.response.setHeader(

--- a/src/utils/fhirResponseExcelStreamer.js
+++ b/src/utils/fhirResponseExcelStreamer.js
@@ -102,7 +102,7 @@ class FhirResponseExcelStreamer extends BaseResponseStreamer {
                 /**
                  * @type {Buffer}
                  */
-                const excelBuffer = await exporter.convert(
+                const excelBuffer = exporter.convert(
                     {
                         bundle
                     }
@@ -110,7 +110,7 @@ class FhirResponseExcelStreamer extends BaseResponseStreamer {
 
                 // Verify buffer before sending
                 if (excelBuffer.length === 0) {
-                    throw new Error('Generated zip buffer is empty');
+                    throw new Error('Generated Excel buffer is empty');
                 }
 
                 await new BufferToChunkTransferResponse().sendLargeFileChunked(

--- a/src/utils/removeUnderscoreProps.js
+++ b/src/utils/removeUnderscoreProps.js
@@ -18,4 +18,4 @@ function removeUnderscoreProps(obj) {
 
 module.exports = {
     removeUnderscoreProps
-}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,13 +1488,13 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@imranq2/fhir-to-csv@^1.0.10":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.10.tgz#2004f3edf88cf1aee6fea2883548102fa029d5ca"
-  integrity sha512-YxVAcjoFOf6rV85+gt8o6XxpoEJlRdDyljxX2jc/cyzj4yjSp1QFkPXaEsjf0C/R1CdR7lowf335j3tFob0KAA==
+"@imranq2/fhir-to-csv@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.11.tgz#b427a4cd8abf3f8884743e793cc432f8fe73e9f1"
+  integrity sha512-bFA2p7e75PFITbMFg0O5Pj1vSRRXB5dzjmQaUXvwVcEQYQvCzjA8QsqfJoG5xGIJ1qjbzWZQ11hV5aLyQOJEaQ==
   dependencies:
     "@json2csv/node" "^7.0.6"
-    jszip "^3.10.1"
+    fflate "^0.8.2"
     xlsx "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
 
 "@isaacs/cliui@^8.0.2":
@@ -5390,6 +5390,11 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
   integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
 
+fflate@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
+  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
 file-entry-cache@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz#7787bddcf1131bffb92636c69457bbc0edd6d81f"
@@ -5963,11 +5968,6 @@ ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
-
-immediate@~3.0.5:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
-  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -6785,16 +6785,6 @@ jsonwebtoken@^9.0.0, jsonwebtoken@^9.0.2:
     ms "^2.1.1"
     semver "^7.5.4"
 
-jszip@^3.10.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
-  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
-  dependencies:
-    lie "~3.3.0"
-    pako "~1.0.2"
-    readable-stream "~2.3.6"
-    setimmediate "^1.0.5"
-
 jwa@^1.4.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.2.tgz#16011ac6db48de7b102777e57897901520eec7b9"
@@ -6875,13 +6865,6 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
-
-lie@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
-  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
-  dependencies:
-    immediate "~3.0.5"
 
 limiter@1.1.5, limiter@^1.1.5:
   version "1.1.5"
@@ -7884,11 +7867,6 @@ pacote@15.2.0:
     ssri "^10.0.0"
     tar "^6.1.11"
 
-pako@~1.0.2:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -8394,7 +8372,7 @@ read-package-json@^6.0.0:
     normalize-package-data "^5.0.0"
     npm-normalize-package-bin "^3.0.0"
 
-readable-stream@^2.2.2, readable-stream@~2.3.6:
+readable-stream@^2.2.2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
@@ -8707,11 +8685,6 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
-
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 setprototypeof@1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9804,6 +9804,10 @@ xlsx@^0.18.5:
     wmf "~1.0.1"
     word "~0.3.0"
 
+"xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz":
+  version "0.20.3"
+  resolved "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz#992725af0bb69fa9733590fcb8ab4a57e10b929b"
+
 xss@^1.0.15:
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.15.tgz#96a0e13886f0661063028b410ed1b18670f4e59a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,12 +1488,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@imranq2/fhir-to-csv@^1.0.13":
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.13.tgz#8a8904da0a79ec54da8dd7bee38933e82df38a23"
-  integrity sha512-BGin6mX0Wr9/+dedjhHfCHz50elN7UueH5rJ7+XfmmozOuLjj+RUuAGURC2Op1q0C5EzSdu1bZ64WReQ6zk1pA==
+"@imranq2/fhir-to-csv@^1.0.15":
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.15.tgz#48e12e660ebb5a90e0ee9bc397d5380a8f78c0f7"
+  integrity sha512-XGRa9Ym5mq5vYLGjrUWBuLnoK6PY7hWqPbn+16Lqk1pH9I1vdxs6vL2fD9y8uv+mqPUd7UzwrW0cWtG13Blu1g==
   dependencies:
-    "@json2csv/node" "^7.0.6"
     fflate "^0.8.2"
     xlsx "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,33 +261,33 @@
     tslib "^2.6.2"
 
 "@aws-sdk/client-s3@^3.592.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.804.0.tgz#07f9591078815457e8f21c1a2ebd780b357987d2"
-  integrity sha512-oLBCq/wOzMEv4HhEDxttl5km0KGuptqnl4MlzzDcxPpsDmXjQU7egZdfQtwKRlB7748F+/uTcYc7khFvX2I1DA==
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.806.0.tgz#64740518a393a105e3c9687d3a8c32c1ee8d8c15"
+  integrity sha512-kQaBBBxEBU/IJ2wKG+LL2BK+uvBwpdvOA9jy1WhW+U2/DIMwMrjVs7M/ZvTlmVOJwhZaONcJbgQqsN4Yirjj4g==
   dependencies:
     "@aws-crypto/sha1-browser" "5.2.0"
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "3.804.0"
-    "@aws-sdk/credential-provider-node" "3.804.0"
-    "@aws-sdk/middleware-bucket-endpoint" "3.804.0"
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/credential-provider-node" "3.806.0"
+    "@aws-sdk/middleware-bucket-endpoint" "3.806.0"
     "@aws-sdk/middleware-expect-continue" "3.804.0"
-    "@aws-sdk/middleware-flexible-checksums" "3.804.0"
+    "@aws-sdk/middleware-flexible-checksums" "3.806.0"
     "@aws-sdk/middleware-host-header" "3.804.0"
     "@aws-sdk/middleware-location-constraint" "3.804.0"
     "@aws-sdk/middleware-logger" "3.804.0"
     "@aws-sdk/middleware-recursion-detection" "3.804.0"
-    "@aws-sdk/middleware-sdk-s3" "3.804.0"
+    "@aws-sdk/middleware-sdk-s3" "3.806.0"
     "@aws-sdk/middleware-ssec" "3.804.0"
-    "@aws-sdk/middleware-user-agent" "3.804.0"
-    "@aws-sdk/region-config-resolver" "3.804.0"
-    "@aws-sdk/signature-v4-multi-region" "3.804.0"
+    "@aws-sdk/middleware-user-agent" "3.806.0"
+    "@aws-sdk/region-config-resolver" "3.806.0"
+    "@aws-sdk/signature-v4-multi-region" "3.806.0"
     "@aws-sdk/types" "3.804.0"
-    "@aws-sdk/util-endpoints" "3.804.0"
+    "@aws-sdk/util-endpoints" "3.806.0"
     "@aws-sdk/util-user-agent-browser" "3.804.0"
-    "@aws-sdk/util-user-agent-node" "3.804.0"
+    "@aws-sdk/util-user-agent-node" "3.806.0"
     "@aws-sdk/xml-builder" "3.804.0"
-    "@smithy/config-resolver" "^4.1.0"
+    "@smithy/config-resolver" "^4.1.1"
     "@smithy/core" "^3.3.1"
     "@smithy/eventstream-serde-browser" "^4.0.2"
     "@smithy/eventstream-serde-config-resolver" "^4.1.0"
@@ -299,22 +299,22 @@
     "@smithy/invalid-dependency" "^4.0.2"
     "@smithy/md5-js" "^4.0.2"
     "@smithy/middleware-content-length" "^4.0.2"
-    "@smithy/middleware-endpoint" "^4.1.2"
-    "@smithy/middleware-retry" "^4.1.3"
+    "@smithy/middleware-endpoint" "^4.1.3"
+    "@smithy/middleware-retry" "^4.1.4"
     "@smithy/middleware-serde" "^4.0.3"
     "@smithy/middleware-stack" "^4.0.2"
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.0"
     "@smithy/node-http-handler" "^4.0.4"
     "@smithy/protocol-http" "^5.1.0"
-    "@smithy/smithy-client" "^4.2.2"
+    "@smithy/smithy-client" "^4.2.3"
     "@smithy/types" "^4.2.0"
     "@smithy/url-parser" "^4.0.2"
     "@smithy/util-base64" "^4.0.0"
     "@smithy/util-body-length-browser" "^4.0.0"
     "@smithy/util-body-length-node" "^4.0.0"
-    "@smithy/util-defaults-mode-browser" "^4.0.10"
-    "@smithy/util-defaults-mode-node" "^4.0.10"
-    "@smithy/util-endpoints" "^3.0.2"
+    "@smithy/util-defaults-mode-browser" "^4.0.11"
+    "@smithy/util-defaults-mode-node" "^4.0.11"
+    "@smithy/util-endpoints" "^3.0.3"
     "@smithy/util-middleware" "^4.0.2"
     "@smithy/util-retry" "^4.0.3"
     "@smithy/util-stream" "^4.2.0"
@@ -322,106 +322,106 @@
     "@smithy/util-waiter" "^4.0.3"
     tslib "^2.6.2"
 
-"@aws-sdk/client-sso@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.804.0.tgz#99f130025c7225087d730ef83fbefb2cc167a4f4"
-  integrity sha512-6D5iQbL0MqlJ7B5aaHdP21k9+3H/od0jHjHSXegvFd4h2KQbD+QVTdEOSLeakgBGgHYRfiQXsrdMMzUz8vcpsw==
+"@aws-sdk/client-sso@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.806.0.tgz#fc09e505d41eaca3f3199bcae537caed1221528a"
+  integrity sha512-X0p/9/u9e6b22rlQqKucdtjdqmjSNB4c/8zDEoD5MvgYAAbMF9HNE0ST2xaA/WsJ7uE0jFfhPY2/00pslL1DqQ==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "3.804.0"
+    "@aws-sdk/core" "3.806.0"
     "@aws-sdk/middleware-host-header" "3.804.0"
     "@aws-sdk/middleware-logger" "3.804.0"
     "@aws-sdk/middleware-recursion-detection" "3.804.0"
-    "@aws-sdk/middleware-user-agent" "3.804.0"
-    "@aws-sdk/region-config-resolver" "3.804.0"
+    "@aws-sdk/middleware-user-agent" "3.806.0"
+    "@aws-sdk/region-config-resolver" "3.806.0"
     "@aws-sdk/types" "3.804.0"
-    "@aws-sdk/util-endpoints" "3.804.0"
+    "@aws-sdk/util-endpoints" "3.806.0"
     "@aws-sdk/util-user-agent-browser" "3.804.0"
-    "@aws-sdk/util-user-agent-node" "3.804.0"
-    "@smithy/config-resolver" "^4.1.0"
+    "@aws-sdk/util-user-agent-node" "3.806.0"
+    "@smithy/config-resolver" "^4.1.1"
     "@smithy/core" "^3.3.1"
     "@smithy/fetch-http-handler" "^5.0.2"
     "@smithy/hash-node" "^4.0.2"
     "@smithy/invalid-dependency" "^4.0.2"
     "@smithy/middleware-content-length" "^4.0.2"
-    "@smithy/middleware-endpoint" "^4.1.2"
-    "@smithy/middleware-retry" "^4.1.3"
+    "@smithy/middleware-endpoint" "^4.1.3"
+    "@smithy/middleware-retry" "^4.1.4"
     "@smithy/middleware-serde" "^4.0.3"
     "@smithy/middleware-stack" "^4.0.2"
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.0"
     "@smithy/node-http-handler" "^4.0.4"
     "@smithy/protocol-http" "^5.1.0"
-    "@smithy/smithy-client" "^4.2.2"
+    "@smithy/smithy-client" "^4.2.3"
     "@smithy/types" "^4.2.0"
     "@smithy/url-parser" "^4.0.2"
     "@smithy/util-base64" "^4.0.0"
     "@smithy/util-body-length-browser" "^4.0.0"
     "@smithy/util-body-length-node" "^4.0.0"
-    "@smithy/util-defaults-mode-browser" "^4.0.10"
-    "@smithy/util-defaults-mode-node" "^4.0.10"
-    "@smithy/util-endpoints" "^3.0.2"
+    "@smithy/util-defaults-mode-browser" "^4.0.11"
+    "@smithy/util-defaults-mode-node" "^4.0.11"
+    "@smithy/util-endpoints" "^3.0.3"
     "@smithy/util-middleware" "^4.0.2"
     "@smithy/util-retry" "^4.0.3"
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
-"@aws-sdk/core@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.804.0.tgz#ac0b3108b3803813c077c88e1a784541c39cb6a3"
-  integrity sha512-KrYDEc6HaJE+Mx5lrwq6uhJxj1RYYfggQ+X+zQeKRyrZHl2GOxFl7PdnpdwtnaQIjX0gNkDzquhZSdyT0ar5rA==
+"@aws-sdk/core@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.806.0.tgz#e8e8464238b5070b7fa0a0df7351aa1bcd0540b2"
+  integrity sha512-HJRINPncdjPK0iL3f6cBpqCMaxVwq2oDbRCzOx04tsLZ0tNgRACBfT3d/zNVRvMt6fnOVKXoN1LAtQaw50pjEA==
   dependencies:
     "@aws-sdk/types" "3.804.0"
     "@smithy/core" "^3.3.1"
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/signature-v4" "^5.1.0"
-    "@smithy/smithy-client" "^4.2.2"
+    "@smithy/smithy-client" "^4.2.3"
     "@smithy/types" "^4.2.0"
     "@smithy/util-middleware" "^4.0.2"
     fast-xml-parser "4.4.1"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-env@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.804.0.tgz#b07af9f0841d88ba983f7d2a6acd9a3b1afad18c"
-  integrity sha512-5mjrWPa4iaBK9/HDEIVN8lGxsnjk60eBjwGaJV0I2uqxnTo1EuQmpLV3XdY/OzQeqJdpuH/DbC6XUIdy9bXNQA==
+"@aws-sdk/credential-provider-env@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.806.0.tgz#e480de3a5340d0297ff96a4612f3c913e24994c0"
+  integrity sha512-nbPwmZn0kt6Q1XI2FaJWP6AhF9tro4cO5HlmZQx8NU+B0H1y9WMo659Q5zLLY46BXgoQVIJEsPSZpcZk27O4aw==
   dependencies:
-    "@aws-sdk/core" "3.804.0"
+    "@aws-sdk/core" "3.806.0"
     "@aws-sdk/types" "3.804.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-http@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.804.0.tgz#9d5fd383e703bd87c569ca18461ccc5b8aa03858"
-  integrity sha512-TD84TXS/iDWcf+ggCq3n6yx36p1WXB2qgyHkbP/yVbdmix/vKU1twuB5qJvaY0PJWI0TOwBa9680XfsYrzaJAA==
+"@aws-sdk/credential-provider-http@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.806.0.tgz#17cdea3fb73062f14aec1aadba1b66c717578253"
+  integrity sha512-e/gB2iJQQ4ZpecOVpEFhEvjGwuTqNCzhVaVsFYVc49FPfR1seuN7qBGYe1MO7mouGDQFInzJgcNup0DnYUrLiw==
   dependencies:
-    "@aws-sdk/core" "3.804.0"
+    "@aws-sdk/core" "3.806.0"
     "@aws-sdk/types" "3.804.0"
     "@smithy/fetch-http-handler" "^5.0.2"
     "@smithy/node-http-handler" "^4.0.4"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/protocol-http" "^5.1.0"
-    "@smithy/smithy-client" "^4.2.2"
+    "@smithy/smithy-client" "^4.2.3"
     "@smithy/types" "^4.2.0"
     "@smithy/util-stream" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-ini@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.804.0.tgz#0f227a306d7cd51d85ffcd5cd8c8aeb65110309f"
-  integrity sha512-LfReL9TnOOunJWeZbDXPePFEnvJE+jcA7iY/ItsThUALgTy+ydLUdOiwzMZFo1f0JZN/Rfrsb9FOd/xTOoZiFw==
+"@aws-sdk/credential-provider-ini@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.806.0.tgz#535cef9b760089e02811030202b69f6d54973ad4"
+  integrity sha512-FogfbuYSEZgFxbNy0QcsBZHHe5mSv5HV3+JyB5n0kCyjOISCVCZD7gwxKdXjt8O1hXq5k5SOdQvydGULlB6rew==
   dependencies:
-    "@aws-sdk/core" "3.804.0"
-    "@aws-sdk/credential-provider-env" "3.804.0"
-    "@aws-sdk/credential-provider-http" "3.804.0"
-    "@aws-sdk/credential-provider-process" "3.804.0"
-    "@aws-sdk/credential-provider-sso" "3.804.0"
-    "@aws-sdk/credential-provider-web-identity" "3.804.0"
-    "@aws-sdk/nested-clients" "3.804.0"
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/credential-provider-env" "3.806.0"
+    "@aws-sdk/credential-provider-http" "3.806.0"
+    "@aws-sdk/credential-provider-process" "3.806.0"
+    "@aws-sdk/credential-provider-sso" "3.806.0"
+    "@aws-sdk/credential-provider-web-identity" "3.806.0"
+    "@aws-sdk/nested-clients" "3.806.0"
     "@aws-sdk/types" "3.804.0"
     "@smithy/credential-provider-imds" "^4.0.2"
     "@smithy/property-provider" "^4.0.2"
@@ -429,17 +429,17 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-node@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.804.0.tgz#6a83d53542e7d5aae846ab5bfc4853ff6d411599"
-  integrity sha512-L2EK5fy2+7El7j7TcRcuwr2lzU5tQfXsfscg+dtFkLPjOqShknnqV/lXylb3QlWx8B3K/c/KK5rcWQl6cYUiDQ==
+"@aws-sdk/credential-provider-node@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.806.0.tgz#7bda185597d31beed9331aef95b00068fb3e1a39"
+  integrity sha512-fZX8xP2Kf0k70kDTog/87fh/M+CV0E2yujSw1cUBJhDSwDX3RlUahiJk7TpB/KGw6hEFESMd6+7kq3UzYuw3rg==
   dependencies:
-    "@aws-sdk/credential-provider-env" "3.804.0"
-    "@aws-sdk/credential-provider-http" "3.804.0"
-    "@aws-sdk/credential-provider-ini" "3.804.0"
-    "@aws-sdk/credential-provider-process" "3.804.0"
-    "@aws-sdk/credential-provider-sso" "3.804.0"
-    "@aws-sdk/credential-provider-web-identity" "3.804.0"
+    "@aws-sdk/credential-provider-env" "3.806.0"
+    "@aws-sdk/credential-provider-http" "3.806.0"
+    "@aws-sdk/credential-provider-ini" "3.806.0"
+    "@aws-sdk/credential-provider-process" "3.806.0"
+    "@aws-sdk/credential-provider-sso" "3.806.0"
+    "@aws-sdk/credential-provider-web-identity" "3.806.0"
     "@aws-sdk/types" "3.804.0"
     "@smithy/credential-provider-imds" "^4.0.2"
     "@smithy/property-provider" "^4.0.2"
@@ -447,65 +447,65 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-process@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.804.0.tgz#e4bd67550f5b05941adb4f9710ccdf78922b0fa7"
-  integrity sha512-s6ng/rZj7WP8GGgxBXsoPZYlSu7MZAm9O8OLgSSWcw8/vaYW7hBVSEVVNMEUkJiJeEo7Lh+Y/3d6SY27S1of/g==
+"@aws-sdk/credential-provider-process@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.806.0.tgz#5b26539982b6f1d29ae072194ba973adae4c25a3"
+  integrity sha512-8Y8GYEw/1e5IZRDQL02H6nsTDcRWid/afRMeWg+93oLQmbHcTtdm48tjis+7Xwqy+XazhMDmkbUht11QPTDJcQ==
   dependencies:
-    "@aws-sdk/core" "3.804.0"
+    "@aws-sdk/core" "3.806.0"
     "@aws-sdk/types" "3.804.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/shared-ini-file-loader" "^4.0.2"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-sso@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.804.0.tgz#5365938fbdc76399ff0d26acb011b0d0e2366431"
-  integrity sha512-9Tt5zmhiK2nBfJv52Is5gNtW6bhK0W20GRhckg4T+BlnxOkPy//2ui23DzYacrwETH6TE3kdoyL3xgEL++HSLg==
+"@aws-sdk/credential-provider-sso@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.806.0.tgz#2d241d5e6179b4f60bc06018d9de3db9bd8ef64a"
+  integrity sha512-hT9OBwCxWMPBydNhXm2gdNNzx5AJNheS9RglwDDvXWzQ9qDuRztjuMBilMSUMb0HF9K4IqQjYzGqczMuktz4qQ==
   dependencies:
-    "@aws-sdk/client-sso" "3.804.0"
-    "@aws-sdk/core" "3.804.0"
-    "@aws-sdk/token-providers" "3.804.0"
+    "@aws-sdk/client-sso" "3.806.0"
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/token-providers" "3.806.0"
     "@aws-sdk/types" "3.804.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/shared-ini-file-loader" "^4.0.2"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/credential-provider-web-identity@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.804.0.tgz#87377f3bbacfe01ad736df3360222a46b03de8c1"
-  integrity sha512-eBICjQUnqaoiHl9/AHKVPt/YkrifDddAUNGWUj+9cb3bRml6PEBSHE0k/tbbCTMq1xz7CCP+gmnnAA92ChnseA==
+"@aws-sdk/credential-provider-web-identity@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.806.0.tgz#8c656f39d93a33b6efa63c52b368f691bcb6e66b"
+  integrity sha512-XxaSY9Zd3D4ClUGENYMvi52ac5FuJPPAsvRtEfyrSdEpf6QufbMpnexWBZMYRF31h/VutgqtJwosGgNytpxMEg==
   dependencies:
-    "@aws-sdk/core" "3.804.0"
-    "@aws-sdk/nested-clients" "3.804.0"
+    "@aws-sdk/core" "3.806.0"
+    "@aws-sdk/nested-clients" "3.806.0"
     "@aws-sdk/types" "3.804.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
 "@aws-sdk/lib-storage@^3.609.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/lib-storage/-/lib-storage-3.804.0.tgz#00aac043f3309337e49d26e1a3c1006ff8ef0088"
-  integrity sha512-o7/YYquJeIbsplqHwo78L39UigmQpsXHY3WrJ3j2kAzBBN9T6rPsBU6dPIBMHdtx06uHehcZwm/+B8GVMfMc8A==
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/lib-storage/-/lib-storage-3.806.0.tgz#c08d563e552bcb65cd099245bae5dafe491366dc"
+  integrity sha512-8FjceMZWyqdu3jEa5iryqMH+XdR2iM6kcD/pcsv1JNQUfKicMcW6Db8dXVc29MdMw3f/3kokXqNLGvSKAl81SQ==
   dependencies:
     "@smithy/abort-controller" "^4.0.2"
-    "@smithy/middleware-endpoint" "^4.1.2"
-    "@smithy/smithy-client" "^4.2.2"
+    "@smithy/middleware-endpoint" "^4.1.3"
+    "@smithy/smithy-client" "^4.2.3"
     buffer "5.6.0"
     events "3.3.0"
     stream-browserify "3.0.0"
     tslib "^2.6.2"
 
-"@aws-sdk/middleware-bucket-endpoint@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.804.0.tgz#c4286b8124e2dd18676eb2f47068356ea35000d1"
-  integrity sha512-vVphifJ5Ab2JUjB27UvdNV51ezxTn3f/jNbC/Y+KF1vNcYkwWXqo+U1gD8SUsDK+NhnD3wasfVBVLOdJa7qqKw==
+"@aws-sdk/middleware-bucket-endpoint@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.806.0.tgz#7cb900442cb00d5b82e03636977815f317ae1323"
+  integrity sha512-ACjuyKJw9OZl8z8HzPEaqn1o7ElVW94mowyoZvyUIDouwAPGqPGJbJ5V35qx1oDTFSAJX+N3O3AO6RyFc8nUhw==
   dependencies:
     "@aws-sdk/types" "3.804.0"
     "@aws-sdk/util-arn-parser" "3.804.0"
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.0"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/types" "^4.2.0"
     "@smithy/util-config-provider" "^4.0.0"
@@ -521,18 +521,18 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/middleware-flexible-checksums@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.804.0.tgz#dabce925af91ae92d30caf87e599bd37026a319d"
-  integrity sha512-bQbh3hTrp+3XEuu8G5DkPDK9u3nnIabw2N1GpqlIwv8oGM+GTtGH35gBZtbbd2WAxfSUIBOAwkc86kTS0g0mFg==
+"@aws-sdk/middleware-flexible-checksums@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.806.0.tgz#2e9407e1d73ef416869b0d77a0832c33fb0640da"
+  integrity sha512-YEmuU2Nr/+blhi70gS38fnCe2IoL6OVVZXMp4MbzqZRUqeBbnxZhHQrd5YOiboJz7iq+g98xwFebHY167iejcg==
   dependencies:
     "@aws-crypto/crc32" "5.2.0"
     "@aws-crypto/crc32c" "5.2.0"
     "@aws-crypto/util" "5.2.0"
-    "@aws-sdk/core" "3.804.0"
+    "@aws-sdk/core" "3.806.0"
     "@aws-sdk/types" "3.804.0"
     "@smithy/is-array-buffer" "^4.0.0"
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.0"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/types" "^4.2.0"
     "@smithy/util-middleware" "^4.0.2"
@@ -578,19 +578,19 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/middleware-sdk-s3@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.804.0.tgz#32f64ce59d475bade50cffe71885e8f90e4b8881"
-  integrity sha512-kiuqjV2ozoyI6w34+KMhZU+YVOLTPgh1Kp1DSpuS+tbkwkxnQCrPGziQhuSA5/Y0bUFaa2zLwUh2jpCmJQbLyA==
+"@aws-sdk/middleware-sdk-s3@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.806.0.tgz#2bdd8df38679b7833628ad83236ac1215d1084df"
+  integrity sha512-K1ssdovHH/kPN9EUS1LznwzoL+r89Cx8qAkp0K8MqdCQuBjZ0KRnjvo9nx69Vg5d/rg01VYTxomFUPXfcPtVXw==
   dependencies:
-    "@aws-sdk/core" "3.804.0"
+    "@aws-sdk/core" "3.806.0"
     "@aws-sdk/types" "3.804.0"
     "@aws-sdk/util-arn-parser" "3.804.0"
     "@smithy/core" "^3.3.1"
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.0"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/signature-v4" "^5.1.0"
-    "@smithy/smithy-client" "^4.2.2"
+    "@smithy/smithy-client" "^4.2.3"
     "@smithy/types" "^4.2.0"
     "@smithy/util-config-provider" "^4.0.0"
     "@smithy/util-middleware" "^4.0.2"
@@ -607,93 +607,93 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/middleware-user-agent@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.804.0.tgz#6399bd2bd79fcca80e34e9866651e4fb7ae70bea"
-  integrity sha512-HoBaun4t3vAFhMj/I7L/HNBKBrAYu7Sb5bTFINx8kFCxPbqsvF+jOrEE8WiljHNy7FbPjz0mPVRUwO7RZSYNiQ==
+"@aws-sdk/middleware-user-agent@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.806.0.tgz#a0777ed71b1d41a77d5d3f425e55682a763de91b"
+  integrity sha512-XoIromVffgXnc+/mjlR2EVzQVIei3bPVtafIZNsHuEmUvIWJXiWsa2eJpt3BUqa0HF9YPknK7ommNEhqRb8ucg==
   dependencies:
-    "@aws-sdk/core" "3.804.0"
+    "@aws-sdk/core" "3.806.0"
     "@aws-sdk/types" "3.804.0"
-    "@aws-sdk/util-endpoints" "3.804.0"
+    "@aws-sdk/util-endpoints" "3.806.0"
     "@smithy/core" "^3.3.1"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/nested-clients@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.804.0.tgz#b73be267a161378c99313865307d894aca6eb49b"
-  integrity sha512-IOUcw6stjqYBMhLoAXlLVipYpAqLlA17jcyI0OzpS0pTD1RvBqEBckYibF4HJeReI+IiEHu/m0If0SKVR5WyXQ==
+"@aws-sdk/nested-clients@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.806.0.tgz#701ff67a713fd202eeffe3ecba0844bb23a2e22e"
+  integrity sha512-ua2gzpfQ9MF8Rny+tOAivowOWWvqEusez2rdcQK8jdBjA1ANd/0xzToSZjZh0ziN8Kl8jOhNnHbQJ0v6dT6+hg==
   dependencies:
     "@aws-crypto/sha256-browser" "5.2.0"
     "@aws-crypto/sha256-js" "5.2.0"
-    "@aws-sdk/core" "3.804.0"
+    "@aws-sdk/core" "3.806.0"
     "@aws-sdk/middleware-host-header" "3.804.0"
     "@aws-sdk/middleware-logger" "3.804.0"
     "@aws-sdk/middleware-recursion-detection" "3.804.0"
-    "@aws-sdk/middleware-user-agent" "3.804.0"
-    "@aws-sdk/region-config-resolver" "3.804.0"
+    "@aws-sdk/middleware-user-agent" "3.806.0"
+    "@aws-sdk/region-config-resolver" "3.806.0"
     "@aws-sdk/types" "3.804.0"
-    "@aws-sdk/util-endpoints" "3.804.0"
+    "@aws-sdk/util-endpoints" "3.806.0"
     "@aws-sdk/util-user-agent-browser" "3.804.0"
-    "@aws-sdk/util-user-agent-node" "3.804.0"
-    "@smithy/config-resolver" "^4.1.0"
+    "@aws-sdk/util-user-agent-node" "3.806.0"
+    "@smithy/config-resolver" "^4.1.1"
     "@smithy/core" "^3.3.1"
     "@smithy/fetch-http-handler" "^5.0.2"
     "@smithy/hash-node" "^4.0.2"
     "@smithy/invalid-dependency" "^4.0.2"
     "@smithy/middleware-content-length" "^4.0.2"
-    "@smithy/middleware-endpoint" "^4.1.2"
-    "@smithy/middleware-retry" "^4.1.3"
+    "@smithy/middleware-endpoint" "^4.1.3"
+    "@smithy/middleware-retry" "^4.1.4"
     "@smithy/middleware-serde" "^4.0.3"
     "@smithy/middleware-stack" "^4.0.2"
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.0"
     "@smithy/node-http-handler" "^4.0.4"
     "@smithy/protocol-http" "^5.1.0"
-    "@smithy/smithy-client" "^4.2.2"
+    "@smithy/smithy-client" "^4.2.3"
     "@smithy/types" "^4.2.0"
     "@smithy/url-parser" "^4.0.2"
     "@smithy/util-base64" "^4.0.0"
     "@smithy/util-body-length-browser" "^4.0.0"
     "@smithy/util-body-length-node" "^4.0.0"
-    "@smithy/util-defaults-mode-browser" "^4.0.10"
-    "@smithy/util-defaults-mode-node" "^4.0.10"
-    "@smithy/util-endpoints" "^3.0.2"
+    "@smithy/util-defaults-mode-browser" "^4.0.11"
+    "@smithy/util-defaults-mode-node" "^4.0.11"
+    "@smithy/util-endpoints" "^3.0.3"
     "@smithy/util-middleware" "^4.0.2"
     "@smithy/util-retry" "^4.0.3"
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
-"@aws-sdk/region-config-resolver@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.804.0.tgz#c27044e7a3c660056e57d6fa59e55a8a6449f7e9"
-  integrity sha512-Qlr8jVUL5U8Ej+84ElUTGeOok6hQXcJdx5IOSRoqKs6bCKVa8TtwgX1zZIajzjMhMgMlR3/V+M8oDVDKPB43Ug==
+"@aws-sdk/region-config-resolver@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.806.0.tgz#dd0240cff0f96f3e4229585bf533800091d4f802"
+  integrity sha512-cuv5pX55JOlzKC/iLsB5nZ9eUyVgncim3VhhWHZA/KYPh7rLMjOEfZ+xyaE9uLJXGmzOJboFH7+YdTRdIcOgrg==
   dependencies:
     "@aws-sdk/types" "3.804.0"
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.0"
     "@smithy/types" "^4.2.0"
     "@smithy/util-config-provider" "^4.0.0"
     "@smithy/util-middleware" "^4.0.2"
     tslib "^2.6.2"
 
-"@aws-sdk/signature-v4-multi-region@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.804.0.tgz#851f1dd954bf367dbc4a62a8890aea35fa82d81f"
-  integrity sha512-6wxi+f/uvddm2PVRG1gDkjnukfwhEtu3JUAvGqQ56VWbDyM69pxPnGjcwoxCKf0dX16mU8+kHT5CpXsRIpEkkw==
+"@aws-sdk/signature-v4-multi-region@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.806.0.tgz#917e632c29c3ec765121d749ccea5a9f680d2d55"
+  integrity sha512-IrbEnpKvG8d9rUWAvsF28g8qBlQ02FaOxn4cGXtTs0b0BGMK1M+cGQrYjJ7Ak08kIXDxBqsdIlZGsKYr+Ds9+w==
   dependencies:
-    "@aws-sdk/middleware-sdk-s3" "3.804.0"
+    "@aws-sdk/middleware-sdk-s3" "3.806.0"
     "@aws-sdk/types" "3.804.0"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/signature-v4" "^5.1.0"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/token-providers@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.804.0.tgz#6b84452bbcdb3070f60b6e0b540c697c5e4db1ba"
-  integrity sha512-ndcLGD1nHEVJdWRl0lK8SfC0dN4j3X4gcGXEJxK16KZD23veMB2adHP69ySYXNFNo5gI6W9Ct9QXnB+tJCCS1Q==
+"@aws-sdk/token-providers@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.806.0.tgz#e67e9488902c3888b2b2e23f1f93d88ad348a12f"
+  integrity sha512-I6SxcsvV7yinJZmPgGullFHS0tsTKa7K3jEc5dmyCz8X+kZPfsWNffZmtmnCvWXPqMXWBvK6hVaxwomx79yeHA==
   dependencies:
-    "@aws-sdk/nested-clients" "3.804.0"
+    "@aws-sdk/nested-clients" "3.806.0"
     "@aws-sdk/types" "3.804.0"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/shared-ini-file-loader" "^4.0.2"
@@ -715,14 +715,14 @@
   dependencies:
     tslib "^2.6.2"
 
-"@aws-sdk/util-endpoints@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.804.0.tgz#77733192f26672a32b999816870fcb2581dd3036"
-  integrity sha512-mT2R1De1fBT3vgm00ELVFoaArblW3PqGUCVteGGSUdJA525To7h6xPThrNrw3Dn8blAcR8VYGYte/JX7vKgFxw==
+"@aws-sdk/util-endpoints@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.806.0.tgz#bb45ce9a5e10e84014d9114829185752547b98ad"
+  integrity sha512-3YRRgZ+qFuWDdm5uAbxKsr65UAil4KkrFKua9f4m7Be3v24ETiFOOqhanFUIk9/WOtvzF7oFEiDjYKDGlwV2xg==
   dependencies:
     "@aws-sdk/types" "3.804.0"
     "@smithy/types" "^4.2.0"
-    "@smithy/util-endpoints" "^3.0.2"
+    "@smithy/util-endpoints" "^3.0.3"
     tslib "^2.6.2"
 
 "@aws-sdk/util-locate-window@^3.0.0":
@@ -742,14 +742,14 @@
     bowser "^2.11.0"
     tslib "^2.6.2"
 
-"@aws-sdk/util-user-agent-node@3.804.0":
-  version "3.804.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.804.0.tgz#942327170e0acd4581ba1ed1c812db631580908a"
-  integrity sha512-TacXL50ZHOeTUvN9LbHjS3muvvJNpzZp9cAtGRKpKXzlu8zCxPHrVU7dGOF6ONuNG30GpN2xzz81/XcCtg+8/A==
+"@aws-sdk/util-user-agent-node@3.806.0":
+  version "3.806.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.806.0.tgz#a34cd1d72f5ea164c90dcf69008ee4f19449a8a6"
+  integrity sha512-Az2e4/gmPZ4BpB7QRj7U76I+fctXhNcxlcgsaHnMhvt+R30nvzM2EhsyBUvsWl8+r9bnLeYt9BpvEZeq2ANDzA==
   dependencies:
-    "@aws-sdk/middleware-user-agent" "3.804.0"
+    "@aws-sdk/middleware-user-agent" "3.806.0"
     "@aws-sdk/types" "3.804.0"
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.0"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
@@ -1488,10 +1488,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@imranq2/fhir-to-csv@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.7.tgz#86db0bddeda9e39b4faa4d2ec28f236a514ad909"
-  integrity sha512-O5JTsyv8cVr7wwtw/V4svqSYTqC3rYRe0FzqMfgMe9TT4kTkLkHGX4WSanGI7QQW32wFnUQ3AyEfQAsGGNXt3Q==
+"@imranq2/fhir-to-csv@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.8.tgz#3522cbdfe44cd1e37f584a81786f9e2b819a91fd"
+  integrity sha512-LY8/erP6Fyzk4+tiB867ON5J/mYeOGHq8maIj7NGwLZA0GaludZGJMlCHekn22fAGkiUdfPfsPQSlNSjno3bfw==
   dependencies:
     "@json2csv/node" "^7.0.6"
     jszip "^3.10.1"
@@ -1827,9 +1827,9 @@
     ws "^8.18.0"
 
 "@modelcontextprotocol/sdk@^1.8.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz#9f1762efe6f3365f0bf3b019cc9bd1629d19bc50"
-  integrity sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.11.1.tgz#c7f4a1432872ef10130f5d9b0072060c17a3946b"
+  integrity sha512-9LfmxKTb1v+vUS1/emSk1f5ePmTLkb9Le9AxOB5T0XM59EUumwcS45z05h7aiZx3GI0Bl7mjb3FMEglYj+acuQ==
   dependencies:
     content-type "^1.0.5"
     cors "^2.8.5"
@@ -2872,12 +2872,12 @@
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/config-resolver@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-4.1.0.tgz#de1043cbd75f05d99798b0fbcfdaf4b89b0f2f41"
-  integrity sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==
+"@smithy/config-resolver@^4.1.1", "@smithy/config-resolver@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-4.1.2.tgz#a02d6b4c4a68223fd3a2e59d71609517cede2a7b"
+  integrity sha512-7r6mZGwb5LmLJ+zPtkLoznf2EtwEuSWdtid10pjGl/7HefCE4mueOkrfki8JCUm99W6UfP47/r3tbxx9CfBN5A==
   dependencies:
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.1"
     "@smithy/types" "^4.2.0"
     "@smithy/util-config-provider" "^4.0.0"
     "@smithy/util-middleware" "^4.0.2"
@@ -2897,12 +2897,12 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
-"@smithy/credential-provider-imds@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz#1ec34a04842fa69996b151a695b027f0486c69a8"
-  integrity sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==
+"@smithy/credential-provider-imds@^4.0.2", "@smithy/credential-provider-imds@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.4.tgz#01315ab90c4cb3e017c1ee2c6e5f958aeaa7cf78"
+  integrity sha512-jN6M6zaGVyB8FmNGG+xOPQB4N89M1x97MMdMnm1ESjljLS3Qju/IegQizKujaNcy2vXAvrz0en8bobe6E55FEA==
   dependencies:
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.1"
     "@smithy/property-provider" "^4.0.2"
     "@smithy/types" "^4.2.0"
     "@smithy/url-parser" "^4.0.2"
@@ -3033,29 +3033,29 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@smithy/middleware-endpoint@^4.1.2":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.2.tgz#d8ad5e4e439126d7bcc79f0046fc5f9518d8afd8"
-  integrity sha512-EqOy3xaEGQpsKxLlzYstDRJ8eY90CbyBP4cl+w7r45mE60S8YliyL9AgWsdWcyNiB95E2PMqHBEv67nNl1zLfg==
+"@smithy/middleware-endpoint@^4.1.3", "@smithy/middleware-endpoint@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.4.tgz#340de1af8629cd87698d7ee778baea803ff540cd"
+  integrity sha512-qWyYvszzvDjT2AxRvEpNhnMTo8QX9MCAtuSA//kYbXewb+2mEGQCk1UL4dNIrKLcF5KT11dOJtxFYT0kzajq5g==
   dependencies:
     "@smithy/core" "^3.3.1"
     "@smithy/middleware-serde" "^4.0.3"
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.1"
     "@smithy/shared-ini-file-loader" "^4.0.2"
     "@smithy/types" "^4.2.0"
     "@smithy/url-parser" "^4.0.2"
     "@smithy/util-middleware" "^4.0.2"
     tslib "^2.6.2"
 
-"@smithy/middleware-retry@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.1.3.tgz#6d22d21321b2089b4caeb79577a9b40bf4ac6ace"
-  integrity sha512-AsJtI9KiFoEGAhcEKZyzzPfrszAQGcf4HSYKmenz0WGx/6YNvoPPv4OSGfZTCsDmgPHv4pXzxE+7QV7jcGWNKw==
+"@smithy/middleware-retry@^4.1.4":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.1.5.tgz#5ead6fa3ae1f7bcc1b968019a46b06fac887894d"
+  integrity sha512-eQguCTA2TRGyg4P7gDuhRjL2HtN5OKJXysq3Ufj0EppZe4XBmSyKIvVX9ws9KkD3lkJskw1tfE96wMFsiUShaw==
   dependencies:
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.1"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/service-error-classification" "^4.0.3"
-    "@smithy/smithy-client" "^4.2.2"
+    "@smithy/smithy-client" "^4.2.4"
     "@smithy/types" "^4.2.0"
     "@smithy/util-middleware" "^4.0.2"
     "@smithy/util-retry" "^4.0.3"
@@ -3078,10 +3078,10 @@
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@smithy/node-config-provider@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz#017ba626828bced0fa588e795246e5468632f3ef"
-  integrity sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==
+"@smithy/node-config-provider@^4.1.0", "@smithy/node-config-provider@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-4.1.1.tgz#11a7ee33a8874f1842443b1d927c5c14b67bce9f"
+  integrity sha512-1slS5jf5icHETwl5hxEVBj+mh6B+LbVW4yRINsGtUKH+nxM5Pw2H59+qf+JqYFCHp9jssG4vX81f5WKnjMN3Vw==
   dependencies:
     "@smithy/property-provider" "^4.0.2"
     "@smithy/shared-ini-file-loader" "^4.0.2"
@@ -3161,13 +3161,13 @@
     "@smithy/util-utf8" "^4.0.0"
     tslib "^2.6.2"
 
-"@smithy/smithy-client@^4.2.2":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.2.2.tgz#b599c841c376994a3b3019942b1d3f1ecfaf964b"
-  integrity sha512-3AnHfsMdq9Wg7+3BeR1HuLWI9+DMA/SoHVpCWq6xSsa52ikNd6nlF/wFzdpHyGtVa+Aji6lMgvwOF4sGcVA7SA==
+"@smithy/smithy-client@^4.2.3", "@smithy/smithy-client@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.2.4.tgz#a6b5b8338fdcdd5a517689c105a6730eb20ec8f4"
+  integrity sha512-oolSEpr/ABUtVmFMdNgi6sSXsK4csV9n4XM9yXgvDJGRa32tQDUdv9s+ztFZKccay1AiTWLSGsyDj2xy1gsv7Q==
   dependencies:
     "@smithy/core" "^3.3.1"
-    "@smithy/middleware-endpoint" "^4.1.2"
+    "@smithy/middleware-endpoint" "^4.1.4"
     "@smithy/middleware-stack" "^4.0.2"
     "@smithy/protocol-http" "^5.1.0"
     "@smithy/types" "^4.2.0"
@@ -3236,36 +3236,36 @@
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/util-defaults-mode-browser@^4.0.10":
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.10.tgz#50cc8aff3e1881848d574ea777439ff74a465550"
-  integrity sha512-2k6fgUNOZ1Rn0gEjvGPGrDEINLG8qSBHsN7xlkkbO+fnHJ36BQPDzhFfMmYSDS8AgzoygqQiDOQ+6Hp2vBTUdA==
+"@smithy/util-defaults-mode-browser@^4.0.11":
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.12.tgz#e82d846277c28d3da1cb391a2720c4c152195741"
+  integrity sha512-0vPKiC+rXWMq397tsa/RFcO/kJ1UsibgNCXScMsRwzm9WMT4QjGf43zVPWZ5hPLu3z/1XddiZFIlKcu2j/yUuQ==
   dependencies:
     "@smithy/property-provider" "^4.0.2"
-    "@smithy/smithy-client" "^4.2.2"
+    "@smithy/smithy-client" "^4.2.4"
     "@smithy/types" "^4.2.0"
     bowser "^2.11.0"
     tslib "^2.6.2"
 
-"@smithy/util-defaults-mode-node@^4.0.10":
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.10.tgz#f85b0a12fe3d1bc63e776ee8100d14055a211526"
-  integrity sha512-2XR1WRglLVmoIFts7bODUTgBdVyvkfKNkydHrlsI5VxW9q3s1hnJCuY+f1OHzvj5ue23q4vydM2fjrMjf2HSdQ==
+"@smithy/util-defaults-mode-node@^4.0.11":
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.12.tgz#a883cba94d64fc0da65a98c2081c9f383fea95a3"
+  integrity sha512-zCx9noceM3Pw2jvcJ3w3RbvKnPe3lCo6txH9ksZj6CeRZPkvRZPLXmKVSOvDr9QQP3VRq/WnBLd+LTZAL7+0IQ==
   dependencies:
-    "@smithy/config-resolver" "^4.1.0"
-    "@smithy/credential-provider-imds" "^4.0.2"
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/config-resolver" "^4.1.2"
+    "@smithy/credential-provider-imds" "^4.0.4"
+    "@smithy/node-config-provider" "^4.1.1"
     "@smithy/property-provider" "^4.0.2"
-    "@smithy/smithy-client" "^4.2.2"
+    "@smithy/smithy-client" "^4.2.4"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
-"@smithy/util-endpoints@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@smithy/util-endpoints/-/util-endpoints-3.0.2.tgz#6933a0d6d4a349523ef71ca9540c9c0b222b559e"
-  integrity sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==
+"@smithy/util-endpoints@^3.0.3":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@smithy/util-endpoints/-/util-endpoints-3.0.4.tgz#6211dc92aff6ed747b060b257d3669e9fce0685f"
+  integrity sha512-VfFATC1bmZLV2858B/O1NpMcL32wYo8DPPhHxYxDCodDl3f3mSZ5oJheW1IF91A0EeAADz2WsakM/hGGPGNKLg==
   dependencies:
-    "@smithy/node-config-provider" "^4.0.2"
+    "@smithy/node-config-provider" "^4.1.1"
     "@smithy/types" "^4.2.0"
     tslib "^2.6.2"
 
@@ -3541,9 +3541,9 @@
     form-data "^4.0.0"
 
 "@types/node@*", "@types/node@>=13.7.0", "@types/node@^22.0.0":
-  version "22.15.15"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.15.tgz#8877c05c18e552e738438e477d7ba22c5d73a57c"
-  integrity sha512-R5muMcZob3/Jjchn5LcO8jdKwSCbzqmPB6ruBxMcf9kbxtniZHP327s6C37iOfuw8mbKK3cAQa7sEl7afLrQ8A==
+  version "22.15.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.17.tgz#355ccec95f705b664e4332bb64a7f07db30b7055"
+  integrity sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==
   dependencies:
     undici-types "~6.21.0"
 
@@ -3555,9 +3555,9 @@
     "@types/pg" "*"
 
 "@types/pg@*":
-  version "8.15.0"
-  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.15.0.tgz#a11bffa2277cab3d091d6024edb507aff4f21b5c"
-  integrity sha512-JFxVIO0hZCbQXQGbRBQjbRWNCG3CujfEUBD4Ny2l0QqDyE0vqAPiMSyx0AIszMS0KdLZxz2GxZUUF3FBUXhOXA==
+  version "8.15.1"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.15.1.tgz#ee6fad7608d2348f55226a5fb5118efdab97ecf9"
+  integrity sha512-YKHrkGWBX5+ivzvOQ66I0fdqsQTsvxqM0AGP2i0XrVZ9DP5VA/deEbTf7VuLPGpY7fJB9uGbkZ6KjVhuHcrTkQ==
   dependencies:
     "@types/node" "*"
     pg-protocol "*"
@@ -3705,9 +3705,9 @@
     tslib "^2.3.1"
 
 "@whatwg-node/promise-helpers@^1.0.0":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@whatwg-node/promise-helpers/-/promise-helpers-1.3.1.tgz#65f1820fa652ddc1062aa0fe7456726e8676ea43"
-  integrity sha512-D+OwTEunoQhVHVToD80dPhfz9xgPLqJyEA3F5jCRM14A2u8tBBQVdZekqfqx6ZAfZ+POT4Hb0dn601UKMsvADw==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz#3b54987ad6517ef6db5920c66a6f0dada606587d"
+  integrity sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==
   dependencies:
     tslib "^2.6.3"
 
@@ -4944,9 +4944,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.5.149:
-  version "1.5.150"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.150.tgz#3120bf34453a7a82cb4d9335df20680b2bb40649"
-  integrity sha512-rOOkP2ZUMx1yL4fCxXQKDHQ8ZXwisb2OycOQVKHgvB3ZI4CvehOd4y2tfnnLDieJ3Zs1RL1Dlp3cMkyIn7nnXA==
+  version "1.5.151"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.151.tgz#5edd6c17e1b2f14b4662c41b9379f96cc8c2bb7c"
+  integrity sha512-Rl6uugut2l9sLojjS4H4SAr3A4IgACMLgpuEMPYCVcKydzfyPrn5absNRju38IhQOf/NwjJY8OGWjlteqYeBCA==
 
 emitter-listener@^1.0.1:
   version "1.1.2"
@@ -5186,9 +5186,9 @@ eventsource-parser@^3.0.1:
   integrity sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==
 
 eventsource@^3.0.2:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.6.tgz#5c4b24cd70c0323eed2651a5ee07bd4bc391e656"
-  integrity sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.7.tgz#1157622e2f5377bb6aef2114372728ba0c156989"
+  integrity sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==
   dependencies:
     eventsource-parser "^3.0.1"
 
@@ -5896,9 +5896,9 @@ htmlparser2@^8.0.0:
     entities "^4.4.0"
 
 http-cache-semantics@^4.1.0, http-cache-semantics@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
-  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#205f4db64f8562b76a4ff9235aa5279839a09dd5"
+  integrity sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==
 
 http-errors@2.0.0, http-errors@^2.0.0:
   version "2.0.0"
@@ -8251,9 +8251,9 @@ proto-list@~1.2.1:
   integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
 
 protobufjs@^7.2.3, protobufjs@^7.2.5:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.4.0.tgz#7efe324ce9b3b61c82aae5de810d287bc08a248a"
-  integrity sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.1.tgz#0567c329db2868672a91438d1b1d3fc011628729"
+  integrity sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,14 +1488,14 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@imranq2/fhir-to-csv@^1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.9.tgz#f47398d95d6db0d2ba529a428865aa220e83f983"
-  integrity sha512-YRbAChVVVEB1lmwY2C0uX/eT2fUUWDu/NThzf6u2P8uHIobEMDBzMQylhIclICSh3XYCj1dZgQoZATIXdbGhRg==
+"@imranq2/fhir-to-csv@^1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.10.tgz#2004f3edf88cf1aee6fea2883548102fa029d5ca"
+  integrity sha512-YxVAcjoFOf6rV85+gt8o6XxpoEJlRdDyljxX2jc/cyzj4yjSp1QFkPXaEsjf0C/R1CdR7lowf335j3tFob0KAA==
   dependencies:
     "@json2csv/node" "^7.0.6"
     jszip "^3.10.1"
-    xlsx "^0.18.5"
+    xlsx "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -3747,11 +3747,6 @@ acorn@^8.14.0, acorn@^8.8.2:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
   integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
 
-adler-32@~1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/adler-32/-/adler-32-1.3.1.tgz#1dbf0b36dda0012189a32b3679061932df1821e2"
-  integrity sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==
-
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -4286,14 +4281,6 @@ caniuse-lite@^1.0.30001716:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz#5d9fec5ce09796a1893013825510678928aca129"
   integrity sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==
 
-cfb@~1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/cfb/-/cfb-1.2.2.tgz#94e687628c700e5155436dac05f74e08df23bc44"
-  integrity sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==
-  dependencies:
-    adler-32 "~1.3.0"
-    crc-32 "~1.2.0"
-
 chalk@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -4402,11 +4389,6 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
-
-codepage@~1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/codepage/-/codepage-1.15.0.tgz#2e00519024b39424ec66eeb3ec07227e692618ab"
-  integrity sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.2"
@@ -4654,11 +4636,6 @@ cosmiconfig@^5.2.1:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
-
-crc-32@~1.2.0, crc-32@~1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
-  integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
 
 create-jest@^29.7.0:
   version "29.7.0"
@@ -5546,11 +5523,6 @@ fp-and-or@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/fp-and-or/-/fp-and-or-0.1.4.tgz#0268c800c359ede259cdcbc352654e698b7ea299"
   integrity sha512-+yRYRhpnFPWXSly/6V4Lw9IfOV26uu30kynGJ03PW+MnjOEQe45RZ141QcS0aJehYBYA50GfCDnsRbFJdhssRw==
-
-frac@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/frac/-/frac-1.1.2.tgz#3d74f7f6478c88a1b5020306d747dc6313c74d0b"
-  integrity sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==
 
 fresh@0.5.2:
   version "0.5.2"
@@ -8972,13 +8944,6 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-ssf@~0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/ssf/-/ssf-0.11.2.tgz#0b99698b237548d088fc43cdf2b70c1a7512c06c"
-  integrity sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==
-  dependencies:
-    frac "~1.1.2"
-
 ssri@^10.0.0:
   version "10.0.6"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-10.0.6.tgz#a8aade2de60ba2bce8688e3fa349bad05c7dc1e5"
@@ -9716,20 +9681,10 @@ winston@^3.13.0:
     triple-beam "^1.3.0"
     winston-transport "^4.9.0"
 
-wmf@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wmf/-/wmf-1.0.2.tgz#7d19d621071a08c2bdc6b7e688a9c435298cc2da"
-  integrity sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==
-
 word-wrap@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
-
-word@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/word/-/word-0.3.0.tgz#8542157e4f8e849f4a363a288992d47612db9961"
-  integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
@@ -9790,19 +9745,6 @@ xdg-basedir@^5.0.1, xdg-basedir@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-5.1.0.tgz#1efba19425e73be1bc6f2a6ceb52a3d2c884c0c9"
   integrity sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==
-
-xlsx@^0.18.5:
-  version "0.18.5"
-  resolved "https://registry.yarnpkg.com/xlsx/-/xlsx-0.18.5.tgz#16711b9113c848076b8a177022799ad356eba7d0"
-  integrity sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==
-  dependencies:
-    adler-32 "~1.3.0"
-    cfb "~1.2.1"
-    codepage "~1.15.0"
-    crc-32 "~1.2.1"
-    ssf "~0.11.2"
-    wmf "~1.0.1"
-    word "~0.3.0"
 
 "xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz":
   version "0.20.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,10 +1488,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@imranq2/fhir-to-csv@^1.0.11":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.11.tgz#b427a4cd8abf3f8884743e793cc432f8fe73e9f1"
-  integrity sha512-bFA2p7e75PFITbMFg0O5Pj1vSRRXB5dzjmQaUXvwVcEQYQvCzjA8QsqfJoG5xGIJ1qjbzWZQ11hV5aLyQOJEaQ==
+"@imranq2/fhir-to-csv@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.12.tgz#1a5ef8d1b6466d0cb80f02aa55a7ae701fa6db83"
+  integrity sha512-TEUQWFWwP2IKRyzUQJ15RGXRCgaDS6WbJxuaOmrUc1G7toBFhkG/w+N424RohJQUOT5znWyVdnLtosjId7Y3QQ==
   dependencies:
     "@json2csv/node" "^7.0.6"
     fflate "^0.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,10 +1488,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@imranq2/fhir-to-csv@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.8.tgz#3522cbdfe44cd1e37f584a81786f9e2b819a91fd"
-  integrity sha512-LY8/erP6Fyzk4+tiB867ON5J/mYeOGHq8maIj7NGwLZA0GaludZGJMlCHekn22fAGkiUdfPfsPQSlNSjno3bfw==
+"@imranq2/fhir-to-csv@^1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.9.tgz#f47398d95d6db0d2ba529a428865aa220e83f983"
+  integrity sha512-YRbAChVVVEB1lmwY2C0uX/eT2fUUWDu/NThzf6u2P8uHIobEMDBzMQylhIclICSh3XYCj1dZgQoZATIXdbGhRg==
   dependencies:
     "@json2csv/node" "^7.0.6"
     jszip "^3.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,10 +1488,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@imranq2/fhir-to-csv@^1.0.12":
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.12.tgz#1a5ef8d1b6466d0cb80f02aa55a7ae701fa6db83"
-  integrity sha512-TEUQWFWwP2IKRyzUQJ15RGXRCgaDS6WbJxuaOmrUc1G7toBFhkG/w+N424RohJQUOT5znWyVdnLtosjId7Y3QQ==
+"@imranq2/fhir-to-csv@^1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@imranq2/fhir-to-csv/-/fhir-to-csv-1.0.13.tgz#8a8904da0a79ec54da8dd7bee38933e82df38a23"
+  integrity sha512-BGin6mX0Wr9/+dedjhHfCHz50elN7UueH5rJ7+XfmmozOuLjj+RUuAGURC2Op1q0C5EzSdu1bZ64WReQ6zk1pA==
   dependencies:
     "@json2csv/node" "^7.0.6"
     fflate "^0.8.2"


### PR DESCRIPTION
This PR updates the fhir-to-csv package and related code to support Excel output formats alongside CSV/TSV. It adjusts import paths, updates asynchronous API calls to synchronous ones where applicable, and integrates new Excel writer logic throughout streaming and conversion files.

Update of the fhir-to-csv dependency and related import paths
Addition of new functionality for handling Excel responses in both production and tests
Minor refactoring in documentation and JSDoc comments