### PR TITLE
DCON-3443: Route access-logs to ClickHouse (write + admin read)

### DIFF
--- a/clickhouse-init/04-access-log.sql
+++ b/clickhouse-init/04-access-log.sql
@@ -1,0 +1,32 @@
+-- AccessLog table for FHIR server HTTP access logs
+-- Hybrid schema: full nested sub-objects (agent, details, request) as Native JSON
+-- columns preserving the exact shape emitted by AccessLogger; lean flat mirrors
+-- (agent_altId, origin_service, request_id) materialized from the JSON for
+-- indexed point lookups.
+
+SET allow_experimental_json_type = 1;
+
+CREATE TABLE IF NOT EXISTS fhir.AccessLog (
+    timestamp                    DateTime64(3, 'UTC'),
+    outcome_desc                 LowCardinality(String),
+
+    -- Full nested sub-objects, preserved verbatim
+    agent                        JSON(max_dynamic_paths=16),
+    details                      JSON(max_dynamic_paths=64),
+    request                      JSON(max_dynamic_paths=16),
+
+    -- Lean, indexed mirrors of the most common filter keys.
+    -- Populated by ClickHouse from the JSON columns at insert time.
+    -- Native JSON subfields are Dynamic; toString() coerces them to match the column type.
+    agent_altId                  String                 MATERIALIZED toString(agent.altId),
+    origin_service               LowCardinality(String) MATERIALIZED toString(details.originService),
+    request_id                   String                 MATERIALIZED toString(request.id),
+
+    INDEX idx_request_id     request_id     TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_agent_altId    agent_altId    TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_origin_service origin_service TYPE bloom_filter(0.01) GRANULARITY 4
+)
+ENGINE = MergeTree()
+ORDER BY timestamp
+PARTITION BY toDate(timestamp)
+TTL timestamp + INTERVAL 7 DAY DELETE;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,7 @@ services:
       MONGO_WITH_CLICKHOUSE_RESOURCES: 'Group'
       ENABLE_AUDIT_EVENT_CLICKHOUSE: '1'
       CLICKHOUSE_ONLY_RESOURCES: 'AuditEvent'
+      ENABLE_ACCESS_LOGS_CLICKHOUSE: '1'
     ports:
       - '3000:3000'
     volumes:

--- a/src/admin/adminAccessLogClickHouseManager.js
+++ b/src/admin/adminAccessLogClickHouseManager.js
@@ -1,0 +1,67 @@
+const { logError } = require('../operations/common/logging');
+const { assertTypeEquals } = require('../utils/assertType');
+const { ClickHouseClientManager } = require('../utils/clickHouseClientManager');
+const { TABLES } = require('../constants/clickHouseConstants');
+
+/**
+ * Admin-side reader for access-logs stored in ClickHouse.
+ *
+ * Mirrors AdminLogManager's `getLogAsync(id)` contract but reads directly
+ * from fhir.AccessLog via a parameterized SQL query. AccessLog is not a
+ * FHIR resource, so it bypasses the generic scaffolding (schema registry,
+ * query parser, query builder) used for AuditEvent.
+ *
+ * The row shape stored in ClickHouse is reassembled into the same
+ * { timestamp, outcomeDesc, agent, details, request } envelope the Mongo
+ * path returns, so the admin endpoint's response shape is unchanged
+ * regardless of backend.
+ */
+class AdminAccessLogClickHouseManager {
+    /**
+     * @param {Object} params
+     * @param {ClickHouseClientManager} params.clickHouseClientManager
+     */
+    constructor ({ clickHouseClientManager }) {
+        this.clickHouseClientManager = clickHouseClientManager;
+        assertTypeEquals(clickHouseClientManager, ClickHouseClientManager);
+    }
+
+    /**
+     * Returns access-log rows for the given request id, in the same envelope
+     * shape AccessLogger emits and AdminLogManager.getLogAsync returns.
+     *
+     * The request_id bloom-filter skip-index prunes granules on equality
+     * lookups; the 7-day TTL caps scanned data. Returns [] on error so the
+     * admin UI doesn't crash when CH is briefly unavailable.
+     *
+     * @param {string} id - user request id (stored as request.id / request_id)
+     * @returns {Promise<Object[]>}
+     */
+    async getLogAsync (id) {
+        try {
+            const rows = await this.clickHouseClientManager.queryAsync({
+                query: `SELECT timestamp, outcome_desc, agent, details, request
+                        FROM ${TABLES.ACCESS_LOG}
+                        WHERE request_id = {id:String}
+                        ORDER BY timestamp DESC
+                        LIMIT 100`,
+                query_params: { id }
+            });
+
+            return rows.map((row) => ({
+                timestamp: row.timestamp,
+                outcomeDesc: row.outcome_desc,
+                agent: row.agent,
+                details: row.details,
+                request: row.request
+            }));
+        } catch (e) {
+            logError(e.message, { error: e });
+        }
+        return [];
+    }
+}
+
+module.exports = {
+    AdminAccessLogClickHouseManager
+};

--- a/src/constants/clickHouseConstants.js
+++ b/src/constants/clickHouseConstants.js
@@ -11,7 +11,8 @@ module.exports = {
         GROUP_MEMBER_EVENTS: 'fhir.Group_4_0_0_MemberEvents',
         GROUP_MEMBER_CURRENT: 'fhir.Group_4_0_0_MemberCurrent',
         GROUP_MEMBER_CURRENT_BY_ENTITY: 'fhir.Group_4_0_0_MemberCurrentByEntity',
-        AUDIT_EVENT: 'fhir.AuditEvent_4_0_0'
+        AUDIT_EVENT: 'fhir.AuditEvent_4_0_0',
+        ACCESS_LOG: 'fhir.AccessLog'
     },
 
     // Event types for CRUD operations

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -372,6 +372,28 @@ const createContainer = function () {
         }
         return null;
     });
+    // Register AccessLog ClickHouse repository (if enabled)
+    container.register('accessLogClickHouseRepository', (c) => {
+        if (c.configManager.enableAccessLogsClickHouse && c.clickHouseClientManager) {
+            const { AccessLogClickHouseRepository } = require('./dataLayer/repositories/accessLogClickHouseRepository');
+            return new AccessLogClickHouseRepository({
+                clickHouseClientManager: c.clickHouseClientManager
+            });
+        }
+        return null;
+    });
+    // Register AccessLog ClickHouse writer (if repository available)
+    container.register('accessLogClickHouseWriter', (c) => {
+        if (c.accessLogClickHouseRepository) {
+            const { AccessLogClickHouseWriter } = require('./utils/accessLogClickHouseWriter');
+            const { AccessLogTransformer } = require('./dataLayer/clickHouse/accessLogTransformer');
+            return new AccessLogClickHouseWriter({
+                accessLogClickHouseRepository: c.accessLogClickHouseRepository,
+                accessLogTransformer: new AccessLogTransformer()
+            });
+        }
+        return null;
+    });
     container.register('indexManager', (c) => new IndexManager(
         {
             indexProvider: c.indexProvider,
@@ -652,7 +674,8 @@ const createContainer = function () {
                 imageVersion: getImageVersion(),
                 configManager: c.configManager,
                 databaseBulkInserter: c.databaseBulkInserter,
-                accessLogsEventProducer: c.accessLogsEventProducer
+                accessLogsEventProducer: c.accessLogsEventProducer,
+                accessLogClickHouseWriter: c.accessLogClickHouseWriter
             }
         )
     );
@@ -1041,6 +1064,16 @@ const createContainer = function () {
             accessIndexManager: c.accessIndexManager,
             r4ArgsParser: c.r4ArgsParser
         }));
