### PR TITLE
PAY-2012: Extract entitlements from delegated user JWT for AuditEvent purposeOfEvent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,6 +189,7 @@ services:
       MY_DELEGATED_ACCESS_USER_MASTER_PATIENT_ID: 668d0748-1484-4bba-9cbe-0faf0de8965c
       DELEGATED_ACT_REFERENCE: RelatedPerson/36265db4-0da2-4436-b4e8-85bf7e52a425
       DELEGATED_ACT_SUB: 46265db4-0da2-4436-b4e8-85bf7e52a426
+      DELEGATED_USER_ENTITLEMENTS: FAMRQT
       DELEGATED_MANAGING_ORGANIZATION: 8a7cbd9c-5b1e-5c3d-9c4f-0b2e5f1a7c6d
       # This is the user and password that will be created in the realm for admin scope token
       MY_ADMIN_USER_NAME: admin

--- a/keycloak-config/realm-import.json
+++ b/keycloak-config/realm-import.json
@@ -124,7 +124,8 @@
         "username": "${MY_DELEGATED_ACCESS_USER_TOKEN_USERNAME}",
         "act.reference": "${DELEGATED_ACT_REFERENCE}",
         "act.sub": "${DELEGATED_ACT_SUB}",
-        "managingOrganization": "${DELEGATED_MANAGING_ORGANIZATION}"
+        "managingOrganization": "${DELEGATED_MANAGING_ORGANIZATION}",
+        "entitlements": ["${DELEGATED_USER_ENTITLEMENTS}"]
       }
     },
     {

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -232,6 +232,9 @@ class AuthService {
                 } else if (result.actor) {
                     context.actor = result.actor;
                     context.userType = AUTH_USER_TYPES.delegatedUser;
+                    if (Array.isArray(jwt_payload.entitlements)) {
+                        context.purposeOfUse = jwt_payload.entitlements;
+                    }
                 }
             }
             // if userType is not already set through delegated access detection,

