### PR TITLE
PAY-1513: Add Index for Consent.actor.reference field

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -221,6 +221,7 @@ module.exports = {
         CODE: 'hidden'
     },
     CONSENT_OF_LINKED_PERSON_INDEX: 'consent_of_linked_person',
+    CONSENT_OF_LINKED_ACTOR_INDEX: 'consent_of_linked_actor',
     EXTERNAL_REQUEST_RETRY_COUNT: 3,
     DEFAULT_CACHE_MAX_COUNT: 25,
     DEFAULT_CACHE_EXPIRY_TIME: 24 * 60 * 60 * 1000,

--- a/src/indexes/customIndexes.js
+++ b/src/indexes/customIndexes.js
@@ -1,4 +1,4 @@
-const { ACCESS_LOGS_COLLECTION_NAME, CONSENT_OF_LINKED_PERSON_INDEX } = require('../constants');
+const { ACCESS_LOGS_COLLECTION_NAME, CONSENT_OF_LINKED_PERSON_INDEX, CONSENT_OF_LINKED_ACTOR_INDEX } = require('../constants');
 
 /**
  * List of custom indexes to add.  (* means these indexes should be applied to all collections)
@@ -360,6 +360,15 @@ module.exports = {
                 },
                 options: {
                     name: CONSENT_OF_LINKED_PERSON_INDEX
+                }
+            },
+            {
+                keys: {
+                    status: 1,
+                    'provision.actor.reference._uuid': 1
+                },
+                options: {
+                    name: CONSENT_OF_LINKED_ACTOR_INDEX
                 }
             },
             {


### PR DESCRIPTION
# Changes:                                                                                                                     
  - Added a new constant CONSENT_OF_LINKED_ACTOR_INDEX ('consent_of_linked_actor') in src/constants.js                         
  - Added a new compound index on Consent_4_0_0 in src/indexes/customIndexes.js with keys:                                     
    - status: 1                                                                                                              
    - provision.actor.reference._uuid: 1                                                                                       
                                                                                                                               

