### PR TITLE
PAY-2047 Add Write Access Manager -  Handler for supporting consent based delegated writes

### DIFF
--- a/readme/delegatedActorAccess.md
+++ b/readme/delegatedActorAccess.md
@@ -149,6 +149,12 @@ Delegated users are restricted to **read-only** operations. Access is enforced b
 
 Any denied operation returns **403 Forbidden**. GraphQL mutations return an error in the GraphQL response body.
 
+### Write Access Support (Upcoming Changes)
+
+- Write allowed based on JWT scopes and filtering rules
+- Only if the sensitivity is not denied via the consent
+- Delete operation not allowed
+
 ## Redis Caching
 
 Redis response caching is **disabled** for delegated users. The `$everything` and `$summary` operations skip both cache reads and writes when the requesting user is a delegated actor.

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -141,6 +141,8 @@ const { FhirCacheKeyManager } = require('./utils/fhirCacheKeyManager');
 const { SummaryCacheKeyGenerator } = require('./operations/summary/summaryCacheKeyGenerator');
 const { DelegatedAccessRulesManager } = require('./utils/delegatedAccessRulesManager');
 const { DelegatedAccessScopeManager } = require('./operations/security/delegatedAccessScopeManager');
+const { WriteAccessManager } = require('./operations/security/writeAccessManager');
+const { DelegatedAccessWriteCheck } = require('./operations/security/writeAccessChecks/delegatedAccessWriteCheck');
 const { FastMergeManager } = require('./operations/merge/fastMergeManager');
 const { MongoBulkWriteExecutor } = require('./dataLayer/bulkWriteExecutors/mongoBulkWriteExecutor');
 const { ClickHouseBulkWriteExecutor } = require('./dataLayer/bulkWriteExecutors/clickHouseBulkWriteExecutor');
