### PR TITLE
DCON-4167 Fix event loop starvation in $merge by yielding between resources

### DIFF
--- a/src/operations/merge/fastMergeManager.js
+++ b/src/operations/merge/fastMergeManager.js
@@ -508,25 +508,26 @@ class FastMergeManager {
              * @type {number}
              */
             const chunkSize = this.configManager.mergeParallelChunkSize;
-            const mergeResourceFn = async (/** @type {Object} */ x) => {
-                await new Promise(resolve => setImmediate(resolve));
-                return this.mergeResourceWithRetryAsync({
-                    resourceToMerge: x,
-                    resourceType,
-                    base_version,
-                    requestInfo,
-                    smartMerge
-                });
-            };
+            const mergeResourceFn = async (/** @type {Object} */ x) => this.mergeResourceWithRetryAsync({
+                resourceToMerge: x,
+                resourceType,
+                base_version,
+                requestInfo,
+                smartMerge
+            });
 
             /**
              * @type {{resource: (Object|null), mergeError: (MergeResultEntry|null)}[]}
              */
-            const result = await async.mapLimit(
-                resources_incoming,
-                chunkSize,
-                mergeResourceFn
-            );
+            const result = [];
+            for (let i = 0; i < resources_incoming.length; i += chunkSize) {
+                const chunk = resources_incoming.slice(i, i + chunkSize);
+                const chunkResults = await async.mapLimit(chunk, chunkSize, mergeResourceFn);
+                result.push(...chunkResults);
+                if (i + chunkSize < resources_incoming.length) {
+                    await new Promise(resolve => setImmediate(resolve));
+                }
+            }
             return result.filter(r => (r.resource || r.mergeError));
         } catch (e) {
             throw new RethrownError({

--- a/src/operations/merge/fastMergeManager.js
+++ b/src/operations/merge/fastMergeManager.js
@@ -508,13 +508,16 @@ class FastMergeManager {
              * @type {number}
              */
             const chunkSize = this.configManager.mergeParallelChunkSize;
-            const mergeResourceFn = async (/** @type {Object} */ x) => await this.mergeResourceWithRetryAsync({
-                resourceToMerge: x,
-                resourceType,
-                base_version,
-                requestInfo,
-                smartMerge
-            });
+            const mergeResourceFn = async (/** @type {Object} */ x) => {
+                await new Promise(resolve => setImmediate(resolve));
+                return this.mergeResourceWithRetryAsync({
+                    resourceToMerge: x,
+                    resourceType,
+                    base_version,
+                    requestInfo,
+                    smartMerge
+                });
+            };
 
             /**
              * @type {{resource: (Object|null), mergeError: (MergeResultEntry|null)}[]}

--- a/src/operations/merge/mergeManager.js
+++ b/src/operations/merge/mergeManager.js
@@ -502,25 +502,26 @@ class MergeManager {
              * @type {number}
              */
             const chunkSize = this.configManager.mergeParallelChunkSize;
-            const mergeResourceFn = async (/** @type {Object} */ x) => {
-                await new Promise(resolve => setImmediate(resolve));
-                return this.mergeResourceWithRetryAsync({
-                    resourceToMerge: x,
-                    resourceType,
-                    base_version,
-                    requestInfo,
-                    smartMerge
-                });
-            };
+            const mergeResourceFn = async (/** @type {Resource} */ x) => this.mergeResourceWithRetryAsync({
+                resourceToMerge: x,
+                resourceType,
+                base_version,
+                requestInfo,
+                smartMerge
+            });
 
             /**
              * @type {{resource: (Resource|null), mergeError: (MergeResultEntry|null)}[]}
              */
-            const result = await async.mapLimit(
-                resources_incoming,
-                chunkSize,
-                mergeResourceFn
-            );
+            const result = [];
+            for (let i = 0; i < resources_incoming.length; i += chunkSize) {
+                const chunk = resources_incoming.slice(i, i + chunkSize);
+                const chunkResults = await async.mapLimit(chunk, chunkSize, mergeResourceFn);
+                result.push(...chunkResults);
+                if (i + chunkSize < resources_incoming.length) {
+                    await new Promise(resolve => setImmediate(resolve));
+                }
+            }
             return result.filter(r => (r.resource || r.mergeError));
         } catch (e) {
             throw new RethrownError({

--- a/src/operations/merge/mergeManager.js
+++ b/src/operations/merge/mergeManager.js
@@ -502,13 +502,16 @@ class MergeManager {
              * @type {number}
              */
             const chunkSize = this.configManager.mergeParallelChunkSize;
-            const mergeResourceFn = async (/** @type {Object} */ x) => await this.mergeResourceWithRetryAsync({
-                resourceToMerge: x,
-                resourceType,
-                base_version,
-                requestInfo,
-                smartMerge
-            });
+            const mergeResourceFn = async (/** @type {Object} */ x) => {
+                await new Promise(resolve => setImmediate(resolve));
+                return this.mergeResourceWithRetryAsync({
+                    resourceToMerge: x,
+                    resourceType,
+                    base_version,
+                    requestInfo,
+                    smartMerge
+                });
+            };
 
             /**
              * @type {{resource: (Resource|null), mergeError: (MergeResultEntry|null)}[]}


### PR DESCRIPTION
## Summary

- Manually chunks `resources_incoming` into batches of `MERGE_PARALLEL_CHUNK_SIZE`
  in both `MergeManager` and `FastMergeManager`
- Yields the event loop via `setImmediate` between chunks (not before every resource)
- Replaces the original per-resource yield approach with a deterministic
  chunk-boundary yield

## Problem

Groundcover telemetry shows the Node.js event loop on `fhir-server-pipeline` pods is
blocked for **up to 298 seconds** (nearly 5 minutes), with 75% of pods experiencing
max delays > 10 seconds in the last hour alone. This causes:

1. **Liveness probe failures** → Kubernetes kills pods → logged as OOM events
2. **Heap growth** → GC can't run while event loop is blocked → unbounded memory growth
3. **Misleading traces** → OTel span-end callbacks can't fire, making MongoDB look slow
   (reported 60-70s avg) when actual wire latency is **3.6ms median** (confirmed via
   eBPF `flora_mongodb_parser_stat_latency_seconds` and AWS CloudWatch
   `aws_rds_read_latency` at 0.109ms avg)
4. **Client timeouts** → Traefik 120s gateway timeout hit while pods are CPU-blocked

## Root Cause

`async.mapLimit(resources, 50, mergeResourceFn)` fires up to 50 concurrent functions.
Each function performs heavy **synchronous** CPU work before its first real I/O await:

- `deepcopy()` / `clone()` of FHIR resources
- `mergeObject()` (lodash deep merge)
- `deepEqual()` comparison
- JSON serialization (`toJSON()` in slow path)

With 50 concurrent, these synchronous chunks execute back-to-back in a single event
loop turn without ever yielding. The event loop is held hostage for hundreds of
seconds.

## Fix

Process `resources_incoming` in explicit chunks of `MERGE_PARALLEL_CHUNK_SIZE`, with
a single `await new Promise(resolve => setImmediate(resolve))` **between** chunks:

```js
const result = [];
for (let i = 0; i < resources_incoming.length; i += chunkSize) {
    const chunk = resources_incoming.slice(i, i + chunkSize);
    const chunkResults = await async.mapLimit(chunk, chunkSize, mergeResourceFn);
    result.push(...chunkResults);
    if (i + chunkSize < resources_incoming.length) {
        await new Promise(resolve => setImmediate(resolve));
    }
}
```

This gives the event loop a deterministic, guaranteed window between every batch of
`chunkSize` resources — probes, GC, I/O callbacks, and OTel span-end callbacks can
all run on those ticks.

**Why between chunks instead of before each resource?** An earlier iteration of this
fix put the yield inside `mergeResourceFn` itself. That works in theory, but
`async.mapLimit`'s rolling concurrency made the yield timing fuzzy — once the pool
of `chunkSize` workers is saturated, slots get recycled within the same tick and
the yields stack up in the microtask queue rather than spreading across event loop
turns. The chunk-boundary approach makes the yield explicit and unambiguous.

**Tradeoff:** Chunks now act as barriers — all `chunkSize` resources in a batch
must finish before the next batch starts. With `mapLimit` over the full list,
new tasks started as soon as any in-flight task finished. In the pathological case
where one resource in a batch is much slower than the others, the rest of the
batch's slots sit idle until it completes. In practice the merge work per resource
is uniform enough (the heavy work is the same `clone`/`mergeObject`/`deepEqual`
sequence) that this barrier cost is minimal compared to the event-loop wins.

**Performance overhead:** Negligible. Each `setImmediate` yield costs ~1-2µs.
For a 1000-resource bundle with `chunkSize=50`, that's 20 chunks → 19 yields →
~20-40µs total overhead. The current 298-second delays are wasted blocked time,
not useful computation.

**`MERGE_PARALLEL_CHUNK_SIZE=50` is fine** — the chunk size still controls
concurrency of DB calls. The issue isn't too many concurrent DB calls (MongoDB
responds in <1ms); it's that 50 functions all run their synchronous preamble in
one shot. The yield fixes this regardless of chunk size.

## Evidence (from Groundcover, prod-ue1, last hour)

| Metric | Source | Value |
|--------|--------|-------|
| MongoDB actual p50 latency | eBPF (flora parser) | **3.6ms** median |
| MongoDB actual read latency | AWS CloudWatch | **0.109ms** avg |
| MongoDB OTel-reported latency | Trace spans | 64-67s avg (17,000x inflated) |
| Event loop max delay | nodejs_eventloop_delay_max_seconds | **298s** top pod |
| Pods with delay > 10s | nodejs_eventloop_delay_max_seconds | 906/1207 (75%) |
| Pods with delay > 100s | nodejs_eventloop_delay_max_seconds | 242/1207 (20%) |
| Pods hitting utilization > 0.8 | nodejs_eventloop_utilization_ratio | 484/1207 (40%) |

## Test plan

- [ ] CI passes (lint + existing merge tests)
- [ ] Deploy to staging, observe `nodejs_eventloop_delay_max_seconds` drops below 1s
- [ ] Confirm liveness probe failures stop (no more OOM-killed pods)
- [ ] Verify merge throughput is not degraded (bundle processing time stays flat)
- [ ] Specifically verify the chunk barrier doesn't materially hurt large-bundle
      latency (compare p50/p95 bundle processing time before/after)