### PR TITLE
DCON-3458: Added POST endpoint for the match test

### DIFF
--- a/src/admin/personMatchManager.js
+++ b/src/admin/personMatchManager.js
@@ -493,7 +493,7 @@ class PersonMatchManager {
                     new OperationOutcomeIssue({
                         severity: 'error',
                         code: 'invalid',
-                        diagnostics: 'parameter array must not be empty'
+                        diagnostics: 'parameter must be a non-empty array'
                     })
                 ]
             }).toJSON();

--- a/src/admin/personMatchManager.js
+++ b/src/admin/personMatchManager.js
@@ -524,7 +524,7 @@ class PersonMatchManager {
                         new OperationOutcomeIssue({
                             severity: 'error',
                             code: 'timeout',
-                            diagnostics: 'Request timed out while sending edited payload to person-matching service'
+                            diagnostics: 'Request timed out while sending Parameters payload to person-matching service'
                         })
                     ]
                 }).toJSON();

--- a/src/admin/personMatchManager.js
+++ b/src/admin/personMatchManager.js
@@ -468,6 +468,70 @@ class PersonMatchManager {
             }
         }
     }
+
+    /**
+     * Forwards a Parameters payload to the Person Matching Service.
+     * @param {Object} parameters - FHIR Parameters resource
+     * @returns {Promise<Object>}
+     */
+    async runMatchWithPayloadAsync ({ parameters }) {
+        if (!parameters || parameters.resourceType !== 'Parameters') {
+            return new OperationOutcome({
+                issue: [
+                    new OperationOutcomeIssue({
+                        severity: 'error',
+                        code: 'invalid',
+                        diagnostics: 'resourceType must be "Parameters"'
+                    })
+                ]
+            }).toJSON();
+        }
+
+        if (!parameters.parameter || !Array.isArray(parameters.parameter) || parameters.parameter.length === 0) {
+            return new OperationOutcome({
+                issue: [
+                    new OperationOutcomeIssue({
+                        severity: 'error',
+                        code: 'invalid',
+                        diagnostics: 'parameter array must not be empty'
+                    })
+                ]
+            }).toJSON();
+        }
+
+        const url = this.configManager.personMatchingServiceUrl;
+        assertIsValid(url, 'PERSON_MATCHING_SERVICE_URL environment variable is not set');
+
+        const accessToken = await this.oauthClientCredentialsHelper.getAccessTokenAsync();
+        const header = {
+            'Content-Type': 'application/fhir+json',
+            Accept: 'application/fhir+json',
+            Authorization: `Bearer ${accessToken}`
+        };
+
+        try {
+            const res = await superagent
+                .post(url)
+                .send(parameters)
+                .set(header)
+                .retry(EXTERNAL_REQUEST_RETRY_COUNT)
+                .timeout(this.configManager.requestTimeoutMs);
+            return res.body;
+        } catch (error) {
+            if (error.timeout) {
+                return new OperationOutcome({
+                    issue: [
+                        new OperationOutcomeIssue({
+                            severity: 'error',
+                            code: 'timeout',
+                            diagnostics: 'Request timed out while sending edited payload to person-matching service'
+                        })
+                    ]
+                }).toJSON();
+            }
+            throw error;
+        }
+    }
 }
 
 module.exports = {

--- a/src/routeHandlers/admin.js
+++ b/src/routeHandlers/admin.js
@@ -490,6 +490,17 @@ async function handleAdminPost (
                         return res.status(error.statusCode || 500).json(operationOutcome);
                     }
                 }
+
+                case 'runMatchWithPayload': {
+                    logInfo('', { operation: 'runMatchWithPayload' });
+                    const parameters = req.body;
+                    const personMatchManager = container.personMatchManager;
+                    assertIsValid(personMatchManager);
+                    const json = await personMatchManager.runMatchWithPayloadAsync({
+                        parameters
+                    });
+                    return res.json(json);
+                }
                 default: {
                     return res.json({ message: 'Invalid Path' });
                 }

