### PR TITLE
PAY-1706 Fix edge case when we try to add unclassified tag to a resource with no unclassified tag and supress headers false

### DIFF
--- a/src/operations/merge/fastMergeManager.js
+++ b/src/operations/merge/fastMergeManager.js
@@ -160,7 +160,7 @@ class FastMergeManager {
         // found an existing resource
         const existingResourcePreSaveOptions = new PreSaveOptions({
             ...preSaveOptions,
-            suppressUnclassifiedTag: true
+            skipUnclassifiedTagging: true
         });
         currentResource = await this.preSaveManager.preSaveAsync({
             resource: currentResource, options: existingResourcePreSaveOptions

--- a/src/operations/merge/fastMergeManager.js
+++ b/src/operations/merge/fastMergeManager.js
@@ -158,8 +158,12 @@ class FastMergeManager {
         assertIsValid(uuid, `No uuid found for resource ${resourceToMerge.resourceType}/${resourceToMerge.id}`);
 
         // found an existing resource
+        const existingResourcePreSaveOptions = new PreSaveOptions({
+            ...preSaveOptions,
+            suppressUnclassifiedTag: true
+        });
         currentResource = await this.preSaveManager.preSaveAsync({
-            resource: currentResource, options: preSaveOptions
+            resource: currentResource, options: existingResourcePreSaveOptions
         });
 
         /**

--- a/src/operations/merge/mergeManager.js
+++ b/src/operations/merge/mergeManager.js
@@ -159,8 +159,12 @@ class MergeManager {
         assertIsValid(uuid, `No uuid found for resource ${resourceToMerge.resourceType}/${resourceToMerge.id}`);
 
         // found an existing resource
+        const existingResourcePreSaveOptions = new PreSaveOptions({
+            ...preSaveOptions,
+            suppressUnclassifiedTag: true
+        });
         currentResource = await this.preSaveManager.preSaveAsync({
-            resource: currentResource, options: preSaveOptions
+            resource: currentResource, options: existingResourcePreSaveOptions
         });
 
         /**

--- a/src/operations/merge/mergeManager.js
+++ b/src/operations/merge/mergeManager.js
@@ -161,7 +161,7 @@ class MergeManager {
         // found an existing resource
         const existingResourcePreSaveOptions = new PreSaveOptions({
             ...preSaveOptions,
-            suppressUnclassifiedTag: true
+            skipUnclassifiedTagging: true
         });
         currentResource = await this.preSaveManager.preSaveAsync({
             resource: currentResource, options: existingResourcePreSaveOptions

--- a/src/operations/security/scopesValidator.js
+++ b/src/operations/security/scopesValidator.js
@@ -306,9 +306,7 @@ class ScopesValidator {
         try {
             // Run preSave to generate _uuid values for references and resource
             const preSaveOptions = PreSaveOptions.fromRequestInfo(requestInfo);
-            // supress unclassified tag addition during access check preSave
-            // since it mutates resource and can cause sideeffects
-            preSaveOptions.suppressUnclassifiedTag = true;
+            preSaveOptions.skipUnclassifiedTagging = true;
             resource = await this.preSaveManager.preSaveAsync({resource, options: preSaveOptions});
             // validate access scopes for resource
             this.isAccessToResourceAllowedByAccessScopes({requestInfo, resource, accessRequested});

--- a/src/operations/security/scopesValidator.js
+++ b/src/operations/security/scopesValidator.js
@@ -306,6 +306,9 @@ class ScopesValidator {
         try {
             // Run preSave to generate _uuid values for references and resource
             const preSaveOptions = PreSaveOptions.fromRequestInfo(requestInfo);
+            // supress unclassified tag addition during access check preSave
+            // since it mutates resource and can cause sideeffects
+            preSaveOptions.suppressUnclassifiedTag = true;
             resource = await this.preSaveManager.preSaveAsync({resource, options: preSaveOptions});
             // validate access scopes for resource
             this.isAccessToResourceAllowedByAccessScopes({requestInfo, resource, accessRequested});

--- a/src/preSaveHandlers/handlers/unclassifiedSensitivityTagHandler.js
+++ b/src/preSaveHandlers/handlers/unclassifiedSensitivityTagHandler.js
@@ -23,7 +23,7 @@ class UnclassifiedSensitivityTagHandler extends PreSaveHandler {
      * @returns {Promise<import('../../fhir/classes/4_0_0/resources/resource')>}
      */
     async preSaveAsync ({ resource, options }) {
-        if (!this.configManager.resourceTypesForUnclassifiedTagging.has(resource.resourceType)) {
+        if (!this.configManager.resourceTypesForUnclassifiedTagging.has(resource.resourceType) || options?.skipUnclassifiedTagging) {
             return resource;
         }
         if (!resource.meta || !resource.meta.security) {
@@ -34,7 +34,7 @@ class UnclassifiedSensitivityTagHandler extends PreSaveHandler {
         const unclassifiedTags = resource.meta.security.filter(isUnclassified);
         const tagLength = unclassifiedTags.length;
 
-        // remove any duplicate unclassified tag
+        // dedup and normalize existing tags
         if (tagLength > 0) {
             const firstUnclassifiedTag = unclassifiedTags[0];
             firstUnclassifiedTag.id = generateUUIDv5(`${SENSITIVE_CATEGORY.SYSTEM}|${SENSITIVE_CATEGORY.UNCLASSIFIED_CODE}`);

--- a/src/preSaveHandlers/preSaveOptions.js
+++ b/src/preSaveHandlers/preSaveOptions.js
@@ -7,11 +7,14 @@ const { SENSITIVE_CATEGORY } = require('../constants');
 class PreSaveOptions {
     /**
      * @param {Object} [params]
-     * @param {boolean} [params.suppressUnclassifiedTag]
+     * @param {boolean} [params.suppressUnclassifiedTag] Suprress adding unclassified tag if missing
+     * @param {boolean} [params.skipUnclassifiedTagging] Skips the unclassified tagging flow. This can be used to prevent side effects of mutating the existing resource.
      */
-    constructor ({ suppressUnclassifiedTag } = {}) {
+    constructor ({ suppressUnclassifiedTag, skipUnclassifiedTagging } = {}) {
         /** @type {boolean} */
         this.suppressUnclassifiedTag = suppressUnclassifiedTag;
+        /** @type {boolean} */
+        this.skipUnclassifiedTagging = skipUnclassifiedTagging;
     }
 
     /**

--- a/src/tests/patientScope/unclassified_sensitivity_tag_with_delegated_access/unclassified_sensitivity_tag_fast_merge.test.js
+++ b/src/tests/patientScope/unclassified_sensitivity_tag_with_delegated_access/unclassified_sensitivity_tag_fast_merge.test.js
@@ -400,6 +400,190 @@ describe('Unclassified Sensitivity Tag (Fast Merge Serializer)', () => {
         )).toBeDefined();
     });
 
+    test('$merge should add unclassified tag to previously suppressed resource when suppress header is not set', async () => {
+        const request = await createTestRequest((c) => {
+            c.register('configManager', () => new MockConfigManager());
+            return c;
+        });
+
+        await seedBaseFixtures(request);
+
+        let resp = await request
+            .post('/4_0_0/Observation/1/$merge?validate=true')
+            .send(observation1Resource)
+            .set({ ...getHeaders(), [SENSITIVE_CATEGORY.SUPPRESS_HEADER]: 'true' });
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeUndefined();
+
+        const observationWithTag = deepcopy(observation1Resource);
+        observationWithTag.meta.security.push({
+            system: SENSITIVE_CATEGORY.SYSTEM,
+            code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE,
+            id: "2a642de9-eaea-53d5-a5d5-277d9d46ac1e"
+        });
+
+        resp = await request
+            .post('/4_0_0/Observation/1/$merge?validate=true')
+            .send(observationWithTag)
+            .set(getHeaders());
+        expect(resp).toHaveMergeResponse({ updated: true });
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeDefined();
+        expect(resp.body.meta.versionId).toBe('2');
+    });
+
+    test('put should add unclassified tag to previously suppressed resource when suppress header is not set and unclassified is passed', async () => {
+        const request = await createTestRequest((c) => {
+            c.register('configManager', () => new MockConfigManager());
+            return c;
+        });
+
+        await seedBaseFixtures(request);
+
+        let resp = await request
+            .post('/4_0_0/Observation/1/$merge?validate=true')
+            .send(observation1Resource)
+            .set({ ...getHeaders(), [SENSITIVE_CATEGORY.SUPPRESS_HEADER]: 'true' });
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeUndefined();
+
+        const serverResource = resp.body;
+
+        // PUT the server response back with unclassified tag added — should update
+        const observationWithTag = deepcopy(serverResource);
+        observationWithTag.meta.security.push({
+            id: '2a642de9-eaea-53d5-a5d5-277d9d46ac1e',
+            system: SENSITIVE_CATEGORY.SYSTEM,
+            code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        });
+
+        resp = await request
+            .put('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .send(observationWithTag)
+            .set(getHeaders());
+        expect(resp.status).toBe(200);
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeDefined();
+        expect(resp.body.meta.versionId).toBe('2');
+    });
+
+     test('patch should add unclassified tag to previously suppressed resource when suppress header is not set and unclassified is passed', async () => {
+        const request = await createTestRequest((c) => {
+            c.register('configManager', () => new MockConfigManager());
+            return c;
+        });
+
+        await seedBaseFixtures(request);
+
+        let resp = await request
+            .post('/4_0_0/Observation/1/$merge?validate=true')
+            .send(observation1Resource)
+            .set({ ...getHeaders(), [SENSITIVE_CATEGORY.SUPPRESS_HEADER]: 'true' });
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeUndefined();
+
+        const patchOps = [
+            { op: 'add', path: '/meta/security/-', value: {
+                system: SENSITIVE_CATEGORY.SYSTEM,
+                code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE,
+                id: "2a642de9-eaea-53d5-a5d5-277d9d46ac1e"
+            }}
+        ];
+
+        resp = await request
+            .patch('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .send(patchOps)
+            .set(getHeadersJsonPatch());
+        expect(resp.status).toBe(200);
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeDefined();
+        expect(resp.body.meta.versionId).toBe('2');
+    });
+
+    test('$merge with smartMerge adds unclassified tag to previously suppressed resource', async () => {
+        const request = await createTestRequest((c) => {
+            c.register('configManager', () => new MockConfigManager());
+            return c;
+        });
+
+        await seedBaseFixtures(request);
+
+        let resp = await request
+            .post('/4_0_0/Observation/1/$merge?validate=true')
+            .send(observation1Resource)
+            .set({ ...getHeaders(), [SENSITIVE_CATEGORY.SUPPRESS_HEADER]: 'true' });
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeUndefined();
+
+        const observationWithTag = deepcopy(observation1Resource);
+        observationWithTag.meta.security.push({
+            system: SENSITIVE_CATEGORY.SYSTEM,
+            code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE,
+            id: '2a642de9-eaea-53d5-a5d5-277d9d46ac1e'
+        });
+
+        resp = await request
+            .post('/4_0_0/Observation/1/$merge?validate=true&smartMerge=1')
+            .send(observationWithTag)
+            .set(getHeaders());
+        expect(resp).toHaveMergeResponse({ updated: true });
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeDefined();
+        expect(resp.body.meta.versionId).toBe('2');
+    });
+
     test('suppress header on PATCH preserves existing unclassified tag', async () => {
         const request = await createTestRequest((c) => {
             c.register('configManager', () => new MockConfigManager());

--- a/src/tests/patientScope/unclassified_sensitivity_tag_with_delegated_access/unclassified_sensitivity_tag_with_delegated_access.test.js
+++ b/src/tests/patientScope/unclassified_sensitivity_tag_with_delegated_access/unclassified_sensitivity_tag_with_delegated_access.test.js
@@ -510,6 +510,191 @@ describe('Unclassified Sensitivity Tag', () => {
         expect(tags[0].id).toBeDefined();
     });
 
+    test('$merge should add unclassified tag to previously suppressed resource when suppress header is not set', async () => {
+        const request = await createTestRequest((c) => {
+            c.register('configManager', () => new MockConfigManager());
+            return c;
+        });
+
+        await seedBaseFixtures(request);
+
+        let resp = await request
+            .post('/4_0_0/Observation/1/$merge?validate=true')
+            .send(observation1Resource)
+            .set({ ...getHeaders(), [SENSITIVE_CATEGORY.SUPPRESS_HEADER]: 'true' });
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeUndefined();
+
+        const observationWithTag = deepcopy(observation1Resource);
+        observationWithTag.meta.security.push({
+            system: SENSITIVE_CATEGORY.SYSTEM,
+            code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE,
+            id: "2a642de9-eaea-53d5-a5d5-277d9d46ac1e"
+        });
+
+        resp = await request
+            .post('/4_0_0/Observation/1/$merge?validate=true')
+            .send(observationWithTag)
+            .set(getHeaders());
+        expect(resp).toHaveMergeResponse({ updated: true });
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeDefined();
+        expect(resp.body.meta.versionId).toBe('2');
+    });
+
+    test('put should add unclassified tag to previously suppressed resource when suppress header is not set and unclassified is passed', async () => {
+        const request = await createTestRequest((c) => {
+            c.register('configManager', () => new MockConfigManager());
+            return c;
+        });
+
+        await seedBaseFixtures(request);
+
+        let resp = await request
+            .post('/4_0_0/Observation/1/$merge?validate=true')
+            .send(observation1Resource)
+            .set({ ...getHeaders(), [SENSITIVE_CATEGORY.SUPPRESS_HEADER]: 'true' });
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeUndefined();
+
+        const serverResource = resp.body;
+
+        // PUT the server response back with unclassified tag added — should update
+        const observationWithTag = deepcopy(serverResource);
+        observationWithTag.meta.security.push({
+            id: '2a642de9-eaea-53d5-a5d5-277d9d46ac1e',
+            system: SENSITIVE_CATEGORY.SYSTEM,
+            code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        });
+
+        resp = await request
+            .put('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .send(observationWithTag)
+            .set(getHeaders());
+        expect(resp.status).toBe(200);
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeDefined();
+        expect(resp.body.meta.versionId).toBe('2');
+    });
+
+     test('patch should add unclassified tag to previously suppressed resource when suppress header is not set and unclassified is passed', async () => {
+        const request = await createTestRequest((c) => {
+            c.register('configManager', () => new MockConfigManager());
+            return c;
+        });
+
+        await seedBaseFixtures(request);
+
+        let resp = await request
+            .post('/4_0_0/Observation/1/$merge?validate=true')
+            .send(observation1Resource)
+            .set({ ...getHeaders(), [SENSITIVE_CATEGORY.SUPPRESS_HEADER]: 'true' });
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeUndefined();
+
+        const patchOps = [
+            { op: 'add', path: '/meta/security/-', value: {
+                system: SENSITIVE_CATEGORY.SYSTEM,
+                code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE,
+                id: "2a642de9-eaea-53d5-a5d5-277d9d46ac1e"
+            }}
+        ];
+
+        resp = await request
+            .patch('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .send(patchOps)
+            .set(getHeadersJsonPatch());
+        expect(resp.status).toBe(200);
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeDefined();
+        expect(resp.body.meta.versionId).toBe('2');
+    });
+
+    test('$merge with smartMerge adds unclassified tag to previously suppressed resource', async () => {
+        const request = await createTestRequest((c) => {
+            c.register('configManager', () => new MockConfigManager());
+            return c;
+        });
+
+        await seedBaseFixtures(request);
+
+        let resp = await request
+            .post('/4_0_0/Observation/1/$merge?validate=true')
+            .send(observation1Resource)
+            .set({ ...getHeaders(), [SENSITIVE_CATEGORY.SUPPRESS_HEADER]: 'true' });
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeUndefined();
+
+        const observationWithTag = deepcopy(observation1Resource);
+        observationWithTag.meta.security.push({
+            system: SENSITIVE_CATEGORY.SYSTEM,
+            code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE,
+            id: '2a642de9-eaea-53d5-a5d5-277d9d46ac1e'
+        });
+
+        resp = await request
+            .post('/4_0_0/Observation/1/$merge?validate=true&smartMerge=1')
+            .send(observationWithTag)
+            .set(getHeaders());
+        expect(resp).toHaveMergeResponse({ updated: true });
+
+        resp = await request
+            .get('/4_0_0/Observation/b7d5e8a1-3c2f-4d9e-a1b6-8f7c3e2d1a0b')
+            .set(getHeaders());
+        expect(resp).toHaveStatusOk();
+        expect(resp.body.meta.security.find(
+            s => s.system === SENSITIVE_CATEGORY.SYSTEM && s.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+        )).toBeDefined();
+        expect(resp.body.meta.versionId).toBe('2');
+    });
+
+
     describe('GraphQL mutations with unclassified tagging', () => {
         test('updateGeneralPractitioner mutation does NOT add tag to Patient (non-configured type)', async () => {
             const request = await createTestRequest((c) => {

--- a/src/tests/patientScope/unclassified_sensitivity_tag_with_delegated_access/unclassified_sensitivity_tag_with_delegated_access.test.js
+++ b/src/tests/patientScope/unclassified_sensitivity_tag_with_delegated_access/unclassified_sensitivity_tag_with_delegated_access.test.js
@@ -34,6 +34,10 @@ class MockConfigManager extends ConfigManager {
     get resourceTypesForUnclassifiedTagging () {
         return new Set(['Observation', 'CareTeam']);
     }
+
+    get enableMergeFastSerializer() {
+        return false;
+    }
 }
 
 async function seedBaseFixtures (request) {


### PR DESCRIPTION
When a resource without an unclassified tag is updated via $merge, PUT, or
PATCH to add the tag, the resource comparer incorrectly reports no change.

Root cause: preSave adds the unclassified tag to both the incoming resource
and the existing (current) resource before comparison, making them equal.
Additionally, ScopesValidator.isAccessToResourceAllowedByAccessAndPatientScopes
runs preSave on the bulk-loader-cached DB resource, mutating the shared
reference and causing the same false-equality in downstream comparisons.

Fix: suppress the unclassified tag handler when running preSave on
existing resources during merge comparison (mergeManager, fastMergeManager)
and during scope validation (scopesValidator). The tag is still correctly
added to the incoming resource through the normal write path.