--- a/src/tests/internalAuditLogs/auditLogIsCreated/auditLogIsCreated.test.js
+++ b/src/tests/internalAuditLogs/auditLogIsCreated/auditLogIsCreated.test.js
@@ -14,6 +14,7 @@ const expectedAuditEvents2 = require('./fixtures/expected/expected_audit_events_
 const expectedAuditEvents3 = require('./fixtures/expected/expected_audit_events_3.json');
 const expectedPatientScopeAuditEvent = require('./fixtures/expected/expected_audit_event_patient_scope.json');
 const expectedDelegatedActorAuditEvent = require('./fixtures/expected/expected_audit_event_delegated_actor.json');
+const expectedDelegatedActorWithPurposeOfEvent = require('./fixtures/expected/expected_audit_event_delegated_actor_with_purpose_of_event.json');
 
 const {
     commonBeforeEach,
@@ -558,6 +559,103 @@ describe('InternalAuditLog Tests', () => {
             delete latestLog._sourceId;
             delete latestLog.recorded;
             expect(latestLog).toStrictEqual(expectedDelegatedActorAuditEvent);
+            delete process.env.ENABLE_DELEGATED_ACCESS_DETECTION;
+            hintSpy.mockRestore();
+        });
+
+        test('InternalAuditLog creates audit logs with purposeOfEvent from delegated actor entitlements', async () => {
+            const hintSpy = jest.spyOn(DatabaseCursor.prototype, 'hint').mockReturnThis();
+            process.env.ENABLE_DELEGATED_ACCESS_DETECTION = 'true';
+            const request = await createTestRequest((container) => {
+                container.register(
+                    'auditLogger',
+                    (c) =>
+                        new AuditLogger({
+                            postRequestProcessor: c.postRequestProcessor,
+                            databaseBulkInserter: c.databaseBulkInserter,
+                            preSaveManager: c.preSaveManager,
+                            configManager: c.configManager
+                        })
+                );
+                return container;
+            });
+            const container = getTestContainer();
+
+            const postRequestProcessor = container.postRequestProcessor;
+            const auditLogger = container.auditLogger;
+            const mongoDatabaseManager = container.mongoDatabaseManager;
+            const auditEventDb = await mongoDatabaseManager.getAuditDbAsync();
+            const auditEventCollection = auditEventDb.collection('AuditEvent_4_0_0');
+
+            expect(await auditEventCollection.countDocuments()).toStrictEqual(0);
+
+            let resp = await request
+                .post(`/4_0_0/Patient/${patient.id}/$merge?validate=true`)
+                .send(patient)
+                .set(getHeaders());
+            expect(resp).toHaveMergeResponse({ created: true });
+
+            resp = await request
+                .post(`/4_0_0/Person/${person.id}/$merge?validate=true`)
+                .send(person)
+                .set(getHeaders());
+            expect(resp).toHaveMergeResponse({ created: true });
+
+            resp = await request
+                .post(`/4_0_0/Observation/${observation.id}/$merge?validate=true`)
+                .send(observation)
+                .set(getHeaders());
+            expect(resp).toHaveMergeResponse({ created: true });
+
+            resp = await request
+                .post(`/4_0_0/Consent/${consent.id}/$merge?validate=true`)
+                .send(consent)
+                .set(getHeaders());
+            expect(resp).toHaveMergeResponse({ created: true });
+
+            await postRequestProcessor.waitTillDoneAsync({ requestId });
+            await auditLogger.flushAsync();
+
+            const initialCount = await auditEventCollection.countDocuments();
+
+            const delegatedHeaders = {
+                ...getHeadersWithCustomPayload({
+                    scope: 'patient/*.* user/*.* access/*.*',
+                    username: 'patient-123@example.com',
+                    clientFhirPersonId: person.id,
+                    clientFhirPatientId: patient.id,
+                    bwellFhirPersonId: person.id,
+                    bwellFhirPatientId: patient.id,
+                    sub: 'unique-identifier-123',
+                    token_use: 'access',
+                    act: {
+                        reference: 'RelatedPerson/8d5fcbff-3707-405c-b0b2-3053a3adc013',
+                        sub: 'related-person-sub-123'
+                    },
+                    entitlements: ['FAMRQT']
+                }),
+                Host: 'localhost:3000'
+            };
+
+            resp = await request.get(`/4_0_0/Observation/${observation.id}`).set(delegatedHeaders);
+            expect(resp).toHaveResourceCount(1);
+
+            await postRequestProcessor.waitTillDoneAsync({ requestId });
+            await auditLogger.flushAsync();
+
+            const logs = await auditEventCollection
+                .find({})
+                .sort({ 'meta.lastUpdated': -1, _id: -1 })
+                .toArray();
+            expect(logs.length).toStrictEqual(initialCount + 1);
+            const latestLog = logs[0];
+            delete latestLog.meta.lastUpdated;
+            delete latestLog._id;
+            delete latestLog.id;
+            delete latestLog._uuid;
+            delete latestLog._sourceId;
+            delete latestLog.recorded;
+            expect(latestLog).toStrictEqual(expectedDelegatedActorWithPurposeOfEvent);
             delete process.env.ENABLE_DELEGATED_ACCESS_DETECTION;
             hintSpy.mockRestore();
         });

--- a/src/tests/internalAuditLogs/auditLogIsCreated/fixtures/expected/expected_audit_event_delegated_actor_with_purpose_of_event.json
+++ b/src/tests/internalAuditLogs/auditLogIsCreated/fixtures/expected/expected_audit_event_delegated_actor_with_purpose_of_event.json
@@ -1,0 +1,109 @@
+{
+    "resourceType": "AuditEvent",
+    "meta": {
+        "versionId": "1",
+        "security": [
+            {
+                "id": "70ae40c6-f2bd-54a0-aa66-656be4cce72b",
+                "system": "https://www.icanbwell.com/owner",
+                "code": "bwell"
+            },
+            {
+                "id": "2d1e0b6f-56fb-5dd9-bc38-f01b5902fde2",
+                "system": "https://www.icanbwell.com/access",
+                "code": "bwell"
+            },
+            {
+                "id": "33ced3c5-0807-582a-b03a-df7d6e95a41c",
+                "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+                "code": "bwell"
+            }
+        ]
+    },
+    "type": {
+        "id": "e896a34e-1806-5b5a-9b10-3ca6e97d6ccf",
+        "system": "http://dicom.nema.org/resources/ontology/DCM",
+        "code": "110112",
+        "display": "Query"
+    },
+    "action": "R",
+    "purposeOfEvent": [
+        {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
+                    "id": "b3519187-ca38-52e4-be3f-4fbc00c9a5e3",
+                    "code": "FAMRQT"
+                }
+            ]
+        }
+    ],
+    "agent": [
+        {
+            "who": {
+                "reference": "Patient/person.person1",
+                "_sourceAssigningAuthority": "bwell",
+                "_uuid": "Patient/fa7cb5b3-b6fd-5996-9674-5291f076dca5",
+                "_sourceId": "Patient/person.person1"
+            },
+            "altId": "unique-identifier-123",
+            "requestor": false,
+            "network": {
+                "type": "2"
+            }
+        },
+        {
+            "who": {
+                "reference": "RelatedPerson/8d5fcbff-3707-405c-b0b2-3053a3adc013",
+                "_sourceAssigningAuthority": "bwell",
+                "_uuid": "RelatedPerson/8d5fcbff-3707-405c-b0b2-3053a3adc013",
+                "_sourceId": "RelatedPerson/8d5fcbff-3707-405c-b0b2-3053a3adc013"
+            },
+            "altId": "related-person-sub-123",
+            "policy": [
+                "Consent/05eb6663-b84b-5ec2-9a4d-cf20d61400dd?version=1"
+            ],
+            "requestor": true,
+            "network": {
+                "address": "::ffff:127.0.0.1",
+                "type": "2"
+            }
+        }
+    ],
+    "source": {
+        "observer": {
+            "reference": "Organization/ecce70a8-f5ff-5562-b28f-dbbc0f543661",
+            "_sourceAssigningAuthority": "bwell",
+            "_uuid": "Organization/ecce70a8-f5ff-5562-b28f-dbbc0f543661",
+            "_sourceId": "Organization/ecce70a8-f5ff-5562-b28f-dbbc0f543661"
+        }
+    },
+    "entity": [
+        {
+            "what": {
+                "reference": "Observation/61886699-c643-5e3b-a074-569e4c43bddf",
+                "_sourceAssigningAuthority": "bwell",
+                "_uuid": "Observation/61886699-c643-5e3b-a074-569e4c43bddf",
+                "_sourceId": "Observation/61886699-c643-5e3b-a074-569e4c43bddf"
+            },
+            "detail": [
+                {
+                    "type": "requestUrl",
+                    "valueString": "/4_0_0/Observation/2354-InAgeCohort"
+                },
+                {
+                    "type": "requestId",
+                    "valueString": "12345678"
+                },
+                {
+                    "type": "base_version",
+                    "valueString": "4_0_0"
+                }
+            ]
+        }
+    ],
+    "_access": {
+        "bwell": 1
+    },
+    "_sourceAssigningAuthority": "bwell"
+}

