### PR TITLE
DCON-3127: Added the 1:N person matching endpoint

### DIFF
--- a/src/admin/personMatchManager.js
+++ b/src/admin/personMatchManager.js
@@ -226,6 +226,120 @@ class PersonMatchManager {
             throw error;
         }
     }
+
+    /**
+     * Performs 1:N person matching
+     * @param {string} id
+     * @param {string|undefined} resourceType - "Patient" or "Person"
+     * @returns {Promise<Object>}
+     */
+    async personOneToNMatchAsync ({ id, resourceType }) {
+        resourceType = resourceType || 'Patient';
+        // strip resourceType from id if provided as "Patient/123"
+        if (id.includes('/')) {
+            resourceType = id.split('/')[0];
+            id = id.split('/')[1];
+        }
+
+        if (resourceType !== 'Patient' && resourceType !== 'Person') {
+            return new OperationOutcome({
+                issue: [
+                    new OperationOutcomeIssue({
+                        severity: 'error',
+                        code: 'invalid',
+                        diagnostics: `resourceType must be "Patient" or "Person", got "${resourceType}"`
+                    })
+                ]
+            }).toJSON();
+        }
+
+        const databaseQueryManager = this.databaseQueryFactory.createQuery({
+            resourceType,
+            base_version: '4_0_0'
+        });
+
+        const idQuery = isUuid(id) ? { _uuid: id } : { id };
+        const cursor = await databaseQueryManager.findAsync({ query: idQuery });
+
+        const resources = [];
+        while (await cursor.hasNext()) {
+            const resource = await cursor.nextObject();
+            resources.push(resource);
+        }
+
+        if (resources.length === 0) {
+            return new OperationOutcome({
+                issue: [
+                    new OperationOutcomeIssue({
+                        severity: 'error',
+                        code: 'not-found',
+                        diagnostics: `Resource with type: ${resourceType} and id: ${id} was not found`
+                    })
+                ]
+            }).toJSON();
+        }
+        if (resources.length > 1) {
+            return new OperationOutcome({
+                issue: [
+                    new OperationOutcomeIssue({
+                        severity: 'error',
+                        code: 'info',
+                        diagnostics: `Multiple resources with type: ${resourceType} and id: ${id} found`
+                    })
+                ]
+            }).toJSON();
+        }
+
+        // Convert Date object to string
+        if (resources[0].birthDate instanceof Date) {
+            resources[0].birthDate = resources[0].birthDate.toISOString().split('T')[0];
+        }
+
+        const parameters = {
+            resourceType: 'Parameters',
+            parameter: [
+                {
+                    name: 'resource',
+                    resource: resources[0].toJSON()
+                }
+            ]
+        };
+
+        const url = this.configManager.personMatchingServiceUrl;
+        assertIsValid(url, 'PERSON_MATCHING_SERVICE_URL environment variable is not set');
+
+        logInfo('Sending 1:N patient match request to person-matching service', {});
+
+        const accessToken = await this.oauthClientCredentialsHelper.getAccessTokenAsync();
+        const header = {
+            'Content-Type': 'application/fhir+json',
+            Accept: 'application/fhir+json',
+            Authorization: `Bearer ${accessToken}`
+        };
+
+        try {
+            const res = await superagent
+                .post(url)
+                .send(parameters)
+                .set(header)
+                .retry(EXTERNAL_REQUEST_RETRY_COUNT)
+                .timeout(this.configManager.requestTimeoutMs);
+            return res.body;
+        } catch (error) {
+            if (error.timeout) {
+                return new OperationOutcome({
+                    issue: [
+                        new OperationOutcomeIssue({
+                            severity: 'error',
+                            code: 'timeout',
+                            diagnostics: `Request timed out while sending request to person-matching service for 1:N match on ${resourceType}/${id}`
+                        })
+                    ]
+                }).toJSON();
+            }
+            throw error;
+        }
+    }
 }
 
 module.exports = {

--- a/src/admin/personMatchManager.js
+++ b/src/admin/personMatchManager.js
@@ -6,7 +6,7 @@ const OperationOutcome = require('../fhir/classes/4_0_0/resources/operationOutco
 const OperationOutcomeIssue = require('../fhir/classes/4_0_0/backbone_elements/operationOutcomeIssue');
 const { logInfo } = require('../operations/common/logging');
 const { EXTERNAL_REQUEST_RETRY_COUNT } = require('../constants');
-const { isUuid } = require('../utils/uid.util');
+const { isUuid, generateUUID } = require('../utils/uid.util');
 const { OAuthClientCredentialsHelper } = require('../utils/oauthClientCredentialsHelper');
 const { AuditLogger } = require('../utils/auditLogger');
 const { PostRequestProcessor } = require('../utils/postRequestProcessor');
@@ -248,7 +248,7 @@ class PersonMatchManager {
                     });
                 }
             });
