### PR TITLE
DCON-3502: Harden AuditEvent→ClickHouse migration resume + operator tooling

### DIFF
--- a/clickhouse-init/03-audit-event-migration-state.sql
+++ b/clickhouse-init/03-audit-event-migration-state.sql
@@ -10,9 +10,15 @@ CREATE TABLE IF NOT EXISTS fhir.audit_event_migration_state (
     source_count      UInt64 DEFAULT 0,
     inserted_count    UInt64 DEFAULT 0,
     last_mongo_id     String DEFAULT '',
+    last_recorded     String DEFAULT '',
     started_at        Nullable(DateTime64(3, 'UTC')),
     completed_at      Nullable(DateTime64(3, 'UTC')),
     error_message     String DEFAULT '',
     updated_at        DateTime64(3, 'UTC')
 ) ENGINE = ReplacingMergeTree(updated_at)
 ORDER BY (partition_day);
+
+-- For already-initialized deployments, add the column in place.
+-- Safe to run repeatedly; no-op on fresh installs that hit the CREATE above.
+ALTER TABLE fhir.audit_event_migration_state
+    ADD COLUMN IF NOT EXISTS last_recorded String DEFAULT '' AFTER last_mongo_id;

--- a/src/admin/scripts/migrateAuditEventsToClickhouse.js
+++ b/src/admin/scripts/migrateAuditEventsToClickhouse.js
@@ -23,6 +23,8 @@
  *   --dry-run                Count source docs and seed state without inserting
  *   --verify-only            Skip migration, run count verification only
  *   --resume                 Resume from incomplete partitions
+ *   --show-state             Print audit_event_migration_state rows (no archive creds required)
+ *   --delete-partitions <days> Delete AuditEvent rows for given YYYY-MM-DD days and reset state
  *   --help, -h               Show this help
  *
  * Examples:
