### PR TITLE
BAI-218: add $import endpoint documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ For example:
 
 [Bulk Export](readme/export.md)
 
+## Bulk Import functionality
+
+[Bulk Import](readme/import.md)
+
 ## Proxy Patient
 
 [Proxy Patient](readme/proxyPatient.md)

--- a/readme/import.md
+++ b/readme/import.md
@@ -2,7 +2,11 @@
 
 > **Status:** This endpoint is under active development and not yet available.
 
-The FHIR Server will support bulk data import from S3, modeled after the [Azure FHIR $import operation](https://learn.microsoft.com/en-us/azure/healthcare-apis/fhir/import-data). It allows high-throughput ingestion of FHIR resources in NDJSON format.
+The FHIR Server will support bulk data import from S3. It allows high-throughput ingestion of FHIR resources in NDJSON format.
+
+**References:**
+- [SMART on FHIR Bulk Import (Ping and Pull)](https://github.com/smart-on-fhir/bulk-import/blob/master/import-pnp.md)
+- [HL7 Bulk Data Submit](https://build.fhir.org/ig/HL7/bulk-data/branches/argo25/en/submit.html)
 
 ## API Overview
 
@@ -10,7 +14,7 @@ Bulk data import is triggered by a POST request:
 
 `POST /4_0_0/$import`
 
-The server creates one FHIR Task per input file, publishes processing messages to Kafka, and returns immediately with a `202 Accepted` response. Kafka consumers process the files asynchronously, streaming each file from S3 line-by-line and writing resources to MongoDB in batches.
+The server validates the request, creates a single FHIR Task to track the import, fans out processing across Kafka consumers, and returns immediately with a `202 Accepted` response containing the Task resource. Clients poll the Task to monitor progress.
 
 Note: This endpoint is not allowed for patient-scoped tokens.
 
@@ -20,65 +24,112 @@ Note: This endpoint is not allowed for patient-scoped tokens.
 
 | Header | Value |
 |--------|-------|
-| `Content-Type` | `application/json` |
+| `Content-Type` | `application/fhir+json` |
 | `Authorization` | `Bearer <token>` |
 | `Prefer` | `respond-async` |
 
 ### Body
 
+The request body is a FHIR [Parameters](https://www.hl7.org/fhir/parameters.html) resource. Each input file is specified as a repeating `input` parameter with `type` (optional) and `url` parts:
+
 ```json
 {
-    "filepaths": [
-        "s3://my-bucket/run-20260601/Patient.ndjson",
-        "s3://my-bucket/run-20260601/Condition.ndjson",
-        "s3://my-bucket/run-20260601/Observation.ndjson"
+    "resourceType": "Parameters",
+    "parameter": [
+        {
+            "name": "inputFormat",
+            "valueString": "application/fhir+ndjson"
+        },
+        {
+            "name": "input",
+            "part": [
+                {
+                    "name": "type",
+                    "valueString": "Patient"
+                },
+                {
+                    "name": "url",
+                    "valueUri": "s3://my-bucket/run-20260601/Patient.ndjson"
+                }
+            ]
+        },
+        {
+            "name": "input",
+            "part": [
+                {
+                    "name": "type",
+                    "valueString": "Condition"
+                },
+                {
+                    "name": "url",
+                    "valueUri": "s3://my-bucket/run-20260601/Condition.ndjson"
+                }
+            ]
+        },
+        {
+            "name": "input",
+            "part": [
+                {
+                    "name": "type",
+                    "valueString": "Observation"
+                },
+                {
+                    "name": "url",
+                    "valueUri": "s3://my-bucket/run-20260601/Observation.ndjson"
+                }
+            ]
+        }
     ]
 }
 ```
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `filepaths` | string[] | Yes | Array of S3 URIs (`s3://bucket/key`). Each must have a non-empty bucket and key. Bucket must be in the server's allow-list (`BULK_IMPORT_ALLOWED_S3_BUCKETS`). |
+| Parameter | Type | Cardinality | Description |
+|-----------|------|-------------|-------------|
+| `inputFormat` | valueString | 1..1 | Must be `application/fhir+ndjson` |
+| `input` | part | 1..* | One per input file (max 100) |
+| `input.type` | valueString | 0..1 | FHIR resource type contained in the file |
+| `input.url` | valueUri | 1..1 | S3 URI (`s3://bucket/key`). Bucket must be in the server's allow-list. |
 
 ### Validation Rules
 
-- `filepaths` must be a non-empty array
-- Each filepath must be a valid S3 URI matching `s3://bucket/key`
-- Each bucket must be in the configured allow-list
+- At least one `input` parameter is required, up to 100
+- Each `input.url` must be a valid S3 URI matching `s3://bucket/key`
+- Each bucket must be in the configured allow-list (`BULK_IMPORT_ALLOWED_S3_BUCKETS`)
 - Patient-scoped tokens are rejected (403)
 
 ## Response
 
 ### 202 Accepted
 
-The response body is a FHIR Bundle containing one Task resource per input file:
+The response body is the FHIR Task resource created for this import:
 
 ```json
 {
-    "resourceType": "Bundle",
-    "type": "collection",
-    "entry": [
-        {
-            "resource": {
-                "resourceType": "Task",
-                "id": "import-task-001",
-                "status": "requested",
-                "intent": "order",
-                "code": {
-                    "coding": [
-                        {
-                            "system": "https://www.icanbwell.com/task-type",
-                            "code": "bulk-import"
-                        }
-                    ]
-                },
-                "input": [
-                    {
-                        "type": { "text": "filepath" },
-                        "valueString": "s3://my-bucket/run-20260601/Patient.ndjson"
-                    }
-                ]
+    "resourceType": "Task",
+    "id": "import-task-abc123",
+    "status": "requested",
+    "intent": "order",
+    "code": {
+        "coding": [
+            {
+                "system": "https://www.icanbwell.com/task-type",
+                "code": "bulk-import"
             }
+        ]
+    },
+    "authoredOn": "2026-06-22T14:30:00.000Z",
+    "input": [
+        {
+            "type": { "text": "url" },
+            "valueUri": "s3://my-bucket/run-20260601/Patient.ndjson"
+        },
+        {
+            "type": { "text": "url" },
+            "valueUri": "s3://my-bucket/run-20260601/Condition.ndjson"
+        },
+        {
+            "type": { "text": "url" },
+            "valueUri": "s3://my-bucket/run-20260601/Observation.ndjson"
         }
     ]
 }
@@ -88,7 +139,7 @@ The response body is a FHIR Bundle containing one Task resource per input file:
 
 | Code | Condition |
 |------|-----------|
-| 400 | Missing `filepaths`, empty array, invalid S3 URI, or bucket not in allow-list |
+| 400 | Missing or invalid Parameters resource, no `input` entries, invalid S3 URI, bucket not in allow-list, file size out of range |
 | 401 | Missing or invalid Bearer token |
 | 403 | Patient-scoped token |
 | 500 | Internal server error (e.g. Kafka unavailable, MongoDB write failure) |
@@ -104,8 +155,8 @@ Use the standard FHIR Task read endpoint to check progress:
 | Status | Meaning |
 |--------|---------|
 | `requested` | Task created, not yet picked up by a consumer |
-| `in-progress` | Consumer is actively processing the file |
-| `completed` | All resources processed (check output for partial failures) |
+| `in-progress` | Consumer is actively processing files |
+| `completed` | All files processed (check output for partial failures) |
 | `failed` | Unrecoverable error (e.g. S3 file not found, auth failure) |
 
 ### Completed Task Example
@@ -113,7 +164,7 @@ Use the standard FHIR Task read endpoint to check progress:
 ```json
 {
     "resourceType": "Task",
-    "id": "import-task-001",
+    "id": "import-task-abc123",
     "status": "completed",
     "intent": "order",
     "code": {
@@ -124,34 +175,48 @@ Use the standard FHIR Task read endpoint to check progress:
             }
         ]
     },
+    "authoredOn": "2026-06-22T14:30:00.000Z",
     "input": [
         {
-            "type": { "text": "filepath" },
-            "valueString": "s3://my-bucket/run-20260601/Patient.ndjson"
+            "type": { "text": "url" },
+            "valueUri": "s3://my-bucket/run-20260601/Patient.ndjson"
+        },
+        {
+            "type": { "text": "url" },
+            "valueUri": "s3://my-bucket/run-20260601/Condition.ndjson"
         }
     ],
     "output": [
         {
-            "type": { "text": "resourcesProcessed" },
-            "valueInteger": 49980
+            "type": { "text": "result" },
+            "valueUri": "s3://my-bucket/run-20260601/output/Patient-001.ndjson"
         },
         {
-            "type": { "text": "resourcesFailed" },
-            "valueInteger": 20
+            "type": { "text": "result" },
+            "valueUri": "s3://my-bucket/run-20260601/output/Patient-002.ndjson"
         },
         {
-            "type": { "text": "totalResources" },
-            "valueInteger": 50000
+            "type": { "text": "result" },
+            "valueUri": "s3://my-bucket/run-20260601/output/Condition-001.ndjson"
         },
         {
-            "type": { "text": "errorFile" },
-            "valueString": "s3://my-bucket/run-20260601/errors/Patient-errors.ndjson"
+            "type": { "text": "error" },
+            "valueUri": "s3://my-bucket/run-20260601/output/errors/Patient-errors.ndjson"
         }
     ]
 }
 ```
 
-## NDJSON File Format
+Each input file may produce multiple output files. Output files contain merge result entries in NDJSON format (same format as `$merge` output):
+
+```
+{"created":true,"id":"patient-001","uuid":"849cb4f0-033b-5d6e-a614-9bbbbb3ba11e","resourceType":"Patient","updated":false,"sourceAssigningAuthority":"bwell"}
+{"created":false,"id":"patient-002","uuid":"9575d139-6c60-52e4-83fb-f8534727fbab","resourceType":"Patient","updated":true,"sourceAssigningAuthority":"bwell"}
+```
+
+Error output files contain FHIR OperationOutcome resources in NDJSON format.
+
+## NDJSON Input File Format
 
 Each input file must be NDJSON (newline-delimited JSON) with one FHIR resource per line:
 
@@ -160,21 +225,30 @@ Each input file must be NDJSON (newline-delimited JSON) with one FHIR resource p
 {"resourceType":"Patient","id":"patient-002","name":[{"family":"Johnson","given":["Sarah"]}]}
 ```
 
-### Duplicate Prevention (ifNoneExist wrapper)
+### Duplicate Prevention
 
-Lines can optionally use a wrapper format for conditional creation:
+- **Within a single processing batch (~100MB):** Duplicate resources are rejected.
+- **Across different batches:** Duplicates are processed normally via merge.
+- **Concurrent duplicates:** Rejected after 3 retries. Errors are recorded as OperationOutcome entries in the error output file.
 
-```
-{"ifNoneExist":"identifier=https://www.icanbwell.com/person_id|abc123","resource":{"resourceType":"Patient","id":"patient-001","name":[{"family":"Smith","given":["John"]}]}}
-```
+## Limitations
 
-If a line's parsed JSON has an `ifNoneExist` key, it is treated as a wrapper. Otherwise the entire line is treated as a FHIR resource.
+| Constraint | Value |
+|------------|-------|
+| Minimum file size | 50 MB |
+| Maximum file size | 5 GB |
+| Maximum NDJSON line size | 16 MB |
+| Maximum files per request | 100 |
+| Maximum total data per request | ~500 GB |
+
+Files smaller than 50 MB should be combined before submission. Each NDJSON line must be under 16 MB — lines exceeding this may cause unexpected behavior.
 
 ## Performance Guidance
 
-- **Partition files at the source.** Parallelism comes from processing multiple files across Kafka consumers, not from splitting individual files server-side. Source pipelines (e.g. Databricks) should partition output by resource type or row count so each file maps to one consumer.
-- **Use large files.** Following Azure FHIR's guidance, prefer files >= 50MB. Combining many small files into fewer large ones reduces per-file overhead.
+- **Partition files at the source.** Source pipelines (e.g. Databricks) should partition output by resource type or row count, keeping files between 50 MB and 5 GB.
 - **Submit all files in one request.** Import all files for a run in a single `$import` call rather than multiple calls.
+- **Parallelism is server-controlled.** Once a request is accepted, the server fans out processing internally. Clients do not need to manage parallelism.
+- **Estimated throughput.** At full capacity with 100 files (~500 GB), processing takes approximately 3 hours.
 
 ## Configuration
 
@@ -182,4 +256,3 @@ If a line's parsed JSON has an `ifNoneExist` key, it is treated as a wrapper. Ot
 |---------|---------|-------------|
 | `ENABLE_BULK_IMPORT` | `false` | Feature gate for the `/$import` endpoint |
 | `BULK_IMPORT_ALLOWED_S3_BUCKETS` | `''` | Comma-separated list of allowed S3 bucket names |
-| `BULK_IMPORT_BATCH_SIZE` | `100` | Number of resources per MongoDB write batch |

--- a/readme/import.md
+++ b/readme/import.md
@@ -1,0 +1,185 @@
+# FHIR $import endpoint (Upcoming)
+
+> **Status:** This endpoint is under active development and not yet available.
+
+The FHIR Server will support bulk data import from S3, modeled after the [Azure FHIR $import operation](https://learn.microsoft.com/en-us/azure/healthcare-apis/fhir/import-data). It allows high-throughput ingestion of FHIR resources in NDJSON format.
+
+## API Overview
+
+Bulk data import is triggered by a POST request:
+
+`POST /4_0_0/$import`
+
+The server creates one FHIR Task per input file, publishes processing messages to Kafka, and returns immediately with a `202 Accepted` response. Kafka consumers process the files asynchronously, streaming each file from S3 line-by-line and writing resources to MongoDB in batches.
+
+Note: This endpoint is not allowed for patient-scoped tokens.
+
+## Request
+
+### Headers
+
+| Header | Value |
+|--------|-------|
+| `Content-Type` | `application/json` |
+| `Authorization` | `Bearer <token>` |
+| `Prefer` | `respond-async` |
+
+### Body
+
+```json
+{
+    "filepaths": [
+        "s3://my-bucket/run-20260601/Patient.ndjson",
+        "s3://my-bucket/run-20260601/Condition.ndjson",
+        "s3://my-bucket/run-20260601/Observation.ndjson"
+    ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `filepaths` | string[] | Yes | Array of S3 URIs (`s3://bucket/key`). Each must have a non-empty bucket and key. Bucket must be in the server's allow-list (`BULK_IMPORT_ALLOWED_S3_BUCKETS`). |
+
+### Validation Rules
+
+- `filepaths` must be a non-empty array
+- Each filepath must be a valid S3 URI matching `s3://bucket/key`
+- Each bucket must be in the configured allow-list
+- Patient-scoped tokens are rejected (403)
+
+## Response
+
+### 202 Accepted
+
+The response body is a FHIR Bundle containing one Task resource per input file:
+
+```json
+{
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "Task",
+                "id": "import-task-001",
+                "status": "requested",
+                "intent": "order",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "https://www.icanbwell.com/task-type",
+                            "code": "bulk-import"
+                        }
+                    ]
+                },
+                "input": [
+                    {
+                        "type": { "text": "filepath" },
+                        "valueString": "s3://my-bucket/run-20260601/Patient.ndjson"
+                    }
+                ]
+            }
+        }
+    ]
+}
+```
+
+### Error Responses
+
+| Code | Condition |
+|------|-----------|
+| 400 | Missing `filepaths`, empty array, invalid S3 URI, or bucket not in allow-list |
+| 401 | Missing or invalid Bearer token |
+| 403 | Patient-scoped token |
+| 500 | Internal server error (e.g. Kafka unavailable, MongoDB write failure) |
+
+## Polling Import Status
+
+Use the standard FHIR Task read endpoint to check progress:
+
+`GET /4_0_0/Task/{task-id}`
+
+### Task Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `requested` | Task created, not yet picked up by a consumer |
+| `in-progress` | Consumer is actively processing the file |
+| `completed` | All resources processed (check output for partial failures) |
+| `failed` | Unrecoverable error (e.g. S3 file not found, auth failure) |
+
+### Completed Task Example
+
+```json
+{
+    "resourceType": "Task",
+    "id": "import-task-001",
+    "status": "completed",
+    "intent": "order",
+    "code": {
+        "coding": [
+            {
+                "system": "https://www.icanbwell.com/task-type",
+                "code": "bulk-import"
+            }
+        ]
+    },
+    "input": [
+        {
+            "type": { "text": "filepath" },
+            "valueString": "s3://my-bucket/run-20260601/Patient.ndjson"
+        }
+    ],
+    "output": [
+        {
+            "type": { "text": "resourcesProcessed" },
+            "valueInteger": 49980
+        },
+        {
+            "type": { "text": "resourcesFailed" },
+            "valueInteger": 20
+        },
+        {
+            "type": { "text": "totalResources" },
+            "valueInteger": 50000
+        },
+        {
+            "type": { "text": "errorFile" },
+            "valueString": "s3://my-bucket/run-20260601/errors/Patient-errors.ndjson"
+        }
+    ]
+}
+```
+
+## NDJSON File Format
+
+Each input file must be NDJSON (newline-delimited JSON) with one FHIR resource per line:
+
+```
+{"resourceType":"Patient","id":"patient-001","name":[{"family":"Smith","given":["John"]}]}
+{"resourceType":"Patient","id":"patient-002","name":[{"family":"Johnson","given":["Sarah"]}]}
+```
+
+### Duplicate Prevention (ifNoneExist wrapper)
+
+Lines can optionally use a wrapper format for conditional creation:
+
+```
+{"ifNoneExist":"identifier=https://www.icanbwell.com/person_id|abc123","resource":{"resourceType":"Patient","id":"patient-001","name":[{"family":"Smith","given":["John"]}]}}
+```
+
+If a line's parsed JSON has an `ifNoneExist` key, it is treated as a wrapper. Otherwise the entire line is treated as a FHIR resource.
+
+## Performance Guidance
+
+- **Partition files at the source.** Parallelism comes from processing multiple files across Kafka consumers, not from splitting individual files server-side. Source pipelines (e.g. Databricks) should partition output by resource type or row count so each file maps to one consumer.
+- **Use large files.** Following Azure FHIR's guidance, prefer files >= 50MB. Combining many small files into fewer large ones reduces per-file overhead.
+- **Submit all files in one request.** Import all files for a run in a single `$import` call rather than multiple calls.
+
+## Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `ENABLE_BULK_IMPORT` | `false` | Feature gate for the `/$import` endpoint |
+| `BULK_IMPORT_ALLOWED_S3_BUCKETS` | `''` | Comma-separated list of allowed S3 bucket names |
+| `BULK_IMPORT_BATCH_SIZE` | `100` | Number of resources per MongoDB write batch |


### PR DESCRIPTION
## Summary
- Add `readme/import.md` documenting the upcoming `POST /$import` bulk data import endpoint 
- Add link to the new doc from the main `README.md` next to Bulk Export