### PR TITLE
DCON-3409 Add real-time AuditEvent write to ClickHouse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ up:
 	if [ "`docker inspect --format {{.State.Health.Status}} fhir-clickhouse`" != "healthy" ]; then docker ps && docker logs fhir-clickhouse && printf "========== ERROR: fhir-clickhouse did not start. Run docker logs fhir-clickhouse =========\n" && exit 1; fi && \
 	echo "\nInitializing ClickHouse schema" && \
 	docker exec -i fhir-clickhouse clickhouse-client --multiquery < clickhouse-init/01-init-schema.sql && \
+	docker exec -i fhir-clickhouse clickhouse-client --multiquery < clickhouse-init/02-audit-event.sql && \
 	echo "ClickHouse schema initialized successfully"
 	if [ ! -f ./generatorScripts/data/.collections_created ]; then \
 		echo "\nCreating all mongo collections and indexes" && \

--- a/clickhouse-init/02-audit-event.sql
+++ b/clickhouse-init/02-audit-event.sql
@@ -2,6 +2,8 @@
 -- Lean schema: dedicated columns for frequently-queried fields,
 -- full FHIR JSON in Native JSON `resource` column for all other queries.
 
+SET allow_experimental_json_type = 1;
+
 CREATE TABLE IF NOT EXISTS fhir.AuditEvent_4_0_0 (
     -- Resource identifiers
     id                           String,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       SUMMARY_CACHE_TTL_SECONDS: 300
       # ClickHouse configuration
       ENABLE_CLICKHOUSE: '1'
-      CLICKHOUSE_HOST: 'clickhouse'
+      CLICKHOUSE_HOST: 'http://clickhouse'
       CLICKHOUSE_PORT: '8123'
       CLICKHOUSE_DATABASE: 'fhir'
       CLICKHOUSE_USERNAME: 'default'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,7 @@ services:
       CLICKHOUSE_USERNAME: 'default'
       CLICKHOUSE_PASSWORD: ''
       MONGO_WITH_CLICKHOUSE_RESOURCES: 'Group'
+      ENABLE_AUDIT_EVENT_CLICKHOUSE: '1'
     ports:
       - '3000:3000'
     volumes:

--- a/src/constants/clickHouseConstants.js
+++ b/src/constants/clickHouseConstants.js
@@ -10,7 +10,8 @@ module.exports = {
     TABLES: {
         GROUP_MEMBER_EVENTS: 'fhir.fhir_group_member_events',
         GROUP_MEMBER_CURRENT: 'fhir.fhir_group_member_current',
-        GROUP_MEMBER_CURRENT_BY_ENTITY: 'fhir.fhir_group_member_current_by_entity'
+        GROUP_MEMBER_CURRENT_BY_ENTITY: 'fhir.fhir_group_member_current_by_entity',
+        AUDIT_EVENT: 'fhir.AuditEvent_4_0_0'
     },
 
     // Event types for CRUD operations

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -338,6 +338,28 @@ const createContainer = function () {
         }
         return null;
     });
