### PR TITLE
DCON-3672 Return JSON OperationOutcome on auth failure

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -39,6 +39,25 @@ const {shouldReturnHtml} = require('./utils/requestHelpers.js');
 const {generateLogDetail} = require('./utils/requestCompletionLogData.js');
 const {incrementRequestCount, decrementRequestCount, getRequestCount} = require('./utils/requestCounter');
 
+function createAuthMiddleware(strategyName) {
+    return (req, res, next) => {
+        passport.authenticate(strategyName, {session: false}, (err, user) => {
+            if (err || !user) {
+                return res.status(401).json({
+                    resourceType: 'OperationOutcome',
+                    issue: [{
+                        severity: 'error',
+                        code: 'security',
+                        diagnostics: 'Authentication failed'
+                    }]
+                });
+            }
+            req.user = user;
+            next();
+        })(req, res, next);
+    };
+}
+
 /**
  * Creates the FHIR app
  * @param {function (): SimpleContainer} fnGetContainer
@@ -349,7 +368,7 @@ function createApp({fnGetContainer}) {
     const adminRouter = express.Router({mergeParams: true});
     // Add authentication
     adminRouter.use(passport.initialize());
-    adminRouter.use(passport.authenticate('adminStrategy', {session: false}, null));
+    adminRouter.use(createAuthMiddleware('adminStrategy'));
     // Add admin routes with json body parser
     const allowedContentTypes = ['application/fhir+json', 'application/json+fhir'];
     adminRouter.get('{/:op}{/:id}', (req, res) => handleAdminGet(fnGetContainer, req, res));
@@ -379,7 +398,7 @@ function createApp({fnGetContainer}) {
 
         const router = express.Router();
         router.use(passport.initialize());
-        router.use(passport.authenticate('graphqlStrategy', {session: false}, null));
+        router.use(createAuthMiddleware('graphqlStrategy'));
         router.use(forbidRestrictedUserTypes);
         router.use(cors(fhirServerConfig.server.corsOptions));
         router.use(express.json());
@@ -413,7 +432,7 @@ function createApp({fnGetContainer}) {
 
         const routerv2 = express.Router();
         routerv2.use(passport.initialize());
-        routerv2.use(passport.authenticate('graphqlStrategy', {session: false}, null));
+        routerv2.use(createAuthMiddleware('graphqlStrategy'));
         routerv2.use(forbidRestrictedUserTypes);
         routerv2.use(cors(fhirServerConfig.server.corsOptions));
         routerv2.use(express.json());

--- a/src/app.js
+++ b/src/app.js
@@ -41,7 +41,7 @@ const {incrementRequestCount, decrementRequestCount, getRequestCount} = require(
 
 function createAuthMiddleware(strategyName) {
     return (req, res, next) => {
-        passport.authenticate(strategyName, {session: false}, (err, user) => {
+        passport.authenticate(strategyName, {session: false}, (err, user, info) => {
             if (err || !user) {
                 return res.status(401).json({
                     resourceType: 'OperationOutcome',
@@ -52,8 +52,11 @@ function createAuthMiddleware(strategyName) {
                     }]
                 });
             }
-            req.user = user;
-            next();
+            req.logIn(user, {session: false}, (loginErr) => {
+                if (loginErr) { return next(loginErr); }
+                req.authInfo = info;
+                next();
+            });
         })(req, res, next);
     };
 }

--- a/src/tests/graphqlv2/auth_failure/auth_failure_response.test.js
+++ b/src/tests/graphqlv2/auth_failure/auth_failure_response.test.js
@@ -1,0 +1,75 @@
+const {describe, test, expect} = require('@jest/globals');
+const {createTestRequest, getUnAuthenticatedGraphQLHeaders} = require('../../common');
+
+describe('Authentication failure responses', () => {
+    describe('POST /4_0_0/$graphqlv2', () => {
+        test('returns JSON OperationOutcome on missing auth', async () => {
+            const request = await createTestRequest();
+            const resp = await request
+                .post('/4_0_0/$graphqlv2')
+                .send({operationName: null, variables: {}, query: '{ patient { id } }'})
+                .set(getUnAuthenticatedGraphQLHeaders());
+
+            expect(resp.status).toBe(401);
+            expect(resp.headers['content-type']).toMatch(/application\/json/);
+
+            const body = JSON.parse(resp.text);
+            expect(body.resourceType).toBe('OperationOutcome');
+            expect(body.issue).toHaveLength(1);
+            expect(body.issue[0].severity).toBe('error');
+            expect(body.issue[0].code).toBe('security');
+        });
+
+        test('returns JSON OperationOutcome on invalid token', async () => {
+            const request = await createTestRequest();
+            const resp = await request
+                .post('/4_0_0/$graphqlv2')
+                .send({operationName: null, variables: {}, query: '{ patient { id } }'})
+                .set({
+                    'Content-Type': 'application/json',
+                    Authorization: 'Bearer invalid.jwt.token'
+                });
+
+            expect(resp.status).toBe(401);
+            expect(resp.headers['content-type']).toMatch(/application\/json/);
+
+            const body = JSON.parse(resp.text);
+            expect(body.resourceType).toBe('OperationOutcome');
+            expect(body.issue[0].severity).toBe('error');
+            expect(body.issue[0].code).toBe('security');
+        });
+    });
+
+    describe('POST /4_0_0/$graphql (v1)', () => {
+        test('returns JSON OperationOutcome on missing auth', async () => {
+            const request = await createTestRequest();
+            const resp = await request
+                .post('/4_0_0/$graphql')
+                .send({operationName: null, variables: {}, query: '{ patient { id } }'})
+                .set(getUnAuthenticatedGraphQLHeaders());
+
+            // v1 may return 400 if graphql middleware rejects before auth (content validation)
+            // The critical requirement is that the response body is valid JSON
+            expect([400, 401]).toContain(resp.status);
+            expect(resp.headers['content-type']).toMatch(/application\/json/);
+            expect(() => JSON.parse(resp.text)).not.toThrow();
+        });
+    });
+
+    describe('GET /admin', () => {
+        test('returns JSON OperationOutcome on missing auth', async () => {
+            const request = await createTestRequest();
+            const resp = await request
+                .get('/admin/stats')
+                .set({'Content-Type': 'application/json'});
+
+            expect(resp.status).toBe(401);
+            expect(resp.headers['content-type']).toMatch(/application\/json/);
+
+            const body = JSON.parse(resp.text);
+            expect(body.resourceType).toBe('OperationOutcome');
+            expect(body.issue[0].severity).toBe('error');
+            expect(body.issue[0].code).toBe('security');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fix the root cause of "Failed to fetch from Subgraph 'fhir-server', Reason: invalid JSON" errors reported by Google (GA launch blocker).

## Root Cause (Verified)

When Passport.js JWT authentication fails, the default handler sends:
- **Status:** 401
- **Content-Type:** NOT SET
- **Body:** `Unauthorized` (plain text, 12 bytes)

The federated graph router expects JSON from subgraphs. It tries to `JSON.parse("Unauthorized")` and fails.

**Code path:** `app.js:416` → `passport.authenticate('graphqlStrategy', {session: false}, null)` → Passport default at `node_modules/passport/lib/middleware/authenticate.js:177` → `res.end(http.STATUS_CODES[401])`

## Fix

Replace `passport.authenticate(..., null)` with a custom callback that returns a proper FHIR OperationOutcome JSON response on auth failure. Applied to all three auth routes (admin, graphql v1, graphql v2).

**After fix:**
- **Status:** 401
- **Content-Type:** application/json
- **Body:** `{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"security","diagnostics":"Authentication failed"}]}`

## Test Evidence

New test `src/tests/graphqlv2/auth_failure/auth_failure_response.test.js` verifies:
- graphqlv2 returns JSON OperationOutcome on missing auth
- graphqlv2 returns JSON OperationOutcome on invalid token
- graphql v1 returns valid JSON on missing auth
- admin returns JSON OperationOutcome on missing auth

Existing test `src/tests/graphqlv2/patient/patient.test.js` ("unauthenticated") still passes.

## Related

- [DCON-3672](https://icanbwell.atlassian.net/browse/DCON-3672) — this ticket (response format fix)
- [DCON-3722](https://icanbwell.atlassian.net/browse/DCON-3722) — separate ticket for investigating WHY auth fails intermittently (per-pod JWKS cache desync, token refresh issues)

## Risk

- Low — only changes the response format on auth failure, not the auth logic itself
- No behavioral change for successful auth paths
- Existing tests pass unchanged

[DCON-3672]: https://icanbwell.atlassian.net/browse/DCON-3672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