### PR TITLE
DCON-3811: Switch invalid-request short-circuit from id to indexed _uuid

### DIFF
--- a/src/operations/common/patientQueryCreator.js
+++ b/src/operations/common/patientQueryCreator.js
@@ -288,7 +288,7 @@ class PatientQueryCreator {
         }
         // if no queries found then don't allow access
         if (queries.length === 0) {
-            return {id: '__invalid__'}; // return nothing since no valid query was found
+            return {_uuid: '__invalid__'}; // return nothing since no valid query was found
         }
         // Now combine all the queries into one
         const patientAndPersonQuery = {

--- a/src/operations/everything/everythingHelper.js
+++ b/src/operations/everything/everythingHelper.js
@@ -1353,7 +1353,7 @@ class EverythingHelper {
                             `Expected $or operator in query for resource ${relatedResourceType} when consented PROA data is accessed.`,
                             { query, relatedResourceType }
                         );
-                        query = { id: '__invalid__' };
+                        query = { _uuid: '__invalid__' };
                         continue;
                     }
                     for (const orQuery of query.$or) {

--- a/src/operations/search/dataSharingManager.js
+++ b/src/operations/search/dataSharingManager.js
@@ -295,7 +295,7 @@ class DataSharingManager {
         );
 
         if (patientIdsWithConsent.size === 0) {
-            return { id: '__invalid__' };
+            return { _uuid: '__invalid__' };
         }
 
         if (actor) {
@@ -694,7 +694,7 @@ class DataSharingManager {
 
         // Delegated actor but no consent found — safety net: return impossible query
         if (filteringRules === null) {
-            return { id: '__invalid__' };
+            return { _uuid: '__invalid__' };
         }
 
         const { deniedSensitiveCategories } = filteringRules;

--- a/src/operations/search/searchManager.js
+++ b/src/operations/search/searchManager.js
@@ -254,7 +254,7 @@ class SearchManager {
 
                 if (!this.configManager.doNotRequirePersonOrPatientIdForPatientScope &&
                     allPatientIdsFromJwtToken.length === (personIdFromJwtToken ? 1 : 0)) {
-                    query = { id: '__invalid__' }; // return nothing since no patient ids were passed
+                    query = { _uuid: '__invalid__' }; // return nothing since no patient ids were passed
                 } else {
                     if (applyPatientFilter) {
                         query = this.patientQueryCreator.getQueryWithPatientFilter({

--- a/src/tests/clickhouseOnly/auditEvent/auditEventClickHouseApiSearch.test.js
+++ b/src/tests/clickhouseOnly/auditEvent/auditEventClickHouseApiSearch.test.js
@@ -364,7 +364,7 @@ describe('AuditEvent ClickHouse API search integration', () => {
                 }));
 
             // Patient-scoped tokens go through the patient filter path which generates
-            // { id: '__invalid__' } when no valid patient IDs are resolved from the token.
+            // { _uuid: '__invalid__' } when no valid patient IDs are resolved from the token.
             // The ClickHouse query pipeline cannot handle this fallback query.
             expect(resp.status).not.toBe(200);
             expect(resp.body.resourceType).toBe('OperationOutcome');

--- a/src/tests/data_sharing/cmsDataSharing/cmsDataSharingPatientList.test.js
+++ b/src/tests/data_sharing/cmsDataSharing/cmsDataSharingPatientList.test.js
@@ -151,7 +151,7 @@ describe('CMS Data Sharing - Patient List with cms-partner', () => {
         // Query as person-1 without any consent
         resp = await request.get('/4_0_0/Patient?_bundle=1&_count=100&_debug=1').set(getCmsHeaders(PERSON_ID_1));
 
-        // Should return empty results (CMS returns { id: '__invalid__' } when no consent)
+        // Should return empty results (CMS returns { _uuid: '__invalid__' } when no consent)
         expect(resp).toHaveStatusCode(200);
         expect(resp).toHaveResponse(expectedPatientListNoConsentResponse);
     });

--- a/src/tests/data_sharing/cmsDataSharing/fixtures/expected/expected_patient_list_consent_2_denied.json
+++ b/src/tests/data_sharing/cmsDataSharing/fixtures/expected/expected_patient_list_consent_2_denied.json
@@ -7,7 +7,7 @@
     "tag": [
       {
         "system": "https://www.icanbwell.com/query",
-        "display": "db.Patient_4_0_0.find({'id':'__invalid__'}, {}).sort({'_uuid':1}).limit(100)"
+        "display": "db.Patient_4_0_0.find({'_uuid':'__invalid__'}, {}).sort({'_uuid':1}).limit(100)"
       },
       {
         "system": "https://www.icanbwell.com/queryCollection",
@@ -19,7 +19,7 @@
       },
       {
         "system": "https://www.icanbwell.com/queryFields",
-        "display": "['id','_uuid']"
+        "display": "['_uuid']"
       },
       {
         "system": "https://www.icanbwell.com/queryTime"

--- a/src/tests/data_sharing/cmsDataSharing/fixtures/expected/expected_patient_list_no_consent.json
+++ b/src/tests/data_sharing/cmsDataSharing/fixtures/expected/expected_patient_list_no_consent.json
@@ -7,7 +7,7 @@
     "tag": [
       {
         "system": "https://www.icanbwell.com/query",
-        "display": "db.Patient_4_0_0.find({'id':'__invalid__'}, {}).sort({'_uuid':1}).limit(100)"
+        "display": "db.Patient_4_0_0.find({'_uuid':'__invalid__'}, {}).sort({'_uuid':1}).limit(100)"
       },
       {
         "system": "https://www.icanbwell.com/queryCollection",
@@ -19,7 +19,7 @@
       },
       {
         "system": "https://www.icanbwell.com/queryFields",
-        "display": "['id','_uuid']"
+        "display": "['_uuid']"
       },
       {
         "system": "https://www.icanbwell.com/queryTime"

--- a/src/tests/graphql/sdkSubscription/fixtures/expected/expected_subscription_invalid.json
+++ b/src/tests/graphql/sdkSubscription/fixtures/expected/expected_subscription_invalid.json
@@ -3,7 +3,7 @@
   "meta": {
     "tag": [
       {
-        "display": "[db.Subscription_4_0_0.find({'id':'__invalid__'}, {'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'extension':1,'_id':0,'meta.security.system':1,'meta.security.code':1}).sort({'_uuid':1}).limit(100)]",
+        "display": "[db.Subscription_4_0_0.find({'_uuid':'__invalid__'}, {'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'extension':1,'_id':0,'meta.security.system':1,'meta.security.code':1}).sort({'_uuid':1}).limit(100)]",
         "system": "https://www.icanbwell.com/query"
       },
       {
@@ -15,7 +15,7 @@
         "system": "https://www.icanbwell.com/queryOptions"
       },
       {
-        "display": "[['id','_uuid']]",
+        "display": "[['_uuid']]",
         "system": "https://www.icanbwell.com/queryFields"
       },
       {

--- a/src/tests/graphql/subscription/fixtures/expected/expected_subscription_invalid.json
+++ b/src/tests/graphql/subscription/fixtures/expected/expected_subscription_invalid.json
@@ -3,7 +3,7 @@
   "meta": {
     "tag": [
       {
-        "display": "[db.Subscription_4_0_0.find({'id':'__invalid__'}, {'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'_id':0,'meta.security.system':1,'meta.security.code':1}).sort({'_uuid':1}).limit(100)]",
+        "display": "[db.Subscription_4_0_0.find({'_uuid':'__invalid__'}, {'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'_id':0,'meta.security.system':1,'meta.security.code':1}).sort({'_uuid':1}).limit(100)]",
         "system": "https://www.icanbwell.com/query"
       },
       {
@@ -15,7 +15,7 @@
         "system": "https://www.icanbwell.com/queryOptions"
       },
       {
-        "display": "[['id','_uuid']]",
+        "display": "[['_uuid']]",
         "system": "https://www.icanbwell.com/queryFields"
       },
       {

--- a/src/tests/graphqlv2/subscription/fixtures/expected/expected_subscription_invalid.json
+++ b/src/tests/graphqlv2/subscription/fixtures/expected/expected_subscription_invalid.json
@@ -3,7 +3,7 @@
   "meta": {
     "tag": [
       {
-        "display": "[db.Consent_4_0_0.find({'id':'__invalid__'}, {'_id':0}),db.Subscription_4_0_0.find({'id':'__invalid__'}, {'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'_id':0,'meta.security.system':1,'meta.security.code':1}).sort({'_uuid':1}).limit(100)]",
+        "display": "[db.Consent_4_0_0.find({'_uuid':'__invalid__'}, {'_id':0}),db.Subscription_4_0_0.find({'_uuid':'__invalid__'}, {'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'_id':0,'meta.security.system':1,'meta.security.code':1}).sort({'_uuid':1}).limit(100)]",
         "system": "https://www.icanbwell.com/query"
       },
       {
@@ -15,7 +15,7 @@
         "system": "https://www.icanbwell.com/queryOptions"
       },
       {
-        "display": "[['id','_uuid']]",
+        "display": "[['_uuid']]",
         "system": "https://www.icanbwell.com/queryFields"
       },
       {

--- a/src/tests/operations/common/patientQueryCreator/patientQueryCreator.test.js
+++ b/src/tests/operations/common/patientQueryCreator/patientQueryCreator.test.js
@@ -261,7 +261,7 @@ describe('PatientQueryCreator Tests', () => {
             });
             // Subscription resource is filtered by person id, not patient id
             expect(query).toStrictEqual({
-                id: "__invalid__"
+                _uuid: "__invalid__"
             });
         });
     });

--- a/src/tests/operations/search/delegatedAccessQueryManager.test.js
+++ b/src/tests/operations/search/delegatedAccessQueryManager.test.js
@@ -98,7 +98,7 @@ describe('DataSharingManager - updateQueryForDelegatedAccessSensitiveData Tests'
             personIdFromJwtToken
         });
 
-        expect(result).toEqual({ id: '__invalid__' });
+        expect(result).toEqual({ _uuid: '__invalid__' });
     });
 
     test('Adds exclusion filter with denied categories and unclassified', async () => {

--- a/src/tests/utils/dataSharingManager/cmsConsentPolicy.test.js
+++ b/src/tests/utils/dataSharingManager/cmsConsentPolicy.test.js
@@ -152,8 +152,8 @@ describe('DataSharingManager.updateQueryConsideringCmsDataSharing — actor.cons
         expect(actor.consentPolicy).toEqual(expect.stringMatching(/^Consent\/.+\?version=.+$/));
 
         // Sanity: the returned query should NOT be the short-circuit
-        // { id: '__invalid__' } since we have a valid consent.
-        expect(resultQuery).not.toEqual({ id: '__invalid__' });
+        // { _uuid: '__invalid__' } since we have a valid consent.
+        expect(resultQuery).not.toEqual({ _uuid: '__invalid__' });
     });
 
     test('does NOT stamp actor when no consent exists', async () => {
@@ -177,7 +177,7 @@ describe('DataSharingManager.updateQueryConsideringCmsDataSharing — actor.cons
         });
 
         expect(actor.consentPolicy).toBeUndefined();
-        expect(resultQuery).toEqual({ id: '__invalid__' });
+        expect(resultQuery).toEqual({ _uuid: '__invalid__' });
     });
 
     test('safe when actor is null (no throw)', async () => {
@@ -221,7 +221,7 @@ describe('DataSharingManager.updateQueryConsideringCmsDataSharing — actor.cons
         ).resolves.toBeDefined();
     });
 
-    test('short-circuits with {id: \'__invalid__\'} when no consent (regression guard)', async () => {
+    test('short-circuits with {_uuid: \'__invalid__\'} when no consent (regression guard)', async () => {
         const request = await createTestRequest();
 
         // Seed only Person + Patient; no Consent.
@@ -240,6 +240,6 @@ describe('DataSharingManager.updateQueryConsideringCmsDataSharing — actor.cons
             actor: {}
         });
 
-        expect(resultQuery).toEqual({ id: '__invalid__' });
+        expect(resultQuery).toEqual({ _uuid: '__invalid__' });
     });
 });


### PR DESCRIPTION
## Summary
- The "match nothing" sentinel query `{ id: '__invalid__' }` was hitting an unindexed field, causing COLLSCAN timeouts on large collections. Switch all 5 sites to `{ _uuid: '__invalid__' }` — `_uuid` is unique-sparse indexed across every FHIR collection (`src/indexes/customIndexes.js` wildcard entry) and universally populated by `uuidColumnHandler`, so the empty-result short-circuit is now an instant IXSCAN.
- Production changes: `dataSharingManager.js` (×2), `searchManager.js`, `patientQueryCreator.js`, `everythingHelper.js`.
- Test updates: 5 assertion-level changes + 1 test-name string + 3 cosmetic comments + 5 fixture JSON files (response `meta.tag` echoes the executed Mongo query, so fixtures needed the new query and projection strings).

Jira: https://icanbwell.atlassian.net/browse/DCON-3811

## Test plan
- [x] `make lint` passes
- [x] Targeted Jest suites pass: `cmsConsentPolicy`, `delegatedAccessQueryManager`, `patientQueryCreator`, `cmsDataSharingPatientList`, all 3 subscription suites (graphql/graphqlv2/sdkSubscription), `operations/everything`, `operations/search`, `operations/common`, and `data_sharing/scenario_{1,2,4,7c}` + `data_sharing/everything`
- [x] Regression grep — zero remaining `id: '__invalid__'` in src/ (only the unrelated search-param value at `fhirOperationsManager.js:462` remains, which goes through normal indexed search-param parsing and is out of scope)