### PR TITLE
EA-2263 Propagate trace context across Kafka: enable kafkajs OTel instrumentation

### DIFF
--- a/src/otel_instrumentation.js
+++ b/src/otel_instrumentation.js
@@ -74,6 +74,7 @@ if (process.env.NODE_OPTIONS && process.env.NODE_OPTIONS.includes("/otel-auto-in
     const { MongoDBInstrumentation } = require('@opentelemetry/instrumentation-mongodb');
     const { RedisInstrumentation } = require('@opentelemetry/instrumentation-redis');
     const { RuntimeNodeInstrumentation } = require('@opentelemetry/instrumentation-runtime-node');
+    const { KafkaJsInstrumentation } = require('@opentelemetry/instrumentation-kafkajs');
 
     const sdk = new opentelemetry.NodeSDK({
         traceExporter: new OTLPTraceExporter(),
@@ -89,7 +90,11 @@ if (process.env.NODE_OPTIONS && process.env.NODE_OPTIONS.includes("/otel-auto-in
             new GraphQLInstrumentation(),
             new MongoDBInstrumentation(instrumentationConfigs['@opentelemetry/instrumentation-mongodb']),
             new RedisInstrumentation(),
-            new RuntimeNodeInstrumentation(instrumentationConfigs['@opentelemetry/instrumentation-runtime-node'])
+            new RuntimeNodeInstrumentation(instrumentationConfigs['@opentelemetry/instrumentation-runtime-node']),
+            // Kafka producer/consumer spans and W3C traceparent propagation across the Kafka hop (EA-2263).
+            // The auto-instrumentation path already includes kafkajs via getNodeAutoInstrumentations;
+            // this adds it to the manual SDK path so trace context propagates in both paths.
+            new KafkaJsInstrumentation()
         ],
         // Config needed for Sentry integration
         // https://docs.sentry.io/platforms/javascript/guides/node/opentelemetry/custom-setup/


### PR DESCRIPTION
## What
Add `KafkaJsInstrumentation` (`@opentelemetry/instrumentation-kafkajs`) to the manual OTel SDK path in `src/otel_instrumentation.js`.

## Why (EA-2263)
Validated in Groundcover: Java services already link across Kafka in a single trace (e.g. one trace spanning task-service, hp-notification-service, hp-scheduling-service), but fhir-server emits **0 kafka spans** (`messaging.system=kafka` count = 0 over 6h). The manual SDK path registers every instrumentation except kafkajs, so the service does not inject W3C `traceparent` on Kafka produces and breaks the end-to-end journey trace. The operator auto-instrumentation path already includes kafkajs via `getNodeAutoInstrumentations`; this brings the manual SDK path to parity.

## Scope / notes
- Minimal and additive. No dependency/lockfile change: `@opentelemetry/instrumentation-kafkajs` is already resolved via `@opentelemetry/auto-instrumentations-node`, and the `KafkaJsInstrumentation` export is stable across the resolved versions.
- Follow-ups (separate): promote `@opentelemetry/instrumentation-kafkajs` to a pinned direct dependency; retire the legacy manual `b3` header in `kafkaClient.js` once consumers are confirmed off it (it is in the export `asyncapi.yaml`).

## Validation after deploy
Confirm fhir-server emits kafka producer spans (`messaging.system=kafka`) and that a Patient `\$everything` / `\$merge` journey links producer -> Kafka -> consumer under one `trace_id`.

Part of EA-2263 (cross-service trace correlation); parent EA-2297.