### PR TITLE
DCON-3406: Removed the clickhouse test containers from the perf test

### DIFF
--- a/src/tests/performance/group/incremental_loading.test.js
+++ b/src/tests/performance/group/incremental_loading.test.js
@@ -21,6 +21,8 @@
 process.env.ENABLE_CLICKHOUSE = '1';
 process.env.MONGO_WITH_CLICKHOUSE_RESOURCES = 'Group';
 process.env.CLICKHOUSE_WRITE_MODE = 'sync';
+process.env.CLICKHOUSE_HOST = 'http://127.0.0.1';
+process.env.CLICKHOUSE_PORT = '8123';
 process.env.CLICKHOUSE_DATABASE = 'fhir';
 process.env.LOGLEVEL = 'SILENT'; // Reduce log spam
 process.env.STREAM_RESPONSE = '0';
@@ -32,7 +34,6 @@ const { commonBeforeEach, commonAfterEach, createTestRequest, getHeaders } = req
 const { ConfigManager } = require('../../../utils/configManager');
 const { ClickHouseClientManager } = require('../../../utils/clickHouseClientManager');
 const { USE_EXTERNAL_STORAGE_HEADER } = require('../../../utils/contextDataBuilder');
-const { ClickHouseTestContainer } = require('../../clickHouseTestContainer');
 
 function getHeadersWithExternalStorage() {
     return { ...getHeaders(), [USE_EXTERNAL_STORAGE_HEADER]: 'true' };
@@ -41,11 +42,7 @@ function getHeadersWithExternalStorage() {
 describe('Incremental Loading - FHIR R4B Compliant Pattern', () => {
     let clickHouseManager;
 
-    let clickHouseTestContainer;
     beforeAll(async () => {
-        clickHouseTestContainer = new ClickHouseTestContainer();
-        await clickHouseTestContainer.start();
-        clickHouseTestContainer.applyEnvVars();
         await commonBeforeEach();
 
         const configManager = new ConfigManager();
@@ -71,9 +68,6 @@ describe('Incremental Loading - FHIR R4B Compliant Pattern', () => {
             }
 
             await clickHouseManager.closeAsync();
-        }
-        if (clickHouseTestContainer) {
-            await clickHouseTestContainer.stop();
         }
         await commonAfterEach();
     }, 30000);

--- a/src/tests/performance/group/incremental_loading_1m_patch.test.js
+++ b/src/tests/performance/group/incremental_loading_1m_patch.test.js
@@ -13,6 +13,8 @@
 process.env.ENABLE_CLICKHOUSE = '1';
 process.env.MONGO_WITH_CLICKHOUSE_RESOURCES = 'Group';
 process.env.CLICKHOUSE_WRITE_MODE = 'sync';
+process.env.CLICKHOUSE_HOST = 'http://127.0.0.1';
+process.env.CLICKHOUSE_PORT = '8123';
 process.env.CLICKHOUSE_DATABASE = 'fhir';
 process.env.LOGLEVEL = 'SILENT';
 process.env.STREAM_RESPONSE = '0';
@@ -23,7 +25,6 @@ const { commonBeforeEach, commonAfterEach, createTestRequest, getHeaders } = req
 const { ConfigManager } = require('../../../utils/configManager');
 const { ClickHouseClientManager } = require('../../../utils/clickHouseClientManager');
 const { USE_EXTERNAL_STORAGE_HEADER } = require('../../../utils/contextDataBuilder');
-const { ClickHouseTestContainer } = require('../../clickHouseTestContainer');
 
 function getHeadersWithExternalStorage() {
     return { ...getHeaders(), [USE_EXTERNAL_STORAGE_HEADER]: 'true' };
@@ -32,11 +33,7 @@ function getHeadersWithExternalStorage() {
 describe('1M Member Loading - FHIR R4B PATCH Pattern', () => {
     let clickHouseManager;
 
-    let clickHouseTestContainer;
     beforeAll(async () => {
-        clickHouseTestContainer = new ClickHouseTestContainer();
-        await clickHouseTestContainer.start();
-        clickHouseTestContainer.applyEnvVars();
         await commonBeforeEach();
 
         const configManager = new ConfigManager();
@@ -62,9 +59,6 @@ describe('1M Member Loading - FHIR R4B PATCH Pattern', () => {
             }
 
             await clickHouseManager.closeAsync();
-        }
-        if (clickHouseTestContainer) {
-            await clickHouseTestContainer.stop();
         }
         await commonAfterEach();
     }, 30000);

--- a/src/tests/performance/group/patch_performance.test.js
+++ b/src/tests/performance/group/patch_performance.test.js
@@ -41,6 +41,14 @@ describe('PATCH Performance Testing', () => {
 
     afterAll(async () => {
         if (clickHouseManager) {
+            try {
+                await clickHouseManager.truncateTableAsync('Group_4_0_0_MemberCurrentByEntity');
+                await clickHouseManager.truncateTableAsync('Group_4_0_0_MemberCurrent');
+                await clickHouseManager.truncateTableAsync('Group_4_0_0_MemberEvents');
+            } catch (e) {
+                console.warn('Cleanup warning:', e.message);
+            }
+
             await clickHouseManager.closeAsync();
         }
         await commonAfterEach();

--- a/src/tests/performance/group/patch_performance.test.js
+++ b/src/tests/performance/group/patch_performance.test.js
@@ -72,7 +72,7 @@ describe('PATCH Performance Testing', () => {
                 const request = await createTestRequest();
 
                 // Create empty Group
-                await request
+                const createResponse = await request
                     .post('/4_0_0/Group')
                     .send({
                         resourceType: 'Group',
@@ -101,11 +101,13 @@ describe('PATCH Performance Testing', () => {
                 const startTime = Date.now();
                 const memBefore = process.memoryUsage().heapUsed / 1024 / 1024; // MB
 
-                const patchResponse = await request
-                    .patch(`/4_0_0/Group/${groupId}`)
-                    .set('Content-Type', 'application/json-patch+json')
+                const actualGroupId = createResponse.body.id;
+
+                const patchResponse = await request 
+                    .patch(`/4_0_0/Group/${actualGroupId}`)
                     .send(operations)
-                    .set(getHeadersWithExternalStorage());
+                    .set(getHeadersWithExternalStorage())
+                    .set('Content-Type', 'application/json-patch+json');
 
                 const responseTime = Date.now() - startTime;
                 const memAfter = process.memoryUsage().heapUsed / 1024 / 1024; // MB
@@ -123,7 +125,7 @@ describe('PATCH Performance Testing', () => {
                                 GROUP BY entity_reference
                                 HAVING argMax(event_type, (event_time, event_id)) = 'added'
                             )`,
-                    query_params: { groupId }
+                    query_params: { groupId: actualGroupId }
                 });
 
                 const verified = parseInt(countResult[0].count) === numOps;

--- a/src/tests/performance/group/patch_performance.test.js
+++ b/src/tests/performance/group/patch_performance.test.js
@@ -103,7 +103,7 @@ describe('PATCH Performance Testing', () => {
 
                 const actualGroupId = createResponse.body.id;
 
-                const patchResponse = await request 
+                const patchResponse = await request
                     .patch(`/4_0_0/Group/${actualGroupId}`)
                     .send(operations)
                     .set(getHeadersWithExternalStorage())

--- a/src/tests/performance/group/patch_performance.test.js
+++ b/src/tests/performance/group/patch_performance.test.js
@@ -11,6 +11,8 @@
 process.env.ENABLE_CLICKHOUSE = '1';
 process.env.MONGO_WITH_CLICKHOUSE_RESOURCES = 'Group';
 process.env.CLICKHOUSE_WRITE_MODE = 'sync';
+process.env.CLICKHOUSE_HOST = 'http://127.0.0.1';
+process.env.CLICKHOUSE_PORT = '8123';
 process.env.CLICKHOUSE_DATABASE = 'fhir';
 process.env.LOGLEVEL = 'SILENT';
 process.env.STREAM_RESPONSE = '0';
@@ -21,7 +23,6 @@ const { commonBeforeEach, commonAfterEach, createTestRequest, getHeaders } = req
 const { ConfigManager } = require('../../../utils/configManager');
 const { ClickHouseClientManager } = require('../../../utils/clickHouseClientManager');
 const { USE_EXTERNAL_STORAGE_HEADER } = require('../../../utils/contextDataBuilder');
-const { ClickHouseTestContainer } = require('../../clickHouseTestContainer');
 
 function getHeadersWithExternalStorage() {
     return { ...getHeaders(), [USE_EXTERNAL_STORAGE_HEADER]: 'true' };
@@ -30,11 +31,7 @@ function getHeadersWithExternalStorage() {
 describe('PATCH Performance Testing', () => {
     let clickHouseManager;
 
-    let clickHouseTestContainer;
     beforeAll(async () => {
-        clickHouseTestContainer = new ClickHouseTestContainer();
-        await clickHouseTestContainer.start();
-        clickHouseTestContainer.applyEnvVars();
         await commonBeforeEach();
 
         const configManager = new ConfigManager();
@@ -45,9 +42,6 @@ describe('PATCH Performance Testing', () => {
     afterAll(async () => {
         if (clickHouseManager) {
             await clickHouseManager.closeAsync();
-        }
-        if (clickHouseTestContainer) {
-            await clickHouseTestContainer.stop();
         }
         await commonAfterEach();
     }, 30000);


### PR DESCRIPTION
This pull request refactors the performance test setup for ClickHouse integration by removing the use of the `ClickHouseTestContainer` and instead directly configuring ClickHouse connection parameters via environment variables. 