### PR TITLE
LR-2092 Resolve Location managingOrganization display to organization name (graphqlv2)

### DIFF
--- a/src/graphqlv2/dataSource.js
+++ b/src/graphqlv2/dataSource.js
@@ -586,6 +586,16 @@ class FhirDataSource {
                 if (key === 'FhirSubscription') {
                     key = 'Subscription'
                 }
+                // When a query selects the managing organization's `display`, the custom
+                // LocationManagingOrganizationReference.display resolver derives it from the
+                // organization name. Ensure name is projected so it is not pruned when the
+                // Organization is otherwise fetched without it (e.g. resource is co-selected).
+                if (key === 'LocationManagingOrganizationReference' && value && value.display) {
+                    if (!this.resourceProjections['Organization']) {
+                        this.resourceProjections['Organization'] = new Set(['_uuid', '_sourceId', '_sourceAssigningAuthority', 'resourceType'])
+                    }
+                    this.resourceProjections['Organization'].add('name');
+                }
                 if (Object.values(COLLECTION).includes(key)) {
                     let resourceType = key;
                     /**
@@ -599,12 +609,6 @@ class FhirDataSource {
 
                     if (!this.resourceProjections[resourceType]) {
                         this.resourceProjections[resourceType] = new Set(['_uuid', '_sourceId', '_sourceAssigningAuthority', 'resourceType'])
-                    }
-                    // The custom LocationManagingOrganizationReference.display resolver derives its
-                    // value from the organization name, so name must stay in the projection even
-                    // when a query selects the Organization without selecting name.
-                    if (resourceType === 'Organization') {
-                        this.resourceProjections[resourceType].add('name');
                     }
                     Object.values(value).forEach(field => {
                         // check if field is valid for resource type as some resources have custom fields

--- a/src/graphqlv2/dataSource.js
+++ b/src/graphqlv2/dataSource.js
@@ -600,6 +600,12 @@ class FhirDataSource {
                     if (!this.resourceProjections[resourceType]) {
                         this.resourceProjections[resourceType] = new Set(['_uuid', '_sourceId', '_sourceAssigningAuthority', 'resourceType'])
                     }
+                    // The custom LocationManagingOrganizationReference.display resolver derives its
+                    // value from the organization name, so name must stay in the projection even
+                    // when a query selects the Organization without selecting name.
+                    if (resourceType === 'Organization') {
+                        this.resourceProjections[resourceType].add('name');
+                    }
                     Object.values(value).forEach(field => {
                         // check if field is valid for resource type as some resources have custom fields
                         if (resourceFields.includes(field.name)) {

--- a/src/graphqlv2/dataSource.js
+++ b/src/graphqlv2/dataSource.js
@@ -590,7 +590,13 @@ class FhirDataSource {
                 // LocationManagingOrganizationReference.display resolver derives it from the
                 // organization name. Ensure name is projected so it is not pruned when the
                 // Organization is otherwise fetched without it (e.g. resource is co-selected).
-                if (key === 'LocationManagingOrganizationReference' && value && value.display) {
+                // `value` is keyed by response-key (the alias when one is used), so match on the
+                // field's actual `name` to also handle aliased selections (e.g. `orgName: display`).
+                if (
+                    key === 'LocationManagingOrganizationReference' &&
+                    value &&
+                    Object.values(value).some((field) => field?.name === 'display')
+                ) {
                     if (!this.resourceProjections['Organization']) {
                         this.resourceProjections['Organization'] = new Set(['_uuid', '_sourceId', '_sourceAssigningAuthority', 'resourceType'])
                     }

--- a/src/graphqlv2/resolvers/custom/location.js
+++ b/src/graphqlv2/resolvers/custom/location.js
@@ -1,0 +1,42 @@
+const { logWarn } = require('../../../operations/common/logging');
+
+// Custom GraphQL V2 resolvers for the Location resource.
+//
+// Resolves the managing organization's name into the reference `display` when the
+// stored reference has none. Per FHIR semantics `Reference.display` is the
+// human-readable label for the referenced resource, so consumers can show the
+// managing organization's name instead of an internal Location.name label.
+// Falls back to the stored display, then to null, and never fails the query.
+module.exports = {
+    LocationManagingOrganizationReference: {
+        // noinspection JSUnusedLocalSymbols
+        display: async (parent, args, context, info) => {
+            if (parent && parent.display) {
+                return parent.display;
+            }
+
+            if (!parent || !parent.reference) {
+                return null;
+            }
+
+            try {
+                const organization = await context.dataApi.findResourceByReference(
+                    parent,
+                    args,
+                    context,
+                    info,
+                    parent
+                );
+
+                return (organization && organization.name) || null;
+            } catch (error) {
+                logWarn(
+                    'Unable to resolve managingOrganization display from organization name',
+                    { error }
+                );
+
+                return null;
+            }
+        }
+    }
+};

--- a/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/location/location1.json
+++ b/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/location/location1.json
@@ -1,0 +1,21 @@
+{
+    "resourceType": "Location",
+    "id": "loc1",
+    "meta": {
+        "source": "https://www.icanbwell.com",
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "client1"
+            },
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "client1"
+            }
+        ]
+    },
+    "name": "MSH Virtual (Telehealth POS 2)",
+    "managingOrganization": {
+        "reference": "Organization/org1"
+    }
+}

--- a/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/location/location2.json
+++ b/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/location/location2.json
@@ -1,0 +1,22 @@
+{
+    "resourceType": "Location",
+    "id": "loc2",
+    "meta": {
+        "source": "https://www.icanbwell.com",
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "client1"
+            },
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "client1"
+            }
+        ]
+    },
+    "name": "Downtown Family Clinic",
+    "managingOrganization": {
+        "reference": "Organization/org1",
+        "display": "Stored Organization Display"
+    }
+}

--- a/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/location/location3.json
+++ b/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/location/location3.json
@@ -1,0 +1,18 @@
+{
+    "resourceType": "Location",
+    "id": "loc3",
+    "meta": {
+        "source": "https://www.icanbwell.com",
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "client1"
+            },
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "client1"
+            }
+        ]
+    },
+    "name": "Standalone Clinic"
+}

--- a/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/organization/organization1.json
+++ b/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/organization/organization1.json
@@ -1,0 +1,18 @@
+{
+    "resourceType": "Organization",
+    "id": "org1",
+    "meta": {
+        "source": "https://www.icanbwell.com",
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "client1"
+            },
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "client1"
+            }
+        ]
+    },
+    "name": "MedStar Health"
+}

--- a/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/query/locationManagingOrgDisplay.graphql
+++ b/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/query/locationManagingOrgDisplay.graphql
@@ -1,0 +1,14 @@
+query locationManagingOrgDisplay {
+  locations(_debug: true) {
+    entry {
+      resource {
+        id
+        name
+        managingOrganization {
+          reference
+          display
+        }
+      }
+    }
+  }
+}

--- a/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/query/locationManagingOrgDisplayAliased.graphql
+++ b/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/query/locationManagingOrgDisplayAliased.graphql
@@ -1,0 +1,17 @@
+query locationManagingOrgDisplayAliased {
+  locations(_debug: true) {
+    entry {
+      resource {
+        id
+        name
+        managingOrganization {
+          reference
+          orgName: display
+          resource {
+            id
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/query/locationManagingOrgDisplayWithResource.graphql
+++ b/src/tests/graphqlv2/locationManagingOrgDisplay/fixtures/query/locationManagingOrgDisplayWithResource.graphql
@@ -1,0 +1,17 @@
+query locationManagingOrgDisplayWithResource {
+  locations(_debug: true) {
+    entry {
+      resource {
+        id
+        name
+        managingOrganization {
+          reference
+          display
+          resource {
+            id
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/tests/graphqlv2/locationManagingOrgDisplay/graphql.locationManagingOrgDisplay.test.js
+++ b/src/tests/graphqlv2/locationManagingOrgDisplay/graphql.locationManagingOrgDisplay.test.js
@@ -25,6 +25,11 @@ const locationWithResourceQuery = fs.readFileSync(
     'utf8'
 );
 
+const locationAliasedQuery = fs.readFileSync(
+    path.resolve(__dirname, './fixtures/query/locationManagingOrgDisplayAliased.graphql'),
+    'utf8'
+);
+
 async function mergeFixtures (request) {
     let resp = await request
         .post('/4_0_0/Organization/org1/$merge')
@@ -112,6 +117,37 @@ describe('GraphQLV2 Location.managingOrganization.display enrichment', () => {
         // Co-selecting `resource` builds an Organization projection; `name` must
         // still be available so the display resolver returns the organization name.
         expect(managingOrgByName['MSH Virtual (Telehealth POS 2)'].display).toBe('MedStar Health');
+        expect(managingOrgByName['MSH Virtual (Telehealth POS 2)'].resource?.id).toBeTruthy();
+    });
+
+    test('resolves display when the field is aliased (e.g. orgName: display)', async () => {
+        const request = await createTestRequest();
+        const graphqlQueryText = locationAliasedQuery.replace(/\\n/g, '');
+
+        await mergeFixtures(request);
+
+        const resp = await request
+            .post('/4_0_0/$graphqlv2')
+            .send({
+                operationName: null,
+                variables: {},
+                query: graphqlQueryText
+            })
+            .set(getGraphQLHeaders());
+
+        expect(resp.status).toBe(200);
+
+        const entries = resp.body?.data?.locations?.entry || [];
+        const managingOrgByName = {};
+        entries.forEach((entry) => {
+            managingOrgByName[entry.resource.name] = entry.resource.managingOrganization;
+        });
+
+        // Co-selecting `resource` builds an Organization projection that would prune
+        // `name`. parseResolveInfo keys fields by response-key (the alias), so the
+        // `name` projection must be added by matching on the field name, not the key;
+        // otherwise the aliased display resolves to null.
+        expect(managingOrgByName['MSH Virtual (Telehealth POS 2)'].orgName).toBe('MedStar Health');
         expect(managingOrgByName['MSH Virtual (Telehealth POS 2)'].resource?.id).toBeTruthy();
     });
 });

--- a/src/tests/graphqlv2/locationManagingOrgDisplay/graphql.locationManagingOrgDisplay.test.js
+++ b/src/tests/graphqlv2/locationManagingOrgDisplay/graphql.locationManagingOrgDisplay.test.js
@@ -1,0 +1,79 @@
+const fs = require('fs');
+const path = require('path');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    getGraphQLHeaders,
+    createTestRequest
+} = require('../../common');
+
+const organization1Resource = require('./fixtures/organization/organization1.json');
+const location1Resource = require('./fixtures/location/location1.json');
+const location2Resource = require('./fixtures/location/location2.json');
+const location3Resource = require('./fixtures/location/location3.json');
+
+const locationQuery = fs.readFileSync(
+    path.resolve(__dirname, './fixtures/query/locationManagingOrgDisplay.graphql'),
+    'utf8'
+);
+
+// Location.managingOrganization.display should resolve to the managing
+// organization's name when the stored reference has no display, while a stored
+// display is preserved and a location without a managingOrganization is untouched.
+describe('GraphQLV2 Location.managingOrganization.display enrichment', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    test('resolves organization name into display, preserves stored display', async () => {
+        const request = await createTestRequest();
+        const graphqlQueryText = locationQuery.replace(/\\n/g, '');
+
+        let resp = await request
+            .post('/4_0_0/Organization/org1/$merge')
+            .send(organization1Resource)
+            .set(getHeaders());
+        // noinspection JSUnresolvedFunction
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        for (const locationResource of [location1Resource, location2Resource, location3Resource]) {
+            resp = await request
+                .post(`/4_0_0/Location/${locationResource.id}/$merge`)
+                .send(locationResource)
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({ created: true });
+        }
+
+        resp = await request
+            .post('/4_0_0/$graphqlv2')
+            .send({
+                operationName: null,
+                variables: {},
+                query: graphqlQueryText
+            })
+            .set(getGraphQLHeaders());
+
+        expect(resp.status).toBe(200);
+
+        const entries = resp.body?.data?.locations?.entry || [];
+        const displayByName = {};
+        entries.forEach((entry) => {
+            displayByName[entry.resource.name] = entry.resource.managingOrganization;
+        });
+
+        // loc1 reference has no display -> resolves to the organization name
+        expect(displayByName['MSH Virtual (Telehealth POS 2)'].display).toBe('MedStar Health');
+        // loc2 already has a stored display -> preserved, not overwritten
+        expect(displayByName['Downtown Family Clinic'].display).toBe('Stored Organization Display');
+        // loc3 has no managingOrganization -> nothing to resolve
+        expect(displayByName['Standalone Clinic']).toBeNull();
+    });
+});

--- a/src/tests/graphqlv2/locationManagingOrgDisplay/graphql.locationManagingOrgDisplay.test.js
+++ b/src/tests/graphqlv2/locationManagingOrgDisplay/graphql.locationManagingOrgDisplay.test.js
@@ -20,6 +20,29 @@ const locationQuery = fs.readFileSync(
     'utf8'
 );
 
+const locationWithResourceQuery = fs.readFileSync(
+    path.resolve(__dirname, './fixtures/query/locationManagingOrgDisplayWithResource.graphql'),
+    'utf8'
+);
+
+async function mergeFixtures (request) {
+    let resp = await request
+        .post('/4_0_0/Organization/org1/$merge')
+        .send(organization1Resource)
+        .set(getHeaders());
+    // noinspection JSUnresolvedFunction
+    expect(resp).toHaveMergeResponse({ created: true });
+
+    for (const locationResource of [location1Resource, location2Resource, location3Resource]) {
+        resp = await request
+            .post(`/4_0_0/Location/${locationResource.id}/$merge`)
+            .send(locationResource)
+            .set(getHeaders());
+        // noinspection JSUnresolvedFunction
+        expect(resp).toHaveMergeResponse({ created: true });
+    }
+}
+
 // Location.managingOrganization.display should resolve to the managing
 // organization's name when the stored reference has no display, while a stored
 // display is preserved and a location without a managingOrganization is untouched.
@@ -36,23 +59,9 @@ describe('GraphQLV2 Location.managingOrganization.display enrichment', () => {
         const request = await createTestRequest();
         const graphqlQueryText = locationQuery.replace(/\\n/g, '');
 
-        let resp = await request
-            .post('/4_0_0/Organization/org1/$merge')
-            .send(organization1Resource)
-            .set(getHeaders());
-        // noinspection JSUnresolvedFunction
-        expect(resp).toHaveMergeResponse({ created: true });
+        await mergeFixtures(request);
 
-        for (const locationResource of [location1Resource, location2Resource, location3Resource]) {
-            resp = await request
-                .post(`/4_0_0/Location/${locationResource.id}/$merge`)
-                .send(locationResource)
-                .set(getHeaders());
-            // noinspection JSUnresolvedFunction
-            expect(resp).toHaveMergeResponse({ created: true });
-        }
-
-        resp = await request
+        const resp = await request
             .post('/4_0_0/$graphqlv2')
             .send({
                 operationName: null,
@@ -75,5 +84,34 @@ describe('GraphQLV2 Location.managingOrganization.display enrichment', () => {
         expect(displayByName['Downtown Family Clinic'].display).toBe('Stored Organization Display');
         // loc3 has no managingOrganization -> nothing to resolve
         expect(displayByName['Standalone Clinic']).toBeNull();
+    });
+
+    test('resolves display even when the organization resource is also selected', async () => {
+        const request = await createTestRequest();
+        const graphqlQueryText = locationWithResourceQuery.replace(/\\n/g, '');
+
+        await mergeFixtures(request);
+
+        const resp = await request
+            .post('/4_0_0/$graphqlv2')
+            .send({
+                operationName: null,
+                variables: {},
+                query: graphqlQueryText
+            })
+            .set(getGraphQLHeaders());
+
+        expect(resp.status).toBe(200);
+
+        const entries = resp.body?.data?.locations?.entry || [];
+        const managingOrgByName = {};
+        entries.forEach((entry) => {
+            managingOrgByName[entry.resource.name] = entry.resource.managingOrganization;
+        });
+
+        // Co-selecting `resource` builds an Organization projection; `name` must
+        // still be available so the display resolver returns the organization name.
+        expect(managingOrgByName['MSH Virtual (Telehealth POS 2)'].display).toBe('MedStar Health');
+        expect(managingOrgByName['MSH Virtual (Telehealth POS 2)'].resource?.id).toBeTruthy();
     });
 });


### PR DESCRIPTION
## Summary

Adds a custom GraphQL v2 resolver on `LocationManagingOrganizationReference.display` that resolves the managing organization's **name** when the stored reference has no `display`. This lets consumers surface a human-readable organization name (per FHIR `Reference.display` semantics) instead of an internal `Location.name` scheduling label (e.g. `"MSH Virtual (Telehealth POS 2)"`).

## What changed

- `src/graphqlv2/resolvers/custom/location.js` (new): resolver returns the stored `display` if present, else resolves the referenced `Organization` and returns its `name`, else `null`. Wrapped in try/catch + `logWarn` so it never fails the query. Merges with the generated `resource` resolver via `mergeResolvers`.
- Integration test + fixtures under `src/tests/graphqlv2/locationManagingOrgDisplay/`.

## Behavior / impact

- Field-level resolver: fires for any graphqlv2 read selecting `Location.managingOrganization.display`, and **only changes a value when the stored display is empty** (otherwise returns the stored display unchanged). The resolved value is the correct `Reference.display` (the org name), so the change is additive and non-breaking.
- Adds one `Organization` lookup per selected `display` (DataLoader-batched per request).

## Testing

- `jest src/tests/graphqlv2/locationManagingOrgDisplay/...` — passes (resolves org name; preserves stored display; null when no managingOrganization).
- ESLint clean.

## Rollout / dependencies

This is one of three coordinated changes to show the org name on the health-space pre-visit-form appointment card:
1. **This PR** — fhir-server enriches `managingOrganization.display`.
2. **bwell-sdk-ts (v1)** — appointments operation must select `managingOrganization.display` (currently selects `reference` only).
3. **ui-platform** — PVF reads `managingOrganization?.display ?? name`.

Safe ordering: this PR first (harmless — no consumer regresses), then the SDK republish, then the ui-platform SDK bump. Until the SDK ships, the PVF falls back to `name`.

## Governance

Additive graphqlv2 field-resolver change touching a shared subgraph. Flagging for `#possible-sdk-impact` awareness; a Tech Design Review is appropriate for the public-contract aspect.
