### PR TITLE
DCON-3937 Mark ConsentProvision type as @shareable for federation composition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,11 +33,23 @@ yarn run prettier-fix
 # Bring up full local stack (MongoDB, Keycloak, Redis, Kafka, ClickHouse)
 make up
 
+# Restart just the FHIR server container (picks up env changes)
+make restart_fhir
+
+# Tail FHIR server logs (JSON pretty-printed)
+make fhir_logs
+
+# Tear down local stack
+make down
+
 # Code generation (FHIR classes, GraphQL schemas, search parameters)
 make generate
 make graphql
 make classes
 make searchParameters
+
+# Set up pre-commit lint hook (not auto-installed)
+make setup-pre-commit
 ```
 
 ## Testing Notes
@@ -49,6 +61,43 @@ make searchParameters
 - Custom matchers in `src/tests/customMatchers.js`: `toHaveResponse`, `toHaveMongoQuery`, etc. Use `toHaveMongoQuery` before `toHaveResponse` as it modifies the result
 - Global setup/teardown: `src/tests/jestGlobalSetup.js` / `src/tests/jestGlobalTeardown.js`
 - Test container overrides: `src/tests/createTestContainer.js`
+- Must explicitly import from `@jest/globals`: `const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');`
+
+### Test Authoring Pattern
+
+Tests follow a standard structure using `src/tests/common.js` utilities:
+
+```js
+const { commonBeforeEach, commonAfterEach, getHeaders, createTestRequest } = require('../../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+
+describe('MyTest', () => {
+    beforeEach(async () => { await commonBeforeEach(); });
+    afterEach(async () => { await commonAfterEach(); });
+
+    test('does something', async () => {
+        const request = await createTestRequest();
+        // Load fixtures via $merge, then query
+        await request.post('/4_0_0/Patient/$merge').send(fixture).set(getHeaders()).expect(200);
+        const resp = await request.get('/4_0_0/Patient').set(getHeaders()).expect(200);
+    });
+});
+```
+
+To override container services (especially `ConfigManager` for feature flags), pass `fnUpdateContainer` to `createTestRequest`:
+
+```js
+class MockConfigManager extends ConfigManager {
+    get someFeatureFlag() { return true; }
+}
+
+const request = await createTestRequest((container) => {
+    container.register('configManager', () => new MockConfigManager());
+    return container;
+});
+```
+
+Test fixtures live alongside tests in `fixtures/` directories, expected results in `expected/` or `fixtures/expected/`.
 
 ## Architecture
 
@@ -57,6 +106,8 @@ Express middleware chain -> FhirRouter -> Operations -> DataLayer (MongoDB) -> R
 
 ### IoC Container
 All dependency wiring is in `src/createContainer.js` (~130+ services registered in `SimpleContainer`). New classes must be registered here. For tests, override services in `src/tests/createTestContainer.js`.
+
+The container uses lazy instantiation — services are created as singletons on first property access, not at registration time. Re-registering a service name replaces the factory; already-accessed services remain cached until the container is discarded.
 
 ### Key Entry Points
 - `src/index.js` - Process entry, cluster mode, Sentry init
@@ -80,6 +131,12 @@ All dependency wiring is in `src/createContainer.js` (~130+ services registered 
 - `src/queryRewriters/` - Query optimization (patient proxy, access index rewriting)
 - `src/strategies/` - Passport authentication strategies
 - `src/indexes/` - MongoDB index definitions; custom indexes go in `src/indexes/customIndexes.js`
+
+### Key Operations
+- **$merge** (`POST /4_0_0/{ResourceType}/$merge`) — The primary way resources are created/updated. Accepts a resource or bundle and upserts by id+source. Used extensively in tests to load fixtures.
+- **$graph** — Traverses related resources via GraphDefinition
+- **$everything** — Returns all resources related to a patient/encounter
+- **$export** — Bulk FHIR export (async)
 
 ### Multi-Database Architecture
 - **MongoDB**: Primary store for all FHIR resources, with separate configurable connections for audit events and resource history

--- a/generated.sdl/graphql_v2.graphql
+++ b/generated.sdl/graphql_v2.graphql
@@ -28467,7 +28467,9 @@ Consent.Provision
     identified recipient(s) or recipient role(s) to perform one or more actions
     within a given policy context, for specific purposes and periods of time.
 """
-type ConsentProvision {
+type ConsentProvision
+  @shareable
+{
   """None"""
   id: String
 

--- a/generatorScripts/graphqlv2/generate_graphqlv2_classes.py
+++ b/generatorScripts/graphqlv2/generate_graphqlv2_classes.py
@@ -23,6 +23,7 @@ from generatorScripts.generate_everything_operation_data import get_clinical_res
 custom_data = {
     "shareable_directive": [
         "CodeSystemProperty",
+        "ConsentProvision",
         "OperationOutcomeIssue",
         "PatientCommunication",
         "Address",

--- a/src/graphqlv2/schemas/backbone_elements/consentProvision.graphql
+++ b/src/graphqlv2/schemas/backbone_elements/consentProvision.graphql
@@ -14,7 +14,7 @@ Consent.Provision
     identified recipient(s) or recipient role(s) to perform one or more actions
     within a given policy context, for specific purposes and periods of time.
 """
-type ConsentProvision {
+type ConsentProvision @shareable {
     """
     None
     """


### PR DESCRIPTION
- Adds ConsentProvision to the shareable_directive list in the graphqlv2 schema generator, marking the type as @shareable for Apollo/Cosmo federation composition
- Regenerates consentProvision.graphql with the directive applied
- Updates CLAUDE.md with improved test authoring docs and local dev commands

**Context**

The consent service (DCON-3235) extends ConsentProvision with @override to resolve class, securityLabel, and provision fields. Federation schema composition fails because the fhir-server subgraph defines these same fields without @shareable. This follows the existing pattern used for Coding, Meta, Reference, Period, and other shared backbone element types.