-            return json;
+            return { matchRequest: parameters, matchResponse: json };
         } catch (error) {
             if (error.timeout) {
                 return new OperationOutcome({
@@ -372,9 +372,11 @@ class PersonMatchManager {
         }
 
         const demographicResource = this._extractDemographics(resources[0]);
+        demographicResource.id = generateUUID();
         demographicResource.resourceType = matchResourceType || resourceType;
 
         const parameters = {
+            id: generateUUID(),
             resourceType: 'Parameters',
             parameter: [
                 {
@@ -415,7 +417,7 @@ class PersonMatchManager {
                     });
                 }
             });
-            return res.body;
+            return { matchRequest: parameters, matchResponse: res.body };
         } catch (error) {
             if (error.timeout) {
                 return new OperationOutcome({

--- a/src/admin/personMatchManager.js
+++ b/src/admin/personMatchManager.js
@@ -8,6 +8,8 @@ const { logInfo } = require('../operations/common/logging');
 const { EXTERNAL_REQUEST_RETRY_COUNT } = require('../constants');
 const { isUuid } = require('../utils/uid.util');
 const { OAuthClientCredentialsHelper } = require('../utils/oauthClientCredentialsHelper');
+const { AuditLogger } = require('../utils/auditLogger');
+const { PostRequestProcessor } = require('../utils/postRequestProcessor');
 
 class PersonMatchManager {
     /**
@@ -15,12 +17,16 @@ class PersonMatchManager {
      * @param {DatabaseQueryFactory} databaseQueryFactory
      * @param {ConfigManager} configManager
      * @param {OAuthClientCredentialsHelper} oauthClientCredentialsHelper
+     * @param {AuditLogger} auditLogger
+     * @param {PostRequestProcessor} postRequestProcessor
      */
     constructor (
         {
             databaseQueryFactory,
             configManager,
-            oauthClientCredentialsHelper
+            oauthClientCredentialsHelper,
+            auditLogger,
+            postRequestProcessor
         }
     ) {
         /**
@@ -40,6 +46,18 @@ class PersonMatchManager {
          */
         this.oauthClientCredentialsHelper = oauthClientCredentialsHelper;
         assertTypeEquals(oauthClientCredentialsHelper, OAuthClientCredentialsHelper);
+
+        /**
+         * @type {AuditLogger}
+         */
+        this.auditLogger = auditLogger;
+        assertTypeEquals(auditLogger, AuditLogger);
+
+        /**
+         * @type {PostRequestProcessor}
+         */
+        this.postRequestProcessor = postRequestProcessor;
+        assertTypeEquals(postRequestProcessor, PostRequestProcessor);
     }
 
     /**
@@ -48,6 +66,7 @@ class PersonMatchManager {
      * @param {string|undefined} sourceType
      * @param {string} targetId
      * @param {string|undefined} targetType
+     * @param {import('../utils/fhirRequestInfo').FhirRequestInfo} requestInfo
      * @return {Promise<Object>}
      */
     async personMatchAsync (
@@ -55,7 +74,8 @@ class PersonMatchManager {
             sourceId,
             sourceType,
             targetId,
-            targetType
+            targetType,
+            requestInfo
         }
     ) {
         /**
@@ -209,6 +229,25 @@ class PersonMatchManager {
             .retry(EXTERNAL_REQUEST_RETRY_COUNT)
             .timeout(this.configManager.requestTimeoutMs);
             const json = res.body;
+            this.postRequestProcessor.add({
+                requestId: requestInfo.requestId,
+                fnTask: async () => {
+                    await this.auditLogger.logAuditEntryAsync({
+                        requestInfo,
+                        base_version: '4_0_0',
+                        resourceType: sourceType,
+                        operation: 'read',
+                        ids: [sourceId]
+                    });
+                    await this.auditLogger.logAuditEntryAsync({
+                        requestInfo,
+                        base_version: '4_0_0',
+                        resourceType: targetType,
+                        operation: 'read',
+                        ids: [targetId]
+                    });
+                }
+            });
             return json;
         } catch (error) {
             if (error.timeout) {
@@ -260,9 +299,10 @@ class PersonMatchManager {
      * @param {string} id
      * @param {string|undefined} resourceType - "Patient" or "Person"
      * @param {string|undefined} matchResourceType - "Patient" or "Person"
+     * @param {import('../utils/fhirRequestInfo').FhirRequestInfo} requestInfo
      * @returns {Promise<Object>}
      */
-    async personOneToNMatchAsync ({ id, resourceType, matchResourceType }) {
+    async personOneToNMatchAsync ({ id, resourceType, matchResourceType, requestInfo }) {
         resourceType = resourceType || 'Patient';
         // strip resourceType from id if provided as "Patient/123"
         if (id.includes('/')) {
@@ -363,6 +403,18 @@ class PersonMatchManager {
                 .set(header)
                 .retry(EXTERNAL_REQUEST_RETRY_COUNT)
                 .timeout(this.configManager.requestTimeoutMs);
+            this.postRequestProcessor.add({
+                requestId: requestInfo.requestId,
+                fnTask: async () => {
+                    await this.auditLogger.logAuditEntryAsync({
+                        requestInfo,
+                        base_version: '4_0_0',
+                        resourceType,
+                        operation: 'read',
+                        ids: [id]
+                    });
+                }
+            });
             return res.body;
         } catch (error) {
             if (error.timeout) {

--- a/src/admin/personMatchManager.js
+++ b/src/admin/personMatchManager.js
@@ -228,12 +228,41 @@ class PersonMatchManager {
     }
 
     /**
+     * Extracts only demographic fields from a FHIR Patient or Person resource.
+     * @param {Object} resource - A FHIR resource
+     * @returns {Object}
+     * @private
+     */
+    _extractDemographics (resource) {
+        const demographics = {};
+        if (resource.name) {
+            demographics.name = resource.name;
+        }
+        if (resource.gender) {
+            demographics.gender = resource.gender;
+        }
+        if (resource.birthDate) {
+            demographics.birthDate = resource.birthDate instanceof Date
+                ? resource.birthDate.toISOString().split('T')[0]
+                : resource.birthDate;
+        }
+        if (resource.telecom) {
+            demographics.telecom = resource.telecom;
+        }
+        if (resource.address) {
+            demographics.address = resource.address;
+        }
+        return demographics;
+    }
+
+    /**
      * Performs 1:N person matching
      * @param {string} id
      * @param {string|undefined} resourceType - "Patient" or "Person"
+     * @param {string|undefined} matchResourceType - "Patient" or "Person"
      * @returns {Promise<Object>}
      */
-    async personOneToNMatchAsync ({ id, resourceType }) {
+    async personOneToNMatchAsync ({ id, resourceType, matchResourceType }) {
         resourceType = resourceType || 'Patient';
         // strip resourceType from id if provided as "Patient/123"
         if (id.includes('/')) {
@@ -248,6 +277,18 @@ class PersonMatchManager {
                         severity: 'error',
                         code: 'invalid',
                         diagnostics: `resourceType must be "Patient" or "Person", got "${resourceType}"`
+                    })
+                ]
+            }).toJSON();
+        }
+
+        if (matchResourceType && matchResourceType !== 'Patient' && matchResourceType !== 'Person') {
+            return new OperationOutcome({
+                issue: [
+                    new OperationOutcomeIssue({
+                        severity: 'error',
+                        code: 'invalid',
+                        diagnostics: `matchResourceType must be "Patient" or "Person", got "${matchResourceType}"`
                     })
                 ]
             }).toJSON();
@@ -290,17 +331,15 @@ class PersonMatchManager {
             }).toJSON();
         }
 
-        // Convert Date object to string
-        if (resources[0].birthDate instanceof Date) {
-            resources[0].birthDate = resources[0].birthDate.toISOString().split('T')[0];
-        }
+        const demographicResource = this._extractDemographics(resources[0]);
+        demographicResource.resourceType = matchResourceType || resourceType;
 
         const parameters = {
             resourceType: 'Parameters',
             parameter: [
                 {
                     name: 'resource',
-                    resource: resources[0].toJSON()
+                    resource: demographicResource
                 }
             ]
         };

--- a/src/admin/personMatchManager.js
+++ b/src/admin/personMatchManager.js
@@ -66,7 +66,8 @@ class PersonMatchManager {
      * @param {string|undefined} sourceType
      * @param {string} targetId
      * @param {string|undefined} targetType
-     * @param {import('../utils/fhirRequestInfo').FhirRequestInfo} requestInfo
+     * @param {import('../utils/fhirRequestInfo').FhirRequestInfo} [requestInfo]
+     * @param {boolean} [includeMatchRequest]
      * @return {Promise<Object>}
      */
     async personMatchAsync (
@@ -75,7 +76,8 @@ class PersonMatchManager {
             sourceType,
             targetId,
             targetType,
-            requestInfo
+            requestInfo,
+            includeMatchRequest
         }
     ) {
         /**
@@ -229,26 +231,30 @@ class PersonMatchManager {
             .retry(EXTERNAL_REQUEST_RETRY_COUNT)
             .timeout(this.configManager.requestTimeoutMs);
             const json = res.body;
-            this.postRequestProcessor.add({
-                requestId: requestInfo.requestId,
-                fnTask: async () => {
-                    await this.auditLogger.logAuditEntryAsync({
-                        requestInfo,
-                        base_version: '4_0_0',
-                        resourceType: sourceType,
-                        operation: 'read',
-                        ids: [sourceId]
-                    });
-                    await this.auditLogger.logAuditEntryAsync({
-                        requestInfo,
-                        base_version: '4_0_0',
-                        resourceType: targetType,
-                        operation: 'read',
-                        ids: [targetId]
-                    });
-                }
-            });
-            return { matchRequest: parameters, matchResponse: json };
+            if (requestInfo) {
+                this.postRequestProcessor.add({
+                    requestId: requestInfo.requestId,
+                    fnTask: async () => {
+                        await this.auditLogger.logAuditEntryAsync({
+                            requestInfo,
+                            base_version: '4_0_0',
+                            resourceType: sourceType,
+                            operation: 'read',
+                            ids: [sourceId]
+                        });
+                        await this.auditLogger.logAuditEntryAsync({
+                            requestInfo,
+                            base_version: '4_0_0',
+                            resourceType: targetType,
+                            operation: 'read',
+                            ids: [targetId]
+                        });
+                    }
+                });
+            }
+            return includeMatchRequest
+                ? { matchRequest: parameters, matchResponse: json }
+                : json;
         } catch (error) {
             if (error.timeout) {
                 return new OperationOutcome({
@@ -300,9 +306,10 @@ class PersonMatchManager {
      * @param {string|undefined} resourceType - "Patient" or "Person"
      * @param {string|undefined} matchResourceType - "Patient" or "Person"
      * @param {import('../utils/fhirRequestInfo').FhirRequestInfo} requestInfo
+     * @param {boolean} [includeMatchRequest]
      * @returns {Promise<Object>}
      */
-    async personOneToNMatchAsync ({ id, resourceType, matchResourceType, requestInfo }) {
+    async personOneToNMatchAsync ({ id, resourceType, matchResourceType, requestInfo, includeMatchRequest }) {
         resourceType = resourceType || 'Patient';
         // strip resourceType from id if provided as "Patient/123"
         if (id.includes('/')) {
@@ -417,7 +424,9 @@ class PersonMatchManager {
                     });
                 }
             });
-            return { matchRequest: parameters, matchResponse: res.body };
+            return includeMatchRequest
+                ? { matchRequest: parameters, matchResponse: res.body }
+                : res.body;
         } catch (error) {
             if (error.timeout) {
                 return new OperationOutcome({

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -1014,7 +1014,9 @@ const createContainer = function () {
         {
             databaseQueryFactory: c.databaseQueryFactory,
             configManager: c.configManager,
-            oauthClientCredentialsHelper: c.oauthClientCredentialsHelper
+            oauthClientCredentialsHelper: c.oauthClientCredentialsHelper,
+            auditLogger: c.auditLogger,
+            postRequestProcessor: c.postRequestProcessor
         }
     ));
 

--- a/src/routeHandlers/admin.js
+++ b/src/routeHandlers/admin.js
@@ -233,6 +233,24 @@ async function handleAdminGet (
                     });
                 }
 
+                case 'runPersonOneToNMatch': {
+                    logInfo('', { 'req.query': req.query });
+                    const id = req.query.id;
+                    const resourceType = req.query.resourceType;
+                    if (!id) {
+                        return res.status(400).json({
+                            message: 'id query parameter is required'
+                        });
+                    }
+                    const personMatchManager = container.personMatchManager;
+                    assertIsValid(personMatchManager);
+                    const json = await personMatchManager.personOneToNMatchAsync({
+                        id,
+                        resourceType
+                    });
+                    return res.json(json);
+                }
+
                 default: {
                     return res.json({ message: 'Invalid Path' });
                 }

--- a/src/routeHandlers/admin.js
+++ b/src/routeHandlers/admin.js
@@ -14,6 +14,7 @@ const { REQUEST_ID_HEADER, REGEX } = require('../constants');
 const { AdminExportManager } = require('../admin/adminExportManager');
 const { logError } = require('../operations/common/logging');
 const { FhirRequestInfoBuilder } = require('../utils/fhirRequestInfoBuilder');
+const { isTrue } = require('../utils/isTrue');
 
 /**
  * shows indexes
@@ -189,12 +190,14 @@ async function handleAdminGet (
                     const personMatchManager = container.personMatchManager;
                     assertIsValid(personMatchManager);
                     const requestInfo = FhirRequestInfoBuilder.fromRequest(req);
+                    const includeMatchRequest = isTrue(req.query.includeMatchRequest);
                     const json = await personMatchManager.personMatchAsync({
                         sourceType,
                         sourceId,
                         targetType,
                         targetId,
-                        requestInfo
+                        requestInfo,
+                        includeMatchRequest
                     });
                     return res.json(json);
                 }
@@ -248,12 +251,14 @@ async function handleAdminGet (
                     }
                     const personMatchManager = container.personMatchManager;
                     assertIsValid(personMatchManager);
+                    const includeMatchRequest = isTrue(req.query.includeMatchRequest);
                     const requestInfo = FhirRequestInfoBuilder.fromRequest(req);
                     const json = await personMatchManager.personOneToNMatchAsync({
                         id,
                         resourceType,
                         matchResourceType,
-                        requestInfo
+                        requestInfo,
+                        includeMatchRequest
                     });
                     return res.json(json);
                 }

--- a/src/routeHandlers/admin.js
+++ b/src/routeHandlers/admin.js
@@ -13,6 +13,7 @@ const { logInfo } = require('../operations/common/logging');
 const { REQUEST_ID_HEADER, REGEX } = require('../constants');
 const { AdminExportManager } = require('../admin/adminExportManager');
 const { logError } = require('../operations/common/logging');
+const { FhirRequestInfoBuilder } = require('../utils/fhirRequestInfoBuilder');
 
 /**
  * shows indexes
@@ -187,11 +188,13 @@ async function handleAdminGet (
                     const targetType = req.query.targetType;
                     const personMatchManager = container.personMatchManager;
                     assertIsValid(personMatchManager);
+                    const requestInfo = FhirRequestInfoBuilder.fromRequest(req);
                     const json = await personMatchManager.personMatchAsync({
                         sourceType,
                         sourceId,
                         targetType,
-                        targetId
+                        targetId,
+                        requestInfo
                     });
                     return res.json(json);
                 }
@@ -245,10 +248,12 @@ async function handleAdminGet (
                     }
                     const personMatchManager = container.personMatchManager;
                     assertIsValid(personMatchManager);
+                    const requestInfo = FhirRequestInfoBuilder.fromRequest(req);
                     const json = await personMatchManager.personOneToNMatchAsync({
                         id,
                         resourceType,
-                        matchResourceType
+                        matchResourceType,
+                        requestInfo
                     });
                     return res.json(json);
                 }

--- a/src/routeHandlers/admin.js
+++ b/src/routeHandlers/admin.js
@@ -237,6 +237,7 @@ async function handleAdminGet (
                     logInfo('', { 'req.query': req.query });
                     const id = req.query.id;
                     const resourceType = req.query.resourceType;
+                    const matchResourceType = req.query.matchResourceType;
                     if (!id) {
                         return res.status(400).json({
                             message: 'id query parameter is required'
@@ -246,7 +247,8 @@ async function handleAdminGet (
                     assertIsValid(personMatchManager);
                     const json = await personMatchManager.personOneToNMatchAsync({
                         id,
-                        resourceType
+                        resourceType,
+                        matchResourceType
                     });
                     return res.json(json);
                 }


### PR DESCRIPTION
This pull request introduces a new 1:N person matching feature to the admin API. The main changes add a method to perform person matching against the person-matching service and expose this functionality via a new admin route handler.

**New 1:N Person Matching Functionality:**

- Added the `personOneToNMatchAsync` method to the `PersonMatchManager` class, which performs 1:N matching for a given `Patient` or `Person` resource by querying the database, validating the resource, and forwarding the match request to the external person-matching service. The method also handles error cases such as missing or multiple resources, invalid resource types, and request timeouts.