### PR TITLE
BAI-219: Kafka producer for import byte-range events and consumer shell

### DIFF
--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -116,6 +116,8 @@ const {ExportByIdOperation} = require('./operations/export/exportById');
 const {AdminExportManager} = require('./admin/adminExportManager');
 const {BulkExportEventProducer} = require('./utils/bulkExportEventProducer');
 const {ImportOperation} = require('./operations/import/import');
+const {BulkImportEventProducer} = require('./operations/import/bulkImportEventProducer');
+const {BulkImportConsumerRunner} = require('./operations/import/bulkImportConsumerRunner');
 const {S3Client} = require('./utils/s3Client');
 const {CLOUD_STORAGE_CLIENTS} = require('./constants');
 const {MetaUuidEnrichmentProvider} = require('./enrich/providers/metaUuidEnrichmentProvider');
@@ -1191,6 +1193,17 @@ const createContainer = function () {
         databaseExportManager: c.databaseExportManager
     }));
 
+    container.register('bulkImportEventProducer', (c) => new BulkImportEventProducer({
+        kafkaClient: c.kafkaClient,
+        configManager: c.configManager
+    }));
+
+    container.register('bulkImportConsumerRunner', (c) => new BulkImportConsumerRunner({
+        configManager: c.configManager,
+        databaseQueryFactory: c.databaseQueryFactory,
+        databaseUpdateFactory: c.databaseUpdateFactory
+    }));
+
     container.register('importOperation', (c) => new ImportOperation({
         scopesManager: c.scopesManager,
         fhirLoggingManager: c.fhirLoggingManager,
@@ -1200,7 +1213,8 @@ const createContainer = function () {
         securityTagManager: c.securityTagManager,
         databaseUpdateFactory: c.databaseUpdateFactory,
         databaseQueryFactory: c.databaseQueryFactory,
-        postSaveProcessor: c.postSaveProcessor
+        postSaveProcessor: c.postSaveProcessor,
+        bulkImportEventProducer: c.bulkImportEventProducer
     }));
 
     container.register('adminExportManager', (c) => new AdminExportManager({

--- a/src/operations/import/bulkImportConsumer.js
+++ b/src/operations/import/bulkImportConsumer.js
@@ -15,12 +15,11 @@ async function main() {
         logInfo('Starting bulk import consumer', { topic, groupId });
 
         const consumer = await kafkaClient.createConsumerAsync({ groupId });
-        await kafkaClient.waitForConsumerToJoinGroupAsync(consumer, {
+
+        const joinPromise = kafkaClient.waitForConsumerToJoinGroupAsync(consumer, {
             maxWait: 30000,
             label: 'bulk-import-consumer'
         });
-
-        logInfo('Bulk import consumer joined group', { groupId });
 
         const shutdown = async (signal) => {
             logInfo(`Received ${signal}, shutting down bulk import consumer`);
@@ -35,7 +34,7 @@ async function main() {
         process.on('SIGTERM', () => shutdown('SIGTERM'));
         process.on('SIGINT', () => shutdown('SIGINT'));
 
-        await kafkaClient.receiveMessagesAsync({
+        kafkaClient.receiveMessagesAsync({
             consumer,
             topic,
             fromBeginning: false,
@@ -43,6 +42,9 @@ async function main() {
                 await bulkImportConsumerRunner.handleMessageAsync(message);
             }
         });
+
+        await joinPromise;
+        logInfo('Bulk import consumer joined group', { groupId });
     } catch (e) {
         console.error(JSON.stringify({
             method: 'bulkImportConsumer.main',

--- a/src/operations/import/bulkImportConsumer.js
+++ b/src/operations/import/bulkImportConsumer.js
@@ -1,0 +1,56 @@
+const { createContainer } = require('../../createContainer');
+const { initialize } = require('../../winstonInit');
+const { logInfo, logError } = require('../common/logging');
+const { getCircularReplacer } = require('../../utils/getCircularReplacer');
+
+async function main() {
+    try {
+        initialize();
+        const container = createContainer();
+
+        const { kafkaClient, configManager, bulkImportConsumerRunner } = container;
+        const topic = configManager.kafkaBulkImportEventTopic;
+        const groupId = configManager.bulkImportConsumerGroupId;
+
+        logInfo('Starting bulk import consumer', { topic, groupId });
+
+        const consumer = await kafkaClient.createConsumerAsync({ groupId });
+        await kafkaClient.waitForConsumerToJoinGroupAsync(consumer, {
+            maxWait: 30000,
+            label: 'bulk-import-consumer'
+        });
+
+        logInfo('Bulk import consumer joined group', { groupId });
+
+        const shutdown = async (signal) => {
+            logInfo(`Received ${signal}, shutting down bulk import consumer`);
+            try {
+                await kafkaClient.removeConsumerAsync({ consumer });
+            } catch (e) {
+                logError('Error during consumer shutdown', { error: e.message });
+            }
+            process.exit(0);
+        };
+
+        process.on('SIGTERM', () => shutdown('SIGTERM'));
+        process.on('SIGINT', () => shutdown('SIGINT'));
+
+        await kafkaClient.receiveMessagesAsync({
+            consumer,
+            topic,
+            fromBeginning: false,
+            onMessageAsync: async (message) => {
+                await bulkImportConsumerRunner.handleMessageAsync(message);
+            }
+        });
+    } catch (e) {
+        console.error(JSON.stringify({
+            method: 'bulkImportConsumer.main',
+            message: e.message,
+            stack: JSON.stringify(e.stack, getCircularReplacer())
+        }));
+        process.exit(1);
+    }
+}
+
+main();

--- a/src/operations/import/bulkImportConsumerRunner.js
+++ b/src/operations/import/bulkImportConsumerRunner.js
@@ -70,16 +70,17 @@ class BulkImportConsumerRunner {
             base_version: '4_0_0'
         });
 
-        task.status = status;
-        task.meta.lastUpdated = new Date(moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
+        const updated = task.clone();
+        updated.status = status;
+        updated.meta.lastUpdated = new Date(moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
         if (statusReason) {
-            if (!task.statusReason) {
-                task.statusReason = {};
+            if (!updated.statusReason) {
+                updated.statusReason = {};
             }
-            task.statusReason.text = statusReason;
+            updated.statusReason.text = statusReason;
         }
 
-        await databaseUpdateManager.updateOneAsync({ doc: task });
+        await databaseUpdateManager.updateOneAsync({ doc: updated });
     }
 
     /**

--- a/src/operations/import/bulkImportConsumerRunner.js
+++ b/src/operations/import/bulkImportConsumerRunner.js
@@ -1,0 +1,135 @@
+const moment = require('moment-timezone');
+const { assertTypeEquals } = require('../../utils/assertType');
+const { ConfigManager } = require('../../utils/configManager');
+const { DatabaseQueryFactory } = require('../../dataLayer/databaseQueryFactory');
+const { DatabaseUpdateFactory } = require('../../dataLayer/databaseUpdateFactory');
+const { logInfo, logError } = require('../common/logging');
+
+class BulkImportConsumerRunner {
+    /**
+     * @typedef {Object} ConstructorParams
+     * @property {ConfigManager} configManager
+     * @property {DatabaseQueryFactory} databaseQueryFactory
+     * @property {DatabaseUpdateFactory} databaseUpdateFactory
+     *
+     * @param {ConstructorParams}
+     */
+    constructor({ configManager, databaseQueryFactory, databaseUpdateFactory }) {
+        this.configManager = configManager;
+        assertTypeEquals(configManager, ConfigManager);
+
+        this.databaseQueryFactory = databaseQueryFactory;
+        assertTypeEquals(databaseQueryFactory, DatabaseQueryFactory);
+
+        this.databaseUpdateFactory = databaseUpdateFactory;
+        assertTypeEquals(databaseUpdateFactory, DatabaseUpdateFactory);
+    }
+
+    /**
+     * Parses a CloudEvent message from Kafka
+     * @param {string} messageValue
+     * @returns {Object} parsed CloudEvent data
+     */
+    parseCloudEvent(messageValue) {
+        const envelope = JSON.parse(messageValue);
+        if (envelope.type !== 'ImportRangeRequested') {
+            throw new Error(`Unexpected event type: ${envelope.type}`);
+        }
+        if (!envelope.data || !envelope.data.taskId || !envelope.data.filepath) {
+            throw new Error('Invalid ImportRangeRequested event: missing taskId or filepath');
+        }
+        return envelope.data;
+    }
+
+    /**
+     * Loads the Task resource by ID
+     * @param {string} taskId
+     * @returns {Promise<Object|null>}
+     */
+    async loadTaskAsync(taskId) {
+        const databaseQueryManager = this.databaseQueryFactory.createQuery({
+            resourceType: 'Task',
+            base_version: '4_0_0'
+        });
+
+        return databaseQueryManager.findOneAsync({
+            query: { id: taskId }
+        });
+    }
+
+    /**
+     * Updates the Task status in MongoDB
+     * @param {Object} task
+     * @param {string} status
+     * @param {string} [statusReason]
+     * @returns {Promise<void>}
+     */
+    async updateTaskStatusAsync(task, status, statusReason) {
+        const databaseUpdateManager = this.databaseUpdateFactory.createDatabaseUpdateManager({
+            resourceType: 'Task',
+            base_version: '4_0_0'
+        });
+
+        task.status = status;
+        task.meta.lastUpdated = new Date(moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
+        if (statusReason) {
+            if (!task.statusReason) {
+                task.statusReason = {};
+            }
+            task.statusReason.text = statusReason;
+        }
+
+        await databaseUpdateManager.updateOneAsync({ doc: task });
+    }
+
+    /**
+     * Handles a single Kafka message (ImportRangeRequested)
+     * @param {{ key: string, value: string, headers: Array<{key: string, value: string}> }} message
+     * @returns {Promise<void>}
+     */
+    async handleMessageAsync(message) {
+        let eventData;
+        try {
+            eventData = this.parseCloudEvent(message.value);
+        } catch (e) {
+            logError('Failed to parse bulk import Kafka message', {
+                error: e.message,
+                key: message.key
+            });
+            return;
+        }
+
+        const { taskId, filepath, byteRangeStart, byteRangeEnd, rangeIndex, totalRanges } = eventData;
+
+        logInfo('Processing bulk import range', {
+            taskId,
+            filepath,
+            byteRangeStart,
+            byteRangeEnd,
+            rangeIndex,
+            totalRanges
+        });
+
+        const task = await this.loadTaskAsync(taskId);
+        if (!task) {
+            logError('Task not found for bulk import message', { taskId });
+            return;
+        }
+
+        if (task.status === 'requested') {
+            await this.updateTaskStatusAsync(task, 'in-progress');
+        }
+
+        // Placeholder: actual byte-range processing will be added in Phase 3 (S3 NDJSON Reader)
+        // and Phase 4 (MongoDB Write Pacing). For now, just mark the range as acknowledged.
+
+        logInfo('Bulk import range acknowledged', {
+            taskId,
+            filepath,
+            rangeIndex,
+            totalRanges
+        });
+    }
+}
+
+module.exports = { BulkImportConsumerRunner };

--- a/src/operations/import/bulkImportEventProducer.js
+++ b/src/operations/import/bulkImportEventProducer.js
@@ -48,10 +48,15 @@ class BulkImportEventProducer {
      * @returns {Promise<number>} total number of messages published
      */
     async publishImportEventsAsync({ taskId, inputs, requestId, scope, user }) {
+        if (!this.configManager.kafkaEnableEvents) {
+            return 0;
+        }
+
         const topic = this.configManager.kafkaBulkImportEventTopic;
         const messages = [];
 
-        for (const input of inputs) {
+        for (let inputIndex = 0; inputIndex < inputs.length; inputIndex++) {
+            const input = inputs[inputIndex];
             const ranges = this.calculateByteRanges(input.fileSize);
 
             for (let rangeIndex = 0; rangeIndex < ranges.length; rangeIndex++) {
@@ -78,7 +83,7 @@ class BulkImportEventProducer {
                 };
 
                 messages.push({
-                    key: `${taskId}-${rangeIndex}`,
+                    key: `${taskId}-${inputIndex}-${rangeIndex}`,
                     value: JSON.stringify(cloudEvent)
                 });
             }

--- a/src/operations/import/bulkImportEventProducer.js
+++ b/src/operations/import/bulkImportEventProducer.js
@@ -1,0 +1,111 @@
+const { generateUUID } = require('../../utils/uid.util');
+const { assertTypeEquals } = require('../../utils/assertType');
+const { KafkaClient } = require('../../utils/kafkaClient');
+const { ConfigManager } = require('../../utils/configManager');
+const { logInfo, logError } = require('../common/logging');
+
+class BulkImportEventProducer {
+    /**
+     * @typedef {Object} ConstructorParams
+     * @property {KafkaClient} kafkaClient
+     * @property {ConfigManager} configManager
+     *
+     * @param {ConstructorParams}
+     */
+    constructor({ kafkaClient, configManager }) {
+        this.kafkaClient = kafkaClient;
+        assertTypeEquals(kafkaClient, KafkaClient);
+
+        this.configManager = configManager;
+        assertTypeEquals(configManager, ConfigManager);
+    }
+
+    /**
+     * Calculates byte-range markers for a file of the given size
+     * @param {number} fileSize
+     * @returns {Array<{start: number, end: number}>}
+     */
+    calculateByteRanges(fileSize) {
+        const rangeSizeBytes = this.configManager.bulkImportRangeSizeMb * 1024 * 1024;
+        const ranges = [];
+        for (let start = 0; start < fileSize; start += rangeSizeBytes) {
+            ranges.push({
+                start,
+                end: Math.min(start + rangeSizeBytes, fileSize)
+            });
+        }
+        return ranges;
+    }
+
+    /**
+     * Publishes ImportRangeRequested Kafka messages for each byte-range of each file
+     * @param {Object} params
+     * @param {string} params.taskId
+     * @param {Array<{url: string, fileSize: number}>} params.inputs
+     * @param {string} params.requestId
+     * @param {string} params.scope
+     * @param {string} params.user
+     * @returns {Promise<number>} total number of messages published
+     */
+    async publishImportEventsAsync({ taskId, inputs, requestId, scope, user }) {
+        const topic = this.configManager.kafkaBulkImportEventTopic;
+        const messages = [];
+
+        for (const input of inputs) {
+            const ranges = this.calculateByteRanges(input.fileSize);
+
+            for (let rangeIndex = 0; rangeIndex < ranges.length; rangeIndex++) {
+                const range = ranges[rangeIndex];
+                const eventId = generateUUID();
+
+                const cloudEvent = {
+                    specversion: '1.0',
+                    id: eventId,
+                    source: 'https://www.icanbwell.com/fhir-server',
+                    type: 'ImportRangeRequested',
+                    datacontenttype: 'application/json',
+                    data: {
+                        taskId,
+                        filepath: input.url,
+                        byteRangeStart: range.start,
+                        byteRangeEnd: range.end,
+                        rangeIndex,
+                        totalRanges: ranges.length,
+                        requestId,
+                        scope,
+                        user
+                    }
+                };
+
+                messages.push({
+                    key: `${taskId}-${rangeIndex}`,
+                    value: JSON.stringify(cloudEvent)
+                });
+            }
+        }
+
+        if (messages.length === 0) {
+            return 0;
+        }
+
+        try {
+            await this.kafkaClient.sendCloudEventMessageAsync({ topic, messages });
+            logInfo(`Published ${messages.length} ImportRangeRequested message(s)`, {
+                taskId,
+                topic,
+                messageCount: messages.length
+            });
+        } catch (e) {
+            logError('Failed to publish bulk import Kafka events', {
+                taskId,
+                topic,
+                error: e.message
+            });
+            throw e;
+        }
+
+        return messages.length;
+    }
+}
+
+module.exports = { BulkImportEventProducer };

--- a/src/operations/import/import.js
+++ b/src/operations/import/import.js
@@ -156,7 +156,7 @@ class ImportOperation {
                 fileSize = response.ContentLength;
             } catch (e) {
                 throw new BadRequestError(new Error(
-                    `Cannot access S3 file "${input.url}": ${e.name || e.message}`
+                    `Cannot access S3 file "${input.url}": ${e.name}: ${e.message}`
                 ));
             }
 

--- a/src/operations/import/import.js
+++ b/src/operations/import/import.js
@@ -1,8 +1,10 @@
+const { S3Client: S3, HeadObjectCommand } = require('@aws-sdk/client-s3');
 const moment = require('moment-timezone');
 const Coding = require('../../fhir/classes/4_0_0/complex_types/coding');
 const Task = require('../../fhir/classes/4_0_0/resources/task');
 const { AuditLogger } = require('../../utils/auditLogger');
 const { BadRequestError, ForbiddenError } = require('../../utils/httpErrors');
+const { BulkImportEventProducer } = require('./bulkImportEventProducer');
 const { ConfigManager } = require('../../utils/configManager');
 const { DatabaseQueryFactory } = require('../../dataLayer/databaseQueryFactory');
 const { DatabaseUpdateFactory } = require('../../dataLayer/databaseUpdateFactory');
@@ -29,6 +31,7 @@ class ImportOperation {
      * @property {DatabaseUpdateFactory} databaseUpdateFactory
      * @property {DatabaseQueryFactory} databaseQueryFactory
      * @property {PostSaveProcessor} postSaveProcessor
+     * @property {BulkImportEventProducer} bulkImportEventProducer
      *
      * @param {ConstructorParams}
      */
@@ -41,7 +44,8 @@ class ImportOperation {
         securityTagManager,
         databaseUpdateFactory,
         databaseQueryFactory,
-        postSaveProcessor
+        postSaveProcessor,
+        bulkImportEventProducer
     }) {
         this.scopesManager = scopesManager;
         assertTypeEquals(scopesManager, ScopesManager);
@@ -69,6 +73,9 @@ class ImportOperation {
 
         this.postSaveProcessor = postSaveProcessor;
         assertTypeEquals(postSaveProcessor, PostSaveProcessor);
+
+        this.bulkImportEventProducer = bulkImportEventProducer;
+        assertTypeEquals(bulkImportEventProducer, BulkImportEventProducer);
     }
 
     /**
@@ -117,6 +124,58 @@ class ImportOperation {
             id: body.id.trim(),
             inputs
         };
+    }
+
+    /**
+     * Parses an S3 URI into bucket and key
+     * @param {string} uri
+     * @returns {{ bucket: string, key: string }}
+     */
+    parseS3Uri(uri) {
+        const match = uri.match(/^s3:\/\/([^/]+)\/(.+)$/);
+        return { bucket: match[1], key: match[2] };
+    }
+
+    /**
+     * HEADs each S3 file to get file sizes and validate they exist
+     * @param {Array<{ url: string }>} inputs
+     * @returns {Promise<Array<{ url: string, fileSize: number }>>}
+     */
+    async headS3FilesAsync(inputs) {
+        const region = this.configManager.awsRegion || 'us-east-1';
+        const s3 = new S3({ region });
+        const minBytes = this.configManager.bulkImportMinFileSizeMb * 1024 * 1024;
+        const maxBytes = this.configManager.bulkImportMaxFileSizeGb * 1024 * 1024 * 1024;
+
+        const results = [];
+        for (const input of inputs) {
+            const { bucket, key } = this.parseS3Uri(input.url);
+            let fileSize;
+            try {
+                const response = await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+                fileSize = response.ContentLength;
+            } catch (e) {
+                throw new BadRequestError(new Error(
+                    `Cannot access S3 file "${input.url}": ${e.name || e.message}`
+                ));
+            }
+
+            if (fileSize < minBytes) {
+                throw new BadRequestError(new Error(
+                    `File "${input.url}" is ${(fileSize / (1024 * 1024)).toFixed(1)} MB, ` +
+                    `below the minimum of ${this.configManager.bulkImportMinFileSizeMb} MB`
+                ));
+            }
+            if (fileSize > maxBytes) {
+                throw new BadRequestError(new Error(
+                    `File "${input.url}" is ${(fileSize / (1024 * 1024 * 1024)).toFixed(1)} GB, ` +
+                    `above the maximum of ${this.configManager.bulkImportMaxFileSizeGb} GB`
+                ));
+            }
+
+            results.push({ url: input.url, fileSize });
+        }
+        return results;
     }
 
     /**
@@ -279,10 +338,20 @@ class ImportOperation {
             const { id: importJobId, inputs } = this.parseParametersResource(resource);
             this.validateS3Inputs(inputs);
 
+            const inputsWithSizes = await this.headS3FilesAsync(inputs);
+
             const taskResource = await this.createTaskAsync({
                 id: importJobId,
                 inputs,
                 requestInfo
+            });
+
+            await this.bulkImportEventProducer.publishImportEventsAsync({
+                taskId: importJobId,
+                inputs: inputsWithSizes,
+                requestId,
+                scope,
+                user: requestInfo.user
             });
 
             // Task is committed — logging and audit are best-effort so a

--- a/src/tests/import/bulkImportConsumerRunner.test.js
+++ b/src/tests/import/bulkImportConsumerRunner.test.js
@@ -1,0 +1,174 @@
+const { commonBeforeEach, commonAfterEach, getHeaders, createTestRequest } = require('../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+const { BulkImportConsumerRunner } = require('../../operations/import/bulkImportConsumerRunner');
+const { ConfigManager } = require('../../utils/configManager');
+const { ImportOperation } = require('../../operations/import/import');
+
+const makeCloudEvent = (overrides = {}) => {
+    const data = {
+        taskId: 'import-consumer-001',
+        filepath: 's3://allowed-bucket/Patient.ndjson',
+        byteRangeStart: 0,
+        byteRangeEnd: 104857600,
+        rangeIndex: 0,
+        totalRanges: 1,
+        requestId: 'req-001',
+        scope: 'user/*.write',
+        user: 'test-user',
+        ...overrides
+    };
+
+    return JSON.stringify({
+        specversion: '1.0',
+        id: 'evt-001',
+        source: 'https://www.icanbwell.com/fhir-server',
+        type: 'ImportRangeRequested',
+        datacontenttype: 'application/json',
+        data
+    });
+};
+
+const validParametersBody = {
+    resourceType: 'Parameters',
+    id: 'import-consumer-001',
+    parameter: [
+        {
+            name: 'input',
+            valueUri: 's3://allowed-bucket/Patient.ndjson'
+        }
+    ]
+};
+
+describe('BulkImportConsumerRunner', () => {
+    let originalHeadS3FilesAsync;
+
+    beforeEach(async () => {
+        process.env.ENABLE_BULK_IMPORT = '1';
+        process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS = 'allowed-bucket';
+        originalHeadS3FilesAsync = ImportOperation.prototype.headS3FilesAsync;
+        ImportOperation.prototype.headS3FilesAsync = async (inputs) =>
+            inputs.map((i) => ({ url: i.url, fileSize: 100 * 1024 * 1024 }));
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        ImportOperation.prototype.headS3FilesAsync = originalHeadS3FilesAsync;
+        delete process.env.ENABLE_BULK_IMPORT;
+        delete process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS;
+        await commonAfterEach();
+    });
+
+    test('parseCloudEvent extracts data from valid message', () => {
+        const { createTestContainer } = require('../createTestContainer');
+        const container = createTestContainer();
+        const runner = container.bulkImportConsumerRunner;
+
+        const data = runner.parseCloudEvent(makeCloudEvent());
+        expect(data.taskId).toBe('import-consumer-001');
+        expect(data.filepath).toBe('s3://allowed-bucket/Patient.ndjson');
+        expect(data.byteRangeStart).toBe(0);
+        expect(data.byteRangeEnd).toBe(104857600);
+        expect(data.rangeIndex).toBe(0);
+        expect(data.totalRanges).toBe(1);
+    });
+
+    test('parseCloudEvent rejects wrong event type', () => {
+        const { createTestContainer } = require('../createTestContainer');
+        const container = createTestContainer();
+        const runner = container.bulkImportConsumerRunner;
+
+        const badEvent = JSON.stringify({
+            type: 'SomethingElse',
+            data: { taskId: 'x', filepath: 'y' }
+        });
+        expect(() => runner.parseCloudEvent(badEvent)).toThrow('Unexpected event type');
+    });
+
+    test('handleMessageAsync updates Task status to in-progress', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send(validParametersBody)
+            .set(getHeaders())
+            .expect(202);
+
+        let taskResp = await request
+            .get('/4_0_0/Task/import-consumer-001')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('requested');
+
+        const { createTestContainer } = require('../createTestContainer');
+        const container = createTestContainer();
+        const runner = container.bulkImportConsumerRunner;
+
+        await runner.handleMessageAsync({
+            key: 'import-consumer-001-0',
+            value: makeCloudEvent(),
+            headers: []
+        });
+
+        taskResp = await request
+            .get('/4_0_0/Task/import-consumer-001')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('in-progress');
+    });
+
+    test('handleMessageAsync skips update if Task not found', async () => {
+        const { createTestContainer } = require('../createTestContainer');
+        const container = createTestContainer();
+        const runner = container.bulkImportConsumerRunner;
+
+        await runner.handleMessageAsync({
+            key: 'nonexistent-task-0',
+            value: makeCloudEvent({ taskId: 'nonexistent-task' }),
+            headers: []
+        });
+    });
+
+    test('handleMessageAsync does not downgrade in-progress to in-progress', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send(validParametersBody)
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../createTestContainer');
+        const container = createTestContainer();
+        const runner = container.bulkImportConsumerRunner;
+
+        await runner.handleMessageAsync({
+            key: 'import-consumer-001-0',
+            value: makeCloudEvent({ rangeIndex: 0, totalRanges: 2 }),
+            headers: []
+        });
+
+        await runner.handleMessageAsync({
+            key: 'import-consumer-001-1',
+            value: makeCloudEvent({ rangeIndex: 1, totalRanges: 2 }),
+            headers: []
+        });
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-consumer-001')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('in-progress');
+    });
+
+    test('handleMessageAsync ignores malformed messages', async () => {
+        const { createTestContainer } = require('../createTestContainer');
+        const container = createTestContainer();
+        const runner = container.bulkImportConsumerRunner;
+
+        await runner.handleMessageAsync({
+            key: 'bad-message',
+            value: 'not-valid-json{{{',
+            headers: []
+        });
+    });
+});

--- a/src/tests/import/bulkImportConsumerRunner.test.js
+++ b/src/tests/import/bulkImportConsumerRunner.test.js
@@ -1,7 +1,5 @@
 const { commonBeforeEach, commonAfterEach, getHeaders, createTestRequest } = require('../common');
 const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
-const { BulkImportConsumerRunner } = require('../../operations/import/bulkImportConsumerRunner');
-const { ConfigManager } = require('../../utils/configManager');
 const { ImportOperation } = require('../../operations/import/import');
 
 const makeCloudEvent = (overrides = {}) => {
@@ -44,6 +42,7 @@ describe('BulkImportConsumerRunner', () => {
 
     beforeEach(async () => {
         process.env.ENABLE_BULK_IMPORT = '1';
+        process.env.ENABLE_EVENTS_KAFKA = '1';
         process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS = 'allowed-bucket';
         originalHeadS3FilesAsync = ImportOperation.prototype.headS3FilesAsync;
         ImportOperation.prototype.headS3FilesAsync = async (inputs) =>
@@ -54,6 +53,7 @@ describe('BulkImportConsumerRunner', () => {
     afterEach(async () => {
         ImportOperation.prototype.headS3FilesAsync = originalHeadS3FilesAsync;
         delete process.env.ENABLE_BULK_IMPORT;
+        delete process.env.ENABLE_EVENTS_KAFKA;
         delete process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS;
         await commonAfterEach();
     });
@@ -104,7 +104,7 @@ describe('BulkImportConsumerRunner', () => {
         const runner = container.bulkImportConsumerRunner;
 
         await runner.handleMessageAsync({
-            key: 'import-consumer-001-0',
+            key: 'import-consumer-001-0-0',
             value: makeCloudEvent(),
             headers: []
         });
@@ -142,7 +142,7 @@ describe('BulkImportConsumerRunner', () => {
         const runner = container.bulkImportConsumerRunner;
 
         await runner.handleMessageAsync({
-            key: 'import-consumer-001-0',
+            key: 'import-consumer-001-0-0',
             value: makeCloudEvent({ rangeIndex: 0, totalRanges: 2 }),
             headers: []
         });

--- a/src/tests/import/bulkImportEventProducer.test.js
+++ b/src/tests/import/bulkImportEventProducer.test.js
@@ -1,4 +1,4 @@
-const { describe, beforeEach, test, expect } = require('@jest/globals');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
 const { BulkImportEventProducer } = require('../../operations/import/bulkImportEventProducer');
 const { MockKafkaClient } = require('../mocks/mockKafkaClient');
 const { ConfigManager } = require('../../utils/configManager');

--- a/src/tests/import/bulkImportEventProducer.test.js
+++ b/src/tests/import/bulkImportEventProducer.test.js
@@ -1,0 +1,147 @@
+const { describe, beforeEach, test, expect } = require('@jest/globals');
+const { BulkImportEventProducer } = require('../../operations/import/bulkImportEventProducer');
+const { MockKafkaClient } = require('../mocks/mockKafkaClient');
+const { ConfigManager } = require('../../utils/configManager');
+
+describe('BulkImportEventProducer', () => {
+    let producer;
+    let kafkaClient;
+
+    beforeEach(() => {
+        const configManager = new ConfigManager();
+        kafkaClient = new MockKafkaClient({ configManager });
+        producer = new BulkImportEventProducer({ kafkaClient, configManager });
+    });
+
+    test('calculateByteRanges splits a file into correct ranges', () => {
+        const fileSize = 250 * 1024 * 1024; // 250MB
+        const ranges = producer.calculateByteRanges(fileSize);
+
+        expect(ranges).toHaveLength(3);
+        expect(ranges[0]).toEqual({ start: 0, end: 100 * 1024 * 1024 });
+        expect(ranges[1]).toEqual({ start: 100 * 1024 * 1024, end: 200 * 1024 * 1024 });
+        expect(ranges[2]).toEqual({ start: 200 * 1024 * 1024, end: 250 * 1024 * 1024 });
+    });
+
+    test('calculateByteRanges returns single range for small file', () => {
+        const fileSize = 50 * 1024 * 1024; // 50MB
+        const ranges = producer.calculateByteRanges(fileSize);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0]).toEqual({ start: 0, end: 50 * 1024 * 1024 });
+    });
+
+    test('calculateByteRanges returns single range for exact range-size file', () => {
+        const fileSize = 100 * 1024 * 1024; // exactly 100MB
+        const ranges = producer.calculateByteRanges(fileSize);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0]).toEqual({ start: 0, end: 100 * 1024 * 1024 });
+    });
+
+    test('publishImportEventsAsync sends one message per byte range', async () => {
+        const count = await producer.publishImportEventsAsync({
+            taskId: 'task-001',
+            inputs: [
+                { url: 's3://bucket/Patient.ndjson', fileSize: 250 * 1024 * 1024 }
+            ],
+            requestId: 'req-001',
+            scope: 'user/*.write',
+            user: 'test-user'
+        });
+
+        expect(count).toBe(3);
+        const messages = kafkaClient.getCloudEventMessages();
+        expect(messages).toHaveLength(3);
+
+        const event0 = JSON.parse(messages[0].value);
+        expect(event0.type).toBe('ImportRangeRequested');
+        expect(event0.data.taskId).toBe('task-001');
+        expect(event0.data.filepath).toBe('s3://bucket/Patient.ndjson');
+        expect(event0.data.byteRangeStart).toBe(0);
+        expect(event0.data.byteRangeEnd).toBe(100 * 1024 * 1024);
+        expect(event0.data.rangeIndex).toBe(0);
+        expect(event0.data.totalRanges).toBe(3);
+        expect(event0.data.requestId).toBe('req-001');
+
+        const event2 = JSON.parse(messages[2].value);
+        expect(event2.data.rangeIndex).toBe(2);
+        expect(event2.data.byteRangeStart).toBe(200 * 1024 * 1024);
+        expect(event2.data.byteRangeEnd).toBe(250 * 1024 * 1024);
+    });
+
+    test('publishImportEventsAsync handles multiple files', async () => {
+        const count = await producer.publishImportEventsAsync({
+            taskId: 'task-002',
+            inputs: [
+                { url: 's3://bucket/Patient.ndjson', fileSize: 100 * 1024 * 1024 },
+                { url: 's3://bucket/Condition.ndjson', fileSize: 200 * 1024 * 1024 }
+            ],
+            requestId: 'req-002',
+            scope: 'user/*.write',
+            user: 'test-user'
+        });
+
+        // 1 range for 100MB file + 2 ranges for 200MB file = 3
+        expect(count).toBe(3);
+        const messages = kafkaClient.getCloudEventMessages();
+        expect(messages).toHaveLength(3);
+
+        const event0 = JSON.parse(messages[0].value);
+        expect(event0.data.filepath).toBe('s3://bucket/Patient.ndjson');
+        expect(event0.data.totalRanges).toBe(1);
+
+        const event1 = JSON.parse(messages[1].value);
+        expect(event1.data.filepath).toBe('s3://bucket/Condition.ndjson');
+        expect(event1.data.totalRanges).toBe(2);
+    });
+
+    test('publishImportEventsAsync returns 0 for empty inputs', async () => {
+        const count = await producer.publishImportEventsAsync({
+            taskId: 'task-003',
+            inputs: [],
+            requestId: 'req-003',
+            scope: 'user/*.write',
+            user: 'test-user'
+        });
+
+        expect(count).toBe(0);
+        expect(kafkaClient.getCloudEventMessages()).toHaveLength(0);
+    });
+
+    test('message keys include task ID and range index', async () => {
+        await producer.publishImportEventsAsync({
+            taskId: 'task-004',
+            inputs: [
+                { url: 's3://bucket/file.ndjson', fileSize: 250 * 1024 * 1024 }
+            ],
+            requestId: 'req-004',
+            scope: 'user/*.write',
+            user: 'test-user'
+        });
+
+        const messages = kafkaClient.getCloudEventMessages();
+        expect(messages[0].key).toBe('task-004-0');
+        expect(messages[1].key).toBe('task-004-1');
+        expect(messages[2].key).toBe('task-004-2');
+    });
+
+    test('CloudEvent envelope has required fields', async () => {
+        await producer.publishImportEventsAsync({
+            taskId: 'task-005',
+            inputs: [
+                { url: 's3://bucket/file.ndjson', fileSize: 100 * 1024 * 1024 }
+            ],
+            requestId: 'req-005',
+            scope: 'user/*.write',
+            user: 'test-user'
+        });
+
+        const event = JSON.parse(kafkaClient.getCloudEventMessages()[0].value);
+        expect(event.specversion).toBe('1.0');
+        expect(event.id).toBeDefined();
+        expect(event.source).toBe('https://www.icanbwell.com/fhir-server');
+        expect(event.type).toBe('ImportRangeRequested');
+        expect(event.datacontenttype).toBe('application/json');
+    });
+});

--- a/src/tests/import/bulkImportEventProducer.test.js
+++ b/src/tests/import/bulkImportEventProducer.test.js
@@ -8,9 +8,14 @@ describe('BulkImportEventProducer', () => {
     let kafkaClient;
 
     beforeEach(() => {
+        process.env.ENABLE_EVENTS_KAFKA = '1';
         const configManager = new ConfigManager();
         kafkaClient = new MockKafkaClient({ configManager });
         producer = new BulkImportEventProducer({ kafkaClient, configManager });
+    });
+
+    afterEach(() => {
+        delete process.env.ENABLE_EVENTS_KAFKA;
     });
 
     test('calculateByteRanges splits a file into correct ranges', () => {
@@ -121,9 +126,9 @@ describe('BulkImportEventProducer', () => {
         });
 
         const messages = kafkaClient.getCloudEventMessages();
-        expect(messages[0].key).toBe('task-004-0');
-        expect(messages[1].key).toBe('task-004-1');
-        expect(messages[2].key).toBe('task-004-2');
+        expect(messages[0].key).toBe('task-004-0-0');
+        expect(messages[1].key).toBe('task-004-0-1');
+        expect(messages[2].key).toBe('task-004-0-2');
     });
 
     test('CloudEvent envelope has required fields', async () => {
@@ -143,5 +148,25 @@ describe('BulkImportEventProducer', () => {
         expect(event.source).toBe('https://www.icanbwell.com/fhir-server');
         expect(event.type).toBe('ImportRangeRequested');
         expect(event.datacontenttype).toBe('application/json');
+    });
+
+    test('publishImportEventsAsync skips sending when Kafka events are disabled', async () => {
+        delete process.env.ENABLE_EVENTS_KAFKA;
+        const configManager = new ConfigManager();
+        const disabledKafka = new MockKafkaClient({ configManager });
+        const disabledProducer = new BulkImportEventProducer({ kafkaClient: disabledKafka, configManager });
+
+        const count = await disabledProducer.publishImportEventsAsync({
+            taskId: 'task-disabled',
+            inputs: [
+                { url: 's3://bucket/Patient.ndjson', fileSize: 250 * 1024 * 1024 }
+            ],
+            requestId: 'req-disabled',
+            scope: 'user/*.write',
+            user: 'test-user'
+        });
+
+        expect(count).toBe(0);
+        expect(disabledKafka.getCloudEventMessages()).toHaveLength(0);
     });
 });

--- a/src/tests/import/import.test.js
+++ b/src/tests/import/import.test.js
@@ -1,5 +1,6 @@
 const { commonBeforeEach, commonAfterEach, getHeaders, createTestRequest, getToken } = require('../common');
 const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+const { ImportOperation } = require('../../operations/import/import');
 
 const validParametersBody = {
     resourceType: 'Parameters',
@@ -28,13 +29,19 @@ const multiFileBody = {
 };
 
 describe('Import Tests', () => {
+    let originalHeadS3FilesAsync;
+
     beforeEach(async () => {
         process.env.ENABLE_BULK_IMPORT = '1';
         process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS = 'allowed-bucket,another-bucket';
+        originalHeadS3FilesAsync = ImportOperation.prototype.headS3FilesAsync;
+        ImportOperation.prototype.headS3FilesAsync = async (inputs) =>
+            inputs.map((i) => ({ url: i.url, fileSize: 100 * 1024 * 1024 }));
         await commonBeforeEach();
     });
 
     afterEach(async () => {
+        ImportOperation.prototype.headS3FilesAsync = originalHeadS3FilesAsync;
         delete process.env.ENABLE_BULK_IMPORT;
         delete process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS;
         delete process.env.BULK_IMPORT_MAX_FILES_PER_REQUEST;

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -1245,6 +1245,49 @@ class ConfigManager {
     }
 
     /**
+     * Kafka topic for bulk import byte-range messages
+     * @return {string}
+     */
+    get kafkaBulkImportEventTopic() {
+        return env.KAFKA_BULK_IMPORT_EVENT_TOPIC || 'fhir.bulk_import.events';
+    }
+
+    /**
+     * Kafka consumer group ID for bulk import consumers
+     * @return {string}
+     */
+    get bulkImportConsumerGroupId() {
+        return env.BULK_IMPORT_CONSUMER_GROUP_ID || 'fhir-bulk-import-consumer';
+    }
+
+    /**
+     * Byte-range marker size in MB for bulk import file splitting
+     * @return {number}
+     */
+    get bulkImportRangeSizeMb() {
+        const parsed = parseInt(env.BULK_IMPORT_RANGE_SIZE_MB, 10);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : 100;
+    }
+
+    /**
+     * Minimum file size in MB for bulk import
+     * @return {number}
+     */
+    get bulkImportMinFileSizeMb() {
+        const parsed = parseInt(env.BULK_IMPORT_MIN_FILE_SIZE_MB, 10);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : 50;
+    }
+
+    /**
+     * Maximum file size in GB for bulk import
+     * @return {number}
+     */
+    get bulkImportMaxFileSizeGb() {
+        const parsed = parseInt(env.BULK_IMPORT_MAX_FILE_SIZE_GB, 10);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : 5;
+    }
+
+    /**
      * returns list of external services where restriction needs to be applied to request
      * @return {Object.<string, string | null>}
      */


### PR DESCRIPTION
## Summary
- Adds `BulkImportEventProducer` that splits S3 files into ~100MB byte ranges and publishes `ImportRangeRequested` CloudEvent messages to Kafka
- Adds `BulkImportConsumerRunner` that receives Kafka messages and transitions the FHIR Task status from `requested` → `in-progress`
- Adds standalone `bulkImportConsumer.js` entry point — the first Kafka consumer process in this codebase
- Extends `ImportOperation` with S3 HEAD validation (50MB–5GB file size limits) and wires the producer into the `$import` flow
- Adds 5 new config properties: `kafkaBulkImportEventTopic`, `bulkImportConsumerGroupId`, `bulkImportRangeSizeMb`, `bulkImportMinFileSizeMb`, `bulkImportMaxFileSizeGb`

## Test plan
- [x] 8 unit tests for `BulkImportEventProducer` (byte-range calculation, message count, multi-file, empty inputs, message keys, CloudEvent envelope)
- [x] 5 tests for `BulkImportConsumerRunner` (parseCloudEvent valid/invalid, Task status transition, missing Task, malformed messages)
- [ ] Existing `import.test.js` tests still pass (S3 HEAD mock added to avoid real AWS calls)
- [ ] CI validation for integration tests (requires Docker/ClickHouse testcontainer)