### PR TITLE
DCON-4012 Make Node cluster mode safe for SIGTERM and per-worker buffers

### DIFF
--- a/k8s-start.sh
+++ b/k8s-start.sh
@@ -3,12 +3,18 @@
 # Default to 536870912 bytes (512 MB) if MAX_OLD_SPACE_SIZE is not set
 : "${MAX_OLD_SPACE_SIZE_BYTES:=536870912}"
 
+# Number of cluster workers; pod-level memory must be divided across them.
+: "${WORKER_COUNT:=1}"
+
 # Convert bytes to megabytes, rounding up to the nearest whole number
 MAX_OLD_SPACE_SIZE_MB=$(( (MAX_OLD_SPACE_SIZE_BYTES + 1048576 - 1) / 1048576 ))
 
+# Per-worker heap, with a 10% safety margin for off-heap (sockets, buffers, native).
+PER_WORKER_MAX_OLD_SPACE_SIZE_MB=$(( (MAX_OLD_SPACE_SIZE_MB / WORKER_COUNT) * 9 / 10 ))
+
 # Start the Node.js application with the calculated memory limit & instrumentation
 if [ "$1" = "otel" ]; then
-    OTEL_NODE_ENABLED_INSTRUMENTATIONS=dataloader,express,graphql,lru-memoizer,router,winston,http,mongodb,redis exec node --max-old-space-size=$MAX_OLD_SPACE_SIZE_MB --require=./src/otel_instrumentation.js src/index.js
+    OTEL_NODE_ENABLED_INSTRUMENTATIONS=dataloader,express,graphql,lru-memoizer,router,winston,http,mongodb,redis exec node --max-old-space-size=$PER_WORKER_MAX_OLD_SPACE_SIZE_MB --require=./src/otel_instrumentation.js src/index.js
 else
-    exec node --max-old-space-size=$MAX_OLD_SPACE_SIZE_MB src/index.js
+    exec node --max-old-space-size=$PER_WORKER_MAX_OLD_SPACE_SIZE_MB src/index.js
 fi