+
+    container.register('adminAccessLogClickHouseManager', (c) => {
+        if (c.configManager.enableAccessLogsClickHouse && c.clickHouseClientManager) {
+            const { AdminAccessLogClickHouseManager } = require('./admin/adminAccessLogClickHouseManager');
+            return new AdminAccessLogClickHouseManager({
+                clickHouseClientManager: c.clickHouseClientManager
+            });
+        }
+        return null;
+    });
 
     container.register('adminPersonPatientLinkManager', (c) => new AdminPersonPatientLinkManager({
         databaseQueryFactory: c.databaseQueryFactory,

--- a/src/dataLayer/clickHouse/accessLogTransformer.js
+++ b/src/dataLayer/clickHouse/accessLogTransformer.js
@@ -1,0 +1,77 @@
+/**
+ * Transforms AccessLogger documents into ClickHouse rows for the
+ * fhir.AccessLog table (see clickhouse-init/04-access-log.sql).
+ *
+ * The doc shape (see src/utils/accessLogger.js logEntry) is preserved
+ * verbatim in three JSON columns (agent, details, request). Materialized
+ * columns (agent_altId, origin_service, request_id) are derived by
+ * ClickHouse from the JSON and do not appear here.
+ */
+
+class AccessLogTransformer {
+    /**
+     * Converts a Date or ISO 8601 string to ClickHouse DateTime64 format.
+     * @param {string|Date} date
+     * @returns {string}
+     */
+    toClickHouseDateTime(date) {
+        const iso = typeof date === 'string' ? date : date.toISOString();
+        return iso.replace('T', ' ').replace('Z', '');
+    }
+
+    /**
+     * Coerces a scopes value to an array of strings.
+     * AccessLogger stores requestInfo.scope, which may be a space-delimited
+     * string or an array.
+     * @param {string|string[]|undefined} scopes
+     * @returns {string[]}
+     */
+    normalizeScopes(scopes) {
+        if (Array.isArray(scopes)) return scopes.filter((s) => typeof s === 'string');
+        if (typeof scopes === 'string') return scopes.split(/\s+/).filter(Boolean);
+        return [];
+    }
+
+    /**
+     * Transforms a single access-log document to a ClickHouse row.
+     * Skips documents missing required fields.
+     * @param {Object} doc - AccessLogger logEntry
+     * @returns {Object|null}
+     */
+    transformDocument(doc) {
+        if (!doc || !doc.timestamp || !doc.request?.id) {
+            return null;
+        }
+
+        const agent = doc.agent ? { ...doc.agent, scopes: this.normalizeScopes(doc.agent.scopes) } : {};
+
+        return {
+            timestamp: this.toClickHouseDateTime(doc.timestamp),
+            outcome_desc: doc.outcomeDesc || '',
+            agent,
+            details: doc.details || {},
+            request: doc.request
+        };
+    }
+
+    /**
+     * Transforms a batch of documents, skipping malformed ones.
+     * @param {Object[]} docs
+     * @returns {{rows: Object[], skipped: number}}
+     */
+    transformBatch(docs) {
+        const rows = [];
+        let skipped = 0;
+        for (const doc of docs) {
+            const row = this.transformDocument(doc);
+            if (row) {
+                rows.push(row);
+            } else {
+                skipped++;
+            }
+        }
+        return { rows, skipped };
+    }
+}
+
+module.exports = { AccessLogTransformer };

--- a/src/dataLayer/repositories/accessLogClickHouseRepository.js
+++ b/src/dataLayer/repositories/accessLogClickHouseRepository.js
@@ -1,0 +1,77 @@
+const { TABLES, QUERY_FORMAT } = require('../../constants/clickHouseConstants');
+const { RethrownError } = require('../../utils/rethrownError');
+const { logWarn } = require('../../operations/common/logging');
+
+/**
+ * Repository for AccessLog ClickHouse data access.
+ *
+ * Encapsulates insert logic with retry for the fhir.AccessLog table.
+ * Access-logs tolerate brief CH unavailability: the caller
+ * (AccessLogClickHouseWriter) logs-and-swallows failures rather than
+ * propagating, because a lost access-log must not break the request cycle.
+ */
+class AccessLogClickHouseRepository {
+    /**
+     * @param {Object} params
+     * @param {import('../../utils/clickHouseClientManager').ClickHouseClientManager} params.clickHouseClientManager
+     * @param {number} [params.maxRetries=3] - Maximum number of retry attempts
+     * @param {number} [params.initialRetryDelayMs=2000] - Initial delay before first retry in ms
+     */
+    constructor({ clickHouseClientManager, maxRetries = 3, initialRetryDelayMs = 2000 }) {
+        this.clickHouseClientManager = clickHouseClientManager;
+        this.maxRetries = maxRetries;
+        this.initialRetryDelayMs = initialRetryDelayMs;
+    }
+
+    /**
+     * Inserts a batch of pre-transformed AccessLog rows into ClickHouse.
+     * Retries up to 3 times with exponential backoff (2s → 4s → 8s) on failure.
+     *
+     * @param {Object[]} rows - Transformed rows matching the fhir.AccessLog schema
+     * @returns {Promise<void>}
+     * @throws {RethrownError} After retries exhausted
+     */
+    async insertBatchAsync(rows) {
+        if (!rows || rows.length === 0) {
+            return;
+        }
+
+        const insertParams = {
+            table: TABLES.ACCESS_LOG,
+            values: rows,
+            format: QUERY_FORMAT.JSON_EACH_ROW,
+            clickhouse_settings: {
+                async_insert: 1,
+                wait_for_async_insert: 1
+            }
+        };
+
+        let delay = this.initialRetryDelayMs;
+        for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+            try {
+                if (attempt > 0) {
+                    logWarn('ClickHouse AccessLog insert failed, retrying', {
+                        attempt,
+                        maxRetries: this.maxRetries,
+                        batchSize: rows.length,
+                        delay
+                    });
+                    await new Promise((resolve) => setTimeout(resolve, delay));
+                    delay *= 2;
+                }
+                await this.clickHouseClientManager.insertAsync(insertParams);
+                return;
+            } catch (error) {
+                if (attempt === this.maxRetries) {
+                    throw new RethrownError({
+                        message: `ClickHouse AccessLog insert failed after ${this.maxRetries} retries (batch size ${rows.length})`,
+                        error,
+                        args: { batchSize: rows.length }
+                    });
+                }
+            }
+        }
+    }
+}
+
+module.exports = { AccessLogClickHouseRepository };

--- a/src/routeHandlers/admin.js
+++ b/src/routeHandlers/admin.js
@@ -122,6 +122,10 @@ async function handleAdminGet (
                                 message: 'Invalid id parameter'
                             });
                         }
+                        if (container.configManager.enableAccessLogsClickHouse) {
+                            const json = await container.adminAccessLogClickHouseManager.getLogAsync(id);
+                            return res.json(json);
+                        }
                         const adminLogManager = new AdminLogManager({ mongoDatabaseManager: container.mongoDatabaseManager });
                         const json = await adminLogManager.getLogAsync(id);
                         return res.json(json);

