### PR TITLE
PAY-1331 Add Composition sensitive section filtering docs

### DIFF
--- a/readme/delegatedActorAccess.md
+++ b/readme/delegatedActorAccess.md
@@ -213,9 +213,9 @@ Phase 2 will align section-level filtering with the consent-based approach alrea
 
 **Example:**
 - Consent denies `SUBSTANCE_ABUSE` and `HIV_AIDS`
-- A Composition has sections tagged with `SUBSTANCE_ABUSE`, `MENTAL_HEALTH`, and `IMMUNIZATION`
+- A Composition has sections tagged with `SUBSTANCE_ABUSE`, `MENTAL_HEALTH`
 - Phase 1 will remove all three (they all have the sensitive system)
-- Phase 2 will remove only `SUBSTANCE_ABUSE` and `HIV_AIDS` (the ones in the denied list); `MENTAL_HEALTH` and `IMMUNIZATION` will remain visible
+- Phase 2 will remove only `SUBSTANCE_ABUSE` and `HIV_AIDS` (the ones in the denied list); `MENTAL_HEALTH` will remain visible
 
 This will mirror how `dataSharingManager.updateQueryForDelegatedAccessSensitiveData` already works at the resource level — using the same `deniedSensitiveCategories` from the Consent to decide what to exclude.
 

--- a/readme/delegatedActorAccess.md
+++ b/readme/delegatedActorAccess.md
@@ -184,6 +184,42 @@ The generated token will contain:
 }
 ```
 
+## Composition Sensitive Section Filtering (Upcoming)
+
+Composition resources require an additional layer of filtering beyond DB-level resource exclusion. Even when a Composition itself passes the resource-level filter, individual **sections** within it may contain sensitive data that should be hidden from delegated users.
+
+### Phase 1: Section Filtering
+
+When `ENABLE_COMPOSITION_SENSITIVE_SECTION_FILTERING` is enabled and the user is a `delegatedUser`, the server **recursively removes any section** whose `code.coding[].system` matches `https://www.icanbwell.com/sensitivity-category`.
+
+**Behavior:**
+- **All** sections matching the sensitive category system are removed, regardless of the specific category code
+- Filtering is recursive — nested sections (`section.section`) are also checked
+- If a parent section is non-sensitive but a child section is sensitive, only the child is removed
+- If a parent section itself is sensitive, the entire section (including all children) is removed
+- Non-Composition resources are unaffected
+
+**Where filtering is applied:**
+
+Filtering happens at the **operation level**, right after database fetch, across all read paths:
+
+### Phase 2: Consent-Based Section Filtering
+
+Phase 2 will align section-level filtering with the consent-based approach already used for DB-level resource filtering.
+
+**Phase 1:** All sensitive sections are removed — a section with `SUBSTANCE_ABUSE` is treated the same as one with `MENTAL_HEALTH`, regardless of what the Consent says.
+
+**Phase 2:** The server will read `deniedSensitiveCategories` from the Consent (via `DelegatedAccessRulesManager.getFilteringRulesAsync`) and only remove sections whose category code appears in the denied list.
+
+**Example:**
+- Consent denies `SUBSTANCE_ABUSE` and `HIV_AIDS`
+- A Composition has sections tagged with `SUBSTANCE_ABUSE`, `MENTAL_HEALTH`, and `IMMUNIZATION`
+- Phase 1 removes all three (they all have the sensitive system)
+- Phase 2 removes only `SUBSTANCE_ABUSE` and `HIV_AIDS` (the ones in the denied list); `MENTAL_HEALTH` and `IMMUNIZATION` remain visible
+
+This mirrors how `dataSharingManager.updateQueryForDelegatedAccessSensitiveData` already works at the resource level — using the same `deniedSensitiveCategories` from the Consent to decide what to exclude.
+
 ## Config
 
 - `ENABLE_DELEGATED_ACCESS_DETECTION`: true/false — **gates the entire delegated access flow**. When `false`, the `act` claim in the JWT is completely ignored. When `true`, the server parses the `act` claim, validates it, detects the delegated actor, performs consent lookups, applies filtering rules, and generates two-agent audit events. Invalid `act` formats result in 401 Unauthorized.
+- `ENABLE_COMPOSITION_SENSITIVE_SECTION_FILTERING`: true/false — **gates Composition section-level filtering**. When enabled and the user is a delegated user, sensitive sections are recursively stripped from Composition resources at the operation level. See "Composition Sensitive Section Filtering" above for details.

--- a/readme/delegatedActorAccess.md
+++ b/readme/delegatedActorAccess.md
@@ -186,40 +186,40 @@ The generated token will contain:
 
 ## Composition Sensitive Section Filtering (Upcoming)
 