+    // Register AuditEvent ClickHouse repository (if enabled)
+    container.register('auditEventClickHouseRepository', (c) => {
+        if (c.configManager.enableAuditEventClickHouse && c.clickHouseClientManager) {
+            const { AuditEventClickHouseRepository } = require('./dataLayer/repositories/auditEventClickHouseRepository');
+            return new AuditEventClickHouseRepository({
+                clickHouseClientManager: c.clickHouseClientManager
+            });
+        }
+        return null;
+    });
+    // Register AuditEvent ClickHouse writer (if repository available)
+    container.register('auditEventClickHouseWriter', (c) => {
+        if (c.auditEventClickHouseRepository) {
+            const { AuditEventClickHouseWriter } = require('./utils/auditEventClickHouseWriter');
+            const { AuditEventTransformer } = require('./admin/utils/auditEventTransformer');
+            return new AuditEventClickHouseWriter({
+                auditEventClickHouseRepository: c.auditEventClickHouseRepository,
+                auditEventTransformer: new AuditEventTransformer()
+            });
+        }
+        return null;
+    });
     container.register('indexManager', (c) => new IndexManager(
         {
             indexProvider: c.indexProvider,
@@ -553,7 +575,8 @@ const createContainer = function () {
                 databaseBulkInserter: c.databaseBulkInserter,
                 preSaveManager: c.preSaveManager,
                 configManager: c.configManager,
-                auditEventKafkaProducer: c.auditEventKafkaProducer
+                auditEventKafkaProducer: c.auditEventKafkaProducer,
+                auditEventClickHouseWriter: c.auditEventClickHouseWriter
             }
         )
     );

--- a/src/dataLayer/repositories/auditEventClickHouseRepository.js
+++ b/src/dataLayer/repositories/auditEventClickHouseRepository.js
@@ -48,6 +48,7 @@ class AuditEventClickHouseRepository {
             // Retry with exponential backoff
             const maxRetries = this.maxRetries;
             let delay = this.initialRetryDelayMs;
+            let currentError = error;
             for (let attempt = 1; attempt <= maxRetries; attempt++) {
                 try {
                     logWarn('ClickHouse AuditEvent insert failed, retrying', {
@@ -55,7 +56,7 @@ class AuditEventClickHouseRepository {
                         maxRetries,
                         batchSize: rows.length,
                         delay,
-                        error: error.message
+                        error: currentError.message
                     });
                     await new Promise((resolve) => setTimeout(resolve, delay));
                     await this.clickHouseClientManager.insertAsync({
@@ -65,6 +66,7 @@ class AuditEventClickHouseRepository {
                     });
                     return;
                 } catch (retryError) {
+                    currentError = retryError;
                     if (attempt === maxRetries) {
                         throw new RethrownError({
                             message: `ClickHouse AuditEvent insert failed after ${maxRetries} retries (batch size ${rows.length})`,

--- a/src/dataLayer/repositories/auditEventClickHouseRepository.js
+++ b/src/dataLayer/repositories/auditEventClickHouseRepository.js
@@ -38,7 +38,11 @@ class AuditEventClickHouseRepository {
             await this.clickHouseClientManager.insertAsync({
                 table: TABLES.AUDIT_EVENT,
                 values: rows,
-                format: QUERY_FORMAT.JSON_EACH_ROW
+                format: QUERY_FORMAT.JSON_EACH_ROW,
+                clickhouse_settings: {
+                    async_insert: 1,
+                    wait_for_async_insert: 1
+                }
             });
         } catch (error) {
             // Retry with exponential backoff

--- a/src/dataLayer/repositories/auditEventClickHouseRepository.js
+++ b/src/dataLayer/repositories/auditEventClickHouseRepository.js
@@ -1,0 +1,78 @@
+const { TABLES, QUERY_FORMAT } = require('../../constants/clickHouseConstants');
+const { RethrownError } = require('../../utils/rethrownError');
+const { logWarn } = require('../../operations/common/logging');
+
+/**
+ * Repository for AuditEvent ClickHouse data access.
+ *
+ * Encapsulates insert logic with retry for the AuditEvent_4_0_0 table.
+ * ClickHouse is the source of truth for AuditEvent — writes must succeed.
+ */
+class AuditEventClickHouseRepository {
+    /**
+     * @param {Object} params
+     * @param {import('../../utils/clickHouseClientManager').ClickHouseClientManager} params.clickHouseClientManager
+     * @param {number} [params.maxRetries=3] - Maximum number of retry attempts
+     * @param {number} [params.initialRetryDelayMs=2000] - Initial delay before first retry in ms
+     */
+    constructor({ clickHouseClientManager, maxRetries = 3, initialRetryDelayMs = 2000 }) {
+        this.clickHouseClientManager = clickHouseClientManager;
+        this.maxRetries = maxRetries;
+        this.initialRetryDelayMs = initialRetryDelayMs;
+    }
+
+    /**
+     * Inserts a batch of pre-transformed AuditEvent rows into ClickHouse.
+     * Retries up to 3 times with exponential backoff (2s → 4s → 8s) on failure.
+     *
+     * @param {Object[]} rows - Transformed rows matching the AuditEvent_4_0_0 schema
+     * @returns {Promise<void>}
+     * @throws {RethrownError} After retries exhausted
+     */
+    async insertBatchAsync(rows) {
+        if (!rows || rows.length === 0) {
+            return;
+        }
+
+        try {
+            await this.clickHouseClientManager.insertAsync({
+                table: TABLES.AUDIT_EVENT,
+                values: rows,
+                format: QUERY_FORMAT.JSON_EACH_ROW
+            });
+        } catch (error) {
+            // Retry with exponential backoff
+            const maxRetries = this.maxRetries;
+            let delay = this.initialRetryDelayMs;
+            for (let attempt = 1; attempt <= maxRetries; attempt++) {
+                try {
+                    logWarn('ClickHouse AuditEvent insert failed, retrying', {
+                        attempt,
+                        maxRetries,
+                        batchSize: rows.length,
+                        delay,
+                        error: error.message
+                    });
+                    await new Promise((resolve) => setTimeout(resolve, delay));
+                    await this.clickHouseClientManager.insertAsync({
+                        table: TABLES.AUDIT_EVENT,
+                        values: rows,
+                        format: QUERY_FORMAT.JSON_EACH_ROW
+                    });
+                    return;
+                } catch (retryError) {
+                    if (attempt === maxRetries) {
+                        throw new RethrownError({
+                            message: `ClickHouse AuditEvent insert failed after ${maxRetries} retries (batch size ${rows.length})`,
+                            error: retryError,
+                            args: { batchSize: rows.length }
+                        });
+                    }
+                    delay *= 2;
+                }
+            }
+        }
+    }
+}
+
+module.exports = { AuditEventClickHouseRepository };

--- a/src/dataLayer/repositories/auditEventClickHouseRepository.js
+++ b/src/dataLayer/repositories/auditEventClickHouseRepository.js
@@ -34,47 +34,38 @@ class AuditEventClickHouseRepository {
             return;
         }
 
-        try {
-            await this.clickHouseClientManager.insertAsync({
-                table: TABLES.AUDIT_EVENT,
-                values: rows,
-                format: QUERY_FORMAT.JSON_EACH_ROW,
-                clickhouse_settings: {
-                    async_insert: 1,
-                    wait_for_async_insert: 1
-                }
-            });
-        } catch (error) {
-            // Retry with exponential backoff
-            const maxRetries = this.maxRetries;
-            let delay = this.initialRetryDelayMs;
-            let currentError = error;
-            for (let attempt = 1; attempt <= maxRetries; attempt++) {
-                try {
+        const insertParams = {
+            table: TABLES.AUDIT_EVENT,
+            values: rows,
+            format: QUERY_FORMAT.JSON_EACH_ROW,
+            clickhouse_settings: {
+                async_insert: 1,
+                wait_for_async_insert: 1
+            }
+        };
+
+        let delay = this.initialRetryDelayMs;
+        for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+            try {
+                if (attempt > 0) {
                     logWarn('ClickHouse AuditEvent insert failed, retrying', {
                         attempt,
-                        maxRetries,
+                        maxRetries: this.maxRetries,
                         batchSize: rows.length,
-                        delay,
-                        error: currentError.message
+                        delay
                     });
                     await new Promise((resolve) => setTimeout(resolve, delay));
-                    await this.clickHouseClientManager.insertAsync({
-                        table: TABLES.AUDIT_EVENT,
-                        values: rows,
-                        format: QUERY_FORMAT.JSON_EACH_ROW
-                    });
-                    return;
-                } catch (retryError) {
-                    currentError = retryError;
-                    if (attempt === maxRetries) {
-                        throw new RethrownError({
-                            message: `ClickHouse AuditEvent insert failed after ${maxRetries} retries (batch size ${rows.length})`,
-                            error: retryError,
-                            args: { batchSize: rows.length }
-                        });
-                    }
                     delay *= 2;
+                }
+                await this.clickHouseClientManager.insertAsync(insertParams);
+                return;
+            } catch (error) {
+                if (attempt === this.maxRetries) {
+                    throw new RethrownError({
+                        message: `ClickHouse AuditEvent insert failed after ${this.maxRetries} retries (batch size ${rows.length})`,
+                        error,
+                        args: { batchSize: rows.length }
+                    });
                 }
             }
         }

--- a/src/tests/createTestContainer.js
+++ b/src/tests/createTestContainer.js
@@ -45,7 +45,8 @@ const createTestContainer = function (fnUpdateContainer) {
             databaseBulkInserter: c.databaseBulkInserter,
             preSaveManager: c.preSaveManager,
             configManager: c.configManager,
-            auditEventKafkaProducer: c.auditEventKafkaProducer
+            auditEventKafkaProducer: c.auditEventKafkaProducer,
+            auditEventClickHouseWriter: c.auditEventClickHouseWriter
         }));
     container.register('mongoDatabaseManager', (c) => new TestMongoDatabaseManager({
         configManager: c.configManager

--- a/src/tests/dataLayer/repositories/auditEventClickHouseRepository.test.js
+++ b/src/tests/dataLayer/repositories/auditEventClickHouseRepository.test.js
@@ -1,0 +1,113 @@
+const { describe, test, expect, jest, beforeEach } = require('@jest/globals');
+const { AuditEventClickHouseRepository } = require('../../../dataLayer/repositories/auditEventClickHouseRepository');
+const { TABLES, QUERY_FORMAT } = require('../../../constants/clickHouseConstants');
+
+describe('AuditEventClickHouseRepository', () => {
+    let mockClickHouseClientManager;
+
+    beforeEach(() => {
+        mockClickHouseClientManager = {
+            insertAsync: jest.fn().mockResolvedValue(undefined)
+        };
+    });
+
+    function createRepository (overrides = {}) {
+        return new AuditEventClickHouseRepository({
+            clickHouseClientManager: mockClickHouseClientManager,
+            maxRetries: overrides.maxRetries ?? 3,
+            initialRetryDelayMs: overrides.initialRetryDelayMs ?? 10 // fast for tests
+        });
+    }
+
+    test('inserts rows with correct table and format', async () => {
+        const repository = createRepository();
+        const rows = [
+            { id: 'audit-001', _uuid: 'uuid-001', recorded: '2024-06-15 10:30:00.000' },
+            { id: 'audit-002', _uuid: 'uuid-002', recorded: '2024-06-15 11:00:00.000' }
+        ];
+
+        await repository.insertBatchAsync(rows);
+
+        expect(mockClickHouseClientManager.insertAsync).toHaveBeenCalledTimes(1);
+        expect(mockClickHouseClientManager.insertAsync).toHaveBeenCalledWith({
+            table: TABLES.AUDIT_EVENT,
+            values: rows,
+            format: QUERY_FORMAT.JSON_EACH_ROW
+        });
+    });
+
+    test('does nothing for empty array', async () => {
+        const repository = createRepository();
+        await repository.insertBatchAsync([]);
+
+        expect(mockClickHouseClientManager.insertAsync).not.toHaveBeenCalled();
+    });
+
+    test('does nothing for null input', async () => {
+        const repository = createRepository();
+        await repository.insertBatchAsync(null);
+
+        expect(mockClickHouseClientManager.insertAsync).not.toHaveBeenCalled();
+    });
+
+    test('retries on failure and succeeds', async () => {
+        const error = new Error('Connection refused');
+        mockClickHouseClientManager.insertAsync
+            .mockRejectedValueOnce(error)
+            .mockRejectedValueOnce(error)
+            .mockResolvedValueOnce(undefined);
+
+        const repository = createRepository();
+        const rows = [{ id: 'audit-001', _uuid: 'uuid-001', recorded: '2024-06-15 10:30:00.000' }];
+
+        await repository.insertBatchAsync(rows);
+
+        // Initial attempt + 2 retries = 3 calls total
+        expect(mockClickHouseClientManager.insertAsync).toHaveBeenCalledTimes(3);
+    });
+
+    test('throws after all retries exhausted', async () => {
+        const error = new Error('Connection refused');
+        mockClickHouseClientManager.insertAsync.mockRejectedValue(error);
+
+        const repository = createRepository({ maxRetries: 3 });
+        const rows = [{ id: 'audit-001', _uuid: 'uuid-001', recorded: '2024-06-15 10:30:00.000' }];
+
+        await expect(repository.insertBatchAsync(rows)).rejects.toThrow(
+            'ClickHouse AuditEvent insert failed after 3 retries (batch size 1)'
+        );
+
+        // Initial attempt + 3 retries = 4 calls total
+        expect(mockClickHouseClientManager.insertAsync).toHaveBeenCalledTimes(4);
+    });
+
+    test('succeeds on first retry after initial failure', async () => {
+        const error = new Error('Temporary error');
+        mockClickHouseClientManager.insertAsync
+            .mockRejectedValueOnce(error)
+            .mockResolvedValueOnce(undefined);
+
+        const repository = createRepository();
+        const rows = [{ id: 'audit-001', _uuid: 'uuid-001', recorded: '2024-06-15 10:30:00.000' }];
+
+        await repository.insertBatchAsync(rows);
+
+        // Initial attempt + 1 retry = 2 calls
+        expect(mockClickHouseClientManager.insertAsync).toHaveBeenCalledTimes(2);
+    });
+
+    test('uses exponential backoff for retry delays', async () => {
+        const error = new Error('Connection refused');
+        mockClickHouseClientManager.insertAsync.mockRejectedValue(error);
+
+        const repository = createRepository({ maxRetries: 2, initialRetryDelayMs: 50 });
+        const rows = [{ id: 'audit-001', _uuid: 'uuid-001', recorded: '2024-06-15 10:30:00.000' }];
+
+        const start = Date.now();
+        await expect(repository.insertBatchAsync(rows)).rejects.toThrow();
+        const elapsed = Date.now() - start;
+
+        // 50ms + 100ms = 150ms minimum delay (with some tolerance)
+        expect(elapsed).toBeGreaterThanOrEqual(100);
+    });
+});

--- a/src/tests/dataLayer/repositories/auditEventClickHouseRepository.test.js
+++ b/src/tests/dataLayer/repositories/auditEventClickHouseRepository.test.js
@@ -32,7 +32,11 @@ describe('AuditEventClickHouseRepository', () => {
         expect(mockClickHouseClientManager.insertAsync).toHaveBeenCalledWith({
             table: TABLES.AUDIT_EVENT,
             values: rows,
-            format: QUERY_FORMAT.JSON_EACH_ROW
+            format: QUERY_FORMAT.JSON_EACH_ROW,
+            clickhouse_settings: {
+                async_insert: 1,
+                wait_for_async_insert: 1
+            }
         });
     });
 

--- a/src/tests/dataLayer/repositories/auditEventClickHouseRepository.test.js
+++ b/src/tests/dataLayer/repositories/auditEventClickHouseRepository.test.js
@@ -68,6 +68,20 @@ describe('AuditEventClickHouseRepository', () => {
 
         // Initial attempt + 2 retries = 3 calls total
         expect(mockClickHouseClientManager.insertAsync).toHaveBeenCalledTimes(3);
+
+        // All calls (including retries) must include clickhouse_settings
+        const expectedParams = {
+            table: TABLES.AUDIT_EVENT,
+            values: rows,
+            format: QUERY_FORMAT.JSON_EACH_ROW,
+            clickhouse_settings: {
+                async_insert: 1,
+                wait_for_async_insert: 1
+            }
+        };
+        for (const call of mockClickHouseClientManager.insertAsync.mock.calls) {
+            expect(call[0]).toEqual(expectedParams);
+        }
     });
 
     test('throws after all retries exhausted', async () => {

--- a/src/tests/utils/auditEventClickHouseWriter.test.js
+++ b/src/tests/utils/auditEventClickHouseWriter.test.js
@@ -1,0 +1,92 @@
+const { describe, test, expect, jest, beforeEach } = require('@jest/globals');
+const { AuditEventClickHouseWriter } = require('../../utils/auditEventClickHouseWriter');
+const { AuditEventClickHouseRepository } = require('../../dataLayer/repositories/auditEventClickHouseRepository');
+const { AuditEventTransformer } = require('../../admin/utils/auditEventTransformer');
+const deepcopy = require('deepcopy');
+const auditEventSample = require('../scripts/fixtures/audit_event_sample.json');
+
+describe('AuditEventClickHouseWriter', () => {
+    let mockRepository;
+    let transformer;
+    let writer;
+
+    beforeEach(() => {
+        mockRepository = Object.create(AuditEventClickHouseRepository.prototype);
+        mockRepository.insertBatchAsync = jest.fn().mockResolvedValue(undefined);
+
+        transformer = new AuditEventTransformer();
+        writer = new AuditEventClickHouseWriter({
+            auditEventClickHouseRepository: mockRepository,
+            auditEventTransformer: transformer
+        });
+    });
+
+    test('transforms and inserts a batch of documents', async () => {
+        const docs = [deepcopy(auditEventSample), deepcopy(auditEventSample)];
+        docs[1].id = 'audit-002';
+        docs[1]._uuid = 'audit-uuid-002';
+
+        const result = await writer.writeBatchAsync(docs);
+
+        expect(result.inserted).toBe(2);
+        expect(result.skipped).toBe(0);
+        expect(mockRepository.insertBatchAsync).toHaveBeenCalledTimes(1);
+        const insertedRows = mockRepository.insertBatchAsync.mock.calls[0][0];
+        expect(insertedRows).toHaveLength(2);
+        expect(insertedRows[0]._uuid).toBe('audit-uuid-001');
+        expect(insertedRows[1]._uuid).toBe('audit-uuid-002');
+    });
+
+    test('skips malformed documents and inserts valid ones', async () => {
+        const validDoc = deepcopy(auditEventSample);
+        const malformedDoc = deepcopy(auditEventSample);
+        delete malformedDoc._uuid; // transformer returns null for missing _uuid
+
+        const result = await writer.writeBatchAsync([malformedDoc, validDoc]);
+
+        expect(result.inserted).toBe(1);
+        expect(result.skipped).toBe(1);
+        expect(mockRepository.insertBatchAsync).toHaveBeenCalledTimes(1);
+        const insertedRows = mockRepository.insertBatchAsync.mock.calls[0][0];
+        expect(insertedRows).toHaveLength(1);
+    });
+
+    test('returns zeros for empty input', async () => {
+        const result = await writer.writeBatchAsync([]);
+
+        expect(result.inserted).toBe(0);
+        expect(result.skipped).toBe(0);
+        expect(mockRepository.insertBatchAsync).not.toHaveBeenCalled();
+    });
+
+    test('returns zeros for null input', async () => {
+        const result = await writer.writeBatchAsync(null);
+
+        expect(result.inserted).toBe(0);
+        expect(result.skipped).toBe(0);
+        expect(mockRepository.insertBatchAsync).not.toHaveBeenCalled();
+    });
+
+    test('returns zeros when all documents are malformed', async () => {
+        const doc1 = deepcopy(auditEventSample);
+        const doc2 = deepcopy(auditEventSample);
+        delete doc1._uuid;
+        delete doc2._uuid;
+
+        const result = await writer.writeBatchAsync([doc1, doc2]);
+
+        expect(result.inserted).toBe(0);
+        expect(result.skipped).toBe(2);
+        expect(mockRepository.insertBatchAsync).not.toHaveBeenCalled();
+    });
+
+    test('logs error and re-throws when repository fails', async () => {
+        const insertError = new Error('ClickHouse connection failed');
+        mockRepository.insertBatchAsync.mockRejectedValue(insertError);
+
+        const doc = deepcopy(auditEventSample);
+
+        await expect(writer.writeBatchAsync([doc])).rejects.toThrow('ClickHouse connection failed');
+        expect(mockRepository.insertBatchAsync).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/tests/utils/auditLogger.clickhouse.test.js
+++ b/src/tests/utils/auditLogger.clickhouse.test.js
@@ -1,0 +1,192 @@
+const { describe, test, expect, jest, beforeEach, afterEach } = require('@jest/globals');
+const { AuditLogger } = require('../../utils/auditLogger');
+const { PostRequestProcessor } = require('../../utils/postRequestProcessor');
+const { DatabaseBulkInserter } = require('../../dataLayer/databaseBulkInserter');
+const { PreSaveManager } = require('../../preSaveHandlers/preSave');
+const { ConfigManager } = require('../../utils/configManager');
+const { AuditEventKafkaProducer } = require('../../utils/auditEventKafkaProducer');
+const { AuditEventClickHouseWriter } = require('../../utils/auditEventClickHouseWriter');
+const AuditEvent = require('../../fhir/classes/4_0_0/resources/auditEvent');
+const Meta = require('../../fhir/classes/4_0_0/complex_types/meta');
+const Coding = require('../../fhir/classes/4_0_0/complex_types/coding');
+const Reference = require('../../fhir/classes/4_0_0/complex_types/reference');
+const AuditEventAgent = require('../../fhir/classes/4_0_0/backbone_elements/auditEventAgent');
+const AuditEventSource = require('../../fhir/classes/4_0_0/backbone_elements/auditEventSource');
+
+/**
+ * Creates a minimal AuditEvent resource for testing
+ */
+function createTestAuditEvent (id) {
+    return new AuditEvent({
+        id,
+        _uuid: `AuditEvent/${id}`,
+        _sourceId: id,
+        _sourceAssigningAuthority: 'bwell',
+        meta: new Meta({
+            versionId: '1',
+            lastUpdated: new Date('2024-06-15T10:30:00.000Z'),
+            security: [
+                new Coding({ system: 'https://www.icanbwell.com/owner', code: 'bwell' }),
+                new Coding({ system: 'https://www.icanbwell.com/access', code: 'bwell' })
+            ]
+        }),
+        recorded: new Date('2024-06-15T10:30:00.000Z'),
+        type: new Coding({ system: 'http://dicom.nema.org/resources/ontology/DCM', code: '110112' }),
+        action: 'R',
+        agent: [
+            new AuditEventAgent({
+                who: new Reference({ reference: 'Person/test-user' }),
+                requestor: true
+            })
+        ],
+        source: new AuditEventSource({
+            observer: new Reference({ reference: 'Person/test-user' })
+        })
+    });
+}
+
+describe('AuditLogger ClickHouse Integration', () => {
+    let mockPostRequestProcessor;
+    let mockDatabaseBulkInserter;
+    let mockPreSaveManager;
+    let mockConfigManager;
+    let mockKafkaProducer;
+    let mockClickHouseWriter;
+
+    beforeEach(() => {
+        mockPostRequestProcessor = Object.create(PostRequestProcessor.prototype);
+        mockPostRequestProcessor.add = jest.fn();
+
+        mockDatabaseBulkInserter = Object.create(DatabaseBulkInserter.prototype);
+        mockDatabaseBulkInserter.getOperationForResourceAsync = jest.fn().mockReturnValue({});
+        mockDatabaseBulkInserter.executeAsync = jest.fn().mockResolvedValue([]);
+
+        mockPreSaveManager = Object.create(PreSaveManager.prototype);
+        mockPreSaveManager.preSaveAsync = jest.fn().mockResolvedValue(undefined);
+
+        mockConfigManager = Object.create(ConfigManager.prototype);
+        Object.defineProperty(mockConfigManager, 'enableAuditEventMongoDB', { get: () => false });
+        Object.defineProperty(mockConfigManager, 'enableAuditEventKafka', { get: () => false });
+        Object.defineProperty(mockConfigManager, 'enableAuditEventClickHouse', { get: () => true });
+        Object.defineProperty(mockConfigManager, 'maxIdsPerAuditEvent', { get: () => 50 });
+
+        mockKafkaProducer = Object.create(AuditEventKafkaProducer.prototype);
+        mockKafkaProducer.produce = jest.fn().mockResolvedValue(undefined);
+
+        mockClickHouseWriter = Object.create(AuditEventClickHouseWriter.prototype);
+        mockClickHouseWriter.writeBatchAsync = jest.fn().mockResolvedValue({ inserted: 1, skipped: 0 });
+    });
+
+    function createAuditLogger (overrides = {}) {
+        const config = overrides.configManager || mockConfigManager;
+        return new AuditLogger({
+            postRequestProcessor: mockPostRequestProcessor,
+            databaseBulkInserter: mockDatabaseBulkInserter,
+            preSaveManager: mockPreSaveManager,
+            configManager: config,
+            auditEventKafkaProducer: mockKafkaProducer,
+            auditEventClickHouseWriter: overrides.auditEventClickHouseWriter !== undefined
+                ? overrides.auditEventClickHouseWriter
+                : mockClickHouseWriter
+        });
+    }
+
+    test('writes to ClickHouse when enabled', async () => {
+        const logger = createAuditLogger();
+        const doc = createTestAuditEvent('test-audit-1');
+        logger.queue.push({ doc, requestInfo: { requestId: 'req-1' } });
+
+        await logger.flushAsync();
+
+        expect(mockClickHouseWriter.writeBatchAsync).toHaveBeenCalledTimes(1);
+        const docs = mockClickHouseWriter.writeBatchAsync.mock.calls[0][0];
+        expect(docs).toHaveLength(1);
+        expect(docs[0]._uuid).toBe('AuditEvent/test-audit-1');
+    });
+
+    test('does not write to ClickHouse when disabled', async () => {
+        const disabledConfig = Object.create(ConfigManager.prototype);
+        Object.defineProperty(disabledConfig, 'enableAuditEventMongoDB', { get: () => true });
+        Object.defineProperty(disabledConfig, 'enableAuditEventKafka', { get: () => false });
+        Object.defineProperty(disabledConfig, 'enableAuditEventClickHouse', { get: () => false });
+        Object.defineProperty(disabledConfig, 'maxIdsPerAuditEvent', { get: () => 50 });
+
+        const logger = createAuditLogger({ configManager: disabledConfig });
+        const doc = createTestAuditEvent('test-audit-2');
+        logger.queue.push({ doc, requestInfo: { requestId: 'req-2' } });
+
+        await logger.flushAsync();
+
+        expect(mockClickHouseWriter.writeBatchAsync).not.toHaveBeenCalled();
+    });
+
+    test('does not write to ClickHouse when writer is null', async () => {
+        const logger = createAuditLogger({ auditEventClickHouseWriter: null });
+        const doc = createTestAuditEvent('test-audit-3');
+        logger.queue.push({ doc, requestInfo: { requestId: 'req-3' } });
+
+        await logger.flushAsync();
+
+        // Should not throw, just skip
+        expect(mockClickHouseWriter.writeBatchAsync).not.toHaveBeenCalled();
+    });
+
+    test('logs error but does not throw when ClickHouse write fails', async () => {
+        mockClickHouseWriter.writeBatchAsync.mockRejectedValue(new Error('ClickHouse down'));
+
+        const logger = createAuditLogger();
+        const doc = createTestAuditEvent('test-audit-4');
+        logger.queue.push({ doc, requestInfo: { requestId: 'req-4' } });
+
+        // Should not throw
+        await expect(logger.flushAsync()).resolves.toBeUndefined();
+        expect(mockClickHouseWriter.writeBatchAsync).toHaveBeenCalledTimes(1);
+    });
+
+    test('writes to both MongoDB and ClickHouse when both enabled', async () => {
+        const bothEnabledConfig = Object.create(ConfigManager.prototype);
+        Object.defineProperty(bothEnabledConfig, 'enableAuditEventMongoDB', { get: () => true });
+        Object.defineProperty(bothEnabledConfig, 'enableAuditEventKafka', { get: () => false });
+        Object.defineProperty(bothEnabledConfig, 'enableAuditEventClickHouse', { get: () => true });
+        Object.defineProperty(bothEnabledConfig, 'maxIdsPerAuditEvent', { get: () => 50 });
+
+        const logger = createAuditLogger({ configManager: bothEnabledConfig });
+        const doc = createTestAuditEvent('test-audit-5');
+        logger.queue.push({ doc, requestInfo: { requestId: 'req-5' } });
+
+        await logger.flushAsync();
+
+        // ClickHouse write should happen
+        expect(mockClickHouseWriter.writeBatchAsync).toHaveBeenCalledTimes(1);
+        // MongoDB operations should be created
+        expect(mockDatabaseBulkInserter.getOperationForResourceAsync).toHaveBeenCalledTimes(1);
+        expect(mockDatabaseBulkInserter.executeAsync).toHaveBeenCalledTimes(1);
+    });
+
+    test('writes multiple events in a single batch', async () => {
+        const logger = createAuditLogger();
+        const doc1 = createTestAuditEvent('test-audit-6a');
+        const doc2 = createTestAuditEvent('test-audit-6b');
+        logger.queue.push(
+            { doc: doc1, requestInfo: { requestId: 'req-6' } },
+            { doc: doc2, requestInfo: { requestId: 'req-6' } }
+        );
+
+        await logger.flushAsync();
+
+        expect(mockClickHouseWriter.writeBatchAsync).toHaveBeenCalledTimes(1);
+        const docs = mockClickHouseWriter.writeBatchAsync.mock.calls[0][0];
+        expect(docs).toHaveLength(2);
+    });
+
+    test('isAuditEventEnabled is true when only ClickHouse is enabled', () => {
+        const chOnlyConfig = Object.create(ConfigManager.prototype);
+        Object.defineProperty(chOnlyConfig, 'enableAuditEventMongoDB', { get: () => false });
+        Object.defineProperty(chOnlyConfig, 'enableAuditEventKafka', { get: () => false });
+        Object.defineProperty(chOnlyConfig, 'enableAuditEventClickHouse', { get: () => true });
+        Object.defineProperty(chOnlyConfig, 'maxIdsPerAuditEvent', { get: () => 50 });
+
+        const logger = createAuditLogger({ configManager: chOnlyConfig });
+        expect(logger.isAuditEventEnabled).toBe(true);
+    });
+});

--- a/src/utils/auditEventClickHouseWriter.js
+++ b/src/utils/auditEventClickHouseWriter.js
@@ -1,0 +1,64 @@
+const { logError } = require('../operations/common/logging');
+const { AuditEventClickHouseRepository } = require('../dataLayer/repositories/auditEventClickHouseRepository');
+const { AuditEventTransformer } = require('../admin/utils/auditEventTransformer');
+const { assertTypeEquals } = require('./assertType');
+
+/**
+ * Transforms FHIR AuditEvent JSON documents and writes them to ClickHouse.
+ *
+ * ClickHouse is the source of truth for AuditEvent — errors are logged
+ * with full context and re-thrown so callers are aware of failures.
+ * Retry logic is handled by the repository layer.
+ */
+class AuditEventClickHouseWriter {
+    /**
+     * @param {Object} params
+     * @param {AuditEventClickHouseRepository} params.auditEventClickHouseRepository
+     * @param {AuditEventTransformer} params.auditEventTransformer
+     */
+    constructor({ auditEventClickHouseRepository, auditEventTransformer }) {
+        this.repository = auditEventClickHouseRepository;
+        assertTypeEquals(auditEventClickHouseRepository, AuditEventClickHouseRepository);
+
+        this.transformer = auditEventTransformer;
+        assertTypeEquals(auditEventTransformer, AuditEventTransformer);
+    }
+
+    /**
+     * Transforms and writes a batch of FHIR AuditEvent JSON documents to ClickHouse.
+     *
+     * @param {Object[]} fhirJsonDocs - Array of toJSONInternal() output from AuditEvent resources
+     * @returns {Promise<{inserted: number, skipped: number}>}
+     * @throws {Error} If ClickHouse write fails after retries
+     */
+    async writeBatchAsync(fhirJsonDocs) {
+        if (!fhirJsonDocs || fhirJsonDocs.length === 0) {
+            return { inserted: 0, skipped: 0 };
+        }
+
+        const { rows, skipped } = this.transformer.transformBatch(fhirJsonDocs);
+
+        if (rows.length === 0) {
+            return { inserted: 0, skipped };
+        }
+
+        try {
+            await this.repository.insertBatchAsync(rows);
+            return { inserted: rows.length, skipped };
+        } catch (error) {
+            logError('AuditEventClickHouseWriter: batch write failed', {
+                error: error.message,
+                source: 'AuditEventClickHouseWriter.writeBatchAsync',
+                args: {
+                    batchSize: fhirJsonDocs.length,
+                    transformedRows: rows.length,
+                    skipped,
+                    firstDocId: fhirJsonDocs[0]?._uuid || fhirJsonDocs[0]?.id || 'unknown'
+                }
+            });
+            throw error;
+        }
+    }
+}
+
+module.exports = { AuditEventClickHouseWriter };

--- a/src/utils/auditLogger.js
+++ b/src/utils/auditLogger.js
@@ -20,6 +20,7 @@ const AuditEventNetwork = require('../fhir/classes/4_0_0/backbone_elements/audit
 const { Mutex } = require('async-mutex');
 const { PreSaveManager } = require('../preSaveHandlers/preSave');
 const { AuditEventKafkaProducer } = require('./auditEventKafkaProducer');
+const { AuditEventClickHouseWriter } = require('./auditEventClickHouseWriter');
 const { ConfigManager } = require('./configManager');
 const { PERSON_PROXY_PREFIX, AUTH_USER_TYPES } = require('../constants');
 const mutex = new Mutex();
@@ -33,6 +34,7 @@ class AuditLogger {
      * @property {PreSaveManager} preSaveManager
      * @property {ConfigManager} configManager
      * @property {AuditEventKafkaProducer} auditEventKafkaProducer
+     * @property {AuditEventClickHouseWriter|null} auditEventClickHouseWriter
      * @property {string} base_version
      *
      * @param {params}
@@ -43,6 +45,7 @@ class AuditLogger {
                     preSaveManager,
                     configManager,
                     auditEventKafkaProducer,
+                    auditEventClickHouseWriter,
                     base_version = '4_0_0'
                 }) {
         assertTypeEquals(postRequestProcessor, PostRequestProcessor);
@@ -71,6 +74,10 @@ class AuditLogger {
         this.auditEventKafkaProducer = auditEventKafkaProducer;
         assertTypeEquals(auditEventKafkaProducer, AuditEventKafkaProducer);
         /**
+         * @type {AuditEventClickHouseWriter|null}
+         */
+        this.auditEventClickHouseWriter = auditEventClickHouseWriter || null;
+        /**
          * @type {{doc: import('../fhir/classes/4_0_0/resources/resource'), requestInfo: import('./fhirRequestInfo').FhirRequestInfo}[]}
          */
         this.queue = [];
@@ -82,7 +89,9 @@ class AuditLogger {
         /**
          * @type {boolean}
          */
-        this.isAuditEventEnabled = this.configManager.enableAuditEventMongoDB || this.configManager.enableAuditEventKafka;
+        this.isAuditEventEnabled = this.configManager.enableAuditEventMongoDB
+            || this.configManager.enableAuditEventKafka
+            || this.configManager.enableAuditEventClickHouse;
         /**
          * @type {number}
          */
@@ -306,6 +315,7 @@ class AuditLogger {
         const operationsMap = new Map();
         operationsMap.set(resourceType, []);
         const kafkaAuditEvents = [];
+        const clickHouseAuditEvents = [];
 
         for (const { doc, requestInfo } of currentQueue) {
             assertTypeEquals(doc, AuditEvent);
@@ -328,6 +338,9 @@ class AuditLogger {
                         }
                     })
                 );
+            }
+            if (this.configManager.enableAuditEventClickHouse) {
+                clickHouseAuditEvents.push(doc.toJSONInternal());
             }
         }
         if (kafkaAuditEvents.length > 0) {
@@ -355,6 +368,20 @@ class AuditLogger {
                     args: {
                         request: { id: requestId },
                         errors: mergeResultErrors
+                    }
+                });
+            }
+        }
+        if (clickHouseAuditEvents.length > 0 && this.auditEventClickHouseWriter) {
+            try {
+                await this.auditEventClickHouseWriter.writeBatchAsync(clickHouseAuditEvents);
+            } catch (err) {
+                logError('ClickHouse AuditEvent batch write failed after retries', {
+                    error: err.message,
+                    source: 'AuditLogger.flushAsync',
+                    args: {
+                        count: clickHouseAuditEvents.length,
+                        request: { id: requestId }
                     }
                 });
             }

--- a/src/utils/clickHouseClientManager.js
+++ b/src/utils/clickHouseClientManager.js
@@ -231,9 +231,10 @@ class ClickHouseClientManager {
      * @param {string} params.table - Table name
      * @param {Array<Object>} params.values - Array of rows to insert
      * @param {string} [params.format] - Data format (default: JSONEachRow)
+     * @param {Object} [params.clickhouse_settings] - Per-query ClickHouse settings (e.g. async_insert, wait_for_async_insert)
      * @returns {Promise<void>}
      */
-    async insertAsync({ table, values, format = 'JSONEachRow' }) {
+    async insertAsync({ table, values, format = 'JSONEachRow', clickhouse_settings }) {
         const startTime = Date.now();
         const rowCount = values?.length || 0;
 
@@ -264,7 +265,8 @@ class ClickHouseClientManager {
                 await client.insert({
                     table,
                     values,
-                    format
+                    format,
+                    clickhouse_settings
                 });
 
                 const duration = Date.now() - startTime;

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -599,6 +599,14 @@ class ConfigManager {
     }
 
     /**
+     * whether to write AuditEvent to ClickHouse
+     * @return {boolean}
+     */
+    get enableAuditEventClickHouse() {
+        return isTrue(env.ENABLE_AUDIT_EVENT_CLICKHOUSE) && this.enableClickHouse;
+    }
+
+    /**
      * returns the maximum number of IDs to include in each audit event
      * @returns {number}
      */


### PR DESCRIPTION
## Summary
- Add ClickHouse as a third independent write destination for auto-generated AuditEvent resources (alongside MongoDB and Kafka)
- ClickHouse is treated as the source of truth — writes are awaited with retry logic (3x exponential backoff: 2s → 4s → 8s) and errors are logged with full context
- New `ENABLE_AUDIT_EVENT_CLICKHOUSE` env var controls the feature (also requires `ENABLE_CLICKHOUSE=true`)

## Changes
- **`src/utils/configManager.js`** — Added `enableAuditEventClickHouse` getter (double-gated with `enableClickHouse`)
- **`src/constants/clickHouseConstants.js`** — Added `AUDIT_EVENT` table constant
- **`src/dataLayer/repositories/auditEventClickHouseRepository.js`** — New repository with `insertBatchAsync` + retry with exponential backoff
- **`src/utils/auditEventClickHouseWriter.js`** — New writer: transforms FHIR JSON via `AuditEventTransformer`, inserts via repository, logs errors and re-throws
- **`src/utils/auditLogger.js`** — Added ClickHouse as third parallel write path in `flushAsync()`, updated `isAuditEventEnabled` to include ClickHouse
- **`src/createContainer.js`** — Wired repository, writer, and injected into auditLogger
- **`src/tests/createTestContainer.js`** — Pass `auditEventClickHouseWriter` to MockAuditLogger

## Test plan
- [x] 20 new unit/integration tests across 3 test files
- [x] Existing audit log tests pass (no regressions)
- [x] Existing ClickHouse migration tests pass
- [x] Manual verification with `ENABLE_CLICKHOUSE=1` and `ENABLE_AUDIT_EVENT_CLICKHOUSE=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)