### PR TITLE
DCON-4154 Add Node.js runtime/heap metrics to OpenTelemetry instrumentation

### DIFF
--- a/k8s-start.sh
+++ b/k8s-start.sh
@@ -14,7 +14,7 @@ PER_WORKER_MAX_OLD_SPACE_SIZE_MB=$(( (MAX_OLD_SPACE_SIZE_MB / WORKER_COUNT) * 9 
 
 # Start the Node.js application with the calculated memory limit & instrumentation
 if [ "$1" = "otel" ]; then
-    OTEL_NODE_ENABLED_INSTRUMENTATIONS=dataloader,express,graphql,lru-memoizer,router,winston,http,mongodb,redis exec node --max-old-space-size=$PER_WORKER_MAX_OLD_SPACE_SIZE_MB --require=./src/otel_instrumentation.js src/index.js
+    OTEL_NODE_ENABLED_INSTRUMENTATIONS=dataloader,express,graphql,lru-memoizer,router,winston,http,mongodb,redis,runtime-node exec node --max-old-space-size=$PER_WORKER_MAX_OLD_SPACE_SIZE_MB --require=./src/otel_instrumentation.js src/index.js
 else
     exec node --max-old-space-size=$PER_WORKER_MAX_OLD_SPACE_SIZE_MB src/index.js
 fi

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@opentelemetry/instrumentation-lru-memoizer": "0.62.0",
     "@opentelemetry/instrumentation-mongodb": "0.71.0",
     "@opentelemetry/instrumentation-redis": "0.66.0",
+    "@opentelemetry/instrumentation-runtime-node": "0.31.0",
     "@opentelemetry/instrumentation-winston": "0.62.0",
     "@opentelemetry/resources": "2.7.1",
     "@opentelemetry/sdk-metrics": "2.7.1",

--- a/src/index.js
+++ b/src/index.js
@@ -50,9 +50,26 @@ const numCPUs = process.env.WORKER_COUNT ? parseInt(process.env.WORKER_COUNT, 10
 if (cluster.isPrimary && numCPUs > 1) {
     console.log(JSON.stringify({message: `Master ${process.pid} is running with ${numCPUs} workers`}));
 
+    // Give each worker a distinct, queryable identity on its OpenTelemetry signals
+    // (heap usage, GC, event-loop, traces) so per-worker resource usage is visible
+    // in cluster mode. The attributes are injected via OTEL_RESOURCE_ATTRIBUTES
+    // *before* the worker boots, so the env resource detector picks them up in both
+    // the operator auto-instrumentation path and the manual SDK path. Any pod-level
+    // OTEL_RESOURCE_ATTRIBUTES set on the primary is preserved (prepended).
+    let nextWorkerNumber = 0;
+    const forkWorker = () => {
+        nextWorkerNumber += 1;
+        const otelResourceAttributes = [
+            process.env.OTEL_RESOURCE_ATTRIBUTES,
+            'cluster.role=worker',
+            `cluster.worker.id=${nextWorkerNumber}`
+        ].filter(Boolean).join(',');
+        return cluster.fork({ OTEL_RESOURCE_ATTRIBUTES: otelResourceAttributes });
+    };
+
     // Fork workers
     for (let i = 0; i < numCPUs; i++) {
-        cluster.fork();
+        forkWorker();
     }
 
     // Forward all signals to the worker processes. Setting `shuttingDown`
@@ -75,7 +92,7 @@ if (cluster.isPrimary && numCPUs > 1) {
         if (shuttingDown) {
             return;
         }
-        cluster.fork();
+        forkWorker();
     });
 } else {
     (async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -50,26 +50,9 @@ const numCPUs = process.env.WORKER_COUNT ? parseInt(process.env.WORKER_COUNT, 10
 if (cluster.isPrimary && numCPUs > 1) {
     console.log(JSON.stringify({message: `Master ${process.pid} is running with ${numCPUs} workers`}));
 
-    // Give each worker a distinct, queryable identity on its OpenTelemetry signals
-    // (heap usage, GC, event-loop, traces) so per-worker resource usage is visible
-    // in cluster mode. The attributes are injected via OTEL_RESOURCE_ATTRIBUTES
-    // *before* the worker boots, so the env resource detector picks them up in both
-    // the operator auto-instrumentation path and the manual SDK path. Any pod-level
-    // OTEL_RESOURCE_ATTRIBUTES set on the primary is preserved (prepended).
-    let nextWorkerNumber = 0;
-    const forkWorker = () => {
-        nextWorkerNumber += 1;
-        const otelResourceAttributes = [
-            process.env.OTEL_RESOURCE_ATTRIBUTES,
-            'cluster.role=worker',
-            `cluster.worker.id=${nextWorkerNumber}`
-        ].filter(Boolean).join(',');
-        return cluster.fork({ OTEL_RESOURCE_ATTRIBUTES: otelResourceAttributes });
-    };
-
     // Fork workers
     for (let i = 0; i < numCPUs; i++) {
-        forkWorker();
+        cluster.fork();
     }
 
     // Forward all signals to the worker processes. Setting `shuttingDown`
@@ -92,7 +75,7 @@ if (cluster.isPrimary && numCPUs > 1) {
         if (shuttingDown) {
             return;
         }
-        forkWorker();
+        cluster.fork();
     });
 } else {
     (async () => {

--- a/src/otel_instrumentation.js
+++ b/src/otel_instrumentation.js
@@ -33,6 +33,12 @@ let instrumentationConfigs = {
     // Disabled: produces duplicate spans alongside instrumentation-express
     '@opentelemetry/instrumentation-router': {
         enabled: false
+    },
+    // Emits Node.js runtime metrics: V8 heap usage/limit, per-heap-space stats,
+    // GC duration, and event-loop lag/utilization (standard semantic conventions).
+    // Enabled in both the auto-instrumentation and manual SDK paths below.
+    '@opentelemetry/instrumentation-runtime-node': {
+        enabled: true
     }
 }
 
@@ -67,6 +73,7 @@ if (process.env.NODE_OPTIONS && process.env.NODE_OPTIONS.includes("/otel-auto-in
     const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');
     const { MongoDBInstrumentation } = require('@opentelemetry/instrumentation-mongodb');
     const { RedisInstrumentation } = require('@opentelemetry/instrumentation-redis');
+    const { RuntimeNodeInstrumentation } = require('@opentelemetry/instrumentation-runtime-node');
 
     const sdk = new opentelemetry.NodeSDK({
         traceExporter: new OTLPTraceExporter(),
@@ -81,7 +88,8 @@ if (process.env.NODE_OPTIONS && process.env.NODE_OPTIONS.includes("/otel-auto-in
             new WinstonInstrumentation(),
             new GraphQLInstrumentation(),
             new MongoDBInstrumentation(instrumentationConfigs['@opentelemetry/instrumentation-mongodb']),
-            new RedisInstrumentation()
+            new RedisInstrumentation(),
+            new RuntimeNodeInstrumentation(instrumentationConfigs['@opentelemetry/instrumentation-runtime-node'])
         ],
         // Config needed for Sentry integration
         // https://docs.sentry.io/platforms/javascript/guides/node/opentelemetry/custom-setup/

--- a/yarn.lock
+++ b/yarn.lock
@@ -3025,7 +3025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/instrumentation-runtime-node@npm:^0.31.0":
+"@opentelemetry/instrumentation-runtime-node@npm:0.31.0, @opentelemetry/instrumentation-runtime-node@npm:^0.31.0":
   version: 0.31.0
   resolution: "@opentelemetry/instrumentation-runtime-node@npm:0.31.0"
   dependencies:
@@ -5092,6 +5092,7 @@ __metadata:
     "@opentelemetry/instrumentation-lru-memoizer": "npm:0.62.0"
     "@opentelemetry/instrumentation-mongodb": "npm:0.71.0"
     "@opentelemetry/instrumentation-redis": "npm:0.66.0"
+    "@opentelemetry/instrumentation-runtime-node": "npm:0.31.0"
     "@opentelemetry/instrumentation-winston": "npm:0.62.0"
     "@opentelemetry/resources": "npm:2.7.1"
     "@opentelemetry/sdk-metrics": "npm:2.7.1"


### PR DESCRIPTION
## Summary

Adds Node.js runtime metrics — including V8 heap usage — to the FHIR server's OpenTelemetry setup, and ensures they actually emit in the prod (operator) path.

Jira: [DCON-4154](https://icanbwell.atlassian.net/browse/DCON-4154)

## Background

`src/otel_instrumentation.js` already exports traces/metrics via OTLP gRPC and registers per-library instrumentations, but emitted **no process/heap metrics**, making memory growth and GC pressure hard to diagnose.

## Changes

**Heap/runtime instrumentation** (`package.json`, `src/otel_instrumentation.js`)
- Added dependency `@opentelemetry/instrumentation-runtime-node@0.31.0`, pinned to align with the `@opentelemetry/instrumentation@0.218.0` stack and match `auto-instrumentations-node@0.76.0`'s `^0.31.0`, so the lockfile dedupes to a single instrumentation-core instance.
- Wired `RuntimeNodeInstrumentation` into the manual `NodeSDK` path and added a shared config entry. The operator/auto-instrumentation path already bundles it via `getNodeAutoInstrumentations()`.

**Make it actually emit in prod** (`k8s-start.sh`)
- Added `runtime-node` to `OTEL_NODE_ENABLED_INSTRUMENTATIONS`. That env var is an **allowlist** consumed by `getNodeAutoInstrumentations` in the operator path (prod); without `runtime-node` listed, the instrumentation is disabled regardless of config — heap metrics would silently never emit in prod.

## Metrics emitted (standard semantic conventions)
- `v8js.memory.heap.used`, `v8js.memory.heap.limit`, `v8js.memory.heap.space.*`
- `v8js.gc.duration`
- Event-loop lag / utilization

## Cluster mode

No custom work needed for per-worker attribution: each worker process emits these metrics with its own auto-detected `process.pid` and a unique `service.instance.id` (random UUID from the default `serviceInstanceIdDetector`), so worker series are distinct. The cluster primary is identifiable as `process.pid == 1` (the container `exec`s node, so the master is PID 1).

(An earlier revision injected `cluster.role`/`cluster.worker.id` via `OTEL_RESOURCE_ATTRIBUTES` at fork time; reverted as redundant with `process.pid`.)

## Verification
- `yarn install` regenerated lockfile cleanly; single deduped `runtime-node@0.31.0` against `instrumentation@0.218.0`.
- Smoke test: instrumentation class loads/instantiates. ESLint passes; `k8s-start.sh` shell syntax OK.

## Follow-up
- [ ] Confirm `v8js.*` series arrive in the OTLP backend from a running instance, grouped by `process.pid` / `service.instance.id`.
- [ ] Add/adjust dashboards & alerts for heap usage vs. limit and GC duration.

[DCON-4154]: https://icanbwell.atlassian.net/browse/DCON-4154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