@@ -94,7 +96,9 @@ function parseArgs() {
         concurrency: 3,
         dryRun: false,
         verifyOnly: false,
-        resume: false
+        resume: false,
+        showState: false,
+        deletePartitions: null // Array<string> of 'YYYY-MM-DD' once parsed
     };
 
     for (let i = 0; i < args.length; i++) {
@@ -123,6 +127,15 @@ function parseArgs() {
             case '--resume':
                 options.resume = true;
                 break;
+            case '--show-state':
+                options.showState = true;
+                break;
+            case '--delete-partitions':
+                options.deletePartitions = args[++i]
+                    .split(',')
+                    .map((d) => d.trim())
+                    .filter(Boolean);
+                break;
             case '--help':
             case '-h':
                 logInfo(`
@@ -143,6 +156,10 @@ Options:
   --dry-run                Seed state, count docs, don't insert
   --verify-only            Run count verification only
   --resume                 Resume incomplete partitions
+  --show-state             Print audit_event_migration_state rows (ClickHouse only, no archive needed)
+  --delete-partitions <days> Comma-separated YYYY-MM-DD list. Deletes AuditEvent rows for
+                           those days via ALTER ... DELETE (blocking mutation) and resets
+                           the state row to 'pending' so --resume will re-migrate it.
   --help, -h               Show this help
                 `);
                 process.exit(0);
@@ -204,7 +221,11 @@ async function runWorkersAsync({
             const partition = partitions[idx];
             if (!partition) break;
 
-            const { partition_day: day, last_mongo_id: lastId } = partition;
+            const {
+                partition_day: day,
+                last_mongo_id: lastId,
+                last_recorded: lastRecorded
+            } = partition;
 
             try {
                 const worker = new PartitionWorker({
@@ -218,7 +239,8 @@ async function runWorkersAsync({
 
                 const result = await worker.processAsync({
                     partitionDay: day,
-                    lastMongoId: lastId || ''
+                    lastMongoId: lastId || '',
+                    lastRecorded: lastRecorded || ''
                 });
 
                 totalInserted += result.insertedCount;
@@ -253,10 +275,199 @@ async function runWorkersAsync({
 }
 
 /**
+ * Print the migration state table.
+ *
+ * Runs against ClickHouse only — does not require Online Archive credentials,
+ * so an operator can check progress with just ClickHouse access. Filters by the
+ * same --start-date / --end-date flags the migration modes use, so operators
+ * get a consistent slice across runs.
+ *
+ * @param {Object} params
+ * @param {MigrationStateManager} params.stateManager
+ * @param {string} params.startDate - inclusive 'YYYY-MM-DD'
+ * @param {string} params.endDate - exclusive 'YYYY-MM-DD'
+ * @returns {Promise<void>}
+ */
+async function showMigrationStateAsync({ stateManager, startDate, endDate }) {
+    const allStates = await stateManager.getAllStatesAsync();
+    const states = allStates.filter(
+        (s) => s.partition_day >= startDate && s.partition_day < endDate
+    );
+
+    logInfo('Migration state table', {
+        table: 'fhir.audit_event_migration_state',
+        startDate,
+        endDate,
+        rows: states.length
+    });
+
+    for (const s of states) {
+        logInfo('Partition state', {
+            partitionDay: s.partition_day,
+            status: s.status,
+            sourceCount: Number(s.source_count) || 0,
+            insertedCount: Number(s.inserted_count) || 0,
+            lastMongoId: s.last_mongo_id || '',
+            lastRecorded: s.last_recorded || '',
+            startedAt: s.started_at || null,
+            completedAt: s.completed_at || null,
+            errorMessage: s.error_message || ''
+        });
+    }
+
+    const summary = {
+        total: states.length,
+        pending: 0,
+        in_progress: 0,
+        completed: 0,
+        failed: 0,
+        totalSource: 0,
+        totalInserted: 0
+    };
+    for (const s of states) {
+        summary[s.status] = (summary[s.status] || 0) + 1;
+        summary.totalSource += Number(s.source_count) || 0;
+        summary.totalInserted += Number(s.inserted_count) || 0;
+    }
+    logInfo('Migration state summary', summary);
+}
+
+/**
+ * Validates a YYYY-MM-DD string and normalizes it to canonical form.
+ * Rejects malformed input — critical because this string interpolates into an
+ * ALTER ... DELETE predicate (though we parameterize, we still want clean data).
+ * @param {string} day
+ * @returns {string} canonical 'YYYY-MM-DD'
+ * @throws {Error} if the date is malformed or invalid
+ */
+function validatePartitionDay(day) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) {
+        throw new Error(`Invalid partition day '${day}': expected YYYY-MM-DD`);
+    }
+    const parsed = new Date(day + 'T00:00:00.000Z');
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== day) {
+        throw new Error(`Invalid partition day '${day}': not a real calendar date`);
+    }
+    return day;
+}
+
+/**
+ * Delete AuditEvent rows for specified partition days and reset their state rows.
+ *
+ * AuditEvent_4_0_0 is PARTITION BY toYYYYMM(recorded) (monthly), so we can't
+ * DROP PARTITION for a single day — we use ALTER TABLE ... DELETE with
+ * mutations_sync = 2 so the call blocks until the mutation completes. On a
+ * 55TB table this can take minutes per day.
+ *
+ * State rows are not DELETE-d; they're re-inserted as 'pending' so --resume
+ * will re-migrate them. ReplacingMergeTree collapse does the rest.
+ *
+ * @param {Object} params
+ * @param {ClickHouseClientManager} params.clickHouseClientManager
+ * @param {MigrationStateManager} params.stateManager
+ * @param {string[]} params.days - Array of YYYY-MM-DD strings
+ * @returns {Promise<void>}
+ */
+async function deletePartitionsAsync({ clickHouseClientManager, stateManager, days }) {
+    const validated = days.map(validatePartitionDay);
+
+    // Preview what's about to get nuked
+    const allStates = await stateManager.getAllStatesAsync();
+    const stateByDay = new Map(allStates.map((s) => [s.partition_day, s]));
+
+    logWarn('About to delete partitions', {
+        table: 'fhir.AuditEvent_4_0_0',
+        days: validated,
+        count: validated.length
+    });
+    for (const day of validated) {
+        const s = stateByDay.get(day);
+        logWarn('Partition to delete', {
+            partitionDay: day,
+            currentStatus: s?.status || '(no state row)',
+            currentInsertedCount: Number(s?.inserted_count) || 0,
+            currentSourceCount: Number(s?.source_count) || 0
+        });
+    }
+
+    for (const day of validated) {
+        logInfo('Deleting AuditEvent rows', { partitionDay: day });
+        // mutations_sync = 2 blocks until the mutation finishes on all replicas.
+        // Without this, ALTER DELETE returns immediately and the caller can't
+        // tell whether the data is actually gone yet.
+        await clickHouseClientManager.queryAsync({
+            query: `ALTER TABLE fhir.AuditEvent_4_0_0
+                    DELETE WHERE toDate(recorded) = {day:String}
+                    SETTINGS mutations_sync = 2`,
+            query_params: { day }
+        });
+
+        logInfo('Resetting migration state row', { partitionDay: day });
+        await stateManager.resetPartitionAsync(day);
+
+        logInfo('Partition deleted', { partitionDay: day });
+    }
+
+    logInfo('Delete complete', { days: validated, count: validated.length });
+}
+
+/**
  * Main migration function
  */
 async function main() {
     const options = parseArgs();
+
+    // --show-state and --delete-partitions run without archive credentials;
+    // handle before buildMongoUrl() which exits(1) when the archive URL is absent.
+    if (options.showState) {
+        const configManager = new ConfigManager();
+        const clickHouseManager = new ClickHouseClientManager({ configManager });
+        await clickHouseManager.getClientAsync();
+        const stateManager = new MigrationStateManager({
+            clickHouseClientManager: clickHouseManager
+        });
+        await showMigrationStateAsync({
+            stateManager,
+            startDate: options.startDate,
+            endDate: options.endDate
+        });
+        await clickHouseManager.closeAsync();
+        return;
+    }
+
+    if (options.deletePartitions) {
+        if (options.deletePartitions.length === 0) {
+            logError('--delete-partitions requires at least one YYYY-MM-DD day');
+            process.exit(1);
+        }
+        // Validate days up-front so we fail fast on malformed input — before
+        // opening a ClickHouse connection or printing a scary confirmation banner.
+        let validatedDays;
+        try {
+            validatedDays = options.deletePartitions.map(validatePartitionDay);
+        } catch (err) {
+            logError(err.message);
+            process.exit(1);
+        }
+
+        const configManager = new ConfigManager();
+        const clickHouseManager = new ClickHouseClientManager({ configManager });
+        await clickHouseManager.getClientAsync();
+        const stateManager = new MigrationStateManager({
+            clickHouseClientManager: clickHouseManager
+        });
+        try {
+            await deletePartitionsAsync({
+                clickHouseClientManager: clickHouseManager,
+                stateManager,
+                days: validatedDays
+            });
+        } finally {
+            await clickHouseManager.closeAsync();
+        }
+        return;
+    }
+
     const { mongoUrl, dbName } = buildMongoUrl();
 
     const mode = options.dryRun
@@ -362,7 +573,11 @@ async function main() {
         partitions = await stateManager.getPendingPartitionsAsync(dateRange);
         logInfo('Continuing migration', { partitionsRemaining: partitions.length, ...dateRange });
     } else {
-        partitions = days.map((day) => ({ partition_day: day, last_mongo_id: '' }));
+        partitions = days.map((day) => ({
+            partition_day: day,
+            last_mongo_id: '',
+            last_recorded: ''
+        }));
         logInfo('Processing all partitions', { total: partitions.length });
     }
 

--- a/src/admin/utils/migrationStateManager.js
+++ b/src/admin/utils/migrationStateManager.js
@@ -38,6 +38,7 @@ class MigrationStateManager {
             source_count: 0,
             inserted_count: 0,
             last_mongo_id: '',
+            last_recorded: '',
             started_at: null,
             completed_at: null,
             error_message: '',
@@ -82,10 +83,10 @@ class MigrationStateManager {
      * @param {Object} [options]
      * @param {string} [options.startDate] - Inclusive start date 'YYYY-MM-DD'
      * @param {string} [options.endDate] - Exclusive end date 'YYYY-MM-DD'
-     * @returns {Promise<Array<{partition_day: string, status: string, last_mongo_id: string}>>}
+     * @returns {Promise<Array<{partition_day: string, status: string, last_mongo_id: string, last_recorded: string}>>}
      */
     async getPendingPartitionsAsync({ startDate, endDate } = {}) {
-        let query = `SELECT partition_day, status, last_mongo_id
+        let query = `SELECT partition_day, status, last_mongo_id, last_recorded
                     FROM ${this.table} FINAL
                     WHERE status IN ('pending', 'in_progress', 'failed')`;
         const query_params = {};
@@ -121,6 +122,7 @@ class MigrationStateManager {
                     source_count: Number(current?.source_count) || 0,
                     inserted_count: Number(current?.inserted_count) || 0,
                     last_mongo_id: current?.last_mongo_id || '',
+                    last_recorded: current?.last_recorded || '',
                     started_at: now,
                     completed_at: null,
                     error_message: '',
@@ -136,10 +138,11 @@ class MigrationStateManager {
      * @param {Object} params
      * @param {string} params.partitionDay
      * @param {string} params.lastMongoId
+     * @param {string} params.lastRecorded - ISO-8601 string of the last processed doc's `recorded` field
      * @param {number} params.insertedCount
      * @returns {Promise<void>}
      */
-    async updateCheckpointAsync({ partitionDay, lastMongoId, insertedCount }) {
+    async updateCheckpointAsync({ partitionDay, lastMongoId, lastRecorded, insertedCount }) {
         const now = new Date().toISOString().replace('T', ' ').replace('Z', '');
         const current = await this.getStateForDayAsync(partitionDay);
         await this.clickHouseClientManager.insertAsync({
@@ -151,6 +154,7 @@ class MigrationStateManager {
                     source_count: Number(current?.source_count) || 0,
                     inserted_count: insertedCount,
                     last_mongo_id: lastMongoId,
+                    last_recorded: lastRecorded || '',
                     started_at: current?.started_at || null,
                     completed_at: null,
                     error_message: '',
@@ -168,9 +172,16 @@ class MigrationStateManager {
      * @param {number} params.insertedCount
      * @param {number} params.sourceCount
      * @param {string} [params.lastMongoId] - Final mongo _id processed
+     * @param {string} [params.lastRecorded] - Final mongo `recorded` ISO-8601 string processed
      * @returns {Promise<void>}
      */
-    async markCompletedAsync({ partitionDay, insertedCount, sourceCount, lastMongoId }) {
+    async markCompletedAsync({
+        partitionDay,
+        insertedCount,
+        sourceCount,
+        lastMongoId,
+        lastRecorded
+    }) {
         const now = new Date().toISOString().replace('T', ' ').replace('Z', '');
         const current = await this.getStateForDayAsync(partitionDay);
         await this.clickHouseClientManager.insertAsync({
@@ -182,6 +193,7 @@ class MigrationStateManager {
                     source_count: sourceCount,
                     inserted_count: insertedCount,
                     last_mongo_id: lastMongoId || current?.last_mongo_id || '',
+                    last_recorded: lastRecorded || current?.last_recorded || '',
                     started_at: current?.started_at || null,
                     completed_at: now,
                     error_message: '',
@@ -212,6 +224,7 @@ class MigrationStateManager {
                     source_count: Number(current?.source_count) || 0,
                     inserted_count: insertedCount,
                     last_mongo_id: current?.last_mongo_id || '',
+                    last_recorded: current?.last_recorded || '',
                     started_at: current?.started_at || null,
                     completed_at: null,
                     error_message: errorMessage.substring(0, 1000),
@@ -240,9 +253,44 @@ class MigrationStateManager {
                     source_count: sourceCount,
                     inserted_count: Number(current?.inserted_count) || 0,
                     last_mongo_id: current?.last_mongo_id || '',
+                    last_recorded: current?.last_recorded || '',
                     started_at: current?.started_at || null,
                     completed_at: current?.completed_at || null,
                     error_message: current?.error_message || '',
+                    updated_at: now
+                }
+            ],
+            format: 'JSONEachRow'
+        });
+    }
+
+    /**
+     * Resets a partition back to 'pending' with cleared checkpoints. Used by the
+     * --delete-partitions flow after the AuditEvent rows for this day are deleted.
+     *
+     * We write a fresh row rather than DELETE-ing the existing one: the state table is
+     * ReplacingMergeTree(updated_at) ORDER BY (partition_day), so a later-updated_at
+     * row naturally supersedes earlier ones on merge, and --resume picks up 'pending'
+     * partitions via getPendingPartitionsAsync.
+     *
+     * @param {string} partitionDay
+     * @returns {Promise<void>}
+     */
+    async resetPartitionAsync(partitionDay) {
+        const now = new Date().toISOString().replace('T', ' ').replace('Z', '');
+        await this.clickHouseClientManager.insertAsync({
+            table: this.table,
+            values: [
+                {
+                    partition_day: partitionDay,
+                    status: 'pending',
+                    source_count: 0,
+                    inserted_count: 0,
+                    last_mongo_id: '',
+                    last_recorded: '',
+                    started_at: null,
+                    completed_at: null,
+                    error_message: '',
                     updated_at: now
                 }
             ],

--- a/src/admin/utils/migrationVerifier.js
+++ b/src/admin/utils/migrationVerifier.js
@@ -119,9 +119,18 @@ class MigrationVerifier {
         dayEnd.setUTCDate(dayEnd.getUTCDate() + 1);
 
         const collection = this.sourceDb.collection(this.collectionName);
-        return collection.countDocuments({
+        const query = {
             recorded: { $gte: dayStart, $lt: dayEnd }
+        };
+        logInfo('MongoDB query', {
+            operation: 'countDocuments',
+            db: this.sourceDb.databaseName,
+            collection: this.collectionName,
+            partitionDay,
+            query,
+            context: 'verifier.getSourceCount'
         });
+        return collection.countDocuments(query);
     }
 
     /**

--- a/src/admin/utils/partitionWorker.js
+++ b/src/admin/utils/partitionWorker.js
@@ -9,6 +9,23 @@ const { ObjectId } = require('mongodb');
 const { AuditEventTransformer } = require('../../dataLayer/clickHouse/auditEventTransformer');
 const { logInfo, logWarn } = require('../../operations/common/logging');
 
+/**
+ * Normalize a `recorded` field value to an ISO-8601 string for checkpoint storage.
+ * Online Archive may return either a Date (ISODate-backed docs) or a string
+ * (legacy string-backed docs); both need to round-trip back through
+ * `new Date(lastRecorded)` on resume.
+ * @param {Date|string|null|undefined} value
+ * @returns {string}
+ */
+function toIsoString(value) {
+    if (!value) return '';
+    if (value instanceof Date) return value.toISOString();
+    // Already a string; trust it if it parses, otherwise store as-is so a human
+    // can investigate rather than silently losing the checkpoint.
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? String(value) : parsed.toISOString();
+}
+
 class PartitionWorker {
     /**
      * @param {Object} params
@@ -40,29 +57,57 @@ class PartitionWorker {
      * Process a single day partition
      * @param {Object} params
      * @param {string} params.partitionDay - 'YYYY-MM-DD'
-     * @param {string} params.lastMongoId - Resume point (empty string if fresh start)
+     * @param {string} params.lastMongoId - Resume point _id (empty string if fresh start)
+     * @param {string} params.lastRecorded - Resume point `recorded` ISO-8601 (empty string if fresh start)
      * @returns {Promise<{insertedCount: number, sourceCount: number, skippedCount: number}>}
      */
-    async processAsync({ partitionDay, lastMongoId }) {
+    async processAsync({ partitionDay, lastMongoId, lastRecorded }) {
         const dayStart = new Date(partitionDay + 'T00:00:00.000Z');
         const dayEnd = new Date(dayStart);
         dayEnd.setUTCDate(dayEnd.getUTCDate() + 1);
 
         const collection = this.sourceDb.collection(this.collectionName);
 
-        // Build query: filter by recorded date range + resume from last_mongo_id
-        // Use Date objects (not ISO strings) so the query matches both ISODate and string storage
-        const query = {
-            recorded: { $gte: dayStart, $lt: dayEnd }
-        };
-        if (lastMongoId) {
-            query._id = { $gt: new ObjectId(lastMongoId) };
+        // Build query: filter by recorded date range + resume from (recorded, _id) checkpoint.
+        //
+        // Ordering by (recorded, _id) matches the Online Archive partition layout
+        // (archive field is `recorded`), so the federation engine can stream S3 objects
+        // in order instead of materializing + sorting a full day's worth of documents.
+        //
+        // Resume filter uses $or so the `recorded` bound can prune S3 partitions on the
+        // archive side, unlike a bare `_id: {$gt}` which would force a full-day scan.
+        let query;
+        if (lastRecorded && lastMongoId) {
+            const lastRecordedDate = new Date(lastRecorded);
+            query = {
+                $and: [
+                    { recorded: { $gte: dayStart, $lt: dayEnd } },
+                    {
+                        $or: [
+                            { recorded: { $gt: lastRecordedDate } },
+                            {
+                                recorded: lastRecordedDate,
+                                _id: { $gt: new ObjectId(lastMongoId) }
+                            }
+                        ]
+                    }
+                ]
+            };
+        } else {
+            query = { recorded: { $gte: dayStart, $lt: dayEnd } };
         }
 
         // Get source count for this day (for verification)
         const sourceCountQuery = {
             recorded: { $gte: dayStart, $lt: dayEnd }
         };
+        logInfo('MongoDB query', {
+            operation: 'countDocuments',
+            db: this.sourceDb.databaseName,
+            collection: this.collectionName,
+            partitionDay,
+            query: sourceCountQuery
+        });
         const sourceCount = await collection.countDocuments(sourceCountQuery);
 
         if (this.dryRun) {
@@ -83,7 +128,17 @@ class PartitionWorker {
 
         await this.stateManager.markInProgressAsync(partitionDay);
 
-        const cursor = collection.find(query).sort({ _id: 1 }).batchSize(this.batchSize);
+        const sort = { recorded: 1, _id: 1 };
+        logInfo('MongoDB query', {
+            operation: 'find',
+            db: this.sourceDb.databaseName,
+            collection: this.collectionName,
+            partitionDay,
+            query,
+            sort,
+            batchSize: this.batchSize
+        });
+        const cursor = collection.find(query).sort(sort).batchSize(this.batchSize);
 
         let batch = [];
         let insertedCount = lastMongoId
@@ -91,6 +146,7 @@ class PartitionWorker {
             : 0;
         let skippedCount = 0;
         let lastId = lastMongoId;
+        let lastRecordedCheckpoint = lastRecorded || '';
 
         try {
             while (await cursor.hasNext()) {
@@ -111,12 +167,15 @@ class PartitionWorker {
                     insertedCount += result.inserted;
                     skippedCount += result.skipped;
 
-                    lastId = batch[batch.length - 1]._id.toString();
+                    const tailDoc = batch[batch.length - 1];
+                    lastId = tailDoc._id.toString();
+                    lastRecordedCheckpoint = toIsoString(tailDoc.recorded);
 
                     // Checkpoint after each batch
                     await this.stateManager.updateCheckpointAsync({
                         partitionDay,
                         lastMongoId: lastId,
+                        lastRecorded: lastRecordedCheckpoint,
                         insertedCount
                     });
 
@@ -138,7 +197,9 @@ class PartitionWorker {
                 const result = await this._processBatchAsync(batch);
                 insertedCount += result.inserted;
                 skippedCount += result.skipped;
-                lastId = batch[batch.length - 1]._id.toString();
+                const tailDoc = batch[batch.length - 1];
+                lastId = tailDoc._id.toString();
+                lastRecordedCheckpoint = toIsoString(tailDoc.recorded);
             }
 
             // Mark completed
@@ -146,7 +207,8 @@ class PartitionWorker {
                 partitionDay,
                 insertedCount,
                 sourceCount,
-                lastMongoId: lastId
+                lastMongoId: lastId,
+                lastRecorded: lastRecordedCheckpoint
             });
 
             return { insertedCount, sourceCount, skippedCount };


### PR DESCRIPTION
## Summary

- **Resume correctness on Online Archive.** The worker now keyset-paginates on the compound `(recorded, _id)` sort instead of bare `_id`. This matches the Online Archive partition layout (archive field is `recorded`), so the federation engine can prune S3 Parquet partitions on resume — a bare `_id: {$gt}` would force a full-day scan. An `_id` tiebreaker inside the `$or` handles identical-timestamp clusters correctly.
- **Operator flags.** Two new CLI flags, both runnable with ClickHouse creds only (they short-circuit before the archive-URL check):
  - `--show-state` — prints the `fhir.audit_event_migration_state` table plus a summary, filtered by `--start-date` / `--end-date`.
  - `--delete-partitions <days>` — `ALTER ... DELETE WHERE toDate(recorded) = {day}` (blocking via `mutations_sync = 2`) then resets the state row to `pending` so `--resume` will re-migrate.
- **Query-level observability.** Every MongoDB query the migration issues (both in the worker and the verifier) is now logged via `logInfo` with op name, db, collection, and filter — makes post-hoc debugging of federation behavior tractable.
- **Schema change.** Adds `last_recorded String DEFAULT ''` column to `fhir.audit_event_migration_state`. The DDL file includes an idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for already-initialized deployments.

## Test plan

- [x] Unit behavior verified against a local Docker stack (Mongo + ClickHouse + federation mocked by a real Mongo collection) with 9 scenarios, including the critical crash-mid-cluster test: 15 docs on `2026-03-02` (10 sharing identical `recorded`), crash on batch 3 of size 3 forcing checkpoint *inside* the identical-timestamp cluster, resume from checkpoint → `chTotal: 15, chDistinctUuid: 15, passTotalCount: true, passNoDuplicates: true`.
- [x] `--show-state` round-trip against local ClickHouse.
- [x] `--delete-partitions 2026-03-01,2026-03-02` mutation + state reset verified (rows gone, state back to `pending`).
- [x] Malformed-date rejection: `--delete-partitions 2025-02-30` fails fast with a clear error before opening any connection.
- [ ] Run `--show-state` in the target environment against a recent migration to sanity-check format.
- [ ] Dry-run `--delete-partitions` on a single non-production day before using against production.

## Notes for reviewers

- Non-resume call sites still pass `lastRecorded: ''` and fall through to the simple `{recorded: {$gte, $lt}}` query — behavior for fresh-start runs is unchanged.
- Mutation partition caveat: `AuditEvent_4_0_0` is `PARTITION BY toYYYYMM(recorded)` (monthly), so we can't `DROP PARTITION` for a single day. On a 55TB table `ALTER ... DELETE` can take minutes per day. This is acknowledged in a comment on `deletePartitionsAsync`.
- State rows are re-inserted (not deleted) for the reset path — the state table is `ReplacingMergeTree(updated_at)`, so a later-`updated_at` row supersedes earlier ones on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)