--- a/src/index.js
+++ b/src/index.js
@@ -35,12 +35,11 @@ const main = async function () {
 
         await createServer(() => container);
 
-        // Cron tasks (postSave/audit/access flushes) must run in exactly one
-        // worker, otherwise every flush fires N times per interval.
-        const isCronWorker = !cluster.worker || cluster.worker.id === 1;
-        if (isCronWorker) {
-            await container.cronTasksProcessor.initiateTasks();
-        }
+        // Cron tasks flush per-worker buffers (postSaveProcessor, auditLogger,
+        // accessLogger). The buffers are local to each worker, so every worker
+        // must run its own cron — gating to a single worker drops 7/8 of the
+        // audit/access events at WORKER_COUNT=8.
+        await container.cronTasksProcessor.initiateTasks();
     } catch (e) {
         console.log('ERROR from MAIN: ' + e);
         console.log(JSON.stringify({ method: 'main', message: e.message, stack: JSON.stringify(e.stack, getCircularReplacer()) }));

--- a/src/index.js
+++ b/src/index.js
@@ -37,8 +37,7 @@ const main = async function () {
 
         // Cron tasks flush per-worker buffers (postSaveProcessor, auditLogger,
         // accessLogger). The buffers are local to each worker, so every worker
-        // must run its own cron — gating to a single worker drops 7/8 of the
-        // audit/access events at WORKER_COUNT=8.
+        // must run its own cron task processor.
         await container.cronTasksProcessor.initiateTasks();
     } catch (e) {
         console.log('ERROR from MAIN: ' + e);

--- a/src/index.js
+++ b/src/index.js
@@ -34,8 +34,13 @@ const main = async function () {
         BaseFhirResourceSerializer.setConfigManager(container.configManager);
 
         await createServer(() => container);
-        // Initialize cron tasks processor for processing scheduled tasks
-        await container.cronTasksProcessor.initiateTasks();
+
+        // Cron tasks (postSave/audit/access flushes) must run in exactly one
+        // worker, otherwise every flush fires N times per interval.
+        const isCronWorker = !cluster.worker || cluster.worker.id === 1;
+        if (isCronWorker) {
+            await container.cronTasksProcessor.initiateTasks();
+        }
     } catch (e) {
         console.log('ERROR from MAIN: ' + e);
         console.log(JSON.stringify({ method: 'main', message: e.message, stack: JSON.stringify(e.stack, getCircularReplacer()) }));
@@ -44,16 +49,21 @@ const main = async function () {
 };
 
 const numCPUs = process.env.WORKER_COUNT ? parseInt(process.env.WORKER_COUNT, 10) : 1;
-if (cluster.isMaster && numCPUs > 1) {
-    console.log(JSON.stringify({message: `Master ${process.pid} is running`}));
+const isPrimary = typeof cluster.isPrimary === 'boolean' ? cluster.isPrimary : cluster.isMaster;
+if (isPrimary && numCPUs > 1) {
+    console.log(JSON.stringify({message: `Master ${process.pid} is running with ${numCPUs} workers`}));
 
     // Fork workers
     for (let i = 0; i < numCPUs; i++) {
         cluster.fork();
     }
 
-    // Forward all signals to the worker processes
+    // Forward all signals to the worker processes. Setting `shuttingDown`
+    // first prevents the exit handler from respawning workers that exit
+    // because we asked them to.
+    let shuttingDown = false;
     const forwardSignal = (signal) => {
+        shuttingDown = true;
         for (const id in cluster.workers) {
             cluster.workers[id].process.kill(signal);
         }
@@ -64,8 +74,10 @@ if (cluster.isMaster && numCPUs > 1) {
     process.on('SIGQUIT', () => forwardSignal('SIGQUIT'));
 
     cluster.on('exit', (worker, code, signal) => {
-        console.log(JSON.stringify({message: `Worker ${worker.process.pid} died`}));
-        // Optionally, you can fork a new worker here
+        console.log(JSON.stringify({message: `Worker ${worker.process.pid} died (code=${code}, signal=${signal})`}));
+        if (shuttingDown) {
+            return;
+        }
         cluster.fork();
     });
 } else {

--- a/src/index.js
+++ b/src/index.js
@@ -49,8 +49,7 @@ const main = async function () {
 };
 
 const numCPUs = process.env.WORKER_COUNT ? parseInt(process.env.WORKER_COUNT, 10) : 1;
-const isPrimary = typeof cluster.isPrimary === 'boolean' ? cluster.isPrimary : cluster.isMaster;
-if (isPrimary && numCPUs > 1) {
+if (cluster.isPrimary && numCPUs > 1) {
     console.log(JSON.stringify({message: `Master ${process.pid} is running with ${numCPUs} workers`}));
 
     // Fork workers


### PR DESCRIPTION
## Summary
Prepares `fhir-server` to run safely with `WORKER_COUNT > 1` per pod by fixing three latent issues in the existing cluster code that only surface at multi-worker:

- **SIGTERM safety:** the master previously called `cluster.fork()` unconditionally on every worker exit. During pod termination this fights the kubelet — workers exit on SIGTERM, master immediately respawns them, repeat until grace-period kill. A `shuttingDown` flag now suppresses respawn after the first SIGTERM/SIGINT/SIGQUIT.
- **Per-worker heap:** `k8s-start.sh` previously gave each worker the full pod memory limit as its V8 heap. At `WORKER_COUNT > 1` that is a guaranteed OOMKill. The script now divides `--max-old-space-size` by `WORKER_COUNT` and applies a 10% off-heap safety margin.
- **Deprecation cutover:** replaces `cluster.isMaster` (deprecated in Node 16+) with `cluster.isPrimary`. Engines requires `>=24.14`, so the old name's removal is just a matter of when.

## What's NOT changed (and why)
**Cron tasks run in every worker, not gated to a single worker.** The buffers flushed by `cronTasksProcessor` (`postSaveProcessor`, `auditLogger`, `accessLogger`) are *per-worker instance fields* — `accessLogger.queue` and `auditLogger.queue` belong to the container in that specific worker. Gating cron to a single worker would mean only that worker's buffer ever flushes during steady state; the other workers' buffers would grow until pod shutdown, dropping `(N-1)/N` of audit and access-log events. So every worker schedules its own cron tick and flushes its own local queue — no double-write risk because each `flushAsync()` only touches the calling worker's data.

(Earlier in the PR an `isCronWorker` guard was added by mistake. It was removed in commit 1e4d7f95b after walking through the request flow at `WORKER_COUNT=8` revealed the silent-data-loss issue.)

## Behavior at WORKER_COUNT=1 (default, today's prod)
Unchanged. The non-cluster branch runs `main()` directly, including `cronTasksProcessor.initiateTasks()`, just like today. Heap math reduces to `pod_mb * 0.9`, which is intentional — every pod gets a small off-heap safety margin instead of being told it can use 100% of memory for V8.

## Behavior at WORKER_COUNT=N (>1)
- Master process forks N workers, holds the listening socket, forwards signals, never serves requests.
- Each worker calls `http.createServer(app).listen(:3000)`; Node's cluster module hands accepted connections to workers in round-robin (Linux default).
- Each worker has its own Mongo / ClickHouse / Redis / Kafka connection pools, its own LRU caches, its own audit/access buffers, and runs its own cron flush.
- On SIGTERM: master sets `shuttingDown=true`, forwards SIGTERM to all workers, workers shut down via `terminus`, master does NOT respawn replacements, master exits cleanly.

## Files changed
- `src/index.js` — `cluster.isPrimary`, `shuttingDown` flag, comments around cron behavior.
- `k8s-start.sh` — `WORKER_COUNT` (default 1), per-worker `--max-old-space-size` with 10% safety margin.

## Test plan
- [ ] Local: `MAX_OLD_SPACE_SIZE_BYTES=2147483648 WORKER_COUNT=2 ./k8s-start.sh` — confirm two `Worker N started` log lines, one `Master ... is running with 2 workers`, **two** `Cron job started: CronTasksProcessor` lines (one per worker, by design).
- [ ] Local: with the above, send SIGTERM to the master — confirm both workers exit, master does **not** respawn replacements, process exits within `GRACEFUL_TIMEOUT_MS`.
- [ ] Local: kill a worker with `kill <pid>` (not via the master) — confirm master **does** respawn it (this is the non-shutdown path).
- [x] Local: hit `/4_0_0/Patient` ~1000 times across both workers, send SIGTERM, verify access-log rows in ClickHouse / Mongo correspond to ~1000 (not ~500). This is the regression check for the cron-guard correction.
- [x] CI: existing tests still pass at `WORKER_COUNT=1`.
- [ ] Helm dev/staging: paired Helm PR sets `WORKER_COUNT=2` on `fhir-server-pipeline` staging and `fhir-server-merge` dev. Watch readiness probes, OOM events, and Mongo connection counts.

## Roll-out
1. Merge this PR; tag and publish a new image.
2. Merge the paired Helm PR (`icanbwell/bwell-fhir-server` #35) which sets `WORKER_COUNT=2` for `fhir-server-merge` dev and `fhir-server-pipeline` staging. Soak 24-48 h.
3. Watch in Groundcover:
   - `groundcover_container_cpu_pressure_some_avg300` should drop materially
   - `Unhealthy` (readiness probe) event count should drop
   - per-pod RSS should be ~half of single-process baseline (each worker has half the heap)
   - audit/access write counts to ClickHouse + Mongo should match (not be ~half) request volume
   - Mongo Atlas active connection count should be flat (per-worker pool was halved)
4. After healthy soak, prep follow-up PRs for staging (merge) and prod (both charts), with `maxReplicas` halved for prod to compensate for double-throughput pods.

## Known follow-ups (not in this PR)
- **Cron-worker re-election / exit-rate backoff.** A persistent worker startup failure today causes ~10 forks/sec until the kubelet times out. Worth adding an exit-rate threshold that lets the pod CrashLoopBackOff cleanly. Tracked in the comment thread on this PR.
- **OTel auto-instrumentation in master.** Master process loads `otel_instrumentation.js` but never serves requests. Wasted ~50–100 MB; minor.
- **Async ClickHouse batching.** This PR makes the cluster correct, but per-worker queues mean each cron tick now produces N small CH inserts instead of 1 medium one. Tracked separately in DCON-3983.

## Related
- Tracked in DCON-4012.
- Investigation that motivated this in DCON-3983 (ClickHouse impact / event-loop blocking).
- Helm-side PR: icanbwell/bwell-fhir-server#35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)