@@ -243,6 +245,14 @@ const createContainer = function () {
     }));
     container.register('delegatedAccessScopeManager', (c) => new DelegatedAccessScopeManager({
         delegatedAccessRulesManager: c.delegatedAccessRulesManager
+    }));
+    container.register('delegatedAccessWriteCheck', (c) => new DelegatedAccessWriteCheck({
+        delegatedAccessRulesManager: c.delegatedAccessRulesManager
+    }));
+    container.register('writeAccessManager', (c) => new WriteAccessManager({
+        writeAccessChecks: [
+            c.delegatedAccessWriteCheck
+        ]
     }));
     container.register('scopesValidator', (c) => new ScopesValidator({
         scopesManager: c.scopesManager,

--- a/src/operations/security/writeAccessChecks/delegatedAccessWriteCheck.js
+++ b/src/operations/security/writeAccessChecks/delegatedAccessWriteCheck.js
@@ -1,0 +1,66 @@
+const { assertTypeEquals } = require('../../../utils/assertType');
+const { DelegatedAccessRulesManager } = require('../../../utils/delegatedAccessRulesManager');
+const { ForbiddenError } = require('../../../utils/httpErrors');
+const { SENSITIVE_CATEGORY, AUTH_USER_TYPES } = require('../../../constants');
+const { WriteAccessCheck } = require('./writeAccessCheck');
+
+/**
+ * Write-access check for delegated users, based on their consent rules.
+ */
+class DelegatedAccessWriteCheck extends WriteAccessCheck {
+    /**
+     * @param {Object} params
+     * @param {DelegatedAccessRulesManager} params.delegatedAccessRulesManager
+     */
+    constructor ({ delegatedAccessRulesManager }) {
+        super();
+        /**
+         * @type {DelegatedAccessRulesManager}
+         */
+        this.delegatedAccessRulesManager = delegatedAccessRulesManager;
+        assertTypeEquals(delegatedAccessRulesManager, DelegatedAccessRulesManager);
+    }
+
+    /**
+     * Throws ForbiddenError if a delegated user may not write this resource per consent.
+     * Returns true (allows) for non-delegated requests or permitted writes.
+     * @param {Object} params
+     * @param {import('../../../utils/fhirRequestInfo').FhirRequestInfo} params.requestInfo
+     * @param {Object} params.resource post-preSave resource (sensitivity tags populated)
+     * @param {string} [params.base_version]
+     * @returns {Promise<boolean>}
+     */
+    async checkAsync ({ requestInfo, resource, base_version = '4_0_0' }) {
+        // Not a delegated write → this check does not apply
+        if (requestInfo.userType !== AUTH_USER_TYPES.delegatedUser) {
+            return true;
+        }
+
+        const forbiddenError = new ForbiddenError(
+            `User does not have permission to write ${resource.resourceType}/${resource.id}`
+        );
+        const { filteringRules } = await this.delegatedAccessRulesManager.getFilteringRulesAsync({
+            actor: requestInfo.actor,
+            personIdFromJwtToken: requestInfo.personIdFromJwtToken,
+            base_version
+        });
+
+        if (filteringRules === null) {
+            // No valid consent found for the delegate → deny
+            throw forbiddenError;
+        }
+
+        const deniedCategories = new Set(filteringRules.deniedSensitiveCategories || []);
+        const resourceHasDeniedCategory = (resource.meta?.security || []).some(
+            (s) => s.system === SENSITIVE_CATEGORY.SYSTEM && deniedCategories.has(s.code)
+        );
+        if (resourceHasDeniedCategory) {
+            throw forbiddenError;
+        }
+        return true;
+    }
+}
+
+module.exports = {
+    DelegatedAccessWriteCheck
+};

--- a/src/operations/security/writeAccessChecks/writeAccessCheck.js
+++ b/src/operations/security/writeAccessChecks/writeAccessCheck.js
@@ -1,0 +1,24 @@
+/**
+ * Base class for a single write-access check.
+ * A check decides whether writing one resource is allowed for the current request.
+ * Concrete checks are registered into WriteAccessManager and throw a ForbiddenError
+ * (or subclass) when they deny a write; returning true means the write is allowed.
+ */
+class WriteAccessCheck {
+    /**
+     * Throws when this check denies the write; returns true to allow it.
+     * Default: allow (override in a subclass).
+     * @param {Object} params
+     * @param {import('../../../utils/fhirRequestInfo').FhirRequestInfo} params.requestInfo
+     * @param {Object} params.resource post-preSave resource
+     * @param {string} [params.base_version]
+     * @returns {Promise<boolean>}
+     */
+    async checkAsync ({ requestInfo, resource, base_version }) {
+        return true;
+    }
+}
+
+module.exports = {
+    WriteAccessCheck
+};

--- a/src/operations/security/writeAccessManager.js
+++ b/src/operations/security/writeAccessManager.js
@@ -1,0 +1,43 @@
+const { assertTypeEquals, assertIsValid } = require('../../utils/assertType');
+const { WriteAccessCheck } = require('./writeAccessChecks/writeAccessCheck');
+
+/**
+ * Orchestrates a list of WriteAccessCheck instances. A write is allowed only if
+ * every check allows it.
+ */
+class WriteAccessManager {
+    /**
+     * @param {Object} params
+     * @param {import('./writeAccessChecks/writeAccessCheck').WriteAccessCheck[]} params.writeAccessChecks
+     */
+    constructor ({ writeAccessChecks }) {
+        assertIsValid(Array.isArray(writeAccessChecks), 'writeAccessChecks must be an array');
+        for (const check of writeAccessChecks) {
+            assertTypeEquals(check, WriteAccessCheck);
+        }
+        /**
+         * @type {import('./writeAccessChecks/writeAccessCheck').WriteAccessCheck[]}
+         */
+        this.writeAccessChecks = writeAccessChecks;
+    }
+
+    /**
+     * Runs every check; the first check that denies throws its ForbiddenError.
+     * Returns true if all checks allow the write.
+     * @param {Object} params
+     * @param {import('../../utils/fhirRequestInfo').FhirRequestInfo} params.requestInfo
+     * @param {Object} params.resource post-preSave resource
+     * @param {string} [params.base_version]
+     * @returns {Promise<boolean>}
+     */
+    async checkAsync ({ requestInfo, resource, base_version }) {
+        for (const check of this.writeAccessChecks) {
+            await check.checkAsync({ requestInfo, resource, base_version });
+        }
+        return true;
+    }
+}
+
+module.exports = {
+    WriteAccessManager
+};

--- a/src/tests/operations/security/writeAccessManager/fixtures/Observation/observationHivAids.json
+++ b/src/tests/operations/security/writeAccessManager/fixtures/Observation/observationHivAids.json
@@ -1,0 +1,20 @@
+{
+    "resourceType": "Observation",
+    "id": "7a3b8d21-4c6f-4f0b-9d32-2b3c4d5e6f70",
+    "meta": {
+        "source": "https://www.icanbwell.com/test",
+        "security": [
+            { "system": "https://www.icanbwell.com/owner", "code": "client" },
+            { "system": "https://www.icanbwell.com/access", "code": "client" },
+            { "system": "https://www.icanbwell.com/sourceAssigningAuthority", "code": "client" },
+            { "system": "https://www.icanbwell.com/sensitivity-category", "code": "HIV_AIDS" }
+        ]
+    },
+    "status": "final",
+    "code": {
+        "coding": [
+            { "system": "http://loinc.org", "code": "20447-9", "display": "HIV 1 RNA [#/volume] (viral load)" }
+        ]
+    },
+    "subject": { "reference": "Patient/1c2d3e4f-5a6b-4c7d-8e9f-0a1b2c3d4e5f" }
+}

--- a/src/tests/operations/security/writeAccessManager/fixtures/Observation/observationMentalHealth.json
+++ b/src/tests/operations/security/writeAccessManager/fixtures/Observation/observationMentalHealth.json
@@ -1,0 +1,20 @@
+{
+    "resourceType": "Observation",
+    "id": "6f2a9c10-3b7e-4e9a-8c21-1a2b3c4d5e6f",
+    "meta": {
+        "source": "https://www.icanbwell.com/test",
+        "security": [
+            { "system": "https://www.icanbwell.com/owner", "code": "client" },
+            { "system": "https://www.icanbwell.com/access", "code": "client" },
+            { "system": "https://www.icanbwell.com/sourceAssigningAuthority", "code": "client" },
+            { "system": "https://www.icanbwell.com/sensitivity-category", "code": "MENTAL_HEALTH" }
+        ]
+    },
+    "status": "final",
+    "code": {
+        "coding": [
+            { "system": "http://loinc.org", "code": "44249-1", "display": "PHQ-9 quick depression assessment panel" }
+        ]
+    },
+    "subject": { "reference": "Patient/1c2d3e4f-5a6b-4c7d-8e9f-0a1b2c3d4e5f" }
+}

--- a/src/tests/operations/security/writeAccessManager/fixtures/Observation/observationMultipleSensitive.json
+++ b/src/tests/operations/security/writeAccessManager/fixtures/Observation/observationMultipleSensitive.json
@@ -1,0 +1,21 @@
+{
+    "resourceType": "Observation",
+    "id": "9c5d0f43-6e8b-4b2d-bf54-4d5e6f708192",
+    "meta": {
+        "source": "https://www.icanbwell.com/test",
+        "security": [
+            { "system": "https://www.icanbwell.com/owner", "code": "client" },
+            { "system": "https://www.icanbwell.com/access", "code": "client" },
+            { "system": "https://www.icanbwell.com/sourceAssigningAuthority", "code": "client" },
+            { "system": "https://www.icanbwell.com/sensitivity-category", "code": "MENTAL_HEALTH" },
+            { "system": "https://www.icanbwell.com/sensitivity-category", "code": "HIV_AIDS" }
+        ]
+    },
+    "status": "final",
+    "code": {
+        "coding": [
+            { "system": "http://loinc.org", "code": "44249-1", "display": "PHQ-9 quick depression assessment panel" }
+        ]
+    },
+    "subject": { "reference": "Patient/1c2d3e4f-5a6b-4c7d-8e9f-0a1b2c3d4e5f" }
+}

--- a/src/tests/operations/security/writeAccessManager/fixtures/Observation/observationUnclassified.json
+++ b/src/tests/operations/security/writeAccessManager/fixtures/Observation/observationUnclassified.json
@@ -1,0 +1,20 @@
+{
+    "resourceType": "Observation",
+    "id": "8b4c9e32-5d7a-4a1c-ae43-3c4d5e6f7081",
+    "meta": {
+        "source": "https://www.icanbwell.com/test",
+        "security": [
+            { "system": "https://www.icanbwell.com/owner", "code": "client" },
+            { "system": "https://www.icanbwell.com/access", "code": "client" },
+            { "system": "https://www.icanbwell.com/sourceAssigningAuthority", "code": "client" },
+            { "system": "https://www.icanbwell.com/sensitivity-category", "code": "unclassified" }
+        ]
+    },
+    "status": "final",
+    "code": {
+        "coding": [
+            { "system": "http://loinc.org", "code": "8867-4", "display": "Heart rate" }
+        ]
+    },
+    "subject": { "reference": "Patient/1c2d3e4f-5a6b-4c7d-8e9f-0a1b2c3d4e5f" }
+}

--- a/src/tests/operations/security/writeAccessManager/fixtures/Observation/observationUnclassifiedAndSensitive.json
+++ b/src/tests/operations/security/writeAccessManager/fixtures/Observation/observationUnclassifiedAndSensitive.json
@@ -1,0 +1,21 @@
+{
+    "resourceType": "Observation",
+    "id": "a0d6e154-7f9c-4c3e-8065-5e6f70819203",
+    "meta": {
+        "source": "https://www.icanbwell.com/test",
+        "security": [
+            { "system": "https://www.icanbwell.com/owner", "code": "client" },
+            { "system": "https://www.icanbwell.com/access", "code": "client" },
+            { "system": "https://www.icanbwell.com/sourceAssigningAuthority", "code": "client" },
+            { "system": "https://www.icanbwell.com/sensitivity-category", "code": "unclassified" },
+            { "system": "https://www.icanbwell.com/sensitivity-category", "code": "MENTAL_HEALTH" }
+        ]
+    },
+    "status": "final",
+    "code": {
+        "coding": [
+            { "system": "http://loinc.org", "code": "44249-1", "display": "PHQ-9 quick depression assessment panel" }
+        ]
+    },
+    "subject": { "reference": "Patient/1c2d3e4f-5a6b-4c7d-8e9f-0a1b2c3d4e5f" }
+}

--- a/src/tests/operations/security/writeAccessManager/writeAccessManager.test.js
+++ b/src/tests/operations/security/writeAccessManager/writeAccessManager.test.js
@@ -1,0 +1,200 @@
+const {
+    describe,
+    beforeEach,
+    afterEach,
+    test,
+    expect
+} = require('@jest/globals');
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    createTestRequest,
+    getTestContainer,
+    mockHttpContext
+} = require('../../../common');
+const { AUTH_USER_TYPES } = require('../../../../constants');
+const { FhirRequestInfo } = require('../../../../utils/fhirRequestInfo');
+const { WriteAccessManager } = require('../../../../operations/security/writeAccessManager');
+
+const observationMentalHealth = require('./fixtures/Observation/observationMentalHealth.json');
+const observationHivAids = require('./fixtures/Observation/observationHivAids.json');
+const observationUnclassified = require('./fixtures/Observation/observationUnclassified.json');
+const observationMultipleSensitive = require('./fixtures/Observation/observationMultipleSensitive.json');
+const observationUnclassifiedAndSensitive = require('./fixtures/Observation/observationUnclassifiedAndSensitive.json');
+
+const PERSON_ID = 'd5ad4ef0-1a68-4e8c-9871-819cdfa25da9';
+const ACTOR_ID = 'fc2b3779-1db9-4780-bea1-73dc941b02a7';
+// Sensitive-category codes use the b.well vocabulary (UPPER_SNAKE), e.g. MENTAL_HEALTH.
+const DENIED_CATEGORY = 'MENTAL_HEALTH'; // denied by the test consent; tagged on the mental-health, multi, and combo fixtures
+const NON_DENIED_CATEGORY = 'HIV_AIDS'; // sensitive, but not the denied category in most cases
+const UNRELATED_DENIED_CATEGORY = 'DOMESTIC_VIOLENCE'; // denied, but absent from every fixture's tags
+
+/**
+ * Build a real FhirRequestInfo instance for the given user type and actor.
+ */
+function makeRequestInfo (userType, actor) {
+    return new FhirRequestInfo({
+        user: 'test-user',
+        scope: 'patient/*.read patient/*.write',
+        remoteIpAddress: '127.0.0.1',
+        requestId: 'req-1',
+        userRequestId: 'req-1',
+        protocol: 'https',
+        originalUrl: '/4_0_0/Observation',
+        path: '/4_0_0/Observation',
+        host: 'localhost',
+        body: null,
+        accept: 'application/fhir+json',
+        isUser: true,
+        userType,
+        personIdFromJwtToken: PERSON_ID,
+        masterPersonIdFromJwtToken: null,
+        managingOrganizationId: null,
+        headers: {},
+        method: 'POST',
+        contentTypeFromHeader: null,
+        alternateUserId: null,
+        actor,
+        purposeOfUse: null
+    });
+}
+
+
+function delegatedActor (filteringRules) {
+    return { sub: 'actor-sub', reference: `RelatedPerson/${ACTOR_ID}`, _filteringRules: filteringRules };
+}
+
+function delegatedRequestInfo (filteringRules) {
+    return makeRequestInfo(AUTH_USER_TYPES.delegatedUser, delegatedActor(filteringRules));
+}
+
+describe('WriteAccessManager', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+        mockHttpContext();
+        await createTestRequest();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    test('resolves from the container as a WriteAccessManager', async () => {
+        const writeAccessManager = getTestContainer().writeAccessManager;
+        expect(writeAccessManager).toBeInstanceOf(WriteAccessManager);
+    });
+
+    test('allows a non-delegated user (check does not apply)', async () => {
+        const writeAccessManager = getTestContainer().writeAccessManager;
+        await expect(
+            writeAccessManager.checkAsync({
+                requestInfo: makeRequestInfo('patient', null),
+                resource: observationMentalHealth,
+                base_version: '4_0_0'
+            })
+        ).resolves.toBe(true);
+    });
+
+    test('denies a delegated user with no valid consent', async () => {
+        const writeAccessManager = getTestContainer().writeAccessManager;
+        await expect(
+            writeAccessManager.checkAsync({
+                requestInfo: delegatedRequestInfo(null),
+                resource: observationMentalHealth,
+                base_version: '4_0_0'
+            })
+        ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    test('allows a delegated user whose consent denies no categories', async () => {
+        const writeAccessManager = getTestContainer().writeAccessManager;
+        await expect(
+            writeAccessManager.checkAsync({
+                requestInfo: delegatedRequestInfo({ deniedSensitiveCategories: [] }),
+                resource: observationMentalHealth,
+                base_version: '4_0_0'
+            })
+        ).resolves.toBe(true);
+    });
+
+    test('denies writing a resource in a denied sensitive category', async () => {
+        const writeAccessManager = getTestContainer().writeAccessManager;
+        await expect(
+            writeAccessManager.checkAsync({
+                requestInfo: delegatedRequestInfo({ deniedSensitiveCategories: [DENIED_CATEGORY] }),
+                resource: observationMentalHealth,
+                base_version: '4_0_0'
+            })
+        ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    test('allows writing a resource in a non-denied sensitive category', async () => {
+        const writeAccessManager = getTestContainer().writeAccessManager;
+        await expect(
+            writeAccessManager.checkAsync({
+                requestInfo: delegatedRequestInfo({ deniedSensitiveCategories: [DENIED_CATEGORY] }),
+                resource: observationHivAids,
+                base_version: '4_0_0'
+            })
+        ).resolves.toBe(true);
+    });
+
+    test('allows writing a resource tagged unclassified', async () => {
+        const writeAccessManager = getTestContainer().writeAccessManager;
+        await expect(
+            writeAccessManager.checkAsync({
+                requestInfo: delegatedRequestInfo({ deniedSensitiveCategories: [DENIED_CATEGORY] }),
+                resource: observationUnclassified,
+                base_version: '4_0_0'
+            })
+        ).resolves.toBe(true);
+    });
+
+    // Multiple sensitivity tags: the resource carries MENTAL_HEALTH and HIV_AIDS.
+    // checkAsync denies if ANY tag is in the denied set (Array.some over meta.security).
+    test('denies writing a resource when one of several sensitivity tags is denied', async () => {
+        const writeAccessManager = getTestContainer().writeAccessManager;
+        await expect(
+            writeAccessManager.checkAsync({
+                requestInfo: delegatedRequestInfo({ deniedSensitiveCategories: [DENIED_CATEGORY] }),
+                resource: observationMultipleSensitive,
+                base_version: '4_0_0'
+            })
+        ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    test('allows writing a multi-tagged resource when none of its sensitivity tags are denied', async () => {
+        const writeAccessManager = getTestContainer().writeAccessManager;
+        await expect(
+            writeAccessManager.checkAsync({
+                requestInfo: delegatedRequestInfo({ deniedSensitiveCategories: [UNRELATED_DENIED_CATEGORY] }),
+                resource: observationMultipleSensitive,
+                base_version: '4_0_0'
+            })
+        ).resolves.toBe(true);
+    });
+
+    // Combined tags: the resource carries both `unclassified` and a sensitive category.
+    // The unclassified tag must NOT rescue a resource that also carries a denied category.
+    test('denies writing a resource tagged unclassified plus a denied sensitive category', async () => {
+        const writeAccessManager = getTestContainer().writeAccessManager;
+        await expect(
+            writeAccessManager.checkAsync({
+                requestInfo: delegatedRequestInfo({ deniedSensitiveCategories: [DENIED_CATEGORY] }),
+                resource: observationUnclassifiedAndSensitive,
+                base_version: '4_0_0'
+            })
+        ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    test('allows writing a resource tagged unclassified plus a non-denied sensitive category', async () => {
+        const writeAccessManager = getTestContainer().writeAccessManager;
+        await expect(
+            writeAccessManager.checkAsync({
+                requestInfo: delegatedRequestInfo({ deniedSensitiveCategories: [NON_DENIED_CATEGORY] }),
+                resource: observationUnclassifiedAndSensitive,
+                base_version: '4_0_0'
+            })
+        ).resolves.toBe(true);
+    });
+});


### PR DESCRIPTION
Created a Handler for Consent Based write. It checks the resource for the sensitivity tags. 
- Consent Based Delegated Writes
- If Resource has denied sensitive category for the delegated user, he would not be able to update the resource
- Delegated user allowed to create Resources