### PR TITLE
DCON-3268: Fixed the authservice.verify running twice

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -351,21 +351,21 @@ function createApp({fnGetContainer}) {
     adminRouter.use(passport.authenticate('adminStrategy', {session: false}, null));
     // Add admin routes with json body parser
     const allowedContentTypes = ['application/fhir+json', 'application/json+fhir'];
-    adminRouter.get('/admin{/:op}{/:id}', (req, res) => handleAdminGet(fnGetContainer, req, res));
+    adminRouter.get('{/:op}{/:id}', (req, res) => handleAdminGet(fnGetContainer, req, res));
     adminRouter.post(
-        '/admin{/:op}{/:id}',
+        '{/:op}{/:id}',
         validateContentTypeMiddleware({allowedContentTypes: allowedContentTypes}),
         express.json({type: allowedContentTypes}),
         (req, res) => handleAdminPost(fnGetContainer, req, res)
     );
-    adminRouter.delete('/admin{/:op}', (req, res) => handleAdminDelete(fnGetContainer, req, res));
+    adminRouter.delete('{/:op}', (req, res) => handleAdminDelete(fnGetContainer, req, res));
     adminRouter.put(
-        '/admin{/:op}{/:id}',
+        '{/:op}{/:id}',
         validateContentTypeMiddleware({allowedContentTypes: allowedContentTypes}),
         express.json({type: allowedContentTypes}),
         (req, res) => handleAdminPut(fnGetContainer, req, res));
 
-    app.use(adminRouter);
+    app.use('/admin', adminRouter);
 
     // noinspection JSCheckFunctionSignatures
     passport.use('graphqlStrategy', container.jwt_strategy);

--- a/src/middleware/fhir/router.js
+++ b/src/middleware/fhir/router.js
@@ -266,7 +266,7 @@ class FhirRouter {
                 const metadataPath = baseUrl === '/' ? '/metadata' : `${baseUrl}/metadata`;
                 app.options(metadataPath, cors(corsOptions)); // Enable metadata route
 
-                app.get(metadataPath, cors(corsOptions), getArgsMiddleware(), metadataConfig.controller({
+                app.get(metadataPath, cors(corsOptions), getArgsMiddleware(), authenticationMiddleware(config), metadataConfig.controller({
                     profiles,
                     security,
                     statementGenerator
@@ -278,7 +278,7 @@ class FhirRouter {
             // Enable cors with preflight
             app.options(metadataConfig.path, cors(corsOptions)); // Enable metadata route
 
-            app.get(metadataConfig.path, cors(corsOptions), versionValidationMiddleware(versionValidationConfiguration), getArgsMiddleware(), metadataConfig.controller({
+            app.get(metadataConfig.path, cors(corsOptions), versionValidationMiddleware(versionValidationConfiguration), getArgsMiddleware(), authenticationMiddleware(config), metadataConfig.controller({
                 profiles,
                 security,
                 statementGenerator


### PR DESCRIPTION
This pull request focuses on resolving the bug related to the authService.verify function running twice due to the adminRouter set globally  improving the routing and security of the application's admin and FHIR metadata endpoints. The main changes clarify admin route mounting and add authentication to FHIR metadata endpoints.

**Routing improvements:**
* The `adminRouter` is now mounted at the `/admin` path, and all internal admin route definitions have been updated to remove the redundant `/admin` prefix. This ensures all admin routes are consistently accessed under `/admin`, simplifying route management.

**Security enhancements:**
* The FHIR metadata endpoints now include the `authenticationMiddleware`, ensuring that these endpoints are protected and require authentication. This applies to both the base and versioned metadata routes. [[1]](diffhunk://#diff-3b7b3dd52d95ca92b093dccb6cf7b400fd1840dc57a424d24fc6f0962689a5dbL269-R269) [[2]](diffhunk://#diff-3b7b3dd52d95ca92b093dccb6cf7b400fd1840dc57a424d24fc6f0962689a5dbL281-R281)