### PR TITLE
IGNT-158 Support query string for $merge endpoint to disable smart merge

### DIFF
--- a/src/operations/merge/merge.js
+++ b/src/operations/merge/merge.js
@@ -21,6 +21,7 @@ const { BwellPersonFinder } = require('../../utils/bwellPersonFinder');
 const { MergeValidator } = require('./mergeValidator');
 const { logInfo } = require('../common/logging');
 const { ACCESS_LOGS_ENTRY_DATA } = require('../../constants');
+const { isTrue } = require('../../utils/isTrue');
 
 class MergeOperation {
     /**
@@ -185,7 +186,7 @@ class MergeOperation {
                 /** @type {boolean|null|undefined} */ smartMerge
             } = parsedArgs;
 
-            const effectiveSmartMerge = smartMerge ?? true;
+            const effectiveSmartMerge = isTrue(smartMerge ?? true);
 
             // read the incoming resource from request body
             /**

--- a/src/operations/merge/merge.js
+++ b/src/operations/merge/merge.js
@@ -1,5 +1,5 @@
 const httpContext = require('express-http-context');
-const moment = require('moment-timezone');
+require('moment-timezone');
 const { assertTypeEquals, assertIsValid } = require('../../utils/assertType');
 const { MergeManager } = require('./mergeManager');
 const { DatabaseBulkInserter } = require('../../dataLayer/databaseBulkInserter');

--- a/src/operations/merge/merge.js
+++ b/src/operations/merge/merge.js
@@ -180,7 +180,12 @@ class MergeOperation {
 
         // noinspection JSCheckFunctionSignatures
         try {
-            const { /** @type {string} */ base_version } = parsedArgs;
+            const {
+                /** @type {string} */ base_version,
+                /** @type {boolean|null|undefined} */ smartMerge
+            } = parsedArgs;
+
+            const effectiveSmartMerge = smartMerge ?? true;
 
             // read the incoming resource from request body
             /**
@@ -217,7 +222,8 @@ class MergeOperation {
                 resources_incoming: validResources,
                 resourceType,
                 base_version,
-                requestInfo
+                requestInfo,
+                smartMerge:effectiveSmartMerge
             });
             validResources = mergeResourceResults
                 .flatMap(m => m.resource)

--- a/src/operations/merge/mergeManager.js
+++ b/src/operations/merge/mergeManager.js
@@ -583,7 +583,11 @@ class MergeManager {
             });
             return { resource: resourceToMerge, mergeError };
         } catch (error) {
-            return { resource: null, mergeError: MergeResultEntry.createFromError({ error, resource: resourceToMerge }) }
+            return { resource: null,
+                mergeError: MergeResultEntry.createFromError({ error,
+                    resource: resourceToMerge
+                })
+            };
         }
     }
 

--- a/src/operations/merge/mergeManager.js
+++ b/src/operations/merge/mergeManager.js
@@ -144,13 +144,15 @@ class MergeManager {
      * @param {Resource} currentResource
      * @param {string} base_version
      * @param {FhirRequestInfo} requestInfo
+     * @param {boolean} smartMerge
      * @returns {Promise<OperationOutcome|null>}
      */
     async mergeExistingAsync ({
         resourceToMerge,
         currentResource,
         base_version,
-        requestInfo
+        requestInfo,
+        smartMerge=true
     }) {
         assertTypeEquals(resourceToMerge, Resource);
         assertTypeEquals(currentResource, Resource);
@@ -177,6 +179,7 @@ class MergeManager {
             requestInfo,
             currentResource,
             resourceToMerge,
+            smartMerge,
             limitToPaths: undefined,
             databaseAttachmentManager: this.databaseAttachmentManager
         });