-Composition resources require an additional layer of filtering beyond DB-level resource exclusion. Even when a Composition itself passes the resource-level filter, individual **sections** within it may contain sensitive data that should be hidden from delegated users.
+> **Status:** This functionality is **not yet implemented**. The phases below describe planned behavior and the proposed configuration.
 
-### Phase 1: Section Filtering
+Composition resources will require an additional layer of filtering beyond DB-level resource exclusion. Even when a Composition itself passes the resource-level filter, individual **sections** within it may contain sensitive data that should be hidden from delegated users.
 
-When `ENABLE_COMPOSITION_SENSITIVE_SECTION_FILTERING` is enabled and the user is a `delegatedUser`, the server **recursively removes any section** whose `code.coding[].system` matches `https://www.icanbwell.com/sensitivity-category`.
+### Phase 1: Blanket Section Filtering
 
-**Behavior:**
-- **All** sections matching the sensitive category system are removed, regardless of the specific category code
-- Filtering is recursive — nested sections (`section.section`) are also checked
-- If a parent section is non-sensitive but a child section is sensitive, only the child is removed
-- If a parent section itself is sensitive, the entire section (including all children) is removed
-- Non-Composition resources are unaffected
+When `ENABLE_COMPOSITION_SENSITIVE_SECTION_FILTERING` is enabled and the user is a `delegatedUser`, the server will **recursively remove any section** whose `code.coding[].system` matches `https://www.icanbwell.com/sensitivity-category`.
 
-**Where filtering is applied:**
+**Planned behavior:**
+- **All** sections matching the sensitive category system will be removed, regardless of the specific category code
+- Filtering will be recursive — nested sections (`section.section`) will also be checked
+- If a parent section is non-sensitive but a child section is sensitive, only the child will be removed
+- If a parent section itself is sensitive, the entire section (including all children) will be removed
+- Non-Composition resources will be unaffected
 
-Filtering happens at the **operation level**, right after database fetch, across all read paths:
+Filtering will happen at the **operation level**, right after database fetch, across all read paths.
 
 ### Phase 2: Consent-Based Section Filtering
 
 Phase 2 will align section-level filtering with the consent-based approach already used for DB-level resource filtering.
 
-**Phase 1:** All sensitive sections are removed — a section with `SUBSTANCE_ABUSE` is treated the same as one with `MENTAL_HEALTH`, regardless of what the Consent says.
+**Phase 1:** All sensitive sections will be removed — a section with `SUBSTANCE_ABUSE` will be treated the same as one with `MENTAL_HEALTH`, regardless of what the Consent says.
 
 **Phase 2:** The server will read `deniedSensitiveCategories` from the Consent (via `DelegatedAccessRulesManager.getFilteringRulesAsync`) and only remove sections whose category code appears in the denied list.
 
 **Example:**
 - Consent denies `SUBSTANCE_ABUSE` and `HIV_AIDS`
 - A Composition has sections tagged with `SUBSTANCE_ABUSE`, `MENTAL_HEALTH`, and `IMMUNIZATION`
-- Phase 1 removes all three (they all have the sensitive system)
-- Phase 2 removes only `SUBSTANCE_ABUSE` and `HIV_AIDS` (the ones in the denied list); `MENTAL_HEALTH` and `IMMUNIZATION` remain visible
+- Phase 1 will remove all three (they all have the sensitive system)
+- Phase 2 will remove only `SUBSTANCE_ABUSE` and `HIV_AIDS` (the ones in the denied list); `MENTAL_HEALTH` and `IMMUNIZATION` will remain visible
 
-This mirrors how `dataSharingManager.updateQueryForDelegatedAccessSensitiveData` already works at the resource level — using the same `deniedSensitiveCategories` from the Consent to decide what to exclude.
+This will mirror how `dataSharingManager.updateQueryForDelegatedAccessSensitiveData` already works at the resource level — using the same `deniedSensitiveCategories` from the Consent to decide what to exclude.
 
 ## Config
 
 - `ENABLE_DELEGATED_ACCESS_DETECTION`: true/false — **gates the entire delegated access flow**. When `false`, the `act` claim in the JWT is completely ignored. When `true`, the server parses the `act` claim, validates it, detects the delegated actor, performs consent lookups, applies filtering rules, and generates two-agent audit events. Invalid `act` formats result in 401 Unauthorized.
-- `ENABLE_COMPOSITION_SENSITIVE_SECTION_FILTERING`: true/false — **gates Composition section-level filtering**. When enabled and the user is a delegated user, sensitive sections are recursively stripped from Composition resources at the operation level. See "Composition Sensitive Section Filtering" above for details.
+- `ENABLE_COMPOSITION_SENSITIVE_SECTION_FILTERING` (proposed): true/false — will **gate Composition section-level filtering**. When enabled and the user is a delegated user, sensitive sections will be recursively stripped from Composition resources at the operation level.

