### PR TITLE
BAI-219: create FHIR Task on $import request

### DIFF
--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -1196,7 +1196,11 @@ const createContainer = function () {
         fhirLoggingManager: c.fhirLoggingManager,
         postRequestProcessor: c.postRequestProcessor,
         auditLogger: c.auditLogger,
-        configManager: c.configManager
+        configManager: c.configManager,
+        securityTagManager: c.securityTagManager,
+        databaseUpdateFactory: c.databaseUpdateFactory,
+        databaseQueryFactory: c.databaseQueryFactory,
+        postSaveProcessor: c.postSaveProcessor
     }));
 
     container.register('adminExportManager', (c) => new AdminExportManager({

--- a/src/middleware/fhir/fhirResponseWriter.js
+++ b/src/middleware/fhir/fhirResponseWriter.js
@@ -292,8 +292,7 @@ class FhirResponseWriter {
      * @param {Object} result - results of the import
      */
     import ({ req, res, result }) {
-        const baseUrl = `${req.hostname.includes('localhost') ? 'http://' : 'https://'}${req.headers?.host}`;
-        res.setHeader('Content-Location', `${baseUrl}/4_0_0/Task/${result.id}`);
+        res.setHeader('Content-Location', `/4_0_0/Task/${result.id}`);
         this.setBaseResponseHeaders({ req, res });
         res.status(202).json(result);
     }

--- a/src/middleware/fhir/fhirResponseWriter.js
+++ b/src/middleware/fhir/fhirResponseWriter.js
@@ -292,6 +292,8 @@ class FhirResponseWriter {
      * @param {Object} result - results of the import
      */
     import ({ req, res, result }) {
+        const baseUrl = `${req.hostname.includes('localhost') ? 'http://' : 'https://'}${req.headers?.host}`;
+        res.setHeader('Content-Location', `${baseUrl}/4_0_0/Task/${result.id}`);
         this.setBaseResponseHeaders({ req, res });
         res.status(202).json(result);
     }

--- a/src/operations/import/import.js
+++ b/src/operations/import/import.js
@@ -13,7 +13,7 @@ const { ScopesManager } = require('../security/scopesManager');
 const { SecurityTagManager } = require('../common/securityTagManager');
 const { SecurityTagSystem } = require('../../utils/securityTagSystem');
 const { assertIsValid, assertTypeEquals } = require('../../utils/assertType');
-const { logInfo } = require('../common/logging');
+const { logInfo, logError } = require('../common/logging');
 
 class ImportOperation {
     /**
@@ -225,7 +225,17 @@ class ImportOperation {
             base_version: '4_0_0'
         });
 
-        await databaseUpdateManager.insertOneAsync({ doc: taskResource, requestInfo });
+        try {
+            await databaseUpdateManager.insertOneAsync({ doc: taskResource, requestInfo });
+        } catch (e) {
+            // E11000 from the unique _uuid index means a concurrent request won the race
+            if (e.original_error?.code === 11000 || e.nested?.code === 11000) {
+                throw new BadRequestError(new Error(
+                    `An import Task with id "${id}" already exists`
+                ));
+            }
+            throw e;
+        }
 
         await this.postSaveProcessor.afterSaveAsync({
             requestId,
@@ -272,36 +282,45 @@ class ImportOperation {
                 requestInfo
             });
 
-            logInfo(
-                `$import request accepted with ${inputs.length} input file(s)`,
-                {
+            // Task is committed — logging and audit are best-effort so a
+            // failure here does not mask the successfully created Task.
+            try {
+                logInfo(
+                    `$import request accepted with ${inputs.length} input file(s)`,
+                    {
+                        requestId,
+                        importJobId,
+                        inputCount: inputs.length,
+                        urls: inputs.map((i) => i.url)
+                    }
+                );
+
+                await this.fhirLoggingManager.logOperationSuccessAsync({
+                    requestInfo,
+                    args,
+                    startTime,
+                    action: currentOperationName
+                });
+
+                this.postRequestProcessor.add({
                     requestId,
-                    importJobId,
-                    inputCount: inputs.length,
-                    urls: inputs.map((i) => i.url)
-                }
-            );
-
-            await this.fhirLoggingManager.logOperationSuccessAsync({
-                requestInfo,
-                args,
-                startTime,
-                action: currentOperationName
-            });
-
-            this.postRequestProcessor.add({
-                requestId,
-                fnTask: async () => {
-                    await this.auditLogger.logAuditEntryAsync({
-                        requestInfo,
-                        base_version,
-                        resourceType: 'Task',
-                        operation: currentOperationName,
-                        args,
-                        ids: [importJobId]
-                    });
-                }
-            });
+                    fnTask: async () => {
+                        await this.auditLogger.logAuditEntryAsync({
+                            requestInfo,
+                            base_version,
+                            resourceType: 'Task',
+                            operation: currentOperationName,
+                            args,
+                            ids: [importJobId]
+                        });
+                    }
+                });
+            } catch (loggingError) {
+                logError(
+                    `Post-insert logging failed for import ${importJobId}`,
+                    { error: loggingError.message, requestId }
+                );
+            }
 
             return taskResource.toJSON();
         } catch (e) {

--- a/src/operations/import/import.js
+++ b/src/operations/import/import.js
@@ -12,7 +12,9 @@ const { PostSaveProcessor } = require('../../dataLayer/postSaveProcessor');
 const { ScopesManager } = require('../security/scopesManager');
 const { SecurityTagManager } = require('../common/securityTagManager');
 const { SecurityTagSystem } = require('../../utils/securityTagSystem');
+const { BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY } = require('../../constants');
 const { assertIsValid, assertTypeEquals } = require('../../utils/assertType');
+const { isUuid, generateUUIDv5 } = require('../../utils/uid.util');
 const { logInfo, logError } = require('../common/logging');
 
 class ImportOperation {
@@ -161,8 +163,9 @@ class ImportOperation {
             base_version: '4_0_0'
         });
 
+        const uuid = isUuid(id) ? id : generateUUIDv5(`${id}|${BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY}`);
         const existing = await databaseQueryManager.findOneAsync({
-            query: { _sourceId: id }
+            query: { _uuid: uuid }
         });
 
         if (existing) {
@@ -192,14 +195,14 @@ class ImportOperation {
                 security: [
                     new Coding({
                         system: SecurityTagSystem.owner,
-                        code: 'bwell'
+                        code: BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY
                     }),
                     new Coding({
                         system: SecurityTagSystem.sourceAssigningAuthority,
-                        code: 'bwell'
+                        code: BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY
                     })
                 ],
-                source: requestInfo.host
+                source: BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY
             }
         });
 

--- a/src/operations/import/import.js
+++ b/src/operations/import/import.js
@@ -1,9 +1,17 @@
+const moment = require('moment-timezone');
+const Coding = require('../../fhir/classes/4_0_0/complex_types/coding');
+const Task = require('../../fhir/classes/4_0_0/resources/task');
 const { AuditLogger } = require('../../utils/auditLogger');
 const { BadRequestError, ForbiddenError } = require('../../utils/httpErrors');
+const { ConfigManager } = require('../../utils/configManager');
+const { DatabaseQueryFactory } = require('../../dataLayer/databaseQueryFactory');
+const { DatabaseUpdateFactory } = require('../../dataLayer/databaseUpdateFactory');
 const { FhirLoggingManager } = require('../common/fhirLoggingManager');
 const { PostRequestProcessor } = require('../../utils/postRequestProcessor');
+const { PostSaveProcessor } = require('../../dataLayer/postSaveProcessor');
 const { ScopesManager } = require('../security/scopesManager');
-const { ConfigManager } = require('../../utils/configManager');
+const { SecurityTagManager } = require('../common/securityTagManager');
+const { SecurityTagSystem } = require('../../utils/securityTagSystem');
 const { assertIsValid, assertTypeEquals } = require('../../utils/assertType');
 const { logInfo } = require('../common/logging');
 
@@ -15,6 +23,10 @@ class ImportOperation {
      * @property {PostRequestProcessor} postRequestProcessor
      * @property {AuditLogger} auditLogger
      * @property {ConfigManager} configManager
+     * @property {SecurityTagManager} securityTagManager
+     * @property {DatabaseUpdateFactory} databaseUpdateFactory
+     * @property {DatabaseQueryFactory} databaseQueryFactory
+     * @property {PostSaveProcessor} postSaveProcessor
      *
      * @param {ConstructorParams}
      */
@@ -23,7 +35,11 @@ class ImportOperation {
         fhirLoggingManager,
         postRequestProcessor,
         auditLogger,
-        configManager
+        configManager,
+        securityTagManager,
+        databaseUpdateFactory,
+        databaseQueryFactory,
+        postSaveProcessor
     }) {
         this.scopesManager = scopesManager;
         assertTypeEquals(scopesManager, ScopesManager);
@@ -39,6 +55,18 @@ class ImportOperation {
 
         this.configManager = configManager;
         assertTypeEquals(configManager, ConfigManager);
+
+        this.securityTagManager = securityTagManager;
+        assertTypeEquals(securityTagManager, SecurityTagManager);
+
+        this.databaseUpdateFactory = databaseUpdateFactory;
+        assertTypeEquals(databaseUpdateFactory, DatabaseUpdateFactory);
+
+        this.databaseQueryFactory = databaseQueryFactory;
+        assertTypeEquals(databaseQueryFactory, DatabaseQueryFactory);
+
+        this.postSaveProcessor = postSaveProcessor;
+        assertTypeEquals(postSaveProcessor, PostSaveProcessor);
     }
 
     /**
@@ -122,6 +150,94 @@ class ImportOperation {
     }
 
     /**
+     * @param {{ id: string, inputs: Array<{ url: string }>, requestInfo: Object }} params
+     * @returns {Promise<Task>}
+     */
+    async createTaskAsync({ id, inputs, requestInfo }) {
+        const { user, scope, requestId } = requestInfo;
+
+        const databaseQueryManager = this.databaseQueryFactory.createQuery({
+            resourceType: 'Task',
+            base_version: '4_0_0'
+        });
+
+        const existing = await databaseQueryManager.findOneAsync({
+            query: { _sourceId: id }
+        });
+
+        if (existing) {
+            throw new BadRequestError(new Error(
+                `An import Task with id "${id}" already exists`
+            ));
+        }
+
+        const taskResource = new Task({
+            id,
+            status: 'requested',
+            intent: 'order',
+            code: {
+                coding: [
+                    new Coding({
+                        system: 'https://www.icanbwell.com/task-type',
+                        code: 'bulk-import'
+                    })
+                ]
+            },
+            authoredOn: new Date(moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ')),
+            input: inputs.map((i) => ({
+                type: { text: 'url' },
+                valueUri: i.url
+            })),
+            meta: {
+                security: [
+                    new Coding({
+                        system: SecurityTagSystem.owner,
+                        code: 'bwell'
+                    }),
+                    new Coding({
+                        system: SecurityTagSystem.sourceAssigningAuthority,
+                        code: 'bwell'
+                    })
+                ],
+                source: requestInfo.host
+            }
+        });
+
+        const accessCodesFromScopes = this.securityTagManager.getSecurityTagsFromScope({
+            user,
+            scope,
+            accessRequested: 'write'
+        });
+
+        accessCodesFromScopes.forEach((code) => {
+            taskResource.meta.security.push(
+                new Coding({
+                    system: SecurityTagSystem.access,
+                    code: code
+                })
+            );
+        });
+
+        taskResource.meta.lastUpdated = new Date(moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
+
+        const databaseUpdateManager = this.databaseUpdateFactory.createDatabaseUpdateManager({
+            resourceType: 'Task',
+            base_version: '4_0_0'
+        });
+
+        await databaseUpdateManager.insertOneAsync({ doc: taskResource, requestInfo });
+
+        await this.postSaveProcessor.afterSaveAsync({
+            requestId,
+            eventType: 'C',
+            resourceType: 'Task',
+            doc: taskResource
+        });
+
+        return taskResource;
+    }
+
+    /**
      * @typedef {Object} ImportAsyncParams
      * @property {import('../../utils/fhirRequestInfo').FhirRequestInfo} requestInfo
      * @property {Object} args
@@ -150,6 +266,12 @@ class ImportOperation {
             const { id: importJobId, inputs } = this.parseParametersResource(resource);
             this.validateS3Inputs(inputs);
 
+            const taskResource = await this.createTaskAsync({
+                id: importJobId,
+                inputs,
+                requestInfo
+            });
+
             logInfo(
                 `$import request accepted with ${inputs.length} input file(s)`,
                 {
@@ -160,9 +282,6 @@ class ImportOperation {
                 }
             );
 
-            // Log success first; audit is queued only after the success log lands,
-            // so a failure in success logging produces a single coherent failure
-            // record rather than success-logged-as-failure + an AuditEvent.
             await this.fhirLoggingManager.logOperationSuccessAsync({
                 requestInfo,
                 args,
@@ -176,7 +295,7 @@ class ImportOperation {
                     await this.auditLogger.logAuditEntryAsync({
                         requestInfo,
                         base_version,
-                        resourceType: 'Parameters',
+                        resourceType: 'Task',
                         operation: currentOperationName,
                         args,
                         ids: [importJobId]
@@ -184,17 +303,7 @@ class ImportOperation {
                 }
             });
 
-            return {
-                id: importJobId,
-                resourceType: 'OperationOutcome',
-                issue: [
-                    {
-                        severity: 'information',
-                        code: 'informational',
-                        diagnostics: `Import request accepted with ${inputs.length} input file(s)`
-                    }
-                ]
-            };
+            return taskResource.toJSON();
         } catch (e) {
             await this.fhirLoggingManager.logOperationFailureAsync({
                 requestInfo,

--- a/src/tests/import/import.test.js
+++ b/src/tests/import/import.test.js
@@ -70,7 +70,7 @@ describe('Import Tests', () => {
             .set(getHeaders())
             .expect(202);
 
-        expect(resp.headers['content-location']).toContain('/4_0_0/Task/import-job-001');
+        expect(resp.headers['content-location']).toBe('/4_0_0/Task/import-job-001');
     });
 
     test('multiple input files are stored in Task.input', async () => {

--- a/src/tests/import/import.test.js
+++ b/src/tests/import/import.test.js
@@ -41,7 +41,7 @@ describe('Import Tests', () => {
         await commonAfterEach();
     });
 
-    test('valid Parameters body returns 202 with OperationOutcome', async () => {
+    test('valid Parameters body returns 202 with Task resource', async () => {
         const request = await createTestRequest();
 
         const resp = await request
@@ -50,14 +50,30 @@ describe('Import Tests', () => {
             .set(getHeaders())
             .expect(202);
 
-        expect(resp.body.resourceType).toBe('OperationOutcome');
+        expect(resp.body.resourceType).toBe('Task');
         expect(resp.body.id).toBe('import-job-001');
-        expect(resp.body.issue[0].severity).toBe('information');
-        expect(resp.body.issue[0].code).toBe('informational');
-        expect(resp.body.issue[0].diagnostics).toContain('1 input file(s)');
+        expect(resp.body.status).toBe('requested');
+        expect(resp.body.intent).toBe('order');
+        expect(resp.body.code.coding[0].system).toBe('https://www.icanbwell.com/task-type');
+        expect(resp.body.code.coding[0].code).toBe('bulk-import');
+        expect(resp.body.input).toHaveLength(1);
+        expect(resp.body.input[0].valueUri).toBe('s3://allowed-bucket/run-001/Patient.ndjson');
+        expect(resp.body.meta.versionId).toBe('1');
     });
 
-    test('multiple input files returns count in diagnostics', async () => {
+    test('response includes Content-Location header', async () => {
+        const request = await createTestRequest();
+
+        const resp = await request
+            .post('/4_0_0/$import')
+            .send(validParametersBody)
+            .set(getHeaders())
+            .expect(202);
+
+        expect(resp.headers['content-location']).toContain('/4_0_0/Task/import-job-001');
+    });
+
+    test('multiple input files are stored in Task.input', async () => {
         const request = await createTestRequest();
 
         const resp = await request
@@ -66,7 +82,57 @@ describe('Import Tests', () => {
             .set(getHeaders())
             .expect(202);
 
-        expect(resp.body.issue[0].diagnostics).toContain('2 input file(s)');
+        expect(resp.body.input).toHaveLength(2);
+        expect(resp.body.input[0].valueUri).toBe('s3://allowed-bucket/run-001/Patient.ndjson');
+        expect(resp.body.input[1].valueUri).toBe('s3://allowed-bucket/run-001/Condition.ndjson');
+    });
+
+    test('Task is persisted in the database', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send(validParametersBody)
+            .set(getHeaders())
+            .expect(202);
+
+        const getResp = await request
+            .get('/4_0_0/Task/import-job-001')
+            .set(getHeaders())
+            .expect(200);
+
+        expect(getResp.body.resourceType).toBe('Task');
+        expect(getResp.body.id).toBe('import-job-001');
+        expect(getResp.body.status).toBe('requested');
+    });
+
+    test('duplicate import id returns 400', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send(validParametersBody)
+            .set(getHeaders())
+            .expect(202);
+
+        const resp = await request
+            .post('/4_0_0/$import')
+            .send(validParametersBody)
+            .set(getHeaders())
+            .expect(400);
+
+        expect(resp).toHaveResponse({
+            resourceType: 'OperationOutcome',
+            issue: [
+                {
+                    severity: 'error',
+                    code: 'invalid',
+                    details: {
+                        text: 'An import Task with id "import-job-001" already exists'
+                    }
+                }
+            ]
+        });
     });
 
     test('missing id returns 400 with error message', async () => {


### PR DESCRIPTION
## Summary
- Create a FHIR Task resource in MongoDB when `POST /$import` is accepted, replacing the previous OperationOutcome response
- Task uses the client-supplied `Parameters.id` as its id, with duplicate id rejection for idempotency
- Response includes `Content-Location` header pointing to `GET /4_0_0/Task/:id` for status polling
- Added 4 new dependencies to ImportOperation: securityTagManager, databaseUpdateFactory, databaseQueryFactory, postSaveProcessor

Jira: https://icanbwell.atlassian.net/browse/BAI-219

## Test plan
- [x] Valid request returns 202 with Task resource (correct status, intent, code, inputs)
- [x] Content-Location header points to Task polling URL
- [x] Multiple input files stored in Task.input
- [x] Task persisted in DB and retrievable via GET
- [x] Duplicate import id returns 400
- [x] All existing validation tests still pass (18 total)