--- a/src/tests/strategies/jwt.bearer.strategy.test.js
+++ b/src/tests/strategies/jwt.bearer.strategy.test.js
@@ -1602,4 +1602,27 @@ describe('AuthService.processUserInfo - purposeOfUse claim parsing', () => {
             }
         });
     });
+
+    test('sets purposeOfUse for delegated user when entitlements claim is present', (done) => {
+        const authService = makeAuthService();
+        authService.configManager = new (class extends ConfigManager {
+            get enableDelegatedAccessDetection() { return true; }
+        })();
+        const jwt_payload = {
+            ...basePayload(),
+            entitlements: ['FAMRQT'],
+            act: { reference: 'RelatedPerson/8d5fcbff-3707-405c-b0b2-3053a3adc013', sub: 'patient-1' }
+        };
+
+        authService.processUserInfo({
+            username: 'u', subject: 's', isUser: true,
+            jwt_payload, client_id: 'c', scope: 'patient/*.read',
+            done: (err, user, info) => {
+                expect(err).toBeNull();
+                expect(info.context.userType).toBe('delegatedUser');
+                expect(info.context.purposeOfUse).toEqual(['FAMRQT']);
+                done();
+            }
+        });
+    });
 });


### PR DESCRIPTION
## Summary

- Extract `entitlements` claim from delegated user JWT tokens in `authService.js` so the existing purposeOfEvent pipeline writes it to AuditEvents
- Configure Keycloak to include `entitlements` attribute in delegated user tokens
- Add unit test (jwt.bearer.strategy) and integration test (auditLogIsCreated) for the new behavior

## Test plan

- [ ] Unit test: `node node_modules/.bin/jest src/tests/strategies/jwt.bearer.strategy.test.js -t "sets purposeOfUse for delegated user"`
- [ ] Integration test: `node node_modules/.bin/jest src/tests/internalAuditLogs/auditLogIsCreated/auditLogIsCreated.test.js -t "purposeOfEvent from delegated actor entitlements"`
- [ ] Local Keycloak: verify delegated user token includes `entitlements` claim after `make down && make up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)