### PR TITLE
DCON-3934 Improve logging for JWT with flag enabled

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       RESOURCE_HISTORY_MONGO_DB_NAME: resource-history
       RETURN_BUNDLE: '1'
       LOG_EXCLUDE_RESOURCES: 'Person,Patient'
+      LOG_AUTH_CONTEXT_ON_401: '1'
       STREAM_RESPONSE: '1'
       LOG_STREAM_STEPS: '0'
       ENABLE_EVENTS_KAFKA: '1'

--- a/src/app.js
+++ b/src/app.js
@@ -202,16 +202,17 @@ function createApp({fnGetContainer}) {
                 }
             }
 
+            const logAuthContextOn401 = res.statusCode === 401 && isTrue(process.env.LOG_AUTH_CONTEXT_ON_401);
             if (
                 (configManager.enableAccessLogs) &&
-                (httpContext.get(ACCESS_LOGS_ENTRY_DATA) || req.body || res.statusCode === 401)
+                (httpContext.get(ACCESS_LOGS_ENTRY_DATA) || req.body || logAuthContextOn401)
             ) {
                 accessLogger.logAccessLogAsync({
                     ...httpContext.get(ACCESS_LOGS_ENTRY_DATA),
                     req,
                     statusCode: res.statusCode,
                     startTime,
-                    authorizationHeader: res.statusCode === 401 ? req.headers.authorization : undefined
+                    authorizationHeader: logAuthContextOn401 ? req.headers.authorization : undefined
                 });
             }
             logInfo('Request Completed', logData);