@@ -295,6 +298,7 @@ class MergeManager {
      * @param {string} resourceType
      * @param {string} base_version
      * @param {FhirRequestInfo} requestInfo
+     * @param {boolean} smartMerge
      * @return {Promise<MergeResultEntry|null>}
      */
     async mergeResourceAsync (
@@ -302,7 +306,8 @@ class MergeManager {
             resourceToMerge,
             resourceType,
             base_version,
-            requestInfo
+            requestInfo,
+            smartMerge=true
         }
     ) {
         assertTypeEquals(resourceToMerge, Resource);
@@ -351,7 +356,7 @@ class MergeManager {
             // check if resource was found in database or not
             if (currentResource && currentResource.meta) {
                 validationError = await this.mergeExistingAsync({
-                    resourceToMerge, currentResource, requestInfo, base_version
+                    resourceToMerge, currentResource, requestInfo, base_version, smartMerge
                 });
             } else {
                 // Check if meta & meta.source exists in resource
@@ -496,6 +501,7 @@ class MergeManager {
      * @param {string} resourceType
      * @param {string} base_version
      * @param {FhirRequestInfo} requestInfo
+     * @param {boolean} smartMerge
      * @returns {Promise<{resource: (Resource|null), mergeError: (MergeResultEntry|null)}[]>}
      */
     async mergeResourceListAsync (
@@ -503,7 +509,8 @@ class MergeManager {
             resources_incoming,
             resourceType,
             base_version,
-            requestInfo
+            requestInfo,
+            smartMerge = true
         }
     ) {
         assertTypeEquals(requestInfo, FhirRequestInfo);
@@ -525,7 +532,8 @@ class MergeManager {
                 resourceToMerge: x,
                 resourceType,
                 base_version,
-                requestInfo
+                requestInfo,
+                smartMerge
             });
 
             /**
@@ -552,6 +560,7 @@ class MergeManager {
      * @param {string} resourceType
      * @param {string} base_version
      * @param {FhirRequestInfo} requestInfo
+     * @param {boolean} smartMerge
      * @return {Promise<{resource: Resource|null, mergeError: MergeResultEntry|null}>}
      */
     async mergeResourceWithRetryAsync (
@@ -559,7 +568,8 @@ class MergeManager {
             resourceToMerge,
             resourceType,
             base_version,
-            requestInfo
+            requestInfo,
+            smartMerge=true
         }
     ) {
         assertTypeEquals(resourceToMerge, Resource);
@@ -568,7 +578,8 @@ class MergeManager {
                 resourceToMerge,
                 resourceType,
                 base_version,
-                requestInfo
+                requestInfo,
+                smartMerge
             });
             return { resource: resourceToMerge, mergeError };
         } catch (error) {

--- a/src/tests/merge/merge_replace/fixtures/Person/person1.json
+++ b/src/tests/merge/merge_replace/fixtures/Person/person1.json
@@ -1,0 +1,86 @@
+[
+    {
+        "resourceType": "Person",
+        "id": "aba5bcf41cf64435839cf0568c121843",
+        "meta": {
+            "versionId": "1",
+            "source": "bwell",
+            "profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-person"],
+            "security": [
+                {
+                    "system": "https://www.icanbwell.com/access",
+                    "code": "bwell"
+                },
+                {
+                    "system": "https://www.icanbwell.com/owner",
+                    "code": "bwell"
+                }
+            ],
+            "lastUpdated": "2022-08-28T22:12:13.000Z"
+        },
+        "identifier": [
+            {
+                "type": {
+                    "coding": [
+                        {
+                            "system": "https://www.icanbwell.com",
+                            "code": "FHIR_id",
+                            "display": "bWell FHIR id"
+                        }
+                    ]
+                },
+                "system": "https://www.icanbwell.com",
+                "value": "bwell-aba5bcf41cf64435839cf0568c121843"
+            }
+        ],
+        "name": [
+            {
+                "use": "official",
+                "family": "essnhlmvgt",
+                "given": ["Sweetie"]
+            }
+        ],
+        "telecom": [
+            {
+                "system": "phone",
+                "value": "+15125550156",
+                "use": "home"
+            },
+            {
+                "system": "email",
+                "value": "bwell+62365zoakm@mailinator.com",
+                "use": "home"
+            }
+        ],
+        "gender": "male",
+        "birthDate": "1991-09-10",
+        "address": [
+            {
+                "line": ["801 W 5th St"],
+                "city": "Austin",
+                "state": "TX",
+                "postalCode": "78703"
+            }
+        ],
+        "link": [
+            {
+                "target": {
+                    "reference": "Person/a58e50292d79469691d3048e787434cc",
+                    "type": "Person"
+                },
+                "assurance": "level4"
+            },
+            {
+                "target": {
+                    "reference": "Patient/26a2b5508f6840a1b4c5f67d38360060",
+                    "type": "Patient"
+                },
+                "assurance": "level4"
+            }
+        ],
+        "_access": {
+            "bwell": 1
+        },
+        "_id": "630be83db0fb3dc74a4f4651"
+    }
+]

--- a/src/tests/merge/merge_replace/fixtures/Person/person1_duplicate_phone.json
+++ b/src/tests/merge/merge_replace/fixtures/Person/person1_duplicate_phone.json
@@ -42,7 +42,7 @@
         "telecom": [
             {
                 "system": "phone",
-                "value": "+15125550156",
+                "value": "+15555550123",
                 "use": "home"
             },
             {

--- a/src/tests/merge/merge_replace/fixtures/expected/expected_Replaced_Phone.json
+++ b/src/tests/merge/merge_replace/fixtures/expected/expected_Replaced_Phone.json
@@ -1,0 +1,164 @@
+{
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Person",
+        "id": "aba5bcf41cf64435839cf0568c121843",
+        "meta": {
+          "versionId": "2",
+          "lastUpdated": "2025-05-20T20:47:40.096Z",
+          "source": "bwell",
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-person"
+          ],
+          "security": [
+            {
+              "id": "2d1e0b6f-56fb-5dd9-bc38-f01b5902fde2",
+              "system": "https://www.icanbwell.com/access",
+              "code": "bwell"
+            },
+            {
+              "id": "70ae40c6-f2bd-54a0-aa66-656be4cce72b",
+              "system": "https://www.icanbwell.com/owner",
+              "code": "bwell"
+            },
+            {
+              "id": "33ced3c5-0807-582a-b03a-df7d6e95a41c",
+              "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+              "code": "bwell"
+            }
+          ]
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "id": "866c7fe6-2825-5413-9ca6-3a3fe7846140",
+                  "system": "https://www.icanbwell.com",
+                  "code": "FHIR_id",
+                  "display": "bWell FHIR id"
+                }
+              ]
+            },
+            "system": "https://www.icanbwell.com",
+            "value": "bwell-aba5bcf41cf64435839cf0568c121843"
+          },
+          {
+            "id": "sourceId",
+            "system": "https://www.icanbwell.com/sourceId",
+            "value": "aba5bcf41cf64435839cf0568c121843"
+          },
+          {
+            "id": "uuid",
+            "system": "https://www.icanbwell.com/uuid",
+            "value": "849cb4f0-033b-5d6e-a614-9bbbbb3ba11e"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "essnhlmvgt",
+            "given": [
+              "Sweetie"
+            ]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+15125550156",
+            "use": "home"
+          },
+          {
+            "system": "email",
+            "value": "bwell+62365zoakm@mailinator.com",
+            "use": "home"
+          },
+          {
+            "system": "phone",
+            "value": "+15555550123",
+            "use": "home"
+          }
+        ],
+        "gender": "male",
+        "birthDate": "1991-09-10",
+        "address": [
+          {
+            "line": [
+              "801 W 5th St"
+            ],
+            "city": "Austin",
+            "state": "TX",
+            "postalCode": "78703"
+          }
+        ],
+        "link": [
+          {
+            "target": {
+              "extension": [
+                {
+                  "id": "sourceId",
+                  "url": "https://www.icanbwell.com/sourceId",
+                  "valueString": "Person/a58e50292d79469691d3048e787434cc"
+                },
+                {
+                  "id": "uuid",
+                  "url": "https://www.icanbwell.com/uuid",
+                  "valueString": "Person/d6d3a5b6-3178-5aa1-bca4-f60a5214bd2d"
+                },
+                {
+                  "id": "sourceAssigningAuthority",
+                  "url": "https://www.icanbwell.com/sourceAssigningAuthority",
+                  "valueString": "bwell"
+                }
+              ],
+              "reference": "Person/a58e50292d79469691d3048e787434cc",
+              "type": "Person"
+            },
+            "assurance": "level4"
+          },
+          {
+            "target": {
+              "extension": [
+                {
+                  "id": "sourceId",
+                  "url": "https://www.icanbwell.com/sourceId",
+                  "valueString": "Patient/26a2b5508f6840a1b4c5f67d38360060"
+                },
+                {
+                  "id": "uuid",
+                  "url": "https://www.icanbwell.com/uuid",
+                  "valueString": "Patient/aa0aae87-1b98-50ee-aefa-58f8f04bf6a3"
+                },
+                {
+                  "id": "sourceAssigningAuthority",
+                  "url": "https://www.icanbwell.com/sourceAssigningAuthority",
+                  "valueString": "bwell"
+                }
+              ],
+              "reference": "Patient/26a2b5508f6840a1b4c5f67d38360060",
+              "type": "Patient"
+            },
+            "assurance": "level4"
+          }
+        ]
+      }
+    }
+  ],
+  "resourceType": "Bundle",
+  "id": "1234",
+  "type": "searchset",
+  "timestamp": "2025-05-20T08:47:40.4040Z",
+  "total": 0,
+  "link": [
+    {
+      "relation": "self",
+      "url": "http://localhost:3000/4_0_0/Person/?_bundle=1"
+    },
+    {
+      "relation": "next",
+      "url": "http://localhost:3000/4_0_0/Person/?_bundle=1&id%3Aabove=849cb4f0-033b-5d6e-a614-9bbbbb3ba11e"
+    }
+  ]
+}