--- a/src/tests/admin/personMatchManager.test.js
+++ b/src/tests/admin/personMatchManager.test.js
@@ -125,7 +125,7 @@ describe('PersonMatchManager', () => {
 
         expect(result.issue).toBeDefined();
         expect(result.issue[0].severity).toBe('error');
-        expect(result.issue[0].diagnostics).toContain('parameter array must not be empty');
+        expect(result.issue[0].diagnostics).toContain('parameter must be a non-empty array');
         expect(mockPost).not.toHaveBeenCalled();
     });
 
@@ -139,7 +139,7 @@ describe('PersonMatchManager', () => {
         });
 
         expect(result.issue).toBeDefined();
-        expect(result.issue[0].diagnostics).toContain('parameter array must not be empty');
+        expect(result.issue[0].diagnostics).toContain('parameter must be a non-empty array');
         expect(mockPost).not.toHaveBeenCalled();
     });
 

--- a/src/tests/admin/personMatchManager.test.js
+++ b/src/tests/admin/personMatchManager.test.js
@@ -1,0 +1,161 @@
+const { describe, test, expect, jest, beforeEach } = require('@jest/globals');
+
+const mockRequest = {
+    send: jest.fn(),
+    set: jest.fn(),
+    retry: jest.fn(),
+    timeout: jest.fn()
+};
+
+const mockPost = jest.fn();
+
+jest.mock('superagent', () => ({
+    post: mockPost
+}));
+
+const { PersonMatchManager } = require('../../admin/personMatchManager');
+const { DatabaseQueryFactory } = require('../../dataLayer/databaseQueryFactory');
+const { ConfigManager } = require('../../utils/configManager');
+const { OAuthClientCredentialsHelper } = require('../../utils/oauthClientCredentialsHelper');
+const { AuditLogger } = require('../../utils/auditLogger');
+const { PostRequestProcessor } = require('../../utils/postRequestProcessor');
+const { RequestSpecificCache } = require('../../utils/requestSpecificCache');
+
+describe('PersonMatchManager', () => {
+    let personMatchManager;
+    let mockConfigManager;
+    let mockOauthHelper;
+    let mockAuditLogger;
+    let mockPostRequestProcessor;
+    let mockRequestSpecificCache;
+    let mockDatabaseQueryFactory;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Re-wire the superagent mock chain
+        mockRequest.send.mockReturnValue(mockRequest);
+        mockRequest.set.mockReturnValue(mockRequest);
+        mockRequest.retry.mockReturnValue(mockRequest);
+        mockRequest.timeout.mockResolvedValue({
+            body: { resourceType: 'Bundle', entry: [] }
+        });
+        mockPost.mockReturnValue(mockRequest);
+
+        mockDatabaseQueryFactory = Object.create(DatabaseQueryFactory.prototype);
+        mockConfigManager = Object.create(ConfigManager.prototype);
+        Object.defineProperty(mockConfigManager, 'personMatchingServiceUrl', {
+            get: () => 'https://match.example.com/$match'
+        });
+        Object.defineProperty(mockConfigManager, 'requestTimeoutMs', {
+            get: () => 30000
+        });
+
+        mockOauthHelper = Object.create(OAuthClientCredentialsHelper.prototype);
+        mockOauthHelper.getAccessTokenAsync = jest.fn().mockResolvedValue('mock-token');
+
+        mockAuditLogger = Object.create(AuditLogger.prototype);
+        mockAuditLogger.logAuditEntryAsync = jest.fn().mockResolvedValue(undefined);
+
+        mockPostRequestProcessor = Object.create(PostRequestProcessor.prototype);
+        mockPostRequestProcessor.add = jest.fn();
+        mockPostRequestProcessor.executeAsync = jest.fn().mockResolvedValue(undefined);
+
+        mockRequestSpecificCache = Object.create(RequestSpecificCache.prototype);
+        mockRequestSpecificCache.clearAsync = jest.fn().mockResolvedValue(undefined);
+
+        personMatchManager = new PersonMatchManager({
+            databaseQueryFactory: mockDatabaseQueryFactory,
+            configManager: mockConfigManager,
+            oauthClientCredentialsHelper: mockOauthHelper,
+            auditLogger: mockAuditLogger,
+            postRequestProcessor: mockPostRequestProcessor,
+            requestSpecificCache: mockRequestSpecificCache
+        });
+    });
+
+    test('forwards valid Parameters payload to matching service and returns response', async () => {
+        const parameters = {
+            resourceType: 'Parameters',
+            parameter: [
+                { name: 'resource', resource: { resourceType: 'Patient', id: '123' } },
+                { name: 'match', resource: { resourceType: 'Patient', id: '456' } }
+            ]
+        };
+
+        const result = await personMatchManager.runMatchWithPayloadAsync({
+            parameters
+        });
+
+        expect(mockPost).toHaveBeenCalledWith('https://match.example.com/$match');
+        expect(mockRequest.send).toHaveBeenCalledWith(parameters);
+        expect(mockRequest.set).toHaveBeenCalledWith(
+            expect.objectContaining({
+                Authorization: 'Bearer mock-token'
+            })
+        );
+        expect(result).toEqual({ resourceType: 'Bundle', entry: [] });
+    });
+
+    test('rejects payload missing resourceType Parameters', async () => {
+        const parameters = {
+            resourceType: 'Bundle',
+            parameter: [{ name: 'resource', resource: {} }]
+        };
+
+        const result = await personMatchManager.runMatchWithPayloadAsync({
+            parameters
+        });
+
+        expect(result.issue).toBeDefined();
+        expect(result.issue[0].severity).toBe('error');
+        expect(result.issue[0].diagnostics).toContain('resourceType must be "Parameters"');
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    test('rejects payload with empty parameter array', async () => {
+        const parameters = {
+            resourceType: 'Parameters',
+            parameter: []
+        };
+
+        const result = await personMatchManager.runMatchWithPayloadAsync({
+            parameters
+        });
+
+        expect(result.issue).toBeDefined();
+        expect(result.issue[0].severity).toBe('error');
+        expect(result.issue[0].diagnostics).toContain('parameter array must not be empty');
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    test('rejects payload with missing parameter field', async () => {
+        const parameters = {
+            resourceType: 'Parameters'
+        };
+
+        const result = await personMatchManager.runMatchWithPayloadAsync({
+            parameters
+        });
+
+        expect(result.issue).toBeDefined();
+        expect(result.issue[0].diagnostics).toContain('parameter array must not be empty');
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    test('returns OperationOutcome on timeout', async () => {
+        mockRequest.timeout.mockRejectedValue({ timeout: true });
+
+        const parameters = {
+            resourceType: 'Parameters',
+            parameter: [{ name: 'resource', resource: { resourceType: 'Patient', id: '123' } }]
+        };
+
+        const result = await personMatchManager.runMatchWithPayloadAsync({
+            parameters
+        });
+
+        expect(result.issue).toBeDefined();
+        expect(result.issue[0].code).toBe('timeout');
+    });
+});


### PR DESCRIPTION
This pull request introduces a new feature to allow administrators to forward a FHIR Parameters payload directly to the Person Matching Service, along with robust validation and error handling. It also adds comprehensive unit tests for this new functionality. The most important changes are grouped below:

**New Feature: Forwarding Parameters Payload**

* Added a new method `runMatchWithPayloadAsync` to the `PersonMatchManager` class, which validates a FHIR Parameters payload, handles errors, and forwards the request to the external Person Matching Service with proper authentication and headers.
* Integrated a new admin API endpoint (`runMatchWithPayload`) in the `handleAdminPost` route handler, enabling admins to invoke the new forwarding method via HTTP.