### PR TITLE
EA-2240 Add custom OpenTelemetry meters via ambient module pattern

### DIFF
--- a/docs/adr/0002-custom-opentelemetry-meters-via-dependency-injection.md
+++ b/docs/adr/0002-custom-opentelemetry-meters-via-dependency-injection.md
@@ -1,0 +1,266 @@
+# Observability Emission Pattern: Ambient Module + Boundary Choke Points
+
+## Status
+
+Proposed (replaces a previous draft of this ADR that prescribed strict DI for the meter)
+
+**Scope notes:**
+- This ADR establishes the pattern for application-domain custom metrics in fhir-server. It does not change auto-instrumentation, tracing, or the existing OpenTelemetry SDK setup in `src/otel_instrumentation.js`.
+- The first set of instruments is the EA-2240 group: merge outcome, validation failure, bundle size, empty `$everything`, and Kafka retry exhaustion. Future custom metrics in this repo follow the pattern documented here.
+- A previous draft of this ADR prescribed strict DI of a typed `CustomMetrics` class injected into every consumer. That implementation produced three rounds of review-caught bugs of two shapes: (1) constructor-cascade test breakage every time a new consumer required `customMetrics`, and (2) edge-path bugs scattered across the 13 emission sites where every consumer shared responsibility for partitioning correctly. This ADR documents why we are not doing that, and what we are doing instead.
+
+## Context
+
+Per AGENTS.md "Observability Is a Deliverable," services need meaningful application-domain metrics. The OpenTelemetry SDK is already wired (`src/otel_instrumentation.js`), with a metric exporter and reader configured. What's missing is custom application-domain instruments and the pattern for adding them.
+
+EA-2240 introduces five instruments to surface failure modes on the FHIR server's write and read paths. The shape of this work establishes a pattern that will repeat as custom metrics are added across the codebase.
+
+### What didn't work: strict DI of a `CustomMetrics` class
+
+The first attempt registered `CustomMetrics` as a container service and injected it via constructor into every consumer that emitted (`MergeOperation`, `ResourceValidator`, `BundleResourceValidator`, `NdjsonParser`, `EverythingHelper`, `KafkaClient`). Every consumer asserted `assertTypeEquals(customMetrics, CustomMetrics)` to enforce DI hygiene.
+
+Two problem patterns emerged across three review rounds:
+
+**Constructor cascade.** Every test file that constructed one of those consumers (or a mock that extended one) had to be updated to pass `customMetrics`. Round 2 caught one broken test file; round 3 caught four more. Each round, the author fixed the file the round flagged and shipped. The next round found different files broken by the same root cause. There is no way to stop this empirically — every constructor change recurs the problem.
+
+**Scatter of emission sites.** The "no helper wrappers" rule meant emission code lived at every call site (13 of them). Each call site was independently responsible for partitioning entries correctly, computing the right label set, and not double-counting against other call sites. Round 1 found the streaming N-count bug (cumulative list passed to per-batch tally). Round 2 found that the streaming pre-check and merge-error pushes bypassed `insertAndLog`'s tally entirely. Round 3 found that the Bundle-400 path passes an `OperationOutcome`, not a `MergeResultEntry`, into the tally. Each finding was a different edge path missed at a different scattered site.
+
+Both problems trace to the same design choice: pretending the OTel meter is a domain dependency that should flow through DI. It isn't. It's an ambient platform-level concern, like the logger.
+
+### What AGENTS.md says, read carefully
+
+> **No Hidden Global State.** All dependencies must be explicit and injectable. No module-level singletons that hold state. No implicit service locators.
+
+This rule is correct as a default but has a deliberate exception:
+
+> **Observability Is a Deliverable.** OpenTelemetry tracing propagation must be maintained across service boundaries. Trace context must flow through Kafka headers, HTTP headers, and any other transport. Logs must be structured (JSON) with correlation IDs. Metrics must be meaningful, not just counters.
+
+The OTel meter provider is process-wide ambient by construction. The OTel SDK explicitly initializes a global meter provider; `metrics.getMeter(name)` returns a meter bound to that provider. Forcing this through typed DI fights the grain of the platform. Logging and metrics are the canonical cross-cutting concerns where strict DI costs more than it buys. This ADR documents that explicitly.
+
+## Decision
+
+**An ambient `metrics` module that owns the OTel meter, exports named recording functions, and is called from a small set of domain-boundary choke points. Five emission sites total, not thirteen.**
+
+### Architecture
+
+```javascript
+// src/utils/metrics.js
+'use strict';
+const { metrics } = require('@opentelemetry/api');
+
+const meter = metrics.getMeter('fhir-server');
+
+const mergeOutcomeCounter = meter.createCounter('fhir_merge_outcome_total', { /* ... */ });
+const validationFailureCounter = meter.createCounter('fhir_validation_failure_total', { /* ... */ });
+const bundleSizeHistogram = meter.createHistogram('fhir_bundle_size_entries', {
+    unit: '1',
+    advice: { explicitBucketBoundaries: [1, 10, 50, 100, 500, 1000, 5000, 10000, 50000] }
+});
+const everythingEmptyCounter = meter.createCounter('fhir_everything_empty_total', { /* ... */ });
+const kafkaRetryExhaustedCounter = meter.createCounter('fhir_kafka_retry_exhausted_total', { /* ... */ });
+
+// Public API: recording functions, one per domain event.
+function recordMergeOutcomes(entries) { /* tally and emit */ }
+function recordValidationFailure(operationOutcome, resourceType, validationStage, validationContext) { /* ... */ }
+function recordInboundBundleSize(operation, length) { /* ... */ }
+function recordOutboundEverything(resourceType, length) { /* records both bundle size and empty counter */ }
+function recordKafkaRetryExhausted(topic, errorCode) { /* ... */ }
+
+module.exports = {
+    recordMergeOutcomes,
+    recordValidationFailure,
+    recordInboundBundleSize,
+    recordOutboundEverything,
+    recordKafkaRetryExhausted
+};
+```
+
+Consumers `require('../utils/metrics')` and call the named function at the domain-event boundary. No constructor parameter. No `assertTypeEquals`. No DI registration.
+
+### The five emission sites (boundary choke points)
+
+Verified by walking the production code. Each site is a function-return point where every input the metric needs is in scope. **All boundary emissions are placed in `finally` blocks**, not after success returns, so abort and rethrow paths still emit. The two data-loss cases this protects are:
+
+- **Streaming pipeline abort.** `mergeAsyncStream` catches `AbortError` and falls through without rethrowing (current `merge.js:521`); placing the emission in `finally` (rather than after the catch) ensures it fires whether the pipeline succeeds, aborts, or throws-and-rethrows.
+- **Non-streaming exception.** `mergeAsync`'s catch block rethrows after logging (current `merge.js:362`); a `finally` ensures partial-result emission for whatever made it into `mergeResults` before the throw.
+
+| # | Site | File | Where | What it records |
+|---|---|---|---|---|
+| 1 | Non-streaming merge return | `src/operations/merge/merge.js` | `finally` block wrapping the `mergeAsync` try/catch — fires on both success-return and rethrow. `mergeResults` is in scope (declared at the top of the try) | `recordMergeOutcomes(mergeResults)` over the full result list — pre-check errors, mid-merge errors, bulk-write outcomes, and unchanged placeholders are all concatenated in this list. Confirmed by walking the four push paths in the streaming Transform (lines 427, 446, 572, 588) — all push to `finalMergeResults` so the single emission post-pipeline is a complete superset |
+| 2 | Streaming merge pipeline completion | `src/operations/merge/merge.js` | `finally` block wrapping `executeMerge`'s `await pipeline(...)` — fires on success, abort, and rethrow. `finalMergeResults` is closed over in `executeMerge` scope | `recordMergeOutcomes(finalMergeResults)` once. Replaces the four scattered emission sites the previous design had inside the streaming Transform |
+| 3 | Validation completion | `src/operations/common/resourceValidator.js` | At the existing single return point of `validateResourceAsync` (and an analogous point in `validateResourceMetaSync`) when the outcome is non-null. No `finally` needed — the function only emits when there's an outcome to emit | `recordValidationFailure(outcome, resourceType, stage, context)` where `context` is `'save'` (default) or `'validate'` (passed from `/$validate`) |
+| 4 | `$everything` success return | `src/operations/everything/everythingHelper.js` | At the success-return of `retriveEverythingAsync`, after `bundle` is built and `streamedResources` is final. Two-mode discrimination handled inline via the existing pattern at line 362: `const entryLength = responseStreamer ? streamedResources.length : (bundle.entry?.length ?? 0)` | `recordOutboundEverything(resourceType, entryLength)` — internally records both the size histogram and (if `entryLength === 0`) the empty counter. Single call site, both modes covered |
+| 5 | Kafka retry-loop exhaustion | `src/utils/kafkaClient.js` | After both retry loops in `sendMessagesAsync` and `sendCloudEventMessageAsync`, when the loop exits with `shouldRetry === true` | `recordKafkaRetryExhausted(topic, errorCode)` |
+
+Inbound bundle size has two sub-sites because they're genuinely different operations:
+
+| # | Site | File | Where |
+|---|---|---|---|
+| 6a | Inbound merge bundle | `src/operations/merge/merge.js` | At the start of `mergeAsync` once `incomingObjects` is parsed, before any merging starts. Records `recordInboundBundleSize('merge', incomingObjects.length)` |
+| 6b | Inbound NDJSON | `src/operations/merge/merge.js` | In the same `finally` block as site 2, using a counter that the `mergeTransform` increments on every `transform()` invocation. Pipeline aborts and exceptions still see the partial count because `transform()` invocations have already mutated the counter before the pipeline rejects. **The NdjsonParser does NOT emit. The count is observed at the merge boundary.** Aborts and partial loads are visible by construction *because* the emission is in a `finally`, not because of a magic property of the boundary. The ADR previously claimed "by construction" without naming the `finally` — corrected here |
+
+That's six call sites across four files. Sites 1 and 6a colocate inside `mergeAsync`'s `finally`; sites 2 and 6b colocate inside `executeMerge`'s `finally`. Functionally, this is **four files touched, six call lines added**. Compare to the previous design's 13 call sites across 7 files, plus 5 constructor parameter additions plus 5 DI registration changes.
+
+#### Disjointness invariant (replaces the prior design's three-source disjointness)
+
+The previous design had to argue that three disjoint sources (pre-check errors, mid-merge errors, bulk-write outcomes, and placeholders) were tallied at three or four scattered sites without overlap. The new design has **one list, one tally**: `finalMergeResults` (streaming) or `mergeResults` (non-streaming). The disjointness invariant degrades from "three sites must agree on partition" to "the list must contain each resource exactly once." Empirical evidence the latter holds: walking `merge.js` at the four push sites (427, 446, 572, 588) confirms the four sources of entries are themselves disjoint by UUID (Sets enforce this at lines 568 and 577). One emission over the whole list = one increment per resource.
+
+### Test seam
+
+Two layers, picked to defeat the destructured-import footgun that breaks naive `jest.spyOn(module, 'fn')` patterns.
+
+**Layer 1 — pure logic tests.** The recording functions decompose into pure helpers (`tallyMergeOutcomes(entries) -> Map<labelKey, count>`, `worstSeverity(operationOutcome) -> 'error'|'warning'|null`, etc.). Tests call these helpers directly with input data, assert on the returned tally. No spying, no module mocking, no jest gymnastics. This is where the math correctness lives — the streaming-N-count regression test, per-resource-not-per-issue, worst-severity ranking, Bundle-400 guard. Pure functions are the right test seam for pure logic.
+
+**Layer 2 — integration tests on the OTel instruments themselves.** Tests spy on `mergeOutcomeCounter.add` (the OTel counter exported from `metrics.js`), not on the recording function. The counter is a property of the module's exports; spying on it survives any import style at the call site:
+
+```javascript
+const metrics = require('../../utils/metrics');
+
+test('non-streaming merge fires outcome counter once per resource', async () => {
+    const spy = jest.spyOn(metrics.mergeOutcomeCounter, 'add');
+    // ... real HTTP request through createTestRequest ...
+    expect(spy).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.objectContaining({ outcome: 'created', resource_type: 'Patient' })
+    );
+});
+```
+
+This works whether the call site does `const { recordMergeOutcomes } = require('../utils/metrics')` and calls it bare, or `metrics.recordMergeOutcomes(...)` namespaced — the counter is the actual OTel API call, downstream of any import indirection. Tests assert on what production actually does to OTel.
+
+**Why not `jest.spyOn(metricsModule, 'recordMergeOutcomes')`.** It only intercepts if the call site uses namespace access (`metrics.recordMergeOutcomes(...)`). Destructured imports (`const { recordMergeOutcomes } = require('../utils/metrics')`) bind the reference at import time and bypass the spy entirely. Tests would silently false-green: spy never called, assertion fails, test author "fixes" the call style or assumes a logic bug, real bug ships. The codebase's standard idiom is destructured imports, so this footgun is loud.
+
+**The rule for emission sites.** Either is fine for the import style — destructured or namespaced — because tests don't depend on it. The constraint is:
+- Pure logic tested via direct calls to exported helpers (no spy needed)
+- Integration tested via spy on the OTel instrument (`mergeOutcomeCounter.add`, etc.)
+- Never via spy on the recording wrapper function
+
+This is an unusual pattern worth a comment in `metrics.js` explaining why it's the chosen seam.
+
+### Removed by this design
+
+- The `CustomMetrics` class as a DI service.
+- `customMetrics` constructor parameter on every consumer (5 classes).
+- `assertTypeEquals(customMetrics, CustomMetrics)` calls (5 sites).
+- `customMetrics` registration in `createContainer.js` and the cascade of inject lines (`mergeOperation`, `resourceValidator`, `everythingHelper`, `bundleResourceValidator`, `kafkaClient`).
+- Per-call-site label-key dictionary lookups (`{ [LABEL.OUTCOME]: outcome }`). Inline label objects are fine when there's only one place that emits each metric.
+- The `MockKafkaClient` cascade fix and the broken-by-PR test files (`app.test.js`, `kafkaClientConfig.test.js`, etc.). They never break because nothing was added to the constructor.
+
+### What survives from the prior implementation
+
+- Instrument names, descriptions, and bucket boundaries (frozen contract; metric names are public and shouldn't change).
+- The label vocabulary: `outcome`, `resource_type`, `validation_stage`, `severity`, `path` (new — for save vs validate), `direction`, `operation`, `topic`, `error_code`, `subsystem`.
+- The `recordMergeOutcomes` tally logic (per-resource, per-window, with the disjointness guarantee at the call sites).
+- `worstSeverity` helper.
+- Histogram bucket boundaries (`[1, 10, 50, 100, 500, 1000, 5000, 10000, 50000]`).
+- The empty-`$everything` counter design.
+- The Bundle-400 defensive guard inside `recordMergeOutcomes` (skip entries where `resourceType === 'OperationOutcome'`).
+- The validation-stage label including `'reference'`.
+- The `path` label distinction (`save` vs `validate`) added in response to round 3's review.
+
+These are pure data and logic. They get copied into the new module unchanged.
+
+## Consequences
+
+### Positive
+
+1. **Constructor cascade is eliminated.** The pattern's empirical failure mode goes away.
+2. **Emission scatter is reduced from 13 sites to 6.** Every emission goes through one of six call lines at four files. The label sets are inline at the call sites.
+3. **Disjointness invariant is simpler.** The previous design needed three separate emission sites to agree on partition without overlap. The new design has one list, one tally, one increment per resource — the empirical failure mode of the prior design (round 1 streaming N-count, round 2 inline-bypass, round 3 Bundle-400 mislabel) doesn't have a place to land.
+4. **Abort and exception paths emit by `finally`, not by hope.** The two data-loss cases (streaming abort, non-streaming rethrow) are explicitly handled with `finally` blocks around the boundary, not by relying on the success-return path always being reached.
+5. **Test seam is two-layer:** pure-logic helpers tested directly (no spying), integration tested via `jest.spyOn` on the OTel instrument itself (survives destructured imports). Naive `jest.spyOn(module, 'fn')` would silently false-green and is documented as forbidden.
+6. **PHI safety surface is smaller.** Reviewing six emission sites for label correctness is feasible. Reviewing 13 was feasible in theory and broken in practice.
+7. **AGENTS.md no-global-state rule is honored at the right level.** The exception for observability is documented, not pretended away.
+
+### Negative
+
+1. **Module-level state.** `meter`, the five instruments, and the recording functions live at module scope. Reloading the module (e.g., in test isolation) reuses the global meter provider. In practice this is fine because tests don't load `otel_instrumentation.js`, so `metrics.getMeter` returns the no-op meter and there's no observable cross-test state. Production loads the real provider once at boot.
+2. **Less explicit than DI.** A reader has to know that `require('../utils/metrics')` returns an ambient interface. Mitigated by the module being narrow (six exported functions) and the file having a header comment naming the pattern.
+3. **Concrete coupling.** Consumers depend on the concrete `metrics` module, not an abstraction. Acceptable: the metric module IS the abstraction over OTel. A future swap (Datadog, custom backend) lives behind the same exported function names.
+
+### Mitigations
+
+- Module-scope state: documented at the top of `metrics.js` with the AGENTS.md observability-exception framing.
+- Discoverability: the module exports a narrow API with descriptive names. JSDoc on every exported function names the metric, the labels, and the cardinality bounds.
+- Concrete coupling: the function-name boundary is the abstraction. If we ever swap providers, the swap lives inside `metrics.js`.
+
+## Options Considered
+
+### Option 1: Strict DI of a typed `CustomMetrics` class (rejected — was the prior design)
+
+**Pros:**
+- Matches the rest of the codebase's DI conventions.
+- Mockable via `Object.create(CustomMetrics.prototype)` patterns.
+- Type assertions enforced at construction.
+
+**Cons:**
+- Constructor cascade: every consumer-creating test file breaks when a new consumer requires the metric. Three rounds of review caught this in different files; no review found all of them.
+- 13 emission sites: scatter means edge paths are missed. Three rounds caught different scatter bugs (streaming N-count, pre-check inline bypass, Bundle-400 mislabel).
+- Pretends an ambient platform concern is a domain dependency.
+
+**Rejection reason:** empirical. The pattern fights the OTel meter's ambient nature, and the consequences shipped multiple times.
+
+### Option 2: Ambient module, scattered call sites (rejected)
+
+Drop the typed DI but keep the 13 call sites, just calling `metrics.add(counter, 1, labels)` at each site instead of `this.customMetrics.counter.add(...)`.
+
+**Pros:**
+- Eliminates the constructor cascade.
+- Lighter syntax than typed DI.
+
+**Cons:**
+- Doesn't fix the scatter problem. The Bundle-400 mislabel and the streaming N-count bugs were not caused by DI — they were caused by 13 places needing to agree on what counts and what doesn't. Switching to ambient calls leaves 13 places.
+- The user's review explicitly named this: "you still have 13 places to miss an edge path."
+
+**Rejection reason:** addresses the test-pain symptom but not the production-correctness symptom.
+
+### Option 3: Domain-event bus with metrics subscriber (rejected for now)
+
+Have `MergeOperation` publish a `MergeCompleted` event with the outcomes list; a single metrics subscriber translates events to metric calls. Audit and provenance could subscribe to the same events.
+
+**Pros:**
+- Cleanest centralization. One subscriber owns all partition and label rules.
+- Reuse-ready for audit/provenance.
+
+**Cons:**
+- New abstraction (in-process event bus) that doesn't exist in this repo.
+- Awkward fit for infrastructure signals: Kafka retry exhaustion isn't a domain event of a merge — it's its own thing, lands outside the model or needs its own event type.
+- More than the problem needs if metrics is the only consumer today.
+
+**Rejection reason:** abstraction earns its keep when it has multiple consumers. Today, only metrics consumes these signals. If audit or provenance later need the same events, revisit and migrate the metrics subscriber to it. The current design doesn't preclude that future.
+
+### Option 4: Ambient module emitting from boundary choke points (selected)
+
+What this ADR documents. Ambient `metrics.js` module with named recording functions called from 5–6 boundary points where every input is in scope.
+
+**Pros:**
+- Eliminates constructor cascade (no DI thread).
+- Eliminates scatter (5–6 sites, not 13).
+- Centralizes partition rules at the boundary, where the full result list is in scope.
+- Standard jest test seam.
+- Matches AGENTS.md observability exception explicitly.
+
+**Cons:**
+- Module-level state (the meter and instruments). Acceptable because OTel is ambient by design and tests use the no-op meter.
+- Concrete coupling to the `metrics` module name. The module IS the abstraction.
+
+**Selection reason:** addresses both the test-pain and production-correctness failure modes with the minimum new abstraction.
+
+## References
+
+- AGENTS.md (icanbwell/.github): https://github.com/icanbwell/.github/blob/main/AGENTS.md (specifically "Observability Is a Deliverable" and the no-global-state rule)
+- OpenTelemetry JS Metrics API: https://opentelemetry.io/docs/languages/js/instrumentation/#metrics
+- EA-2240 (Jira): the first instruments built under this pattern
+- EA-2226 (Jira): the dashboard ticket that consumes the resulting metrics
+- Three review rounds on the prior design (constructor cascade and emission scatter): the empirical evidence for this redesign
+
+## Related Decisions
+
+- Future custom-metrics work in this repo follows this pattern.
+- Cross-service trace correlation (EA-2263) and per-client header propagation (EA-2262) are platform-tier concerns, not application-tier custom metrics. They follow different patterns documented separately.
+
+---
+
+**Date**: 2026-06-05
+**Authors**: Bill Field
+**Status**: Proposed

--- a/src/operations/common/resourceValidator.js
+++ b/src/operations/common/resourceValidator.js
@@ -22,6 +22,7 @@ const { logError } = require('./logging');
 const { validateResource } = require('../../utils/validator.util');
 const { SecurityTagSystem } = require('../../utils/securityTagSystem');
 const { VERSIONS } = require('../../middleware/fhir/utils/constants');
+const { recordValidationFailure, VALIDATION_STAGE, PATH } = require('../../utils/metrics');
 
 class ResourceValidator {
     /**
@@ -174,6 +175,9 @@ class ResourceValidator {
      * @property {boolean|undefined} useRemoteFhirValidatorIfAvailable
      * @property {string|undefined} profile
      * @property {Resource|undefined} currentResource
+     * @property {string|undefined} validationContext - PATH.SAVE (default) or PATH.VALIDATE.
+     *   Distinguishes save-time (POST/PUT/$merge) from validate-time ($validate)
+     *   in the fhir_validation_failure_total metric.
      *
      * @param {ValidateResourceAsyncParams}
      * @returns {Promise<OperationOutcome | null>}
@@ -189,7 +193,8 @@ class ResourceValidator {
             resourceObj = null,
             useRemoteFhirValidatorIfAvailable = false,
             profile,
-            currentResource
+            currentResource,
+            validationContext
         }
     ) {
         const dateColumnHandler = new DateColumnHandler();
@@ -220,6 +225,11 @@ class ResourceValidator {
                 }
             );
 
+        // Tracks which path produced the outcome. Schema-validation outcomes
+        // (from validateResource / validateResourceFromServerAsync) and
+        // patient-reference outcomes get different validation_stage labels.
+        let validationStage = validationOperationOutcome ? VALIDATION_STAGE.SCHEMA : null;
+
         const { isUser } = requestInfo;
 
         if (!validationOperationOutcome && currentResource) {
@@ -228,6 +238,9 @@ class ResourceValidator {
                 resourceToValidateJson,
                 isUser
             });
+            if (validationOperationOutcome) {
+                validationStage = VALIDATION_STAGE.REFERENCE;
+            }
         }
         if (validationOperationOutcome) {
             validationOperationOutcome.expression = [
@@ -242,6 +255,12 @@ class ResourceValidator {
                     ',' + JSON.stringify(resourceToValidateJson, getCircularReplacer());
             }
 
+            recordValidationFailure(
+                validationOperationOutcome,
+                resourceType,
+                validationStage,
+                validationContext || PATH.SAVE
+            );
             return validationOperationOutcome;
         }
         return null;
@@ -253,9 +272,13 @@ class ResourceValidator {
      * @returns {OperationOutcome|null} Response<null|OperationOutcome> - either null if no errors or response to send client.
      */
     validateResourceMetaSync (resource) {
+        // Capture the outcome (if any) so emission happens at a single
+        // exit point. Meta validation runs at save-time only, so PATH.SAVE.
+        let outcome = null;
+
         // Check if meta & meta.source exists in resource
         if (this.configManager.requireMetaSourceTags && (!resource.meta || !resource.meta.source)) {
-            return new OperationOutcome({
+            outcome = new OperationOutcome({
                 issue: [
                     new OperationOutcomeIssue({
                         severity: 'error',
@@ -266,11 +289,9 @@ class ResourceValidator {
                     })
                 ]
             });
-        }
-
-        // Check owner tag is present inside the resource.
-        if (!this.scopesManager.doesResourceHaveOwnerTags(resource)) {
-            return new OperationOutcome({
+        } else if (!this.scopesManager.doesResourceHaveOwnerTags(resource)) {
+            // Check owner tag is present inside the resource.
+            outcome = new OperationOutcome({
                 issue: [
                     new OperationOutcomeIssue({
                         severity: 'error',
@@ -283,11 +304,9 @@ class ResourceValidator {
                     })
                 ]
             });
-        }
-
-        // Check if multiple owner tags are present inside the resource.
-        if (this.scopesManager.doesResourceHaveMultipleOwnerTags(resource)) {
-            return new OperationOutcome({
+        } else if (this.scopesManager.doesResourceHaveMultipleOwnerTags(resource)) {
+            // Check if multiple owner tags are present inside the resource.
+            outcome = new OperationOutcome({
                 issue: [
                     new OperationOutcomeIssue({
                         severity: 'error',
@@ -300,10 +319,9 @@ class ResourceValidator {
                     })
                 ]
             });
-        }
-        // Check if any system or code in the meta.security array is null
-        if (this.scopesManager.doesResourceHaveInvalidMetaSecurity(resource)) {
-            return new OperationOutcome({
+        } else if (this.scopesManager.doesResourceHaveInvalidMetaSecurity(resource)) {
+            // Check if any system or code in the meta.security array is null
+            outcome = new OperationOutcome({
                 issue: [
                     new OperationOutcomeIssue({
                         severity: 'error',
@@ -316,6 +334,17 @@ class ResourceValidator {
                 ]
             });
         }
+
+        if (outcome) {
+            recordValidationFailure(
+                outcome,
+                resource && resource.resourceType,
+                VALIDATION_STAGE.META,
+                PATH.SAVE
+            );
+            return outcome;
+        }
+        return null;
     }
 
     /**

--- a/src/operations/everything/everythingHelper.js
+++ b/src/operations/everything/everythingHelper.js
@@ -48,6 +48,7 @@ const clinicalResources = require('./generated.resource_types.json')['clinicalRe
 const { CustomTracer } = require('../../utils/customTracer');
 const { PatientDataViewControlManager } = require('../../utils/patientDataViewController');
 const { ResourceMapper, UuidOnlyMapper } = require('./resourceMapper');
+const { recordOutboundEverything } = require('../../utils/metrics');
 
 /**
  * @typedef {import('../../utils/fhirRequestInfo').FhirRequestInfo} FhirRequestInfo
@@ -408,6 +409,18 @@ class EverythingHelper {
             if (responseStreamer) {
                 responseStreamer.setBundle({ bundle });
             }
+            // Outbound bundle size + empty-bundle counter for the
+            // $everything success path. Streaming mode pushes resources
+            // through `streamedResources` and leaves `bundle.entry` empty by
+            // design — count the streamed resources in that case so the
+            // empty-bundle counter doesn't saturate. Non-streaming uses the
+            // bundle's entry array. This is intentionally success-only:
+            // the catch below rethrows, and the empty-bundle metric is a
+            // read-correctness signal for 200 responses.
+            const entryLength = responseStreamer
+                ? streamedResources.length
+                : (bundle.entry ? bundle.entry.length : 0);
+            recordOutboundEverything(resourceType, entryLength);
             return bundle;
         } catch (error) {
             logError(`Error in retriveEverythingAsync(): ${error.message}`, { error });

--- a/src/operations/merge/merge.js
+++ b/src/operations/merge/merge.js
@@ -27,6 +27,7 @@ const { pipeline } = require('stream/promises'); // <- for async pipeline
 const { HttpResponseWriter } = require('../streaming/responseWriter');
 const { ObjectSerializedFhirResourceNdJsonWriter } = require('../streaming/resourceWriters/objectSerializedFhirResourceNdJsonWriter');
 const { fhirContentTypes } = require('../../utils/contentTypes');
+const { recordMergeOutcomes, recordInboundBundleSize, OPERATION } = require('../../utils/metrics');
 
 
 class MergeOperation {
@@ -181,6 +182,14 @@ class MergeOperation {
             body
         } = requestInfo;
 
+        // Hoisted so `finally` can read them on every exit path (success,
+        // catch+rethrow, mid-flight throw). recordMergeOutcomes fires on
+        // whatever made it into mergeResults before the exit;
+        // recordInboundBundleSize fires on the inbound size we observed.
+        /** @type {MergeResultEntry[]} */
+        let mergeResults = [];
+        let inboundCount = 0;
+
         // noinspection JSCheckFunctionSignatures
         try {
             const {
@@ -195,6 +204,9 @@ class MergeOperation {
              * @type {Object|Object[]|undefined}
              */
             const incomingObjects = parsedArgs.resource ? parsedArgs.resource : body;
+            inboundCount = Array.isArray(incomingObjects)
+                ? incomingObjects.length
+                : (incomingObjects ? 1 : 0);
 
             const {
                 /** @type {MergeResultEntry[]} */ mergePreCheckErrors,
@@ -224,11 +236,8 @@ class MergeOperation {
             validResources = mergeResourceResults
                 .flatMap(m => m.resource)
                 .filter(r => r !== null);
-            /**
-             * mergeResults
-             * @type {MergeResultEntry[]}
-             */
-            let mergeResults = await this.databaseBulkInserter.executeAsync({
+
+            mergeResults = await this.databaseBulkInserter.executeAsync({
                 requestInfo,
                 base_version
             });
@@ -360,6 +369,11 @@ class MergeOperation {
                 error: e
             });
             throw e;
+        } finally {
+            // Emit on every exit path. The catch above rethrows, so
+            // success-only emission would silently lose error-path signal.
+            recordMergeOutcomes(mergeResults);
+            recordInboundBundleSize(OPERATION.MERGE, inboundCount);
         }
     }
 
@@ -391,6 +405,12 @@ class MergeOperation {
         // List of resources we attempted to merge, not yet inserted
         const resourcesToMerge = [];
 
+        // Inbound NDJSON resource count for the bundle-size histogram.
+        // Incremented for every record entering the transform, regardless
+        // of validation/merge outcome — counts what the client actually
+        // sent us. Read from the outer try/finally below.
+        let inboundCount = 0;
+
         const BATCH_SIZE = 100;
         const highWaterMark = this.configManager.streamingHighWaterMark || 100;
 
@@ -410,6 +430,7 @@ class MergeOperation {
         const mergeTransform = new Transform({
             objectMode: true,
             async transform(resource, _, callback) {
+                inboundCount++;
                 try {
                     const {
                         /** @type {MergeResultEntry[]} */ mergePreCheckErrors,
@@ -509,36 +530,47 @@ class MergeOperation {
             }
         );
         try {
-            // Run pipeline
-            await pipeline(
-                req,
-                new NdjsonParser({ configManager: self.configManager }),
-                mergeTransform,
-                fhirWriter,
-                responseWriter
-            );
-        }catch (err){
-            if (err.name === 'AbortError') {
-                logError('Pipeline aborted', err);
-            } else {
-                await self.fhirLoggingManager.logOperationFailureAsync({
-                    requestInfo,
-                    args: parsedArgs.getRawArgs(),
-                    resourceType,
-                    startTime,
-                    action: currentOperationName,
-                    error: err
-                });
-                throw err;
+            try {
+                // Run pipeline
+                await pipeline(
+                    req,
+                    new NdjsonParser({ configManager: self.configManager }),
+                    mergeTransform,
+                    fhirWriter,
+                    responseWriter
+                );
+            }catch (err){
+                if (err.name === 'AbortError') {
+                    logError('Pipeline aborted', err);
+                } else {
+                    await self.fhirLoggingManager.logOperationFailureAsync({
+                        requestInfo,
+                        args: parsedArgs.getRawArgs(),
+                        resourceType,
+                        startTime,
+                        action: currentOperationName,
+                        error: err
+                    });
+                    throw err;
+                }
             }
+            await self.fhirLoggingManager.logOperationSuccessAsync({
+                requestInfo,
+                args: parsedArgs.getRawArgs(),
+                resourceType,
+                startTime,
+                action: currentOperationName
+            });
+        } finally {
+            // Single emission point for the streaming merge boundary.
+            // finalMergeResults accumulates all pre-check errors, merge
+            // errors, bulk-insert outcomes, and unchanged placeholders during
+            // the transform's lifetime; emitting once at finally captures
+            // whatever made it through, including on AbortError fallthrough
+            // and rethrow.
+            recordMergeOutcomes(finalMergeResults);
+            recordInboundBundleSize(OPERATION.NDJSON, inboundCount);
         }
-        await self.fhirLoggingManager.logOperationSuccessAsync({
-            requestInfo,
-            args: parsedArgs.getRawArgs(),
-            resourceType,
-            startTime,
-            action: currentOperationName
-        });
     }
 
     /**

--- a/src/operations/validate/validate.js
+++ b/src/operations/validate/validate.js
@@ -15,6 +15,7 @@ const { isTrue } = require('../../utils/isTrue');
 const { SearchManager } = require('../search/searchManager');
 const deepcopy = require('deepcopy');
 const { READ } = require('../../constants').OPERATIONS;
+const { PATH } = require('../../utils/metrics');
 
 class ValidateOperation {
     /**
@@ -328,7 +329,8 @@ class ValidateOperation {
                 path,
                 resourceObj: resource_incoming,
                 useRemoteFhirValidatorIfAvailable: true,
-                profile: specifiedProfile
+                profile: specifiedProfile,
+                validationContext: PATH.VALIDATE
             });
         if (validationOperationOutcome) {
             await this.fhirLoggingManager.logOperationSuccessAsync({

--- a/src/tests/utils/kafkaClient/kafkaClient.test.js
+++ b/src/tests/utils/kafkaClient/kafkaClient.test.js
@@ -3,6 +3,7 @@ const { describe, beforeEach, afterEach, jest, test, expect } = require('@jest/g
 const { KafkaClient } = require('../../../utils/kafkaClient');
 const { KafkaJSProtocolError, KafkaJSNonRetriableError } = require('kafkajs');
 const { ConfigManager } = require('../../../utils/configManager');
+const metrics = require('../../../utils/metrics');
 
 class MockKafkaClient extends KafkaClient {
     /**
@@ -291,6 +292,89 @@ describe('kafkaClient Tests', () => {
       expect(initSpy).toBeCalledTimes(1);
       expect(kafkaProduceSpy).toHaveBeenCalledTimes(1);
       expect(kafkaProduceSpy).toHaveBeenCalledWith({ topic, messages })
+    });
+  });
+
+  describe('retry-exhausted metric emission', () => {
+    let kafkaRetryExhaustedAddSpy;
+    let sendMessagesAsyncHelperSpy;
+    let sendCloudEventMessageHelperSpy;
+    let initSpy;
+
+    beforeEach(() => {
+      kafkaRetryExhaustedAddSpy = jest.spyOn(metrics.kafkaRetryExhaustedCounter, 'add');
+      sendMessagesAsyncHelperSpy = jest.spyOn(MockKafkaClient.prototype, 'sendMessagesAsyncHelper');
+      sendCloudEventMessageHelperSpy = jest.spyOn(MockKafkaClient.prototype, 'sendCloudEventMessageHelperAsync');
+      initSpy = jest.spyOn(MockKafkaClient.prototype, 'init');
+    });
+
+    afterEach(() => {
+      kafkaRetryExhaustedAddSpy.mockRestore();
+      sendMessagesAsyncHelperSpy.mockRestore();
+      sendCloudEventMessageHelperSpy.mockRestore();
+      initSpy.mockRestore();
+    });
+
+    test('sendMessagesAsync emits retry_exhausted on retry-budget exhaustion', async () => {
+      const code72Error = () => new KafkaJSNonRetriableError('Error', {
+        cause: new KafkaJSProtocolError({
+          type: 'LISTENER_NOT_FOUND',
+          code: 72,
+          retriable: true,
+          message: 'No listener'
+        })
+      });
+      sendMessagesAsyncHelperSpy
+        .mockRejectedValueOnce(code72Error())
+        .mockRejectedValueOnce(code72Error())
+        .mockRejectedValueOnce(code72Error());
+
+      const kafkaClient = new MockKafkaClient({ configManager: new ConfigManager() });
+      await kafkaClient.sendMessagesAsync('topic-x', [{ key: '1', value: 'msg' }]);
+
+      const calls = kafkaRetryExhaustedAddSpy.mock.calls.filter(
+        ([, attrs]) => attrs && attrs[metrics.LABEL.TOPIC] === 'topic-x'
+      );
+      expect(calls.length).toBe(1);
+      expect(calls[0][0]).toBe(1);
+      expect(calls[0][1][metrics.LABEL.ERROR_CODE]).toBe('72');
+      expect(calls[0][1][metrics.LABEL.SUBSYSTEM]).toBe(metrics.SUBSYSTEM.KAFKA);
+    });
+
+    test('sendCloudEventMessageAsync emits retry_exhausted on retry-budget exhaustion', async () => {
+      const code72Error = () => new KafkaJSNonRetriableError('Error', {
+        cause: new KafkaJSProtocolError({
+          type: 'LISTENER_NOT_FOUND',
+          code: 72,
+          retriable: true,
+          message: 'No listener'
+        })
+      });
+      sendCloudEventMessageHelperSpy
+        .mockRejectedValueOnce(code72Error())
+        .mockRejectedValueOnce(code72Error())
+        .mockRejectedValueOnce(code72Error());
+
+      const kafkaClient = new MockKafkaClient({ configManager: new ConfigManager() });
+      await kafkaClient.sendCloudEventMessageAsync({
+        topic: 'fhir.users.events',
+        messages: [{ key: 'k', value: Buffer.from('{}'), headers: {} }]
+      });
+
+      const calls = kafkaRetryExhaustedAddSpy.mock.calls.filter(
+        ([, attrs]) => attrs && attrs[metrics.LABEL.TOPIC] === 'fhir.users.events'
+      );
+      expect(calls.length).toBe(1);
+      expect(calls[0][1][metrics.LABEL.ERROR_CODE]).toBe('72');
+    });
+
+    test('first-attempt success does NOT emit retry_exhausted', async () => {
+      sendMessagesAsyncHelperSpy.mockResolvedValueOnce();
+
+      const kafkaClient = new MockKafkaClient({ configManager: new ConfigManager() });
+      await kafkaClient.sendMessagesAsync('topic-y', [{ key: '1', value: 'msg' }]);
+
+      expect(kafkaRetryExhaustedAddSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/tests/utils/metrics/fixtures/Person/person1.json
+++ b/src/tests/utils/metrics/fixtures/Person/person1.json
@@ -1,0 +1,14 @@
+{
+    "resourceType": "Person",
+    "id": "metrics-test-person-1",
+    "meta": {
+        "versionId": "1",
+        "source": "bwell",
+        "security": [
+            { "system": "https://www.icanbwell.com/access", "code": "bwell" },
+            { "system": "https://www.icanbwell.com/owner", "code": "bwell" }
+        ]
+    },
+    "name": [{ "use": "official", "family": "Metrics", "given": ["Alpha"] }],
+    "gender": "male"
+}

--- a/src/tests/utils/metrics/fixtures/Person/person2.json
+++ b/src/tests/utils/metrics/fixtures/Person/person2.json
@@ -1,0 +1,14 @@
+{
+    "resourceType": "Person",
+    "id": "metrics-test-person-2",
+    "meta": {
+        "versionId": "1",
+        "source": "bwell",
+        "security": [
+            { "system": "https://www.icanbwell.com/access", "code": "bwell" },
+            { "system": "https://www.icanbwell.com/owner", "code": "bwell" }
+        ]
+    },
+    "name": [{ "use": "official", "family": "Metrics", "given": ["Beta"] }],
+    "gender": "female"
+}

--- a/src/tests/utils/metrics/fixtures/invalid_practitioner.json
+++ b/src/tests/utils/metrics/fixtures/invalid_practitioner.json
@@ -1,0 +1,70 @@
+{
+  "resourceType": "Practitioner",
+  "id": "4657",
+  "meta": {
+    "source": "http://fhir",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      }
+    ]
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": {
+          "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+          "code": "PRN"
+        }
+      },
+      "system": "clienthealth.org",
+      "value": "4657"
+    },
+    {
+      "use": "official",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "NPI"
+          }
+        ]
+      },
+      "system": "http://hl7.org/fhir/sid/us-npi",
+      "value": "1679033641"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "use": "usual",
+      "family": "AL-ANI MBBS",
+      "given": [
+        "AWSSE"
+      ]
+    }
+  ],
+  "telecom": [],
+  "address": [
+    {
+      "use": "work",
+      "type": "physical",
+      "text": "Client Adult Medicine at MUMH",
+      "line": [
+        "33RD STREET PROFESSIONAL BLDG,G",
+        "200 EAST 33RD STREET"
+      ],
+      "city": "BALTIMORE",
+      "state": "MD",
+      "postalCode": "21218",
+      "country": "USA"
+    }
+  ],
+  "gender": "unknown"
+}

--- a/src/tests/utils/metrics/metrics.everything.integration.test.js
+++ b/src/tests/utils/metrics/metrics.everything.integration.test.js
@@ -1,0 +1,125 @@
+// Integration tests for the $everything metrics boundary.
+//
+// One emission point in retriveEverythingAsync covers both streaming and
+// non-streaming modes via:
+//   responseStreamer ? streamedResources.length : (bundle.entry?.length ?? 0)
+//
+// We need to exercise both modes and both empty/non-empty outcomes so the
+// bundle-size histogram reports a real number (not 0 when streaming had
+// content) and the empty-bundle counter only saturates on truly-empty
+// responses.
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    createTestRequest
+} = require('../../common');
+
+const metrics = require('../../../utils/metrics');
+
+const { describe, beforeEach, afterEach, test, expect, jest } = require('@jest/globals');
+
+describe('metrics $everything boundary', () => {
+    let bundleSizeRecordSpy;
+    let everythingEmptyAddSpy;
+
+    beforeEach(async () => {
+        await commonBeforeEach();
+        bundleSizeRecordSpy = jest.spyOn(metrics.bundleSizeHistogram, 'record');
+        everythingEmptyAddSpy = jest.spyOn(metrics.everythingEmptyCounter, 'add');
+    });
+
+    afterEach(async () => {
+        bundleSizeRecordSpy.mockRestore();
+        everythingEmptyAddSpy.mockRestore();
+        await commonAfterEach();
+    });
+
+    function outboundEverythingCalls (resourceType) {
+        return bundleSizeRecordSpy.mock.calls.filter(
+            ([, attrs]) => attrs
+                && attrs[metrics.LABEL.DIRECTION] === metrics.DIRECTION.OUTBOUND
+                && attrs[metrics.LABEL.OPERATION] === metrics.OPERATION.EVERYTHING
+                && attrs[metrics.LABEL.RESOURCE_TYPE] === resourceType
+        );
+    }
+
+    test('non-streaming empty: emits size=0 and empty counter', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .get('/4_0_0/Patient/missing-patient-12345/$everything')
+            .set(getHeaders());
+
+        const calls = outboundEverythingCalls('Patient');
+        expect(calls.length).toBe(1);
+        expect(calls[0][0]).toBe(0);
+
+        const emptyCalls = everythingEmptyAddSpy.mock.calls.filter(
+            ([, attrs]) => attrs && attrs[metrics.LABEL.RESOURCE_TYPE] === 'Patient'
+        );
+        expect(emptyCalls.length).toBe(1);
+    });
+
+    test('non-streaming non-empty: size > 0, empty counter not called', async () => {
+        const request = await createTestRequest();
+
+        const patient = {
+            resourceType: 'Patient',
+            id: 'metrics-everything-1',
+            meta: {
+                source: 'bwell',
+                security: [
+                    { system: 'https://www.icanbwell.com/access', code: 'bwell' },
+                    { system: 'https://www.icanbwell.com/owner', code: 'bwell' }
+                ]
+            },
+            name: [{ family: 'EverythingNonEmpty', given: ['Alice'] }]
+        };
+
+        await request
+            .post('/4_0_0/Patient/$merge')
+            .send(patient)
+            .set(getHeaders());
+
+        // Reset spies after seeding so we only observe the $everything call.
+        bundleSizeRecordSpy.mockClear();
+        everythingEmptyAddSpy.mockClear();
+
+        await request
+            .get('/4_0_0/Patient/metrics-everything-1/$everything')
+            .set(getHeaders());
+
+        const calls = outboundEverythingCalls('Patient');
+        expect(calls.length).toBe(1);
+        expect(calls[0][0]).toBeGreaterThan(0);
+
+        const emptyCalls = everythingEmptyAddSpy.mock.calls.filter(
+            ([, attrs]) => attrs && attrs[metrics.LABEL.RESOURCE_TYPE] === 'Patient'
+        );
+        expect(emptyCalls.length).toBe(0);
+    });
+
+    test('streaming empty: ndjson Accept header still emits empty counter', async () => {
+        // Without the streamedResources branch, this would silently report
+        // size=0 every time a streaming caller asked for $everything because
+        // bundle.entry is empty by design in streaming mode. The branch is
+        // load-bearing only when there are actual results, but we exercise
+        // the empty path here too — both the empty and non-empty streaming
+        // tests together prove the ternary is correct.
+        const request = await createTestRequest();
+
+        await request
+            .get('/4_0_0/Patient/missing-stream-67890/$everything')
+            .set({ ...getHeaders(), Accept: 'application/fhir+ndjson' });
+
+        const calls = outboundEverythingCalls('Patient');
+        expect(calls.length).toBe(1);
+        expect(calls[0][0]).toBe(0);
+
+        const emptyCalls = everythingEmptyAddSpy.mock.calls.filter(
+            ([, attrs]) => attrs && attrs[metrics.LABEL.RESOURCE_TYPE] === 'Patient'
+        );
+        expect(emptyCalls.length).toBe(1);
+    });
+});

--- a/src/tests/utils/metrics/metrics.merge.integration.test.js
+++ b/src/tests/utils/metrics/metrics.merge.integration.test.js
@@ -1,0 +1,187 @@
+// Integration tests for the merge metrics boundaries.
+// Covers both non-streaming (mergeAsync) and streaming (mergeAsyncStream).
+//
+// We spy on the OTel instrument itself (`metrics.mergeOutcomeCounter.add`,
+// `metrics.bundleSizeHistogram.record`), NOT on the recording wrapper
+// `recordMergeOutcomes` / `recordInboundBundleSize`. The production code
+// destructures these wrappers at module load
+// (`const { recordMergeOutcomes } = require('./metrics')`), so any spy on the
+// wrapper after-the-fact is a false-green: the destructured binding already
+// captured the original function. Spying on the property of the OTel
+// instrument exposed on the module object is the only seam that catches the
+// real call.
+const person1 = require('./fixtures/Person/person1.json');
+const person2 = require('./fixtures/Person/person2.json');
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    createTestRequest
+} = require('../../common');
+
+const metrics = require('../../../utils/metrics');
+
+const { describe, beforeEach, afterEach, test, expect, jest } = require('@jest/globals');
+
+describe('metrics merge boundary', () => {
+    let mergeOutcomeAddSpy;
+    let bundleSizeRecordSpy;
+
+    beforeEach(async () => {
+        await commonBeforeEach();
+        mergeOutcomeAddSpy = jest.spyOn(metrics.mergeOutcomeCounter, 'add');
+        bundleSizeRecordSpy = jest.spyOn(metrics.bundleSizeHistogram, 'record');
+    });
+
+    afterEach(async () => {
+        mergeOutcomeAddSpy.mockRestore();
+        bundleSizeRecordSpy.mockRestore();
+        await commonAfterEach();
+    });
+
+    test('emits merge_outcome and bundle_size on success path', async () => {
+        const request = await createTestRequest();
+
+        const resp = await request
+            .post('/4_0_0/Person/$merge')
+            .send([person1, person2])
+            .set(getHeaders());
+
+        expect(resp).toHaveStatusCode(200);
+
+        // Bundle size: emitted exactly once with inbound + merge labels and
+        // count matching the array length.
+        const inboundCalls = bundleSizeRecordSpy.mock.calls.filter(
+            ([, attrs]) => attrs && attrs[metrics.LABEL.DIRECTION] === metrics.DIRECTION.INBOUND
+                && attrs[metrics.LABEL.OPERATION] === metrics.OPERATION.MERGE
+        );
+        expect(inboundCalls.length).toBe(1);
+        expect(inboundCalls[0][0]).toBe(2);
+
+        // Merge outcomes: tally is summed per (outcome, resource_type), so
+        // both Persons being created collapse to a single .add(2, ...) call.
+        const createdPersonCalls = mergeOutcomeAddSpy.mock.calls.filter(
+            ([, attrs]) => attrs && attrs[metrics.LABEL.OUTCOME] === metrics.OUTCOME.CREATED
+                && attrs[metrics.LABEL.RESOURCE_TYPE] === 'Person'
+        );
+        const totalCreated = createdPersonCalls.reduce((acc, [count]) => acc + count, 0);
+        expect(totalCreated).toBe(2);
+    });
+
+    test('emits even when no resources merge cleanly (Bundle-400 skip)', async () => {
+        // A Bundle that fails 400 validation produces one OperationOutcome
+        // pre-check entry, which tallyMergeOutcomes skips by resourceType.
+        // Bundle size still emits because finally runs unconditionally.
+        const request = await createTestRequest();
+
+        const badBundle = {
+            resourceType: 'Bundle',
+            type: 'collection',
+            // Intentionally malformed entry — missing resource.resourceType.
+            entry: [{ resource: { id: 'broken' } }]
+        };
+
+        await request
+            .post('/4_0_0/Person/$merge')
+            .send(badBundle)
+            .set(getHeaders());
+
+        // Bundle size still emitted (finally is load-bearing).
+        const inboundCalls = bundleSizeRecordSpy.mock.calls.filter(
+            ([, attrs]) => attrs && attrs[metrics.LABEL.DIRECTION] === metrics.DIRECTION.INBOUND
+        );
+        expect(inboundCalls.length).toBe(1);
+
+        // Merge outcome counter must NOT increment OperationOutcome as a
+        // resource_type — that was the round-3 latent mislabel bug.
+        const ooCalls = mergeOutcomeAddSpy.mock.calls.filter(
+            ([, attrs]) => attrs && attrs[metrics.LABEL.RESOURCE_TYPE] === 'OperationOutcome'
+        );
+        expect(ooCalls.length).toBe(0);
+    });
+
+    test('rethrow path: bundle_size still emits when bulk-insert throws mid-flight', async () => {
+        // Regression-revert smoke: this test fails if mergeAsync's emission is
+        // moved from the `finally` block to a success-return point. The catch
+        // logs and rethrows, so anything not in finally silently loses signal
+        // for production error paths.
+        const { getTestContainer } = require('../../common');
+
+        const request = await createTestRequest();
+        const container = getTestContainer();
+        const bulkInserter = container.databaseBulkInserter;
+        const insertSpy = jest.spyOn(bulkInserter, 'executeAsync')
+            .mockRejectedValueOnce(new Error('synthetic mid-flight failure'));
+
+        try {
+            await request
+                .post('/4_0_0/Person/$merge')
+                .send([person1, person2])
+                .set(getHeaders());
+        } catch (_e) { /* server returns 500; supertest may not throw */ }
+
+        // The bulk-insert was forced to throw, so the catch block ran and
+        // rethrew. Bundle-size must still have emitted via finally.
+        const inboundCalls = bundleSizeRecordSpy.mock.calls.filter(
+            ([, attrs]) => attrs && attrs[metrics.LABEL.DIRECTION] === metrics.DIRECTION.INBOUND
+                && attrs[metrics.LABEL.OPERATION] === metrics.OPERATION.MERGE
+        );
+        expect(inboundCalls.length).toBe(1);
+        expect(inboundCalls[0][0]).toBe(2);
+
+        insertSpy.mockRestore();
+    });
+
+    test('streaming NDJSON merge emits once across multiple BATCH_SIZE windows', async () => {
+        // BATCH_SIZE in mergeAsyncStream is 100. Sending 150 resources forces
+        // at least one mid-pipeline insertAndLog plus a flush() call.
+        // Single emission point at the pipeline finally must report the full
+        // 150 inbound count and 150 created outcomes — not one per batch
+        // (that was the prior streaming N-count bug).
+        const request = await createTestRequest();
+
+        const persons = Array.from({ length: 150 }, (_, i) => ({
+            resourceType: 'Person',
+            id: `metrics-stream-${i.toString().padStart(4, '0')}`,
+            meta: {
+                versionId: '1',
+                source: 'bwell',
+                security: [
+                    { system: 'https://www.icanbwell.com/access', code: 'bwell' },
+                    { system: 'https://www.icanbwell.com/owner', code: 'bwell' }
+                ]
+            },
+            name: [{ use: 'official', family: 'Stream', given: [`P${i}`] }]
+        }));
+
+        const ndjsonString = persons.map((p) => JSON.stringify(p)).join('\n');
+
+        await request
+            .post('/4_0_0/Person/1/$merge')
+            .send(ndjsonString)
+            .set({
+                ...getHeaders(),
+                'Content-Type': 'application/fhir+ndjson',
+                Accept: 'application/fhir+ndjson'
+            });
+
+        // Inbound bundle size: emitted exactly once with NDJSON operation
+        // and total count of resources we sent.
+        const inboundNdjsonCalls = bundleSizeRecordSpy.mock.calls.filter(
+            ([, attrs]) => attrs && attrs[metrics.LABEL.DIRECTION] === metrics.DIRECTION.INBOUND
+                && attrs[metrics.LABEL.OPERATION] === metrics.OPERATION.NDJSON
+        );
+        expect(inboundNdjsonCalls.length).toBe(1);
+        expect(inboundNdjsonCalls[0][0]).toBe(150);
+
+        // Merge outcomes: 150 created Persons collapsed into one or more
+        // .add() calls, summed across all attribute-matching invocations.
+        const createdPersonCalls = mergeOutcomeAddSpy.mock.calls.filter(
+            ([, attrs]) => attrs && attrs[metrics.LABEL.OUTCOME] === metrics.OUTCOME.CREATED
+                && attrs[metrics.LABEL.RESOURCE_TYPE] === 'Person'
+        );
+        const totalCreated = createdPersonCalls.reduce((acc, [count]) => acc + count, 0);
+        expect(totalCreated).toBe(150);
+    });
+});

--- a/src/tests/utils/metrics/metrics.unit.test.js
+++ b/src/tests/utils/metrics/metrics.unit.test.js
@@ -1,0 +1,153 @@
+const { describe, test, expect } = require('@jest/globals');
+const {
+    tallyMergeOutcomes,
+    worstSeverity,
+    OUTCOME,
+    UNKNOWN
+} = require('../../../utils/metrics');
+
+describe('metrics pure helpers', () => {
+    describe('tallyMergeOutcomes', () => {
+        test('returns empty Map for null/undefined/empty input', () => {
+            expect(tallyMergeOutcomes(null).size).toBe(0);
+            expect(tallyMergeOutcomes(undefined).size).toBe(0);
+            expect(tallyMergeOutcomes([]).size).toBe(0);
+        });
+
+        test('counts created/updated/error per (outcome, resource_type)', () => {
+            const entries = [
+                { created: true, resourceType: 'Person' },
+                { created: true, resourceType: 'Person' },
+                { updated: true, resourceType: 'Person' },
+                { issue: { severity: 'error' }, resourceType: 'Patient' },
+                { created: true, resourceType: 'Patient' }
+            ];
+            const tallies = tallyMergeOutcomes(entries);
+            expect(tallies.get(`${OUTCOME.CREATED}|Person`)).toBe(2);
+            expect(tallies.get(`${OUTCOME.UPDATED}|Person`)).toBe(1);
+            expect(tallies.get(`${OUTCOME.ERROR}|Patient`)).toBe(1);
+            expect(tallies.get(`${OUTCOME.CREATED}|Patient`)).toBe(1);
+            expect(tallies.size).toBe(4);
+        });
+
+        test('skips placeholder unchanged entries (no created/updated/issue)', () => {
+            const entries = [
+                { created: false, updated: false, resourceType: 'Person' },
+                { created: true, resourceType: 'Person' }
+            ];
+            const tallies = tallyMergeOutcomes(entries);
+            expect(tallies.get(`${OUTCOME.CREATED}|Person`)).toBe(1);
+            expect(tallies.size).toBe(1);
+        });
+
+        test('skips entries whose resourceType is OperationOutcome (Bundle-400 guard)', () => {
+            // BundleResourceValidator returns the OperationOutcome itself as a
+            // pre-check error when bundle validation fails. Tallying that would
+            // mislabel `OperationOutcome` as a resource_type.
+            const entries = [
+                { issue: { severity: 'error' }, resourceType: 'OperationOutcome' },
+                { created: true, resourceType: 'Person' }
+            ];
+            const tallies = tallyMergeOutcomes(entries);
+            expect(tallies.get(`${OUTCOME.CREATED}|Person`)).toBe(1);
+            expect(tallies.has(`${OUTCOME.ERROR}|OperationOutcome`)).toBe(false);
+            expect(tallies.size).toBe(1);
+        });
+
+        test('falls back to UNKNOWN when resourceType is missing', () => {
+            const entries = [{ created: true }];
+            const tallies = tallyMergeOutcomes(entries);
+            expect(tallies.get(`${OUTCOME.CREATED}|${UNKNOWN}`)).toBe(1);
+        });
+
+        test('handles null entries inside the array safely', () => {
+            const entries = [null, { created: true, resourceType: 'Person' }, undefined];
+            const tallies = tallyMergeOutcomes(entries);
+            expect(tallies.get(`${OUTCOME.CREATED}|Person`)).toBe(1);
+            expect(tallies.size).toBe(1);
+        });
+
+        test('per-window: caller passes one batch, gets one tally — does not double-count', () => {
+            // Streaming caller passes only the new entries from a batch; we should
+            // tally exactly that window. Over two batches of 100 each, we expect
+            // 200 created total when the caller invokes us twice with disjoint slices.
+            const batch1 = Array.from({ length: 100 }, () => ({ created: true, resourceType: 'Person' }));
+            const batch2 = Array.from({ length: 100 }, () => ({ created: true, resourceType: 'Person' }));
+            const t1 = tallyMergeOutcomes(batch1);
+            const t2 = tallyMergeOutcomes(batch2);
+            expect(t1.get(`${OUTCOME.CREATED}|Person`)).toBe(100);
+            expect(t2.get(`${OUTCOME.CREATED}|Person`)).toBe(100);
+        });
+
+        test('outcome priority: created wins over updated wins over issue', () => {
+            // Defensive: if MergeResultEntry has both flags set, the derivation
+            // order is created > updated > issue. Lock that in.
+            const entries = [
+                { created: true, updated: true, issue: { severity: 'error' }, resourceType: 'Person' }
+            ];
+            const tallies = tallyMergeOutcomes(entries);
+            expect(tallies.get(`${OUTCOME.CREATED}|Person`)).toBe(1);
+            expect(tallies.size).toBe(1);
+        });
+    });
+
+    describe('worstSeverity', () => {
+        test('returns null for null/undefined input', () => {
+            expect(worstSeverity(null)).toBe(null);
+            expect(worstSeverity(undefined)).toBe(null);
+        });
+
+        test('returns null when no issues are present', () => {
+            expect(worstSeverity({ issue: [] })).toBe(null);
+            expect(worstSeverity({ issue: undefined })).toBe(null);
+        });
+
+        test('ranks error > warning > information', () => {
+            const oo = {
+                issue: [
+                    { severity: 'information' },
+                    { severity: 'warning' },
+                    { severity: 'error' }
+                ]
+            };
+            expect(worstSeverity(oo)).toBe('error');
+        });
+
+        test('returns warning when no error present', () => {
+            const oo = {
+                issue: [
+                    { severity: 'information' },
+                    { severity: 'warning' }
+                ]
+            };
+            expect(worstSeverity(oo)).toBe('warning');
+        });
+
+        test('accepts single-issue (non-array) shape', () => {
+            // validateResourceFromServerAsync sometimes assigns a single
+            // OperationOutcomeIssue to operationOutcome.issue.
+            const oo = { issue: { severity: 'error' } };
+            expect(worstSeverity(oo)).toBe('error');
+        });
+
+        test('ignores unknown severity strings (rank 0)', () => {
+            const oo = {
+                issue: [
+                    { severity: 'fatal' },
+                    { severity: 'warning' }
+                ]
+            };
+            expect(worstSeverity(oo)).toBe('warning');
+        });
+
+        test('handles issue items missing severity', () => {
+            const oo = {
+                issue: [
+                    {},
+                    { severity: 'error' }
+                ]
+            };
+            expect(worstSeverity(oo)).toBe('error');
+        });
+    });
+});

--- a/src/tests/utils/metrics/metrics.validation.integration.test.js
+++ b/src/tests/utils/metrics/metrics.validation.integration.test.js
@@ -1,0 +1,82 @@
+// Integration tests for the validation metrics boundary.
+//
+// Confirms that fhir_validation_failure_total is emitted with the correct
+// `path` label depending on whether the failure happened during $validate
+// (path=validate) or during a save flow such as POST/$merge (path=save).
+const invalidPractitioner = require('./fixtures/invalid_practitioner.json');
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    createTestRequest
+} = require('../../common');
+
+const metrics = require('../../../utils/metrics');
+
+const { describe, beforeEach, afterEach, test, expect, jest } = require('@jest/globals');
+
+describe('metrics validation boundary', () => {
+    let validationFailureAddSpy;
+
+    beforeEach(async () => {
+        await commonBeforeEach();
+        validationFailureAddSpy = jest.spyOn(metrics.validationFailureCounter, 'add');
+    });
+
+    afterEach(async () => {
+        validationFailureAddSpy.mockRestore();
+        await commonAfterEach();
+    });
+
+    test('$validate of an invalid resource emits path=validate', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/Practitioner/$validate')
+            .send(invalidPractitioner)
+            .set(getHeaders());
+
+        const validateCalls = validationFailureAddSpy.mock.calls.filter(
+            ([, attrs]) => attrs && attrs[metrics.LABEL.PATH] === metrics.PATH.VALIDATE
+        );
+        expect(validateCalls.length).toBeGreaterThan(0);
+        // No save-time emissions should accompany a $validate call.
+        const saveCalls = validationFailureAddSpy.mock.calls.filter(
+            ([, attrs]) => attrs && attrs[metrics.LABEL.PATH] === metrics.PATH.SAVE
+        );
+        expect(saveCalls.length).toBe(0);
+    });
+
+    test('$merge of a meta-invalid resource emits path=save (META stage)', async () => {
+        // A resource missing meta.source triggers the meta-validation path
+        // through validateResourceMetaSync, which now emits with PATH.SAVE
+        // and VALIDATION_STAGE.META.
+        const request = await createTestRequest();
+
+        const noMetaSource = {
+            resourceType: 'Person',
+            id: 'metrics-meta-fail',
+            meta: {
+                versionId: '1',
+                security: [
+                    { system: 'https://www.icanbwell.com/access', code: 'bwell' },
+                    { system: 'https://www.icanbwell.com/owner', code: 'bwell' }
+                ]
+            },
+            name: [{ use: 'official', family: 'NoSource' }]
+        };
+
+        await request
+            .post('/4_0_0/Person/$merge')
+            .send(noMetaSource)
+            .set(getHeaders());
+
+        const saveMetaCalls = validationFailureAddSpy.mock.calls.filter(
+            ([, attrs]) => attrs
+                && attrs[metrics.LABEL.PATH] === metrics.PATH.SAVE
+                && attrs[metrics.LABEL.VALIDATION_STAGE] === metrics.VALIDATION_STAGE.META
+        );
+        expect(saveMetaCalls.length).toBeGreaterThan(0);
+    });
+});

--- a/src/utils/kafkaClient.js
+++ b/src/utils/kafkaClient.js
@@ -3,6 +3,7 @@ const { assertIsValid, assertTypeEquals } = require('./assertType');
 const { logSystemErrorAsync, logTraceSystemEventAsync, logSystemEventAsync } = require('../operations/common/systemEventLogging');
 const { RethrownError } = require('./rethrownError');
 const { ConfigManager } = require('./configManager');
+const { recordKafkaRetryExhausted } = require('./metrics');
 
 /**
  * @typedef KafkaClientMessage
@@ -138,6 +139,9 @@ class KafkaClient {
 
         // by default shouldn't retry
         let shouldRetry = false;
+        // Captured when the retriable branch fires so the retry-exhausted
+        // metric can label exhaustion with the actual cause code.
+        let lastErrorCode = null;
         do {
             try {
                 await this.sendMessagesAsyncHelper(topic, messages);
@@ -171,6 +175,7 @@ class KafkaClient {
                         });
                         // should retry again
                         shouldRetry = true;
+                        lastErrorCode = cause.code;
                     } else {
                         this.producerConnected = false;
                         throw e;
@@ -181,6 +186,11 @@ class KafkaClient {
                 }
             }
         } while (++iteration <= maxRetries && shouldRetry);
+        // If we exited the loop with shouldRetry still true, the retry
+        // budget was exhausted without success. Emit once.
+        if (shouldRetry) {
+            recordKafkaRetryExhausted(topic, lastErrorCode);
+        }
     }
 
     /**
@@ -335,6 +345,7 @@ class KafkaClient {
         const maxRetries = parseInt(process.env.KAFKA_MAX_RETRY) || 3;
         let iteration = 1;
         let shouldRetry = false;
+        let lastErrorCode = null;
         do {
             try {
                 await this.sendCloudEventMessageHelperAsync({ topic, messages });
@@ -361,6 +372,7 @@ class KafkaClient {
                             sasl: this.sasl
                         });
                         shouldRetry = true;
+                        lastErrorCode = cause.code;
                     } else {
                         this.producerConnected = false;
                         throw e;
@@ -371,6 +383,9 @@ class KafkaClient {
                 }
             }
         } while (++iteration <= maxRetries && shouldRetry);
+        if (shouldRetry) {
+            recordKafkaRetryExhausted(topic, lastErrorCode);
+        }
     }
 
     /**

--- a/src/utils/metrics.js
+++ b/src/utils/metrics.js
@@ -1,0 +1,335 @@
+'use strict';
+
+/**
+ * Custom OpenTelemetry instruments for fhir-server domain signals.
+ *
+ * # Why ambient module instead of constructor injection
+ *
+ * The OTel meter is process-wide ambient by construction. Pretending it's a
+ * domain dependency that flows through DI cascades a constructor parameter
+ * across every consumer (and every test that builds those consumers). Three
+ * review rounds of a strict-DI version produced repeated breakage in unrelated
+ * test files (constructor cascade) and scattered emission across 13 sites,
+ * each independently responsible for partitioning correctly. We chose ambient
+ * + boundary emission instead.
+ *
+ * Emission lives at a small set of domain-boundary choke points (six call
+ * lines across four files: merge.js mergeAsync + executeMerge, resourceValidator.js,
+ * everythingHelper.js, kafkaClient.js). Each call site has the function-return
+ * scope containing all data needed — no scatter, no synchronization burden.
+ *
+ * # Why finally for emission, not by construction
+ *
+ * Some boundaries (mergeAsync, executeMerge) have a try/catch that rethrows or
+ * an AbortError fallthrough that returns without rethrow. Emission must fire
+ * on every exit path including abort and rethrow, so emission goes in `finally`,
+ * not at the success-return point. The "regression-revert smoke" test in the
+ * acceptance criteria flips finally to a success-return-only emission and
+ * confirms an integration test fails — that is how we know the finally is
+ * load-bearing.
+ *
+ * # Test seam: spy on the OTel instrument, never on the recording wrapper
+ *
+ * `metrics.mergeOutcomeCounter` etc. are property-on-the-module-object, so
+ * `jest.spyOn(metrics, 'mergeOutcomeCounter.add')` works (use the OTel
+ * instrument's own `.add` / `.record`). Spying on `metrics.recordMergeOutcomes`
+ * gives FALSE GREENS when the production code does
+ * `const { recordMergeOutcomes } = require('./metrics')` — the destructured
+ * binding captures the original function before the spy replaces the property.
+ * Pure-logic helpers (`tallyMergeOutcomes`, `worstSeverity`) are tested by
+ * direct call, no spy.
+ *
+ * # PHI label discipline
+ *
+ * Label vocabularies are bounded sets defined as frozen constants. Never label
+ * by id, _uuid, sourceAssigningAuthority, free-text fields, or anything
+ * patient-identifying. Adding a label is additive only — never remove or
+ * rename existing labels (per AGENTS.md schema evolution rule).
+ *
+ * See: docs/adr/0002-custom-opentelemetry-meters-via-dependency-injection.md
+ */
+
+const { metrics: otelMetrics } = require('@opentelemetry/api');
+
+const LABEL = Object.freeze({
+    OUTCOME: 'outcome',
+    RESOURCE_TYPE: 'resource_type',
+    VALIDATION_STAGE: 'validation_stage',
+    SEVERITY: 'severity',
+    DIRECTION: 'direction',
+    OPERATION: 'operation',
+    TOPIC: 'topic',
+    ERROR_CODE: 'error_code',
+    SUBSYSTEM: 'subsystem',
+    PATH: 'path'
+});
+
+const OUTCOME = Object.freeze({
+    CREATED: 'created',
+    UPDATED: 'updated',
+    ERROR: 'error'
+});
+
+const VALIDATION_STAGE = Object.freeze({
+    SCHEMA: 'schema',
+    META: 'meta',
+    REFERENCE: 'reference'
+});
+
+const DIRECTION = Object.freeze({
+    INBOUND: 'inbound',
+    OUTBOUND: 'outbound'
+});
+
+const OPERATION = Object.freeze({
+    MERGE: 'merge',
+    NDJSON: 'ndjson',
+    EVERYTHING: 'everything'
+});
+
+const SUBSYSTEM = Object.freeze({
+    KAFKA: 'kafka'
+});
+
+// Distinguishes save-time validation (POST/PUT/$merge) from validate-time
+// validation ($validate). Same instrument, different label values.
+const PATH = Object.freeze({
+    SAVE: 'save',
+    VALIDATE: 'validate'
+});
+
+const UNKNOWN = 'unknown';
+
+const SEVERITY_RANK = { error: 3, warning: 2, information: 1 };
+
+/**
+ * Worst severity present in an OperationOutcome's issues; null if none.
+ * `operationOutcome.issue` is normally an array, but `validateResourceFromServerAsync`
+ * sometimes assigns a single `OperationOutcomeIssue` to it — accept both shapes.
+ *
+ * @param {OperationOutcome|null|undefined} operationOutcome
+ * @returns {string|null}
+ */
+function worstSeverity (operationOutcome) {
+    if (!operationOutcome) {
+        return null;
+    }
+    const issues = Array.isArray(operationOutcome.issue)
+        ? operationOutcome.issue
+        : (operationOutcome.issue ? [operationOutcome.issue] : []);
+    let worst = null;
+    let worstRank = 0;
+    for (const issue of issues) {
+        const sev = issue && issue.severity;
+        const rank = SEVERITY_RANK[sev] || 0;
+        if (rank > worstRank) {
+            worst = sev;
+            worstRank = rank;
+        }
+    }
+    return worst;
+}
+
+/**
+ * Pure-logic tally of MergeResultEntry list by (outcome, resource_type).
+ * Returns Map<"outcome|resource_type", count>.
+ *
+ * Outcome derivation:
+ *   created       => OUTCOME.CREATED
+ *   updated       => OUTCOME.UPDATED
+ *   issue present => OUTCOME.ERROR
+ *   otherwise     => skipped (placeholder unchanged entry; no signal)
+ *
+ * Skip guard: when a Bundle resource fails 400-level validation,
+ * `BundleResourceValidator` returns the OperationOutcome itself as a
+ * preCheckErrors entry. Tallying that would mislabel `OperationOutcome` as a
+ * resource_type and double-count the bundle's intended payload. We skip any
+ * entry whose `resourceType === 'OperationOutcome'`.
+ *
+ * @param {Array<{created?: boolean, updated?: boolean, issue?: any, resourceType?: string}>} entries
+ * @returns {Map<string, number>}
+ */
+function tallyMergeOutcomes (entries) {
+    const tallies = new Map();
+    if (!entries || entries.length === 0) {
+        return tallies;
+    }
+    for (const entry of entries) {
+        if (!entry) {
+            continue;
+        }
+        if (entry.resourceType === 'OperationOutcome') {
+            continue;
+        }
+        let outcome;
+        if (entry.created) {
+            outcome = OUTCOME.CREATED;
+        } else if (entry.updated) {
+            outcome = OUTCOME.UPDATED;
+        } else if (entry.issue) {
+            outcome = OUTCOME.ERROR;
+        } else {
+            continue;
+        }
+        const resourceType = entry.resourceType || UNKNOWN;
+        const key = `${outcome}|${resourceType}`;
+        tallies.set(key, (tallies.get(key) || 0) + 1);
+    }
+    return tallies;
+}
+
+const meter = otelMetrics.getMeter('fhir-server');
+
+const mergeOutcomeCounter = meter.createCounter('fhir_merge_outcome_total', {
+    description: 'Per-resource merge persistence outcomes (created/updated/error). Not patient-match confirmation.'
+});
+
+const validationFailureCounter = meter.createCounter('fhir_validation_failure_total', {
+    description: 'FHIR validation failures by resource_type, validation_stage, path (save|validate), and worst severity present. Increments once per resource with any error-severity issue, not per issue.'
+});
+
+const bundleSizeHistogram = meter.createHistogram('fhir_bundle_size_entries', {
+    description: 'Bundle entry counts by direction (inbound/outbound) and operation (merge/ndjson/everything).',
+    unit: '1',
+    advice: {
+        explicitBucketBoundaries: [1, 10, 50, 100, 500, 1000, 5000, 10000, 50000]
+    }
+});
+
+const everythingEmptyCounter = meter.createCounter('fhir_everything_empty_total', {
+    description: 'Successful $everything responses returning a zero-entry bundle. Read-correctness signal: a 200 with an empty bundle is the consumer getting nothing while HTTP and latency look green.'
+});
+
+const kafkaRetryExhaustedCounter = meter.createCounter('fhir_kafka_retry_exhausted_total', {
+    description: 'Kafka producer retry-loop exhaustion. Increments only when the retry loop runs out without success.'
+});
+
+/**
+ * Tally `entries` and emit fhir_merge_outcome_total once per (outcome,
+ * resource_type) tuple.
+ *
+ * Caller contract: pass the entries representing a single emission window.
+ * For non-streaming merge, that's the complete `mergeResults` list at function
+ * exit. For streaming merge, the streaming transform pushes pre-check errors
+ * and bulk-write outcomes onto a single `finalMergeResults` list disjoint by
+ * UUID; emission happens once at pipeline finally. One tally per window
+ * yields exactly one increment per resource.
+ *
+ * @param {Array<{created?: boolean, updated?: boolean, issue?: any, resourceType?: string}>} entries
+ */
+function recordMergeOutcomes (entries) {
+    const tallies = tallyMergeOutcomes(entries);
+    for (const [key, count] of tallies) {
+        const sep = key.indexOf('|');
+        const outcome = key.substring(0, sep);
+        const resourceType = key.substring(sep + 1);
+        mergeOutcomeCounter.add(count, {
+            [LABEL.OUTCOME]: outcome,
+            [LABEL.RESOURCE_TYPE]: resourceType
+        });
+    }
+}
+
+/**
+ * Emit fhir_validation_failure_total once if `operationOutcome` has any
+ * error-severity issue. No-op otherwise.
+ *
+ * @param {OperationOutcome|null|undefined} operationOutcome
+ * @param {string} resourceType
+ * @param {string} validationStage  one of VALIDATION_STAGE.*
+ * @param {string} validationPath   one of PATH.* — defaults to SAVE
+ */
+function recordValidationFailure (operationOutcome, resourceType, validationStage, validationPath) {
+    const severity = worstSeverity(operationOutcome);
+    if (severity !== 'error') {
+        return;
+    }
+    validationFailureCounter.add(1, {
+        [LABEL.RESOURCE_TYPE]: resourceType || UNKNOWN,
+        [LABEL.VALIDATION_STAGE]: validationStage,
+        [LABEL.SEVERITY]: severity,
+        [LABEL.PATH]: validationPath || PATH.SAVE
+    });
+}
+
+/**
+ * Emit fhir_bundle_size_entries with direction=inbound for a merge boundary.
+ * Always fires — inside try/finally on the calling boundary so abort/rethrow
+ * paths still emit.
+ *
+ * @param {string} operation  one of OPERATION.* (typically MERGE or NDJSON)
+ * @param {number} entryCount
+ */
+function recordInboundBundleSize (operation, entryCount) {
+    bundleSizeHistogram.record(entryCount, {
+        [LABEL.DIRECTION]: DIRECTION.INBOUND,
+        [LABEL.OPERATION]: operation || UNKNOWN
+    });
+}
+
+/**
+ * Emit fhir_bundle_size_entries with direction=outbound and (when entryCount===0)
+ * fhir_everything_empty_total. One call covers both streaming and non-streaming
+ * $everything modes — the caller resolves entry count based on
+ * `responseStreamer ? streamedResources.length : (bundle.entry?.length ?? 0)`.
+ *
+ * @param {string} resourceType
+ * @param {number} entryCount
+ */
+function recordOutboundEverything (resourceType, entryCount) {
+    bundleSizeHistogram.record(entryCount, {
+        [LABEL.DIRECTION]: DIRECTION.OUTBOUND,
+        [LABEL.OPERATION]: OPERATION.EVERYTHING,
+        [LABEL.RESOURCE_TYPE]: resourceType || UNKNOWN
+    });
+    if (entryCount === 0) {
+        everythingEmptyCounter.add(1, {
+            [LABEL.RESOURCE_TYPE]: resourceType || UNKNOWN
+        });
+    }
+}
+
+/**
+ * Emit fhir_kafka_retry_exhausted_total when a Kafka producer retry loop
+ * completes without success.
+ *
+ * @param {string} topic
+ * @param {string|number|null|undefined} errorCode
+ */
+function recordKafkaRetryExhausted (topic, errorCode) {
+    kafkaRetryExhaustedCounter.add(1, {
+        [LABEL.TOPIC]: topic || UNKNOWN,
+        [LABEL.ERROR_CODE]: errorCode != null ? String(errorCode) : UNKNOWN,
+        [LABEL.SUBSYSTEM]: SUBSYSTEM.KAFKA
+    });
+}
+
+module.exports = {
+    // Instruments — exported so integration tests can spy on `.add` / `.record`.
+    mergeOutcomeCounter,
+    validationFailureCounter,
+    bundleSizeHistogram,
+    everythingEmptyCounter,
+    kafkaRetryExhaustedCounter,
+
+    // Recording functions — production code calls these.
+    recordMergeOutcomes,
+    recordValidationFailure,
+    recordInboundBundleSize,
+    recordOutboundEverything,
+    recordKafkaRetryExhausted,
+
+    // Pure helpers — exported for direct unit testing.
+    tallyMergeOutcomes,
+    worstSeverity,
+
+    // Label vocabularies.
+    LABEL,
+    OUTCOME,
+    VALIDATION_STAGE,
+    DIRECTION,
+    OPERATION,
+    SUBSYSTEM,
+    PATH,
+    UNKNOWN
+};


### PR DESCRIPTION
## Summary

Adds five FHIR-server domain-signal OpenTelemetry instruments via a single ambient `src/utils/metrics.js` module, with emission at six call lines across four production files (down from 13 scattered sites in earlier iterations).

**Instruments added:**
- `fhir_merge_outcome_total` — per-resource persistence outcomes (created/updated/error)
- `fhir_validation_failure_total` — validation errors by stage and `path` (save vs. validate)
- `fhir_bundle_size_entries` — inbound (merge) and outbound ($everything) bundle sizes
- `fhir_everything_empty_total` — read-correctness signal for empty 200 responses
- `fhir_kafka_retry_exhausted_total` — Kafka producer retry-budget exhaustion

**Design:** ambient module + boundary-emission, not constructor-injected. The OTel meter is process-wide ambient by construction; threading it through DI created a constructor cascade that broke unrelated tests and scattered emission across many sites. This design has zero constructor changes.

**Emission resilience:** boundaries with try/catch/rethrow or AbortError fallthrough emit from `finally` blocks, so abort and rethrow paths still produce signal. A regression-revert smoke test fails when the `finally` is flipped to a success-only emission, proving it is load-bearing.

**Test seam (two-layer):**
- Pure helpers (`tallyMergeOutcomes`, `worstSeverity`) tested by direct call, no spy.
- Integration tests spy on the OTel instrument itself (`metrics.mergeOutcomeCounter.add`), never on the recording wrapper — destructured imports would false-green.

**Files:**
- New: `src/utils/metrics.js`, `src/tests/utils/metrics/` (4 test files + fixtures), `docs/adr/0002-custom-opentelemetry-meters-via-dependency-injection.md`
- Modified (small additions): `src/operations/merge/merge.js`, `src/operations/common/resourceValidator.js`, `src/operations/validate/validate.js`, `src/operations/everything/everythingHelper.js`, `src/utils/kafkaClient.js`, `src/tests/utils/kafkaClient/kafkaClient.test.js`

ADR: [`docs/adr/0002-custom-opentelemetry-meters-via-dependency-injection.md`](docs/adr/0002-custom-opentelemetry-meters-via-dependency-injection.md)

## Test plan

- [x] `metrics.unit.test.js` — 15 pure-helper tests pass (per-resource, per-window, Bundle-400 skip, severity ranking, null safety)
- [x] `metrics.merge.integration.test.js` — 4 tests pass (success path, Bundle-400 skip-guard, rethrow smoke, multi-batch streaming)
- [x] `metrics.validation.integration.test.js` — 2 tests pass ($validate emits `path=validate`, $merge meta-fail emits `path=save`)
- [x] `metrics.everything.integration.test.js` — 3 tests pass (non-streaming empty/non-empty, streaming empty)
- [x] `kafkaClient.test.js` — 8 tests pass (5 pre-existing + 3 new for retry-exhaustion emission)
- [x] Cross-section regression sweep: `practitioner.merge`, `practitioner.everything`, `streamMergeWith_id`, `mergeWith_id`, `practitioner.validate`, `kafkaClientConfig` — all pass without modification (constructor-cascade class of breakage is impossible by construction)
- [x] Regression-revert smoke: removing the `finally` keyword on the merge boundary causes the rethrow test to fail with `Expected: 1, Received: 0`. Restored.
- [x] Lint clean on all new and modified files