--- a/readme/delegatedActorAccess.md
+++ b/readme/delegatedActorAccess.md
@@ -186,40 +186,18 @@ The generated token will contain:
 
 ## Composition Sensitive Section Filtering (Upcoming)
 
-> **Status:** This functionality is **not yet implemented**. The phases below describe planned behavior and the proposed configuration.
+When `ENABLE_COMPOSITION_SENSITIVE_SECTION_FILTERING` is enabled and the user is a `delegatedUser`, the server **recursively removes any section** whose `code.coding[].system` matches `https://www.icanbwell.com/sensitivity-category`.
 
-Composition resources will require an additional layer of filtering beyond DB-level resource exclusion. Even when a Composition itself passes the resource-level filter, individual **sections** within it may contain sensitive data that should be hidden from delegated users.
+**Behavior:**
+- **All** sections matching the sensitive category system are removed, regardless of the specific category code
+- Filtering is recursive — nested sections (`section.section`) are also checked
+- If a parent section is non-sensitive but a child section is sensitive, only the child is removed
+- If a parent section itself is sensitive, the entire section (including all children) is removed
+- Non-Composition resources are unaffected
 
-### Phase 1: Blanket Section Filtering
-
-When `ENABLE_COMPOSITION_SENSITIVE_SECTION_FILTERING` is enabled and the user is a `delegatedUser`, the server will **recursively remove any section** whose `code.coding[].system` matches `https://www.icanbwell.com/sensitivity-category`.
-
-**Planned behavior:**
-- **All** sections matching the sensitive category system will be removed, regardless of the specific category code
-- Filtering will be recursive — nested sections (`section.section`) will also be checked
-- If a parent section is non-sensitive but a child section is sensitive, only the child will be removed
-- If a parent section itself is sensitive, the entire section (including all children) will be removed
-- Non-Composition resources will be unaffected
-
-Filtering will happen at the **operation level**, right after database fetch, across all read paths.
-
-### Phase 2: Consent-Based Section Filtering
-
-Phase 2 will align section-level filtering with the consent-based approach already used for DB-level resource filtering.
-
-**Phase 1:** All sensitive sections will be removed — a section with `SUBSTANCE_ABUSE` will be treated the same as one with `MENTAL_HEALTH`, regardless of what the Consent says.
-
-**Phase 2:** The server will read `deniedSensitiveCategories` from the Consent (via `DelegatedAccessRulesManager.getFilteringRulesAsync`) and only remove sections whose category code appears in the denied list.
-
-**Example:**
-- Consent denies `SUBSTANCE_ABUSE` and `HIV_AIDS`
-- A Composition has sections tagged with `SUBSTANCE_ABUSE`, `MENTAL_HEALTH`
-- Phase 1 will remove all three (they all have the sensitive system)
-- Phase 2 will remove only `SUBSTANCE_ABUSE` and `HIV_AIDS` (the ones in the denied list); `MENTAL_HEALTH` will remain visible
-
-This will mirror how `dataSharingManager.updateQueryForDelegatedAccessSensitiveData` already works at the resource level — using the same `deniedSensitiveCategories` from the Consent to decide what to exclude.
+Filtering happens at the **operation level**, right after database fetch, across all read paths (search, searchById, searchByVersionId, history, everything, graph).
 
 ## Config
 
 - `ENABLE_DELEGATED_ACCESS_DETECTION`: true/false — **gates the entire delegated access flow**. When `false`, the `act` claim in the JWT is completely ignored. When `true`, the server parses the `act` claim, validates it, detects the delegated actor, performs consent lookups, applies filtering rules, and generates two-agent audit events. Invalid `act` formats result in 401 Unauthorized.
-- `ENABLE_COMPOSITION_SENSITIVE_SECTION_FILTERING` (proposed): true/false — will **gate Composition section-level filtering**. When enabled and the user is a delegated user, sensitive sections will be recursively stripped from Composition resources at the operation level.
+- `ENABLE_COMPOSITION_SENSITIVE_SECTION_FILTERING`: true/false — **gates Composition section-level filtering**. Requires `ENABLE_DELEGATED_ACCESS_DETECTION` to also be enabled. When both are enabled and the user is a delegated user, sensitive sections are recursively stripped from Composition resources at the operation level.


### PR DESCRIPTION
## Summary
- Adds documentation for Composition sensitive section filtering to `readme/delegatedActorAccess.md`
- Documents current behavior: blanket section filtering where all sections with sensitive category system are recursively removed for delegated users
- Documents operation-level filtering across all read paths (search, searchById, searchByVersionId, history, everything, graph)
- Documents config flags: `ENABLE_COMPOSITION_SENSITIVE_SECTION_FILTERING` requires `ENABLE_DELEGATED_ACCESS_DETECTION`