--- a/src/tests/merge/merge_replace/fixtures/expected/expected_Replaced_Phone.json
+++ b/src/tests/merge/merge_replace/fixtures/expected/expected_Replaced_Phone.json
@@ -150,7 +150,7 @@
   "id": "1234",
   "type": "searchset",
   "timestamp": "2025-05-20T08:47:40.4040Z",
-  "total": 0,
+  "total": 1,
   "link": [
     {
       "relation": "self",

--- a/src/tests/merge/merge_replace/fixtures/expected/expected_Replaced_Phone.json
+++ b/src/tests/merge/merge_replace/fixtures/expected/expected_Replaced_Phone.json
@@ -150,7 +150,7 @@
   "id": "1234",
   "type": "searchset",
   "timestamp": "2025-05-20T08:47:40.4040Z",
-  "total": 1,
+  "total": 0,
   "link": [
     {
       "relation": "self",

--- a/src/tests/merge/merge_replace/fixtures/expected/expected_merged_Phone.json
+++ b/src/tests/merge/merge_replace/fixtures/expected/expected_merged_Phone.json
@@ -5,7 +5,7 @@
         "resourceType": "Person",
         "id": "aba5bcf41cf64435839cf0568c121843",
         "meta": {
-          "versionId": "3",
+          "versionId": "2",
           "lastUpdated": "2025-05-20T20:47:40.096Z",
           "source": "bwell",
           "profile": [
@@ -67,12 +67,17 @@
         "telecom": [
           {
             "system": "phone",
-            "value": "+15555550123",
+            "value": "+15125550156",
             "use": "home"
           },
           {
             "system": "email",
             "value": "bwell+62365zoakm@mailinator.com",
+            "use": "home"
+          },
+          {
+            "system": "phone",
+            "value": "+15555550123",
             "use": "home"
           }
         ],

--- a/src/tests/merge/merge_replace/merge_put_replace_scenario.test.js
+++ b/src/tests/merge/merge_replace/merge_put_replace_scenario.test.js
@@ -1,0 +1,63 @@
+// test file
+const person1Resource = require('./fixtures/Person/person1.json');
+
+// expected
+const expectedReplacedPersonResources = require('./fixtures/expected/expected_Replaced_Phone.json');
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    createTestRequest,
+    mockHttpContext
+} = require('../../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+const deepcopy = require('deepcopy');
+
+describe('Person Tests', () => {
+    let requestId;
+    beforeEach(async () => {
+        await commonBeforeEach();
+        requestId = mockHttpContext();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    test('bulk replace with smartMerge=false simulates bulk PUT', async () => {
+        const request = await createTestRequest();
+
+        person1Resource[0].meta.source = 'bwell';
+
+        // Step 1: Create initial resource
+        let resp = await request
+            .post('/4_0_0/Person/1/$merge')
+            .send(person1Resource)
+            .set(getHeaders());
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        // Step 2: Replace with a new version (simulate PUT)
+        const updatedResource = deepcopy(person1Resource);
+        // Update the phone number for each person in the array
+        updatedResource.forEach((person) => {
+            if (Array.isArray(person.telecom)) {
+                const phoneEntry = person.telecom.find((t) => t.system === 'phone');
+                if (phoneEntry) {
+                    phoneEntry.value = '+15555550123'; // new phone number
+                }
+            }
+        });
+
+        resp = await request
+            .post('/4_0_0/Person/1/$merge?smartMerge=false')
+            .send(updatedResource)
+            .set(getHeaders());
+        expect(resp).toHaveMergeResponse({ updated: true });
+
+        // // Step 3: Assert the resource is fully replaced (not merged)
+        resp = await request.get('/4_0_0/Person/?_bundle=1').set(getHeaders());
+        // noinspection JSUnresolvedFunction
+        expect(resp).toHaveResponse(expectedReplacedPersonResources);
+    });
+});


### PR DESCRIPTION
Key Changes and Improvements:

Smart Merge Functionality Turn ON/FF

Added a new **`smartMerge`** parameter (**`default: true`)** to control merge behavior
Allows simulating a bulk **`PUT`** operation when **`smartMerge`** is set to **`false`**

Code Modifications:

Updated **`merge.js`** and **`mergeManager.js `** to support the new **`smartMerge`** parameter
Propagated the **`smartMerge`** flag through various merge-related methods
Introduced a new test case to validate the bulk replace scenario


NOTE:  [ResourceMerger]( https://github.com/icanbwell/fhir-server/blob/main/src/operations/common/resourceMerger.js#L363-L366) already supports this functionality; we just needed to disable smart merge so that a patch is generated and the update is applied directly to the resource like in PUT [so _NO_ smart merging].