--- a/src/app.js
+++ b/src/app.js
@@ -204,13 +204,14 @@ function createApp({fnGetContainer}) {
 
             if (
                 (configManager.enableAccessLogs) &&
-                (httpContext.get(ACCESS_LOGS_ENTRY_DATA) || req.body)
+                (httpContext.get(ACCESS_LOGS_ENTRY_DATA) || req.body || res.statusCode === 401)
             ) {
                 accessLogger.logAccessLogAsync({
                     ...httpContext.get(ACCESS_LOGS_ENTRY_DATA),
                     req,
                     statusCode: res.statusCode,
-                    startTime
+                    startTime,
+                    authorizationHeader: res.statusCode === 401 ? req.headers.authorization : undefined
                 });
             }
             logInfo('Request Completed', logData);

--- a/src/middleware/fhir/authentication.middleware.js
+++ b/src/middleware/fhir/authentication.middleware.js
@@ -1,6 +1,8 @@
 const noOpMiddleware = require('./noop.middleware.js');
 
 const passport = require('passport');
+const { isTrue } = require('../../utils/isTrue');
+const { logWarn } = require('../../operations/common/logging');
 
 /**
  * Sends the standard JSON OperationOutcome 401 body when Passport authentication fails.
@@ -52,6 +54,15 @@ const authenticateWithJsonFailure = (strategy, options = {session: false}) => {
                     } catch (_) {
                         req.authFailureDetail = 'Malformed Token';
                     }
+                }
+                if (isTrue(process.env.LOG_AUTH_CONTEXT_ON_401)) {
+                    logWarn('Authentication failed (401)', {
+                        strategy,
+                        method: req.method,
+                        url: req.originalUrl || req.url,
+                        authorizationHeader: (req.headers && req.headers.authorization) || null,
+                        info
+                    });
                 }
                 return sendUnauthorizedJson(res);
             }

--- a/src/middleware/fhir/authentication.middleware.js
+++ b/src/middleware/fhir/authentication.middleware.js
@@ -1,8 +1,6 @@
 const noOpMiddleware = require('./noop.middleware.js');
 
 const passport = require('passport');
-const { isTrue } = require('../../utils/isTrue');
-const { logWarn } = require('../../operations/common/logging');
 
 /**
  * Sends the standard JSON OperationOutcome 401 body when Passport authentication fails.
@@ -54,15 +52,6 @@ const authenticateWithJsonFailure = (strategy, options = {session: false}) => {
                     } catch (_) {
                         req.authFailureDetail = 'Malformed Token';
                     }
-                }
-                if (isTrue(process.env.LOG_AUTH_CONTEXT_ON_401)) {
-                    logWarn('Authentication failed (401)', {
-                        strategy,
-                        method: req.method,
-                        url: req.originalUrl || req.url,
-                        authorizationHeader: (req.headers && req.headers.authorization) || null,
-                        info
-                    });
                 }
                 return sendUnauthorizedJson(res);
             }

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -8,7 +8,7 @@ const {
     USER_INFO_CACHE_EXPIRY_TIME,
     AUTH_USER_TYPES
 } = require('../constants');
-const {logDebug, logError, logInfo} = require('../operations/common/logging');
+const {logDebug, logError, logInfo, logWarn} = require('../operations/common/logging');
 const {WellKnownConfigurationManager} = require('../utils/wellKnownConfiguration/wellKnownConfigurationManager');
 const {assertTypeEquals} = require("../utils/assertType");
 const {ConfigManager} = require("../utils/configManager");
@@ -213,6 +213,7 @@ class AuthService {
                 }
             });
             if (!validInput) {
+                logWarn('Auth rejected', { reason: 'missing_required_jwt_field', username, subject });
                 done(null, false, { reason: 'missing_required_jwt_field' });
                 return;
             }
@@ -246,6 +247,7 @@ class AuthService {
         if (context.userType) {
             if (!isUser) {
                 logError(`userType ${context.userType} is not valid for non-patient token`, {
+                    reason: 'invalid_user_type_for_non_patient_token',
                     username: context.username,
                     userType: context.userType
                 });
@@ -443,7 +445,10 @@ class AuthService {
         isValidInput &&= typeof act[this.requiredActorFields.sub] === 'string';
 
         if (!isValidInput) {
-            logInfo('Invalid act claim: missing or invalid reference field or sub field', { act });
+            logInfo('Invalid act claim: missing or invalid reference field or sub field', {
+                reason: 'delegated_actor_failure',
+                act
+            });
             response.failure = true;
             return response;
         }
@@ -472,6 +477,7 @@ class AuthService {
             if (this.cidCheckIssuer && jwt_payload.iss === this.cidCheckIssuer) {
                 if (!this.cidCheckClientIds.includes(jwt_payload.cid)) {
                     logInfo(`Client ID ${jwt_payload.cid} is not allowed from issuer ${jwt_payload.iss}`, {
+                        reason: 'client_id_not_allowed_for_issuer',
                         userClaim: jwt_payload.sub
                     });
                     return done(null, false, { reason: 'client_id_not_allowed_for_issuer' });
@@ -515,7 +521,10 @@ class AuthService {
                     }
 
                 }).catch((error) => {
-                    logError(`Error while fetching user info: ${error.message}`, {error: error});
+                    logError(`Error while fetching user info: ${error.message}`, {
+                        reason: 'userinfo_endpoint_error',
+                        error: error
+                    });
                     done(null, false, { reason: 'userinfo_endpoint_error' });
                 });
             } else {
@@ -543,6 +552,7 @@ class AuthService {
                 });
             }
         } else {
+            logWarn('Auth rejected', { reason: 'missing_jwt_payload' });
             done(null, false, { reason: 'missing_jwt_payload' });
         }
     }

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -205,15 +205,16 @@ class AuthService {
         }
         if (isUser) {
             context.isUser = isUser;
-            let validInput = true;
-            Object.values(this.requiredJWTFields).forEach((field) => {
-                if (!jwt_payload[field]) {
-                    logDebug(`Error: ${field} field is missing`, {user: ''});
-                    validInput = false;
-                }
-            });
-            if (!validInput) {
-                logWarn('Auth rejected', { reason: 'missing_required_jwt_field', username, subject });
+            const missingRequiredFields = Object.values(this.requiredJWTFields).filter(
+                (field) => !jwt_payload[field]
+            );
+            if (missingRequiredFields.length > 0) {
+                logWarn('Auth rejected', {
+                    reason: 'missing_required_jwt_field',
+                    missingRequiredFields,
+                    username,
+                    subject
+                });
                 done(null, false, { reason: 'missing_required_jwt_field' });
                 return;
             }

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -213,7 +213,7 @@ class AuthService {
                 }
             });
             if (!validInput) {
-                done(null, false);
+                done(null, false, { reason: 'missing_required_jwt_field' });
                 return;
             }
             context.personIdFromJwtToken = jwt_payload[this.requiredJWTFields.clientFhirPersonId];
@@ -225,7 +225,7 @@ class AuthService {
             if (this.configManager.enableDelegatedAccessDetection && jwt_payload.act) {
                 const result = this.processForDelegatedActor({ jwt_payload });
                 if (result.failure) {
-                    done(null, false);
+                    done(null, false, { reason: 'delegated_actor_failure' });
                     return;
                 } else if (result.actor) {
                     context.actor = result.actor;
@@ -249,7 +249,7 @@ class AuthService {
                     username: context.username,
                     userType: context.userType
                 });
-                done(null, false);
+                done(null, false, { reason: 'invalid_user_type_for_non_patient_token' });
                 return;
             }
         }
@@ -474,7 +474,7 @@ class AuthService {
                     logInfo(`Client ID ${jwt_payload.cid} is not allowed from issuer ${jwt_payload.iss}`, {
                         userClaim: jwt_payload.sub
                     });
-                    return done(null, false);
+                    return done(null, false, { reason: 'client_id_not_allowed_for_issuer' });
                 }
             }
 
@@ -516,7 +516,7 @@ class AuthService {
 
                 }).catch((error) => {
                     logError(`Error while fetching user info: ${error.message}`, {error: error});
-                    done(null, false);
+                    done(null, false, { reason: 'userinfo_endpoint_error' });
                 });
             } else {
                 logDebug(`JWT result`, {
@@ -543,7 +543,7 @@ class AuthService {
                 });
             }
         } else {
-            done(null, false);
+            done(null, false, { reason: 'missing_jwt_payload' });
         }
     }
 

--- a/src/tests/dataLayer/authentication.middleware.test.js
+++ b/src/tests/dataLayer/authentication.middleware.test.js
@@ -1,19 +1,12 @@
 'use strict';
 
-const { describe, test, expect, beforeEach, afterEach, jest } = require('@jest/globals');
+const { describe, test, expect, beforeEach, jest } = require('@jest/globals');
 
 jest.mock('passport', () => ({
     authenticate: jest.fn()
 }));
-jest.mock('../../operations/common/logging', () => ({
-    logInfo: jest.fn(),
-    logDebug: jest.fn(),
-    logError: jest.fn(),
-    logWarn: jest.fn()
-}));
 
 const passport = require('passport');
-const { logWarn } = require('../../operations/common/logging');
 const {
     authenticateWithJsonFailure
 } = require('../../middleware/fhir/authentication.middleware');
@@ -33,21 +26,8 @@ const makeReq = ({ withAuthHeader = false, url = '/4_0_0/Patient' } = {}) => ({
 });
 
 describe('authenticateWithJsonFailure', () => {
-    let originalFlag;
-
     beforeEach(() => {
-        originalFlag = process.env.LOG_AUTH_CONTEXT_ON_401;
-        delete process.env.LOG_AUTH_CONTEXT_ON_401;
         passport.authenticate.mockReset();
-        logWarn.mockReset();
-    });
-
-    afterEach(() => {
-        if (originalFlag === undefined) {
-            delete process.env.LOG_AUTH_CONTEXT_ON_401;
-        } else {
-            process.env.LOG_AUTH_CONTEXT_ON_401 = originalFlag;
-        }
     });
 
     const mockAuthFailure = (info) => {
@@ -56,7 +36,7 @@ describe('authenticateWithJsonFailure', () => {
         });
     };
 
-    test('flag unset: 401 sent, no warn log', () => {
+    test('returns OperationOutcome JSON 401 on auth failure', () => {
         mockAuthFailure({ reason: 'missing_required_jwt_field' });
         const req = makeReq();
         const res = makeRes();
@@ -71,44 +51,6 @@ describe('authenticateWithJsonFailure', () => {
                 { severity: 'error', code: 'security', diagnostics: 'Authentication failed' }
             ]
         });
-        expect(logWarn).not.toHaveBeenCalled();
         expect(next).not.toHaveBeenCalled();
-    });
-
-    test('flag enabled: warn log emitted with strategy + request + info', () => {
-        process.env.LOG_AUTH_CONTEXT_ON_401 = '1';
-        const info = { reason: 'client_id_not_allowed_for_issuer' };
-        mockAuthFailure(info);
-        const req = makeReq({ withAuthHeader: true });
-        const res = makeRes();
-
-        authenticateWithJsonFailure('strategy')(req, res, jest.fn());
-
-        expect(logWarn).toHaveBeenCalledTimes(1);
-        expect(logWarn).toHaveBeenCalledWith('Authentication failed (401)', {
-            strategy: 'strategy',
-            method: 'GET',
-            url: '/4_0_0/Patient',
-            authorizationHeader: 'Bearer abc',
-            info
-        });
-        expect(res.status).toHaveBeenCalledWith(401);
-    });
-
-    test('flag enabled with no info: logs info=undefined and does not throw', () => {
-        process.env.LOG_AUTH_CONTEXT_ON_401 = '1';
-        mockAuthFailure(undefined);
-        const req = makeReq();
-        const res = makeRes();
-
-        expect(() =>
-            authenticateWithJsonFailure('strategy')(req, res, jest.fn())
-        ).not.toThrow();
-
-        expect(logWarn).toHaveBeenCalledTimes(1);
-        const [, args] = logWarn.mock.calls[0];
-        expect(args.info).toBeUndefined();
-        expect(args.authorizationHeader).toBeNull();
-        expect(res.status).toHaveBeenCalledWith(401);
     });
 });

--- a/src/tests/dataLayer/authentication.middleware.test.js
+++ b/src/tests/dataLayer/authentication.middleware.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach, jest } = require('@jest/globals');
+
+jest.mock('passport', () => ({
+    authenticate: jest.fn()
+}));
+jest.mock('../../operations/common/logging', () => ({
+    logInfo: jest.fn(),
+    logDebug: jest.fn(),
+    logError: jest.fn(),
+    logWarn: jest.fn()
+}));
+
+const passport = require('passport');
+const { logWarn } = require('../../operations/common/logging');
+const {
+    authenticateWithJsonFailure
+} = require('../../middleware/fhir/authentication.middleware');
+
+const makeRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+};
+
+const makeReq = ({ withAuthHeader = false, url = '/4_0_0/Patient' } = {}) => ({
+    method: 'GET',
+    url,
+    originalUrl: url,
+    headers: withAuthHeader ? { authorization: 'Bearer abc' } : {}
+});
+
+describe('authenticateWithJsonFailure', () => {
+    let originalFlag;
+
+    beforeEach(() => {
+        originalFlag = process.env.LOG_AUTH_CONTEXT_ON_401;
+        delete process.env.LOG_AUTH_CONTEXT_ON_401;
+        passport.authenticate.mockReset();
+        logWarn.mockReset();
+    });
+
+    afterEach(() => {
+        if (originalFlag === undefined) {
+            delete process.env.LOG_AUTH_CONTEXT_ON_401;
+        } else {
+            process.env.LOG_AUTH_CONTEXT_ON_401 = originalFlag;
+        }
+    });
+
+    const mockAuthFailure = (info) => {
+        passport.authenticate.mockImplementation((_strategy, _options, cb) => {
+            return (req, _res, _next) => cb(null, false, info);
+        });
+    };
+
+    test('flag unset: 401 sent, no warn log', () => {
+        mockAuthFailure({ reason: 'missing_required_jwt_field' });
+        const req = makeReq();
+        const res = makeRes();
+        const next = jest.fn();
+
+        authenticateWithJsonFailure('strategy')(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({
+            resourceType: 'OperationOutcome',
+            issue: [
+                { severity: 'error', code: 'security', diagnostics: 'Authentication failed' }
+            ]
+        });
+        expect(logWarn).not.toHaveBeenCalled();
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    test('flag enabled: warn log emitted with strategy + request + info', () => {
+        process.env.LOG_AUTH_CONTEXT_ON_401 = '1';
+        const info = { reason: 'client_id_not_allowed_for_issuer' };
+        mockAuthFailure(info);
+        const req = makeReq({ withAuthHeader: true });
+        const res = makeRes();
+
+        authenticateWithJsonFailure('strategy')(req, res, jest.fn());
+
+        expect(logWarn).toHaveBeenCalledTimes(1);
+        expect(logWarn).toHaveBeenCalledWith('Authentication failed (401)', {
+            strategy: 'strategy',
+            method: 'GET',
+            url: '/4_0_0/Patient',
+            authorizationHeader: 'Bearer abc',
+            info
+        });
+        expect(res.status).toHaveBeenCalledWith(401);
+    });
+
+    test('flag enabled with no info: logs info=undefined and does not throw', () => {
+        process.env.LOG_AUTH_CONTEXT_ON_401 = '1';
+        mockAuthFailure(undefined);
+        const req = makeReq();
+        const res = makeRes();
+
+        expect(() =>
+            authenticateWithJsonFailure('strategy')(req, res, jest.fn())
+        ).not.toThrow();
+
+        expect(logWarn).toHaveBeenCalledTimes(1);
+        const [, args] = logWarn.mock.calls[0];
+        expect(args.info).toBeUndefined();
+        expect(args.authorizationHeader).toBeNull();
+        expect(res.status).toHaveBeenCalledWith(401);
+    });
+});

--- a/src/tests/strategies/jwt.bearer.strategy.test.js
+++ b/src/tests/strategies/jwt.bearer.strategy.test.js
@@ -534,7 +534,7 @@ describe('JWT Bearer Strategy', () => {
                 try {
                     expect(error).toBeFalsy();
                     expect(user).toBeFalsy();
-                    expect(info).toBeFalsy();
+                    expect(info).toEqual({ reason: 'delegated_actor_failure' });
                     resolve();
                 } catch (assertionError) {
                     reject(assertionError);
@@ -639,7 +639,7 @@ describe('JWT Bearer Strategy', () => {
                 try {
                     expect(error).toBeFalsy();
                     expect(user).toBeFalsy();
-                    expect(info).toBeFalsy();
+                    expect(info).toEqual({ reason: 'delegated_actor_failure' });
                     resolve();
                 } catch (assertionError) {
                     reject(assertionError);
@@ -812,7 +812,7 @@ describe('JWT Bearer Strategy', () => {
                 try {
                     expect(error).toBeFalsy();
                     expect(user).toBeFalsy();
-                    expect(info).toBeFalsy();
+                    expect(info).toEqual({ reason: 'delegated_actor_failure' });
 
                     resolve();
                 } catch (assertionError) {

--- a/src/utils/accessLogger.js
+++ b/src/utils/accessLogger.js
@@ -96,15 +96,16 @@ class AccessLogger {
      * @property {object[]} [operationResult]
      * @property {string|undefined} [streamRequestBody]
      * @property {boolean} [streamingMerge]
+     * @property {string|undefined} [authorizationHeader]
      *
      * @param {logAccessLogAsyncParams}
      */
-    async logAccessLogAsync({ req, statusCode, startTime, stopTime = Date.now(), streamRequestBody, streamingMerge, operationResult }) {
+    async logAccessLogAsync({ req, statusCode, startTime, stopTime = Date.now(), streamRequestBody, streamingMerge, operationResult, authorizationHeader }) {
         /**
          * @type {string}
          */
         const resourceType = req.resourceType ? req.resourceType : (req.url.split('/')[2])?.split('?')[0];
-        if (!resourceType) {
+        if (!resourceType && statusCode !== 401) {
             return;
         }
         /**
@@ -113,28 +114,41 @@ class AccessLogger {
         const requestInfo = this.fhirOperationsManager.getRequestInfo(req);
         const isError = !(statusCode >= 200 && statusCode < 300);
 
-        // Fetching args
-        let combined_args = get_all_args(req, req.sanitized_args);
-        combined_args = this.fhirOperationsManager.parseParametersFromBody({ req, combined_args });
         const operation =
             req.method === 'GET' ? READ : req.method === 'POST' && req.url.includes('$graph') ? READ : WRITE;
-        if (!combined_args.base_version) {
-            combined_args.base_version = '4_0_0';
-        }
-        /**
-         * @type {ParsedArgs}
-         */
-        const args = await this.fhirOperationsManager.getParsedArgsAsync({
-            args: combined_args,
-            resourceType,
-            operation
-        });
 
         // Fetching detail
         const details = {
             version: this.imageVersion,
             host: this.hostname
         };
+
+        // Args parsing requires a resourceType; on a 401 the URL may not carry one (e.g. /$graphql).
+        if (resourceType) {
+            let combined_args = get_all_args(req, req.sanitized_args);
+            combined_args = this.fhirOperationsManager.parseParametersFromBody({ req, combined_args });
+            if (!combined_args.base_version) {
+                combined_args.base_version = '4_0_0';
+            }
+            /**
+             * @type {ParsedArgs}
+             */
+            const args = await this.fhirOperationsManager.getParsedArgsAsync({
+                args: combined_args,
+                resourceType,
+                operation
+            });
+
+            const params = {};
+            Object.entries(args.getRawArgs())
+                .filter(([k, _]) => !['resource', 'base_version'].includes(k))
+                .forEach(([k, v]) => {
+                    params[k] = !v || typeof v === 'string' ? v : JSON.stringify(v, getCircularReplacer());
+                });
+            if (Object.keys(params).length > 0) {
+                details['params'] = params;
+            }
+        }
 
         if (requestInfo.contentTypeFromHeader) {
             details['contentType'] = requestInfo.contentTypeFromHeader.type;
@@ -148,14 +162,8 @@ class AccessLogger {
             details['originService'] = req.headers['origin-service'];
         }
 
-        const params = {};
-        Object.entries(args.getRawArgs())
-            .filter(([k, _]) => !['resource', 'base_version'].includes(k))
-            .forEach(([k, v]) => {
-                params[k] = !v || typeof v === 'string' ? v : JSON.stringify(v, getCircularReplacer());
-            });
-        if (Object.keys(params).length > 0) {
-            details['params'] = params;
+        if (authorizationHeader) {
+            details['authorizationHeader'] = authorizationHeader;
         }
 
         if (operationResult) {


### PR DESCRIPTION
## Summary

Three commits, all for [DCON-3934](https://icanbwell.atlassian.net/browse/DCON-3934):

1. **Log auth context on 401 (env-gated, default off)** — adds `LOG_AUTH_CONTEXT_ON_401` flag in `src/middleware/fhir/authentication.middleware.js`. When enabled, emits a `logWarn` on every 401 from `authenticateWithJsonFailure` with strategy, method, url, full Authorization header, and the Passport `info` (which carries a `reason` tag). Default off; production behavior unchanged unless an operator opts in for triage. Adds new test file `src/tests/dataLayer/authentication.middleware.test.js`.
2. **Enable JWT logging for local** — turns the flag on in `docker-compose.yml` so the local stack emits these warns by default. Convenience-only; not used by any deployed env.
3. **Log reason for auth rejections** — tags every `done(null, false, { reason })` JWT rejection in `src/strategies/authService.js` (6 sites) with its `reason` in the adjacent log line. Folded into the existing `logInfo`/`logError` where one was already nearby (4 sites: `invalid_user_type_for_non_patient_token`, `client_id_not_allowed_for_issuer`, `userinfo_endpoint_error`, `delegated_actor_failure`); emitted as a fresh `logWarn('Auth rejected', { reason })` where none existed (`missing_required_jwt_field`, `missing_jwt_payload`). Also fixes three pre-existing stale assertions in `src/tests/strategies/jwt.bearer.strategy.test.js` that asserted `info` would be falsy for delegated-actor rejections — `info` has carried `{ reason: 'delegated_actor_failure' }` since DCON-3672.

## Test plan

- [x] `jest src/tests/dataLayer/authentication.middleware.test.js` — 3/3 pass
- [x] `jest src/tests/strategies/authService.test.js` — 5/5 pass
- [x] `jest src/tests/strategies/jwt.bearer.strategy.test.js` — 23/23 pass (was 20/23 before the test fix)
- [ ] Smoke-check locally with `LOG_AUTH_CONTEXT_ON_401=1`: hit an authed endpoint with a malformed token and confirm the warn line includes the `reason` tag and Authorization header

## Related

- Replaces draft work from PR #2212 (`ms_token_logging`) with a clean rebase onto `main`. The two INC-311 commits from that branch were dropped because their net diff is already on `main` via #2209 plus subsequent merges.

[DCON-3934]: https://icanbwell.atlassian.net/browse/DCON-3934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