### PR TITLE
PAY-1537 Prevent deniedSensitiveCategories from being logged

### DIFF
--- a/src/tests/utils/delegatedAccessRulesManager/delegatedAccessRulesManager.test.js
+++ b/src/tests/utils/delegatedAccessRulesManager/delegatedAccessRulesManager.test.js
@@ -304,9 +304,9 @@ describe('DelegatedAccessRulesManager Tests', () => {
                 consentId: '6db13a4f-fee5-485a-b245-18881c0232ac',
                 consentVersion: '1',
                 provisionPeriodStart: '2025-12-23T20:00:00.000Z',
-                provisionPeriodEnd: '2026-01-01T00:00:00.000Z',
-                deniedSensitiveCategories: ['MENTAL_HEALTH', 'HIV_AIDS']
+                provisionPeriodEnd: '2026-01-01T00:00:00.000Z'
             });
+            expect(result.filteringRules.deniedSensitiveCategories).toStrictEqual(['MENTAL_HEALTH', 'HIV_AIDS']);
         });
 
         test('should return only active consent when multiple consents with different statuses exist', async () => {
@@ -332,9 +332,9 @@ describe('DelegatedAccessRulesManager Tests', () => {
                 consentId: '6db13a4f-fee5-485a-b245-18881c0232ac',
                 consentVersion: '1',
                 provisionPeriodStart: '2025-12-23T20:00:00.000Z',
-                provisionPeriodEnd: '2026-01-01T00:00:00.000Z',
-                deniedSensitiveCategories: ['MENTAL_HEALTH', 'HIV_AIDS']
+                provisionPeriodEnd: '2026-01-01T00:00:00.000Z'
             });
+            expect(result.filteringRules.deniedSensitiveCategories).toStrictEqual(['MENTAL_HEALTH', 'HIV_AIDS']);
         });
 
         test('should throw ForbiddenError when multiple active consents found', async () => {
@@ -386,9 +386,9 @@ describe('DelegatedAccessRulesManager Tests', () => {
                 consentId: '6db13a4f-fee5-485a-b245-18881c0232ac',
                 consentVersion: '1',
                 provisionPeriodStart: '2025-12-23T20:00:00.000Z',
-                provisionPeriodEnd: '2026-01-01T00:00:00.000Z',
-                deniedSensitiveCategories: ['MENTAL_HEALTH', 'HIV_AIDS']
+                provisionPeriodEnd: '2026-01-01T00:00:00.000Z'
             });
+            expect(filteringRules.deniedSensitiveCategories).toStrictEqual(['MENTAL_HEALTH', 'HIV_AIDS']);
         });
 
         test('should handle consent without nested provisions', async () => {
@@ -409,9 +409,9 @@ describe('DelegatedAccessRulesManager Tests', () => {
                 consentId: '6db13a4f-fee5-485a-b245-18881c0232ac',
                 consentVersion: '1',
                 provisionPeriodStart: '2025-12-23T20:00:00.000Z',
-                provisionPeriodEnd: '2026-01-01T00:00:00.000Z',
-                deniedSensitiveCategories: []
+                provisionPeriodEnd: '2026-01-01T00:00:00.000Z'
             });
+            expect(filteringRules.deniedSensitiveCategories).toStrictEqual([]);
         });
 
         test('should return null for period dates when not present', async () => {
@@ -429,9 +429,9 @@ describe('DelegatedAccessRulesManager Tests', () => {
                 consentId: '6db13a4f-fee5-485a-b245-18881c0232ac',
                 consentVersion: '1',
                 provisionPeriodStart: undefined,
-                provisionPeriodEnd: undefined,
-                deniedSensitiveCategories: ['MENTAL_HEALTH', 'HIV_AIDS']
+                provisionPeriodEnd: undefined
             });
+            expect(filteringRules.deniedSensitiveCategories).toStrictEqual(['MENTAL_HEALTH', 'HIV_AIDS']);
         });
     });
 

--- a/src/tests/utils/delegatedAccessRulesManager/delegatedAccessRulesManager.test.js
+++ b/src/tests/utils/delegatedAccessRulesManager/delegatedAccessRulesManager.test.js
@@ -389,6 +389,8 @@ describe('DelegatedAccessRulesManager Tests', () => {
                 provisionPeriodEnd: '2026-01-01T00:00:00.000Z'
             });
             expect(filteringRules.deniedSensitiveCategories).toStrictEqual(['MENTAL_HEALTH', 'HIV_AIDS']);
+            expect(Object.keys(filteringRules)).not.toContain('deniedSensitiveCategories');
+            expect(JSON.parse(JSON.stringify(filteringRules))).not.toHaveProperty('deniedSensitiveCategories');
         });
 
         test('should handle consent without nested provisions', async () => {

--- a/src/utils/delegatedAccessRulesManager.js
+++ b/src/utils/delegatedAccessRulesManager.js
@@ -167,13 +167,18 @@ class DelegatedAccessRulesManager {
             }
         }
 
-        return {
+        const rules = {
             consentId: consent._uuid,
             consentVersion: consent.meta?.versionId,
             provisionPeriodStart: consent.provision?.period?.start,
-            provisionPeriodEnd: consent.provision?.period?.end,
-            deniedSensitiveCategories
+            provisionPeriodEnd: consent.provision?.period?.end
         };
+        // Store it as non-enumerable to avoid logging
+        Object.defineProperty(rules, 'deniedSensitiveCategories', {
+            value: deniedSensitiveCategories,
+            enumerable: false
+        });
+        return rules;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Makes `deniedSensitiveCategories` non-enumerable on the `_filteringRules` object so it is excluded from JSON serialization in logs (e.g. Request Completed)
- The property remains fully accessible at runtime via direct property access and destructuring — no functional side effects
- Prevents accidental logging of sensitive consent filtering categories

## Test plan
- [x] `delegatedAccessRulesManager.test.js` — 15/15 passing
- [x] `compositionSectionFilter.test.js` — 15/15 passing
- [x] `delegatedAccessQueryManager.test.js` — 4/4 passing