--- a/src/tests/accessLog/accessLogs.clickhouse.test.js
+++ b/src/tests/accessLog/accessLogs.clickhouse.test.js
@@ -1,0 +1,123 @@
+const { describe, test, expect, jest, beforeEach } = require('@jest/globals');
+const { AccessLogger } = require('../../utils/accessLogger');
+const { AccessLogClickHouseWriter } = require('../../utils/accessLogClickHouseWriter');
+const { AccessLogsEventProducer } = require('../../utils/accessLogsEventProducer');
+const { DatabaseBulkInserter } = require('../../dataLayer/databaseBulkInserter');
+const { ConfigManager } = require('../../utils/configManager');
+const { ScopesManager } = require('../../operations/security/scopesManager');
+const { FhirOperationsManager } = require('../../operations/fhirOperationsManager');
+
+function makeConfig ({
+    kafka = false,
+    mongo = false,
+    clickHouse = true
+} = {}) {
+    const cm = Object.create(ConfigManager.prototype);
+    Object.defineProperty(cm, 'kafkaEnableAccessLogsEvent', { get: () => kafka });
+    Object.defineProperty(cm, 'enableAccessLogsMiddleware', { get: () => mongo });
+    Object.defineProperty(cm, 'enableAccessLogsClickHouse', { get: () => clickHouse });
+    return cm;
+}
+
+function makeLogEntry (id) {
+    return {
+        timestamp: new Date('2024-06-15T10:30:00.000Z'),
+        outcomeDesc: 'Success',
+        agent: { altId: 'user-1', networkAddress: '10.0.0.1', scopes: 'user/*.read' },
+        details: { host: 'fhir.example.com', originService: 'svc' },
+        request: { id, resourceType: 'Patient', operation: 'read', method: 'GET' }
+    };
+}
+
+function makeLogger ({ configManager, writer }) {
+    const scopesManager = Object.create(ScopesManager.prototype);
+    const fhirOperationsManager = Object.create(FhirOperationsManager.prototype);
+    const databaseBulkInserter = Object.create(DatabaseBulkInserter.prototype);
+    databaseBulkInserter.getOperationForResourceAsync = jest.fn().mockReturnValue({});
+    databaseBulkInserter.executeAsync = jest.fn().mockResolvedValue([]);
+    const accessLogsEventProducer = Object.create(AccessLogsEventProducer.prototype);
+    accessLogsEventProducer.produce = jest.fn().mockResolvedValue(undefined);
+
+    return new AccessLogger({
+        scopesManager,
+        fhirOperationsManager,
+        imageVersion: 'test',
+        configManager,
+        databaseBulkInserter,
+        accessLogsEventProducer,
+        accessLogClickHouseWriter: writer
+    });
+}
+
+describe('AccessLogger ClickHouse integration', () => {
+    let writer;
+
+    beforeEach(() => {
+        writer = Object.create(AccessLogClickHouseWriter.prototype);
+        writer.writeBatchAsync = jest.fn().mockResolvedValue({ inserted: 1, skipped: 0 });
+    });
+
+    test('routes queued docs to the ClickHouse writer when enabled', async () => {
+        const logger = makeLogger({ configManager: makeConfig(), writer });
+        logger.queue.push({ doc: makeLogEntry('req-1'), requestInfo: { requestId: 'req-1' } });
+
+        await logger.flushAsync();
+
+        expect(writer.writeBatchAsync).toHaveBeenCalledTimes(1);
+        const docs = writer.writeBatchAsync.mock.calls[0][0];
+        expect(docs).toHaveLength(1);
+        expect(docs[0].request.id).toBe('req-1');
+    });
+
+    test('batches multiple queued docs into a single writeBatchAsync call', async () => {
+        const logger = makeLogger({ configManager: makeConfig(), writer });
+        logger.queue.push(
+            { doc: makeLogEntry('req-a'), requestInfo: { requestId: 'req-a' } },
+            { doc: makeLogEntry('req-b'), requestInfo: { requestId: 'req-b' } }
+        );
+
+        await logger.flushAsync();
+
+        expect(writer.writeBatchAsync).toHaveBeenCalledTimes(1);
+        expect(writer.writeBatchAsync.mock.calls[0][0]).toHaveLength(2);
+    });
+
+    test('does not call writer when ClickHouse flag is disabled', async () => {
+        const logger = makeLogger({ configManager: makeConfig({ clickHouse: false, mongo: true }), writer });
+        logger.queue.push({ doc: makeLogEntry('req-2'), requestInfo: { requestId: 'req-2' } });
+
+        await logger.flushAsync();
+
+        expect(writer.writeBatchAsync).not.toHaveBeenCalled();
+    });
+
+    test('does not call writer when writer is null', async () => {
+        const logger = makeLogger({ configManager: makeConfig(), writer: null });
+        logger.queue.push({ doc: makeLogEntry('req-3'), requestInfo: { requestId: 'req-3' } });
+
+        await expect(logger.flushAsync()).resolves.toBeUndefined();
+    });
+
+    test('swallows writer failures — a CH outage must not break the request cycle', async () => {
+        writer.writeBatchAsync.mockResolvedValue({ inserted: 0, skipped: 1 });
+        const logger = makeLogger({ configManager: makeConfig(), writer });
+        logger.queue.push({ doc: makeLogEntry('req-4'), requestInfo: { requestId: 'req-4' } });
+
+        await expect(logger.flushAsync()).resolves.toBeUndefined();
+        expect(writer.writeBatchAsync).toHaveBeenCalledTimes(1);
+    });
+
+    test('runs Kafka, Mongo, and ClickHouse branches together when all enabled', async () => {
+        const logger = makeLogger({
+            configManager: makeConfig({ kafka: true, mongo: true, clickHouse: true }),
+            writer
+        });
+        logger.queue.push({ doc: makeLogEntry('req-5'), requestInfo: { requestId: 'req-5' } });
+
+        await logger.flushAsync();
+
+        expect(writer.writeBatchAsync).toHaveBeenCalledTimes(1);
+        expect(logger.accessLogsEventProducer.produce).toHaveBeenCalledTimes(1);
+        expect(logger.databaseBulkInserter.executeAsync).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/tests/admin/adminAccessLogClickHouseManager.test.js
+++ b/src/tests/admin/adminAccessLogClickHouseManager.test.js
@@ -1,0 +1,62 @@
+const { describe, test, expect, jest, beforeEach } = require('@jest/globals');
+const { AdminAccessLogClickHouseManager } = require('../../admin/adminAccessLogClickHouseManager');
+const { ClickHouseClientManager } = require('../../utils/clickHouseClientManager');
+const { TABLES } = require('../../constants/clickHouseConstants');
+
+describe('AdminAccessLogClickHouseManager', () => {
+    let mockClient;
+
+    beforeEach(() => {
+        mockClient = Object.create(ClickHouseClientManager.prototype);
+        mockClient.queryAsync = jest.fn();
+    });
+
+    test('queries fhir.AccessLog by request_id with parameterized id', async () => {
+        mockClient.queryAsync.mockResolvedValue([]);
+        const manager = new AdminAccessLogClickHouseManager({ clickHouseClientManager: mockClient });
+
+        await manager.getLogAsync('req-xyz');
+
+        expect(mockClient.queryAsync).toHaveBeenCalledTimes(1);
+        const call = mockClient.queryAsync.mock.calls[0][0];
+        expect(call.query).toContain(`FROM ${TABLES.ACCESS_LOG}`);
+        expect(call.query).toContain('WHERE request_id = {id:String}');
+        expect(call.query).toContain('ORDER BY timestamp DESC');
+        expect(call.query).toContain('LIMIT 100');
+        expect(call.query_params).toEqual({ id: 'req-xyz' });
+    });
+
+    test('reassembles rows into the admin response envelope', async () => {
+        mockClient.queryAsync.mockResolvedValue([
+            {
+                timestamp: '2024-06-15 10:30:00.000',
+                outcome_desc: 'Success',
+                agent: { altId: 'user-1', scopes: ['user/*.read'] },
+                details: { originService: 'svc', host: 'fhir.example.com' },
+                request: { id: 'req-xyz', method: 'GET' }
+            }
+        ]);
+        const manager = new AdminAccessLogClickHouseManager({ clickHouseClientManager: mockClient });
+
+        const result = await manager.getLogAsync('req-xyz');
+
+        expect(result).toEqual([
+            {
+                timestamp: '2024-06-15 10:30:00.000',
+                outcomeDesc: 'Success',
+                agent: { altId: 'user-1', scopes: ['user/*.read'] },
+                details: { originService: 'svc', host: 'fhir.example.com' },
+                request: { id: 'req-xyz', method: 'GET' }
+            }
+        ]);
+    });
+
+    test('returns empty array when the client throws', async () => {
+        mockClient.queryAsync.mockRejectedValue(new Error('boom'));
+        const manager = new AdminAccessLogClickHouseManager({ clickHouseClientManager: mockClient });
+
+        const result = await manager.getLogAsync('req-xyz');
+
+        expect(result).toEqual([]);
+    });
+});

--- a/src/tests/clickHouseTestContainer.js
+++ b/src/tests/clickHouseTestContainer.js
@@ -3,7 +3,12 @@ const path = require('path');
 const { withNockSuspended, setEnvVars, restoreEnvVars } = require('./testContainerUtils');
 
 const CLICKHOUSE_IMAGE = 'clickhouse/clickhouse-server:25.12.1';
-const SCHEMA_PATH = path.join(__dirname, '../../clickhouse-init/01-init-schema.sql');
+const SCHEMA_FILES = [
+    '01-init-schema.sql',
+    '02-audit-event.sql',
+    '03-audit-event-migration-state.sql',
+    '04-access-log.sql'
+];
 
 class ClickHouseTestContainer {
     constructor() {
@@ -38,12 +43,12 @@ class ClickHouseTestContainer {
                 .withEnvironment({
                     CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: '1'
                 })
-                .withCopyFilesToContainer([
-                    {
-                        source: SCHEMA_PATH,
-                        target: '/docker-entrypoint-initdb.d/01-init-schema.sql'
-                    }
-                ])
+                .withCopyFilesToContainer(
+                    SCHEMA_FILES.map((file) => ({
+                        source: path.join(__dirname, '../../clickhouse-init/', file),
+                        target: `/docker-entrypoint-initdb.d/${file}`
+                    }))
+                )
                 .withStartupTimeout(startupTimeoutMs)
                 .start()
         );

--- a/src/tests/clickhouseOnly/accessLog/accessLogClickHouseApiSearch.test.js
+++ b/src/tests/clickhouseOnly/accessLog/accessLogClickHouseApiSearch.test.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const { describe, test, beforeAll, beforeEach, afterAll, expect } = require('@jest/globals');
+const {
+    setupAccessLogClickHouseTests,
+    teardownAccessLogClickHouseTests,
+    cleanupBetweenTests,
+    getSharedRequest,
+    getAdminHeaders,
+    makeAccessLog,
+    recentTimestamp,
+    insertRows
+} = require('./accessLogClickHouseTestSetup');
+const { getHeaders } = require('../../common');
+
+describe('AccessLog ClickHouse API integration (/admin/searchLogResults)', () => {
+    beforeAll(async () => {
+        await setupAccessLogClickHouseTests();
+    }, 90000);
+
+    beforeEach(async () => {
+        await cleanupBetweenTests();
+    });
+
+    afterAll(async () => {
+        await teardownAccessLogClickHouseTests();
+    }, 30000);
+
+    describe('request_id lookup', () => {
+        test('returns the matching row in the admin envelope', async () => {
+            const request = getSharedRequest();
+            await insertRows([makeAccessLog({ requestId: 'api-envelope-1' })]);
+
+            const resp = await request
+                .get('/admin/searchLogResults?id=api-envelope-1')
+                .set(getAdminHeaders());
+
+            expect(resp.status).toBe(200);
+            expect(Array.isArray(resp.body)).toBe(true);
+            expect(resp.body).toHaveLength(1);
+            const row = resp.body[0];
+            expect(row.request.id).toBe('api-envelope-1');
+            expect(row.outcomeDesc).toBe('Success');
+            expect(row).not.toHaveProperty('outcome_desc');
+            expect(row).not.toHaveProperty('request_id');
+            expect(row.agent).toBeDefined();
+            expect(row.details).toBeDefined();
+        });
+
+        test('returns multiple rows for the same id ordered by timestamp DESC', async () => {
+            const request = getSharedRequest();
+            await insertRows([
+                makeAccessLog({ requestId: 'api-multi', timestamp: recentTimestamp(30) }),
+                makeAccessLog({ requestId: 'api-multi', timestamp: recentTimestamp(20) }),
+                makeAccessLog({ requestId: 'api-multi', timestamp: recentTimestamp(10) })
+            ]);
+
+            const resp = await request
+                .get('/admin/searchLogResults?id=api-multi')
+                .set(getAdminHeaders());
+
+            expect(resp.status).toBe(200);
+            expect(resp.body).toHaveLength(3);
+            const timestamps = resp.body.map(r => r.timestamp);
+            const sortedDesc = [...timestamps].sort().reverse();
+            expect(timestamps).toEqual(sortedDesc);
+        });
+
+        test('returns empty array when the id has no matching rows', async () => {
+            const request = getSharedRequest();
+            await insertRows([makeAccessLog({ requestId: 'api-exists' })]);
+
+            const resp = await request
+                .get('/admin/searchLogResults?id=api-does-not-exist')
+                .set(getAdminHeaders());
+
+            expect(resp.status).toBe(200);
+            expect(resp.body).toEqual([]);
+        });
+
+        test('isolates rows by id — unrelated rows do not leak', async () => {
+            const request = getSharedRequest();
+            await insertRows([
+                makeAccessLog({ requestId: 'api-target' }),
+                makeAccessLog({ requestId: 'api-other-1' }),
+                makeAccessLog({ requestId: 'api-other-2' })
+            ]);
+
+            const resp = await request
+                .get('/admin/searchLogResults?id=api-target')
+                .set(getAdminHeaders());
+
+            expect(resp.status).toBe(200);
+            expect(resp.body).toHaveLength(1);
+            expect(resp.body[0].request.id).toBe('api-target');
+        });
+
+        test('preserves JSON subfields (agent and details) verbatim', async () => {
+            const request = getSharedRequest();
+            await insertRows([
+                makeAccessLog({
+                    requestId: 'api-json-shape',
+                    agent: {
+                        altId: 'dr-who',
+                        networkAddress: '::1',
+                        scopes: ['user/Patient.read']
+                    },
+                    details: {
+                        host: 'api.example.com',
+                        originService: 'mobile-app',
+                        contentType: 'application/fhir+json',
+                        params: { _count: '10' }
+                    }
+                })
+            ]);
+
+            const resp = await request
+                .get('/admin/searchLogResults?id=api-json-shape')
+                .set(getAdminHeaders());
+
+            expect(resp.status).toBe(200);
+            expect(resp.body[0].agent.altId).toBe('dr-who');
+            expect(resp.body[0].agent.scopes).toEqual(['user/Patient.read']);
+            expect(resp.body[0].details.host).toBe('api.example.com');
+            expect(resp.body[0].details.params).toEqual({ _count: '10' });
+        });
+    });
+
+    describe('validation', () => {
+        test('rejects id that fails the admin regex with 400', async () => {
+            const request = getSharedRequest();
+
+            const resp = await request
+                .get('/admin/searchLogResults?id=has%20space')
+                .set(getAdminHeaders());
+
+            expect(resp.status).toBe(400);
+            expect(resp.body.message).toBe('Invalid id parameter');
+        });
+
+        test('returns a placeholder message when id is missing', async () => {
+            const request = getSharedRequest();
+
+            const resp = await request
+                .get('/admin/searchLogResults')
+                .set(getAdminHeaders());
+
+            expect(resp.status).toBe(200);
+            expect(resp.body).toEqual({ message: 'No id passed' });
+        });
+    });
+
+    describe('authorization', () => {
+        test('returns 403 for a non-admin token', async () => {
+            const request = getSharedRequest();
+            await insertRows([makeAccessLog({ requestId: 'api-no-admin' })]);
+
+            const resp = await request
+                .get('/admin/searchLogResults?id=api-no-admin')
+                .set(getHeaders());
+
+            expect(resp.status).toBe(403);
+        });
+    });
+});

--- a/src/tests/clickhouseOnly/accessLog/accessLogClickHouseRead.test.js
+++ b/src/tests/clickhouseOnly/accessLog/accessLogClickHouseRead.test.js
@@ -1,0 +1,250 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { describe, test, beforeAll, beforeEach, afterAll, expect } = require('@jest/globals');
+const { AdminAccessLogClickHouseManager } = require('../../../admin/adminAccessLogClickHouseManager');
+const { ClickHouseClientManager } = require('../../../utils/clickHouseClientManager');
+const { ConfigManager } = require('../../../utils/configManager');
+const { ClickHouseTestContainer } = require('../../clickHouseTestContainer');
+const { commonBeforeEach, commonAfterEach } = require('../../common');
+
+const ACCESS_LOG_SCHEMA_PATH = path.join(__dirname, '../../../../clickhouse-init/04-access-log.sql');
+
+let clickHouseTestContainer = null;
+let savedContainerEnvVars = null;
+let clientManager = null;
+let adminManager = null;
+
+async function waitForClickHouse (manager, maxWaitMs = 30000) {
+    const startTime = Date.now();
+    let delay = 100;
+    while (Date.now() - startTime < maxWaitMs) {
+        try {
+            await manager.getClientAsync();
+            const isHealthy = await manager.isHealthyAsync();
+            if (isHealthy) return true;
+        } catch (e) {
+            // retry
+        }
+        await new Promise(resolve => setTimeout(resolve, delay));
+        delay = Math.min(delay * 2, 1000);
+    }
+    throw new Error(`ClickHouse not ready after ${maxWaitMs}ms`);
+}
+
+async function insertRows (rows) {
+    await clientManager.insertAsync({
+        table: 'fhir.AccessLog',
+        values: rows,
+        format: 'JSONEachRow'
+    });
+}
+
+// AccessLog has a 7-day TTL. Default timestamps must fall inside that window
+// (roughly "now"), or ClickHouse will delete the rows before the test reads them.
+function recentTimestamp (offsetMinutes = 0) {
+    const d = new Date(Date.now() - offsetMinutes * 60 * 1000);
+    return d.toISOString().replace('T', ' ').replace('Z', '');
+}
+
+function makeRow (overrides = {}) {
+    const requestId = overrides.requestId || `req-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    return {
+        timestamp: overrides.timestamp || recentTimestamp(),
+        outcome_desc: overrides.outcomeDesc || 'Success',
+        agent: overrides.agent || {
+            altId: 'user-1',
+            networkAddress: '10.0.0.1',
+            scopes: ['user/*.read']
+        },
+        details: overrides.details || {
+            host: 'fhir.example.com',
+            originService: 'patient-portal'
+        },
+        request: overrides.request || {
+            id: requestId,
+            systemGeneratedRequestId: `sys-${requestId}`,
+            url: '/4_0_0/Patient/123',
+            resourceType: 'Patient',
+            operation: 'READ',
+            method: 'GET',
+            duration: 42
+        }
+    };
+}
+
+describe('AdminAccessLogClickHouseManager integration', () => {
+    beforeAll(async () => {
+        clickHouseTestContainer = new ClickHouseTestContainer();
+        await clickHouseTestContainer.start({ startupTimeoutMs: 60000 });
+        savedContainerEnvVars = clickHouseTestContainer.applyEnvVars();
+
+        await commonBeforeEach();
+
+        const configManager = new ConfigManager();
+        clientManager = new ClickHouseClientManager({ configManager });
+        await waitForClickHouse(clientManager, 30000);
+
+        const tableExists = await clientManager.tableExistsAsync('AccessLog');
+        if (!tableExists) {
+            const schemaSQL = fs.readFileSync(ACCESS_LOG_SCHEMA_PATH, 'utf8');
+            const statements = schemaSQL
+                .split(';')
+                .map(s => s.replace(/--.*$/gm, '').trim())
+                .filter(s => s.length > 0)
+                .filter(s => !s.startsWith('SET '));
+
+            const client = await clientManager.getClientAsync();
+            for (const stmt of statements) {
+                await client.query({
+                    query: stmt,
+                    clickhouse_settings: { allow_experimental_json_type: 1 }
+                });
+            }
+        }
+
+        adminManager = new AdminAccessLogClickHouseManager({ clickHouseClientManager: clientManager });
+    }, 90000);
+
+    beforeEach(async () => {
+        await commonBeforeEach();
+        if (clientManager) {
+            try {
+                await clientManager.queryAsync({
+                    query: 'TRUNCATE TABLE IF EXISTS fhir.AccessLog'
+                });
+            } catch (e) {
+                // ignore
+            }
+        }
+    });
+
+    afterAll(async () => {
+        if (clientManager) {
+            await clientManager.closeAsync();
+            clientManager = null;
+        }
+        if (clickHouseTestContainer) {
+            if (savedContainerEnvVars) {
+                clickHouseTestContainer.restoreEnvVars(savedContainerEnvVars);
+            }
+            await clickHouseTestContainer.stop();
+            clickHouseTestContainer = null;
+        }
+        await commonAfterEach();
+    }, 30000);
+
+    describe('getLogAsync', () => {
+        test('returns a single row in the admin envelope shape', async () => {
+            await insertRows([makeRow({ requestId: 'admin-envelope-1' })]);
+
+            const result = await adminManager.getLogAsync('admin-envelope-1');
+
+            expect(result).toHaveLength(1);
+            const row = result[0];
+            expect(row).toEqual({
+                timestamp: expect.any(String),
+                outcomeDesc: 'Success',
+                agent: expect.objectContaining({
+                    altId: 'user-1',
+                    networkAddress: '10.0.0.1'
+                }),
+                details: expect.objectContaining({
+                    host: 'fhir.example.com',
+                    originService: 'patient-portal'
+                }),
+                request: expect.objectContaining({
+                    id: 'admin-envelope-1',
+                    method: 'GET'
+                })
+            });
+            expect(row).not.toHaveProperty('outcome_desc');
+            expect(row).not.toHaveProperty('request_id');
+        });
+
+        test('returns multiple rows for the same request_id ordered by timestamp DESC', async () => {
+            await insertRows([
+                makeRow({ requestId: 'multi-row-1', timestamp: recentTimestamp(30) }),
+                makeRow({ requestId: 'multi-row-1', timestamp: recentTimestamp(20) }),
+                makeRow({ requestId: 'multi-row-1', timestamp: recentTimestamp(10) })
+            ]);
+
+            const result = await adminManager.getLogAsync('multi-row-1');
+
+            expect(result).toHaveLength(3);
+            const timestamps = result.map(r => r.timestamp);
+            const sortedDesc = [...timestamps].sort().reverse();
+            expect(timestamps).toEqual(sortedDesc);
+        });
+
+        test('isolates rows by request_id — unrelated rows are filtered out', async () => {
+            await insertRows([
+                makeRow({ requestId: 'isolate-target' }),
+                makeRow({ requestId: 'isolate-other-1' }),
+                makeRow({ requestId: 'isolate-other-2' })
+            ]);
+
+            const result = await adminManager.getLogAsync('isolate-target');
+
+            expect(result).toHaveLength(1);
+            expect(result[0].request.id).toBe('isolate-target');
+        });
+
+        test('returns empty array when no rows match the request_id', async () => {
+            await insertRows([makeRow({ requestId: 'exists' })]);
+
+            const result = await adminManager.getLogAsync('does-not-exist');
+
+            expect(result).toEqual([]);
+        });
+
+        test('returns empty array when the table is empty', async () => {
+            const result = await adminManager.getLogAsync('anything');
+
+            expect(result).toEqual([]);
+        });
+
+        test('preserves agent and details JSON subfields verbatim', async () => {
+            const customAgent = {
+                altId: 'dr-who',
+                networkAddress: '::1',
+                scopes: ['user/Patient.read', 'user/Patient.write']
+            };
+            const customDetails = {
+                host: 'api.example.com',
+                originService: 'mobile-app',
+                contentType: 'application/fhir+json',
+                params: { _count: '10' }
+            };
+            await insertRows([
+                makeRow({
+                    requestId: 'preserve-json',
+                    agent: customAgent,
+                    details: customDetails
+                })
+            ]);
+
+            const result = await adminManager.getLogAsync('preserve-json');
+
+            expect(result).toHaveLength(1);
+            expect(result[0].agent).toMatchObject(customAgent);
+            expect(result[0].details).toMatchObject(customDetails);
+        });
+
+        test('caps result set at LIMIT 100 even when more rows match', async () => {
+            const rows = [];
+            for (let i = 0; i < 105; i++) {
+                rows.push(makeRow({
+                    requestId: 'cap-target',
+                    timestamp: recentTimestamp(i)
+                }));
+            }
+            await insertRows(rows);
+
+            const result = await adminManager.getLogAsync('cap-target');
+
+            expect(result).toHaveLength(100);
+        });
+    });
+});

--- a/src/tests/clickhouseOnly/accessLog/accessLogClickHouseTestSetup.js
+++ b/src/tests/clickhouseOnly/accessLog/accessLogClickHouseTestSetup.js
@@ -1,0 +1,205 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+// Set env vars FIRST, before any requires that trigger DI container creation.
+process.env.ENABLE_CLICKHOUSE = '1';
+process.env.ENABLE_ACCESS_LOGS_CLICKHOUSE = '1';
+process.env.CLICKHOUSE_DATABASE = 'fhir';
+process.env.LOGLEVEL = 'SILENT';
+process.env.STREAM_RESPONSE = '0';
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    createTestRequest,
+    getJsonHeadersWithAdminToken,
+    getHeadersWithCustomPayload
+} = require('../../common');
+const { ClickHouseClientManager } = require('../../../utils/clickHouseClientManager');
+const { ConfigManager } = require('../../../utils/configManager');
+const { ClickHouseTestContainer } = require('../../clickHouseTestContainer');
+
+const ACCESS_LOG_SCHEMA_PATH = path.join(__dirname, '../../../../clickhouse-init/04-access-log.sql');
+
+let sharedRequest = null;
+let sharedClickHouseManager = null;
+let isSetupComplete = false;
+let setupPromise = null;
+let clickHouseTestContainer = null;
+let savedContainerEnvVars = null;
+
+async function waitForClickHouse (manager, maxWaitMs = 30000) {
+    const startTime = Date.now();
+    let delay = 100;
+    while (Date.now() - startTime < maxWaitMs) {
+        try {
+            await manager.getClientAsync();
+            const isHealthy = await manager.isHealthyAsync();
+            if (isHealthy) return true;
+        } catch (e) {
+            // retry
+        }
+        await new Promise(resolve => setTimeout(resolve, delay));
+        delay = Math.min(delay * 2, 1000);
+    }
+    throw new Error(`ClickHouse not ready after ${maxWaitMs}ms`);
+}
+
+async function loadAccessLogSchema (manager) {
+    const tableExists = await manager.tableExistsAsync('AccessLog');
+    if (!tableExists) {
+        const schemaSQL = fs.readFileSync(ACCESS_LOG_SCHEMA_PATH, 'utf8');
+        const statements = schemaSQL
+            .split(';')
+            .map(s => s.replace(/--.*$/gm, '').trim())
+            .filter(s => s.length > 0)
+            .filter(s => !s.startsWith('SET '));
+
+        const client = await manager.getClientAsync();
+        for (const stmt of statements) {
+            await client.query({
+                query: stmt,
+                clickhouse_settings: { allow_experimental_json_type: 1 }
+            });
+        }
+    }
+}
+
+async function setupAccessLogClickHouseTests () {
+    if (setupPromise) return setupPromise;
+    if (isSetupComplete) return;
+
+    setupPromise = (async () => {
+        try {
+            if (!clickHouseTestContainer) {
+                clickHouseTestContainer = new ClickHouseTestContainer();
+                await clickHouseTestContainer.start({ startupTimeoutMs: 60000 });
+                savedContainerEnvVars = clickHouseTestContainer.applyEnvVars();
+            }
+
+            await commonBeforeEach();
+
+            const configManager = new ConfigManager();
+            sharedClickHouseManager = new ClickHouseClientManager({ configManager });
+            await waitForClickHouse(sharedClickHouseManager, 30000);
+
+            await loadAccessLogSchema(sharedClickHouseManager);
+
+            sharedRequest = await createTestRequest();
+
+            isSetupComplete = true;
+        } catch (error) {
+            setupPromise = null;
+            throw error;
+        }
+    })();
+
+    return setupPromise;
+}
+
+async function teardownAccessLogClickHouseTests () {
+    if (!isSetupComplete) return;
+
+    try {
+        if (sharedClickHouseManager) {
+            await sharedClickHouseManager.closeAsync();
+            sharedClickHouseManager = null;
+        }
+
+        if (clickHouseTestContainer) {
+            if (savedContainerEnvVars) {
+                clickHouseTestContainer.restoreEnvVars(savedContainerEnvVars);
+                savedContainerEnvVars = null;
+            }
+            await clickHouseTestContainer.stop();
+            clickHouseTestContainer = null;
+        }
+
+        await commonAfterEach();
+        sharedRequest = null;
+        isSetupComplete = false;
+        setupPromise = null;
+    } catch (error) {
+        console.error('Error during teardown:', error);
+        throw error;
+    }
+}
+
+async function cleanupBetweenTests () {
+    await commonBeforeEach();
+    if (sharedClickHouseManager) {
+        try {
+            await sharedClickHouseManager.queryAsync({
+                query: 'TRUNCATE TABLE IF EXISTS fhir.AccessLog'
+            });
+        } catch (e) {
+            // ignore
+        }
+    }
+}
+
+// AccessLog has a 7-day TTL. Default timestamps must fall inside that window
+// (roughly "now"), or ClickHouse will delete the rows before the test reads them.
+function recentTimestamp (offsetMinutes = 0) {
+    const d = new Date(Date.now() - offsetMinutes * 60 * 1000);
+    return d.toISOString().replace('T', ' ').replace('Z', '');
+}
+
+function makeAccessLog (overrides = {}) {
+    const requestId = overrides.requestId || `req-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const timestamp = overrides.timestamp || recentTimestamp();
+    const outcomeDesc = overrides.outcomeDesc || 'Success';
+
+    return {
+        timestamp,
+        outcome_desc: outcomeDesc,
+        agent: overrides.agent || {
+            altId: 'user-1',
+            networkAddress: '10.0.0.1',
+            scopes: ['user/*.read', 'user/*.write']
+        },
+        details: overrides.details || {
+            host: 'fhir.example.com',
+            originService: 'patient-portal',
+            contentType: 'application/fhir+json',
+            accept: 'application/fhir+json'
+        },
+        request: overrides.request || {
+            id: requestId,
+            systemGeneratedRequestId: `sys-${requestId}`,
+            url: '/4_0_0/Patient/123',
+            resourceType: 'Patient',
+            operation: 'READ',
+            method: 'GET',
+            duration: 42
+        }
+    };
+}
+
+async function insertRows (rows) {
+    await sharedClickHouseManager.insertAsync({
+        table: 'fhir.AccessLog',
+        values: rows,
+        format: 'JSONEachRow'
+    });
+}
+
+function getSharedRequest () { return sharedRequest; }
+function getClickHouseManager () { return sharedClickHouseManager; }
+function getAdminHeaders () { return getJsonHeadersWithAdminToken(); }
+function getHeadersWithPayload (payload) { return getHeadersWithCustomPayload(payload); }
+
+module.exports = {
+    setupAccessLogClickHouseTests,
+    teardownAccessLogClickHouseTests,
+    cleanupBetweenTests,
+    getSharedRequest,
+    getClickHouseManager,
+    getAdminHeaders,
+    getHeadersWithPayload,
+    makeAccessLog,
+    recentTimestamp,
+    insertRows
+};

--- a/src/tests/dataLayer/clickHouse/accessLogTransformer.test.js
+++ b/src/tests/dataLayer/clickHouse/accessLogTransformer.test.js
@@ -1,0 +1,160 @@
+'use strict';
+
+const { describe, test, expect } = require('@jest/globals');
+const { AccessLogTransformer } = require('../../../dataLayer/clickHouse/accessLogTransformer');
+
+describe('AccessLogTransformer', () => {
+    const transformer = new AccessLogTransformer();
+
+    const baseDoc = () => ({
+        timestamp: new Date('2024-06-15T10:30:00.000Z'),
+        outcomeDesc: 'Success',
+        agent: {
+            altId: 'user-123',
+            networkAddress: '10.0.0.1',
+            scopes: 'user/*.read user/*.write'
+        },
+        details: {
+            host: 'fhir.example.com',
+            originService: 'patient-portal',
+            operationResult: 'ok'
+        },
+        request: {
+            id: 'req-abc',
+            systemGeneratedRequestId: 'sys-req-xyz',
+            url: '/4_0_0/Patient/123',
+            resourceType: 'Patient',
+            operation: 'read',
+            method: 'GET',
+            duration: 42
+        }
+    });
+
+    describe('toClickHouseDateTime', () => {
+        test('converts Date instance to ClickHouse DateTime64 format', () => {
+            const result = transformer.toClickHouseDateTime(new Date('2024-06-15T10:30:00.000Z'));
+            expect(result).toBe('2024-06-15 10:30:00.000');
+        });
+
+        test('converts ISO 8601 string to ClickHouse DateTime64 format', () => {
+            const result = transformer.toClickHouseDateTime('2024-06-15T10:30:00.000Z');
+            expect(result).toBe('2024-06-15 10:30:00.000');
+        });
+    });
+
+    describe('normalizeScopes', () => {
+        test('splits space-delimited scope string into array', () => {
+            expect(transformer.normalizeScopes('user/*.read user/*.write')).toEqual([
+                'user/*.read',
+                'user/*.write'
+            ]);
+        });
+
+        test('collapses runs of whitespace and drops empties', () => {
+            expect(transformer.normalizeScopes('  user/*.read   user/*.write  ')).toEqual([
+                'user/*.read',
+                'user/*.write'
+            ]);
+        });
+
+        test('returns array input filtered to strings', () => {
+            expect(transformer.normalizeScopes(['a', 'b', 42, null, 'c'])).toEqual(['a', 'b', 'c']);
+        });
+
+        test('returns empty array for undefined or non-string/array values', () => {
+            expect(transformer.normalizeScopes(undefined)).toEqual([]);
+            expect(transformer.normalizeScopes(null)).toEqual([]);
+            expect(transformer.normalizeScopes(123)).toEqual([]);
+        });
+    });
+
+    describe('transformDocument', () => {
+        test('produces a ClickHouse row for a valid access-log document', () => {
+            const row = transformer.transformDocument(baseDoc());
+            expect(row).not.toBeNull();
+            expect(row.timestamp).toBe('2024-06-15 10:30:00.000');
+            expect(row.outcome_desc).toBe('Success');
+            expect(row.agent).toEqual({
+                altId: 'user-123',
+                networkAddress: '10.0.0.1',
+                scopes: ['user/*.read', 'user/*.write']
+            });
+            expect(row.details).toEqual({
+                host: 'fhir.example.com',
+                originService: 'patient-portal',
+                operationResult: 'ok'
+            });
+            expect(row.request.id).toBe('req-abc');
+            expect(row).not.toHaveProperty('access_tags');
+        });
+
+        test('preserves already-array scopes', () => {
+            const doc = baseDoc();
+            doc.agent.scopes = ['patient/*.read', 'patient/*.write'];
+            const row = transformer.transformDocument(doc);
+            expect(row.agent.scopes).toEqual(['patient/*.read', 'patient/*.write']);
+        });
+
+        test('defaults outcome_desc to empty string when missing', () => {
+            const doc = baseDoc();
+            delete doc.outcomeDesc;
+            const row = transformer.transformDocument(doc);
+            expect(row.outcome_desc).toBe('');
+        });
+
+        test('defaults details to empty object when missing', () => {
+            const doc = baseDoc();
+            delete doc.details;
+            const row = transformer.transformDocument(doc);
+            expect(row.details).toEqual({});
+        });
+
+        test('defaults agent to empty object when missing', () => {
+            const doc = baseDoc();
+            delete doc.agent;
+            const row = transformer.transformDocument(doc);
+            expect(row.agent).toEqual({});
+        });
+
+        test('returns null when doc is null or undefined', () => {
+            expect(transformer.transformDocument(null)).toBeNull();
+            expect(transformer.transformDocument(undefined)).toBeNull();
+        });
+
+        test('returns null when timestamp is missing', () => {
+            const doc = baseDoc();
+            delete doc.timestamp;
+            expect(transformer.transformDocument(doc)).toBeNull();
+        });
+
+        test('returns null when request.id is missing', () => {
+            const doc = baseDoc();
+            delete doc.request.id;
+            expect(transformer.transformDocument(doc)).toBeNull();
+        });
+
+        test('returns null when request is missing', () => {
+            const doc = baseDoc();
+            delete doc.request;
+            expect(transformer.transformDocument(doc)).toBeNull();
+        });
+    });
+
+    describe('transformBatch', () => {
+        test('splits rows and skipped counts', () => {
+            const good = baseDoc();
+            const missingTimestamp = baseDoc();
+            delete missingTimestamp.timestamp;
+            const missingRequestId = baseDoc();
+            delete missingRequestId.request.id;
+
+            const result = transformer.transformBatch([good, missingTimestamp, missingRequestId, good]);
+            expect(result.rows).toHaveLength(2);
+            expect(result.skipped).toBe(2);
+        });
+
+        test('returns empty result for empty batch', () => {
+            expect(transformer.transformBatch([])).toEqual({ rows: [], skipped: 0 });
+        });
+    });
+});

--- a/src/tests/dataLayer/repositories/accessLogClickHouseRepository.test.js
+++ b/src/tests/dataLayer/repositories/accessLogClickHouseRepository.test.js
@@ -1,0 +1,111 @@
+const { describe, test, expect, jest, beforeEach } = require('@jest/globals');
+const { AccessLogClickHouseRepository } = require('../../../dataLayer/repositories/accessLogClickHouseRepository');
+const { TABLES, QUERY_FORMAT } = require('../../../constants/clickHouseConstants');
+
+describe('AccessLogClickHouseRepository', () => {
+    let mockClickHouseClientManager;
+
+    beforeEach(() => {
+        mockClickHouseClientManager = {
+            insertAsync: jest.fn().mockResolvedValue(undefined)
+        };
+    });
+
+    function createRepository (overrides = {}) {
+        return new AccessLogClickHouseRepository({
+            clickHouseClientManager: mockClickHouseClientManager,
+            maxRetries: overrides.maxRetries ?? 3,
+            initialRetryDelayMs: overrides.initialRetryDelayMs ?? 10 // fast for tests
+        });
+    }
+
+    const sampleRow = () => ({
+        timestamp: '2024-06-15 10:30:00.000',
+        outcome_desc: 'Success',
+        agent: { altId: 'user-1', scopes: ['user/*.read'] },
+        details: { host: 'fhir.example.com', originService: 'svc' },
+        request: { id: 'req-1' },
+        access_tags: ['admin']
+    });
+
+    test('inserts rows with correct table, format, and async settings', async () => {
+        const repository = createRepository();
+        const rows = [sampleRow(), sampleRow()];
+
+        await repository.insertBatchAsync(rows);
+
+        expect(mockClickHouseClientManager.insertAsync).toHaveBeenCalledTimes(1);
+        expect(mockClickHouseClientManager.insertAsync).toHaveBeenCalledWith({
+            table: TABLES.ACCESS_LOG,
+            values: rows,
+            format: QUERY_FORMAT.JSON_EACH_ROW,
+            clickhouse_settings: {
+                async_insert: 1,
+                wait_for_async_insert: 1
+            }
+        });
+    });
+
+    test('does nothing for empty array', async () => {
+        const repository = createRepository();
+        await repository.insertBatchAsync([]);
+        expect(mockClickHouseClientManager.insertAsync).not.toHaveBeenCalled();
+    });
+
+    test('does nothing for null input', async () => {
+        const repository = createRepository();
+        await repository.insertBatchAsync(null);
+        expect(mockClickHouseClientManager.insertAsync).not.toHaveBeenCalled();
+    });
+
+    test('retries on failure and succeeds on attempt 3', async () => {
+        const error = new Error('Connection refused');
+        mockClickHouseClientManager.insertAsync
+            .mockRejectedValueOnce(error)
+            .mockRejectedValueOnce(error)
+            .mockResolvedValueOnce(undefined);
+
+        const repository = createRepository();
+        await repository.insertBatchAsync([sampleRow()]);
+
+        expect(mockClickHouseClientManager.insertAsync).toHaveBeenCalledTimes(3);
+    });
+
+    test('succeeds on first retry after initial failure', async () => {
+        const error = new Error('Temporary error');
+        mockClickHouseClientManager.insertAsync
+            .mockRejectedValueOnce(error)
+            .mockResolvedValueOnce(undefined);
+
+        const repository = createRepository();
+        await repository.insertBatchAsync([sampleRow()]);
+
+        expect(mockClickHouseClientManager.insertAsync).toHaveBeenCalledTimes(2);
+    });
+
+    test('throws RethrownError after all retries exhausted', async () => {
+        const error = new Error('Connection refused');
+        mockClickHouseClientManager.insertAsync.mockRejectedValue(error);
+
+        const repository = createRepository({ maxRetries: 3 });
+
+        await expect(repository.insertBatchAsync([sampleRow()])).rejects.toThrow(
+            'ClickHouse AccessLog insert failed after 3 retries (batch size 1)'
+        );
+        expect(mockClickHouseClientManager.insertAsync).toHaveBeenCalledTimes(4);
+    });
+
+    test('uses exponential backoff for retry delays', async () => {
+        const error = new Error('Connection refused');
+        mockClickHouseClientManager.insertAsync.mockRejectedValue(error);
+
+        const repository = createRepository({ maxRetries: 2, initialRetryDelayMs: 50 });
+
+        const start = Date.now();
+        await expect(repository.insertBatchAsync([sampleRow()])).rejects.toThrow();
+        const elapsed = Date.now() - start;
+
+        // 50ms + 100ms = 150ms minimum delay (with some tolerance)
+        expect(elapsed).toBeGreaterThanOrEqual(100);
+    });
+});

--- a/src/utils/accessLogClickHouseWriter.js
+++ b/src/utils/accessLogClickHouseWriter.js
@@ -1,0 +1,64 @@
+const { logError } = require('../operations/common/logging');
+const { AccessLogClickHouseRepository } = require('../dataLayer/repositories/accessLogClickHouseRepository');
+const { AccessLogTransformer } = require('../dataLayer/clickHouse/accessLogTransformer');
+const { assertTypeEquals } = require('./assertType');
+
+/**
+ * Transforms access-log documents and writes them to ClickHouse.
+ *
+ * Unlike AuditEventClickHouseWriter, errors are logged and swallowed —
+ * a dropped access-log must never break the request cycle. This matches
+ * the failure semantics of the existing Mongo branch in AccessLogger.flushAsync().
+ */
+class AccessLogClickHouseWriter {
+    /**
+     * @param {Object} params
+     * @param {AccessLogClickHouseRepository} params.accessLogClickHouseRepository
+     * @param {AccessLogTransformer} params.accessLogTransformer
+     */
+    constructor({ accessLogClickHouseRepository, accessLogTransformer }) {
+        this.repository = accessLogClickHouseRepository;
+        assertTypeEquals(accessLogClickHouseRepository, AccessLogClickHouseRepository);
+
+        this.transformer = accessLogTransformer;
+        assertTypeEquals(accessLogTransformer, AccessLogTransformer);
+    }
+
+    /**
+     * Transforms and writes a batch of access-log documents to ClickHouse.
+     * Errors are logged with context and swallowed; this method never throws.
+     *
+     * @param {Object[]} docs - AccessLogger logEntry documents
+     * @returns {Promise<{inserted: number, skipped: number}>}
+     */
+    async writeBatchAsync(docs) {
+        if (!docs || docs.length === 0) {
+            return { inserted: 0, skipped: 0 };
+        }
+
+        const { rows, skipped } = this.transformer.transformBatch(docs);
+
+        if (rows.length === 0) {
+            return { inserted: 0, skipped };
+        }
+
+        try {
+            await this.repository.insertBatchAsync(rows);
+            return { inserted: rows.length, skipped };
+        } catch (error) {
+            logError('AccessLogClickHouseWriter: batch write failed', {
+                error: error.message,
+                source: 'AccessLogClickHouseWriter.writeBatchAsync',
+                args: {
+                    batchSize: docs.length,
+                    transformedRows: rows.length,
+                    skipped,
+                    firstRequestId: docs[0]?.request?.id || 'unknown'
+                }
+            });
+            return { inserted: 0, skipped: docs.length };
+        }
+    }
+}
+
+module.exports = { AccessLogClickHouseWriter };

--- a/src/utils/accessLogger.js
+++ b/src/utils/accessLogger.js
@@ -16,6 +16,7 @@ const { ConfigManager } = require('./configManager');
 const { logInfo, logError, logDebug } = require('../operations/common/logging');
 const { DatabaseBulkInserter } = require('../dataLayer/databaseBulkInserter');
 const { AccessLogsEventProducer } = require('./accessLogsEventProducer');
+const { AccessLogClickHouseWriter } = require('./accessLogClickHouseWriter');
 const mutex = new Mutex();
 
 class AccessLogger {
@@ -29,6 +30,7 @@ class AccessLogger {
      * @property {ConfigManager} configManager
      * @property {DatabaseBulkInserter} databaseBulkInserter
      * @property {AccessLogsEventProducer} accessLogsEventProducer
+     * @property {AccessLogClickHouseWriter|null} [accessLogClickHouseWriter]
      *
      * @param {params}
      */
@@ -39,7 +41,8 @@ class AccessLogger {
         imageVersion,
         configManager,
         databaseBulkInserter,
-        accessLogsEventProducer
+        accessLogsEventProducer,
+        accessLogClickHouseWriter = null
     }) {
         /**
          * @type {ScopesManager}
@@ -77,6 +80,13 @@ class AccessLogger {
          */
         this.accessLogsEventProducer = accessLogsEventProducer;
         assertTypeEquals(accessLogsEventProducer, AccessLogsEventProducer);
+        /**
+         * @type {AccessLogClickHouseWriter|null}
+         */
+        this.accessLogClickHouseWriter = accessLogClickHouseWriter;
+        if (accessLogClickHouseWriter) {
+            assertTypeEquals(accessLogClickHouseWriter, AccessLogClickHouseWriter);
+        }
         /**
          * @type {object[]}
          */
@@ -249,6 +259,8 @@ class AccessLogger {
         const operationsMap = new Map();
         operationsMap.set(ACCESS_LOGS_COLLECTION_NAME, []);
         const accessLogs = [];
+        const clickHouseAccessLogs = [];
+        const clickHouseEnabled = this.configManager.enableAccessLogsClickHouse && this.accessLogClickHouseWriter;
 
         for (const { doc, requestInfo } of currentQueue) {
             ({ requestId } = requestInfo);
@@ -274,9 +286,16 @@ class AccessLogger {
                     })
                 );
             }
+            if (clickHouseEnabled) {
+                clickHouseAccessLogs.push(doc);
+            }
         }
         if (accessLogs.length > 0) {
             await this.accessLogsEventProducer.produce(accessLogs);
+        }
+        if (clickHouseAccessLogs.length > 0) {
+            // Writer swallows errors internally; a lost access-log must not break the request cycle.
+            await this.accessLogClickHouseWriter.writeBatchAsync(clickHouseAccessLogs);
         }
         if (operationsMap.get(ACCESS_LOGS_COLLECTION_NAME).length > 0) {
             const requestInfo = currentQueue[0].requestInfo;

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -599,6 +599,14 @@ class ConfigManager {
     }
 
     /**
+     * whether to write access logs to ClickHouse
+     * @return {boolean}
+     */
+    get enableAccessLogsClickHouse() {
+        return isTrue(env.ENABLE_ACCESS_LOGS_CLICKHOUSE) && this.enableClickHouse;
+    }
+
+    /**
      * returns the maximum number of IDs to include in each audit event
      * @returns {number}
      */


### PR DESCRIPTION
## Summary
- Adds a dedicated ClickHouse write path for access-logs (transformer -> repository -> writer), wired into `AccessLogger.flushAsync` and gated on `ENABLE_ACCESS_LOGS_CLICKHOUSE`. Mongo + Kafka sinks are unchanged.
- Adds `AdminAccessLogClickHouseManager` with a parameterized `SELECT` against `fhir.AccessLog` and routes `/admin/searchLogResults` through it when the flag is on; falls back to the existing Mongo manager otherwise.
- Ships `clickhouse-init/04-access-log.sql` — hybrid layout with native `JSON` columns (`agent`, `details`, `request`) plus materialized String mirrors (`request_id`, `agent_altId`, `origin_service`) backed by bloom-filter skip indexes. Daily partitions with a 7-day TTL so aged partitions drop wholesale during merges.
- AccessLog bypasses the generic FHIR ClickHouse scaffolding (schema registry, generic parser/builder). It has no `id`, `resourceType`, `meta.security`, or tenancy — threading it through the registry required workarounds that leaked AccessLog shape into shared code.

## Test plan
- [x] `node node_modules/.bin/jest src/tests/dataLayer/clickHouse/accessLogTransformer.test.js`
- [x] `node node_modules/.bin/jest src/tests/dataLayer/repositories/accessLogClickHouseRepository.test.js`
- [x] `node node_modules/.bin/jest src/tests/admin/adminAccessLogClickHouseManager.test.js`
- [x] `node node_modules/.bin/jest src/tests/accessLog/accessLogs.clickhouse.test.js`
- [x] `node node_modules/.bin/jest src/tests/clickhouseOnly/accessLog/accessLogClickHouseRead.test.js`
- [x] `node node_modules/.bin/jest src/tests/clickhouseOnly/accessLog/accessLogClickHouseApiSearch.test.js`
- [x] `make lint`
- [x] End-to-end smoke against local stack: POST a FHIR request, verify row lands in `fhir.AccessLog`, verify admin manager returns the expected `{ timestamp, outcomeDesc, agent, details, request }` envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)