### PR TITLE
EA-2322 prevent Mongo/ClickHouse split-brain on Group write failure

### DIFF
--- a/src/dataLayer/bulkWriteExecutors/mongoBulkWriteExecutor.js
+++ b/src/dataLayer/bulkWriteExecutors/mongoBulkWriteExecutor.js
@@ -22,6 +22,10 @@ const { ResourceLocatorFactory } = require('../../operations/common/resourceLoca
 const { ConfigManager } = require('../../utils/configManager');
 const { PostSaveProcessor } = require('../postSaveProcessor');
 const { PostRequestProcessor } = require('../../utils/postRequestProcessor');
+const {
+    wasMemberStrippedForExternalStorage,
+    restoreStrippedMembersInMongo
+} = require('../../utils/clickHouseGroupPreSave');
 
 // MongoDB BSON document hard limit is 16 MiB (16,777,216 bytes). The Node driver and
 // libbson allocate a 17 MiB scratch buffer (kMaxBSONSize + 1 MiB headroom = 17,825,792 bytes),
@@ -403,18 +407,43 @@ class MongoBulkWriteExecutor extends BulkWriteExecutor {
 
                     // 3. Call postSaveAsync for each operation
                     for (const operationByCollection of operationsByCollection) {
-                        mergeResultEntries.push(
-                            await this._postSaveAsync({
-                                base_version,
-                                requestInfo,
+                        try {
+                            mergeResultEntries.push(
+                                await this._postSaveAsync({
+                                    base_version,
+                                    requestInfo,
+                                    resourceType,
+                                    bulkInsertUpdateEntry: operationByCollection,
+                                    bulkWriteResult,
+                                    useHistoryCollection,
+                                    isAccessLogOperation,
+                                    insertOneHistoryFn
+                                })
+                            );
+                        } catch (postSaveError) {
+                            // EA-2322: Group dual-write split-brain compensation.
+                            //
+                            // For a Group create/PUT with useExternalStorage, the MongoDB document
+                            // was already committed (above) with member[] stripped, on the
+                            // assumption that the synchronous post-save handler would write the
+                            // members to ClickHouse. A throw here means that ClickHouse write
+                            // failed, so MongoDB now holds a Group with no members and ClickHouse
+                            // holds no events: a silently-empty (orphaned) Group.
+                            //
+                            // Restore the original members onto the committed MongoDB document so
+                            // the submitted membership is not lost, then re-throw so the client
+                            // still receives a 500 and the operation is reported as failed.
+                            // See restoreStrippedMembersInMongo for the rationale and the known
+                            // limitation (members are restored to Mongo, not replayed to ClickHouse).
+                            await this._compensateStrippedGroupMembersOnPostSaveFailure({
+                                collection,
                                 resourceType,
                                 bulkInsertUpdateEntry: operationByCollection,
-                                bulkWriteResult,
-                                useHistoryCollection,
-                                isAccessLogOperation,
-                                insertOneHistoryFn
-                            })
-                        );
+                                requestId,
+                                postSaveError
+                            });
+                            throw postSaveError;
+                        }
                     }
                 } catch (e) {
                     // Errors already wrapped at a lower layer (inner bulkWrite catch, post-save,
@@ -586,6 +615,84 @@ class MongoBulkWriteExecutor extends BulkWriteExecutor {
         }
 
         return mergeResultEntry;
+    }
+
+    /**
+     * EA-2322: Compensates a Group dual-write split-brain after a post-save failure.
+     *
+     * When the synchronous post-save handler (the ClickHouse member write) throws for a Group
+     * whose member[] was stripped from MongoDB before the commit, the committed MongoDB document
+     * is left silently empty. This restores the original members (carried in contextData) back
+     * onto that document so the data is not lost.
+     *
+     * Compensation is best-effort: if the restore itself fails we log and swallow that secondary
+     * error so the ORIGINAL post-save error is the one surfaced to the caller (it is the actionable
+     * failure). This method never throws.
+     *
+     * @param {Object} params
+     * @param {import('mongodb').Collection} params.collection - Open collection for this resource table
+     * @param {string} params.resourceType
+     * @param {BulkInsertUpdateEntry} params.bulkInsertUpdateEntry
+     * @param {string|null} params.requestId
+     * @param {Error} params.postSaveError - The original post-save (ClickHouse) error being compensated
+     * @returns {Promise<void>}
+     * @private
+     */
+    async _compensateStrippedGroupMembersOnPostSaveFailure ({
+        collection,
+        resourceType,
+        bulkInsertUpdateEntry,
+        requestId,
+        postSaveError
+    }) {
+        const contextData = bulkInsertUpdateEntry.contextData || null;
+
+        // Only Group writes that actually stripped members from Mongo can be split-brained.
+        if (resourceType !== 'Group' || !wasMemberStrippedForExternalStorage(contextData)) {
+            return;
+        }
+
+        const originalMembers = contextData?.groupMembers || [];
+        if (originalMembers.length === 0) {
+            // No members were submitted, so there is nothing to lose (empty Group is consistent).
+            return;
+        }
+
+        try {
+            const restored = await restoreStrippedMembersInMongo({
+                collection,
+                uuid: bulkInsertUpdateEntry.uuid,
+                members: originalMembers
+            });
+
+            logError('mongoBulkWriteExecutor: ClickHouse member write failed; restored Group members to MongoDB to prevent data loss', {
+                args: {
+                    source: 'mongoBulkWriteExecutor._compensateStrippedGroupMembersOnPostSaveFailure',
+                    requestId,
+                    resourceType,
+                    id: bulkInsertUpdateEntry.id,
+                    uuid: bulkInsertUpdateEntry.uuid,
+                    memberCount: originalMembers.length,
+                    restored,
+                    originalError: postSaveError && postSaveError.message
+                }
+            });
+        } catch (compensationError) {
+            // Secondary failure: the Group remains empty in Mongo. Log loudly but do not mask the
+            // original post-save error, which the caller re-throws.
+            await logSystemErrorAsync({
+                event: 'mongoBulkWriteExecutor_compensationFailed',
+                message: 'mongoBulkWriteExecutor: failed to restore Group members after ClickHouse write failure',
+                error: compensationError,
+                args: {
+                    requestId,
+                    resourceType,
+                    id: bulkInsertUpdateEntry.id,
+                    uuid: bulkInsertUpdateEntry.uuid,
+                    originalError: postSaveError && postSaveError.message
+                }
+            });
+        }
     }
 
     /**

--- a/src/tests/group/group_clickhouse_compensation.unit.test.js
+++ b/src/tests/group/group_clickhouse_compensation.unit.test.js
@@ -1,0 +1,214 @@
+const { describe, test, beforeEach, expect, jest: jestGlobal } = require('@jest/globals');
+const {
+    wasMemberStrippedForExternalStorage,
+    restoreStrippedMembersInMongo
+} = require('../../utils/clickHouseGroupPreSave');
+const { MongoBulkWriteExecutor } = require('../../dataLayer/bulkWriteExecutors/mongoBulkWriteExecutor');
+
+/**
+ * EA-2322 unit tests for the Group dual-write split-brain compensation.
+ *
+ * These exercise the compensation logic in isolation (no container, ClickHouse, or MongoDB),
+ * so they run fast and deterministically and document the exact intended behavior:
+ *
+ *  - The strip precondition (wasMemberStrippedForExternalStorage) and its inverse
+ *    (restoreStrippedMembersInMongo) are mutually consistent.
+ *  - MongoBulkWriteExecutor._compensateStrippedGroupMembersOnPostSaveFailure restores members to
+ *    MongoDB ONLY for Group writes that actually stripped members, is a no-op otherwise, and
+ *    never throws (a failed restore must not mask the original ClickHouse error).
+ */
+describe('EA-2322 Group ClickHouse compensation (unit)', () => {
+    process.env.LOGLEVEL = 'SILENT';
+
+    /**
+     * Minimal fake MongoDB collection capturing updateOne calls.
+     */
+    function makeFakeCollection({ matchedCount = 1, throwOnUpdate = false } = {}) {
+        const calls = [];
+        return {
+            calls,
+            updateOne: jestGlobal.fn(async (filter, update) => {
+                calls.push({ filter, update });
+                if (throwOnUpdate) {
+                    throw new Error('mongo updateOne failed');
+                }
+                return { matchedCount, modifiedCount: matchedCount };
+            })
+        };
+    }
+
+    function strippedGroupContext(members) {
+        return {
+            resourceType: 'Group',
+            useExternalStorage: true,
+            groupMembers: members
+        };
+    }
+
+    describe('wasMemberStrippedForExternalStorage', () => {
+        test('true when external storage and not PATCH/smartMerge', () => {
+            expect(wasMemberStrippedForExternalStorage({ useExternalStorage: true })).toBe(true);
+        });
+
+        test.each([
+            ['no external storage', { useExternalStorage: false }],
+            ['null contextData', null],
+            ['PATCH already wrote events', { useExternalStorage: true, groupMemberEventsWritten: true }],
+            ['smartMerge $merge', { useExternalStorage: true, smartMerge: true }]
+        ])('false for %s', (_label, contextData) => {
+            expect(wasMemberStrippedForExternalStorage(contextData)).toBe(false);
+        });
+    });
+
+    describe('restoreStrippedMembersInMongo', () => {
+        test('writes serialized members back keyed by _uuid', async () => {
+            const collection = makeFakeCollection();
+            const members = [
+                { entity: { reference: 'Patient/1' } },
+                { entity: { reference: 'Patient/2' } }
+            ];
+
+            const result = await restoreStrippedMembersInMongo({
+                collection,
+                uuid: 'uuid-abc',
+                members
+            });
+
+            expect(result).toBe(true);
+            expect(collection.updateOne).toHaveBeenCalledTimes(1);
+            expect(collection.calls[0].filter).toEqual({ _uuid: 'uuid-abc' });
+            expect(collection.calls[0].update).toEqual({ $set: { member: members } });
+        });
+
+        test('serializes FHIR class instances via toJSONInternal', async () => {
+            const collection = makeFakeCollection();
+            const members = [
+                {
+                    entity: { reference: 'Patient/raw' },
+                    toJSONInternal() {
+                        return { entity: { reference: 'Patient/serialized' } };
+                    }
+                }
+            ];
+
+            await restoreStrippedMembersInMongo({ collection, uuid: 'u1', members });
+
+            expect(collection.calls[0].update).toEqual({
+                $set: { member: [{ entity: { reference: 'Patient/serialized' } }] }
+            });
+        });
+
+        test.each([
+            ['no members', []],
+            ['null members', null],
+            ['missing uuid (members present)', [{ entity: { reference: 'Patient/1' } }]]
+        ])('no-op and returns false for %s', async (label, members) => {
+            const collection = makeFakeCollection();
+            const uuid = label === 'missing uuid (members present)' ? null : 'u1';
+
+            const result = await restoreStrippedMembersInMongo({ collection, uuid, members });
+
+            expect(result).toBe(false);
+            expect(collection.updateOne).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('_compensateStrippedGroupMembersOnPostSaveFailure', () => {
+        // Invoke the private method on a bare object — it relies only on module-level loggers,
+        // not on instance state, so we avoid constructing the full executor (and its deps).
+        const compensate = MongoBulkWriteExecutor.prototype._compensateStrippedGroupMembersOnPostSaveFailure;
+
+        let postSaveError;
+        beforeEach(() => {
+            postSaveError = new Error('Simulated ClickHouse outage');
+        });
+
+        function makeEntry({ contextData, uuid = 'uuid-xyz', id = 'group-1' }) {
+            return { id, uuid, contextData };
+        }
+
+        test('restores members to MongoDB for a stripped Group create/PUT', async () => {
+            const collection = makeFakeCollection();
+            const members = [{ entity: { reference: 'Patient/1' } }];
+
+            await compensate.call({}, {
+                collection,
+                resourceType: 'Group',
+                bulkInsertUpdateEntry: makeEntry({ contextData: strippedGroupContext(members) }),
+                requestId: 'req-1',
+                postSaveError
+            });
+
+            expect(collection.updateOne).toHaveBeenCalledTimes(1);
+            expect(collection.calls[0].filter).toEqual({ _uuid: 'uuid-xyz' });
+            expect(collection.calls[0].update).toEqual({ $set: { member: members } });
+        });
+
+        test('no-op for non-Group resource', async () => {
+            const collection = makeFakeCollection();
+
+            await compensate.call({}, {
+                collection,
+                resourceType: 'Patient',
+                bulkInsertUpdateEntry: makeEntry({
+                    contextData: { useExternalStorage: true, groupMembers: [{ entity: { reference: 'Patient/1' } }] }
+                }),
+                requestId: 'req-1',
+                postSaveError
+            });
+
+            expect(collection.updateOne).not.toHaveBeenCalled();
+        });
+
+        test.each([
+            ['PATCH (groupMemberEventsWritten)', { resourceType: 'Group', useExternalStorage: true, groupMemberEventsWritten: true, groupMembers: [{ entity: { reference: 'Patient/1' } }] }],
+            ['smartMerge $merge', { resourceType: 'Group', useExternalStorage: true, smartMerge: true, groupMembers: [{ entity: { reference: 'Patient/1' } }] }],
+            ['no external storage', { resourceType: 'Group', useExternalStorage: false, groupMembers: [{ entity: { reference: 'Patient/1' } }] }]
+        ])('no-op for %s (members were not stripped from Mongo)', async (_label, contextData) => {
+            const collection = makeFakeCollection();
+
+            await compensate.call({}, {
+                collection,
+                resourceType: 'Group',
+                bulkInsertUpdateEntry: makeEntry({ contextData }),
+                requestId: 'req-1',
+                postSaveError
+            });
+
+            expect(collection.updateOne).not.toHaveBeenCalled();
+        });
+
+        test('no-op when no members were submitted (empty Group is consistent)', async () => {
+            const collection = makeFakeCollection();
+
+            await compensate.call({}, {
+                collection,
+                resourceType: 'Group',
+                bulkInsertUpdateEntry: makeEntry({ contextData: strippedGroupContext([]) }),
+                requestId: 'req-1',
+                postSaveError
+            });
+
+            expect(collection.updateOne).not.toHaveBeenCalled();
+        });
+
+        test('does NOT throw when the restore itself fails (original error must surface)', async () => {
+            const collection = makeFakeCollection({ throwOnUpdate: true });
+            const members = [{ entity: { reference: 'Patient/1' } }];
+
+            // The compensation must resolve (swallow its own secondary error). The caller is the
+            // one that re-throws postSaveError, so this method must never throw.
+            await expect(
+                compensate.call({}, {
+                    collection,
+                    resourceType: 'Group',
+                    bulkInsertUpdateEntry: makeEntry({ contextData: strippedGroupContext(members) }),
+                    requestId: 'req-1',
+                    postSaveError
+                })
+            ).resolves.toBeUndefined();
+
+            expect(collection.updateOne).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/src/tests/group/group_clickhouse_write_failure.test.js
+++ b/src/tests/group/group_clickhouse_write_failure.test.js
@@ -1,0 +1,202 @@
+const { describe, test, beforeAll, beforeEach, afterEach, afterAll, expect } = require('@jest/globals');
+const {
+    setupGroupTests,
+    teardownGroupTests,
+    cleanupAllData,
+    getSharedRequest,
+    getClickHouseManager,
+    getTestHeadersWithExternalStorage
+} = require('./groupTestSetup');
+const { GroupMemberRepository } = require('../../dataLayer/repositories/groupMemberRepository');
+
+/**
+ * EA-2322: Group dual-write split-brain on ClickHouse write failure.
+ *
+ * For a Group create/PUT/$merge with the useExternalStorage header, MongoDB is committed first
+ * with member[] stripped, then the member events are written to ClickHouse in the synchronous
+ * post-save handler. If that ClickHouse write fails, the previous behavior left MongoDB holding
+ * a committed Group with NO members and ClickHouse holding NO events: a silently-empty
+ * (orphaned) Group, with no compensation.
+ *
+ * These tests inject a ClickHouse write failure (by making the member repository's appendEvents
+ * throw) and assert a CONSISTENT outcome:
+ *   1. The API operation fails (non-2xx) so the client knows the write did not fully succeed, AND
+ *   2. The members the client submitted are NOT silently lost. The compensation restores the
+ *      original member[] back onto the committed MongoDB document.
+ *
+ * i.e. never a silently-empty Group.
+ */
+describe('Group ClickHouse write-failure consistency (EA-2322)', () => {
+    let appendEventsSpy;
+
+    beforeAll(async () => {
+        await setupGroupTests();
+    });
+
+    beforeEach(async () => {
+        await cleanupAllData();
+    });
+
+    afterEach(() => {
+        if (appendEventsSpy) {
+            appendEventsSpy.mockRestore();
+            appendEventsSpy = null;
+        }
+    });
+
+    afterAll(async () => {
+        await teardownGroupTests();
+    });
+
+    const defaultMeta = {
+        source: 'http://test-system.com/Group',
+        security: [
+            { system: 'https://www.icanbwell.com/owner', code: 'test-owner' },
+            { system: 'https://www.icanbwell.com/access', code: 'test-access' }
+        ]
+    };
+
+    /**
+     * Forces every ClickHouse member-event write to fail, simulating a ClickHouse outage /
+     * network partition during the post-save handler. The handler is constructed fresh per
+     * request via the factory, so spying on the prototype reliably intercepts the write.
+     */
+    function injectClickHouseWriteFailure() {
+        appendEventsSpy = jest
+            .spyOn(GroupMemberRepository.prototype, 'appendEvents')
+            .mockRejectedValue(new Error('Simulated ClickHouse outage (EA-2322 test)'));
+    }
+
+    /**
+     * Reads the raw stored MongoDB Group document directly by FHIR id (bypassing the read API,
+     * which would route member queries to ClickHouse). Lets us inspect exactly what was persisted.
+     */
+    async function readRawMongoGroupById(id) {
+        const { createTestContainer } = require('../createTestContainer');
+        const container = createTestContainer();
+        const db = container.mongoClient.db(container.configManager.mongoDbName);
+        return db.collection('Group_4_0_0').findOne({ id });
+    }
+
+    async function postGroup(group) {
+        const request = getSharedRequest();
+        return request
+            .post('/4_0_0/Group')
+            .send({ resourceType: 'Group', ...group, meta: group.meta || defaultMeta })
+            .set(getTestHeadersWithExternalStorage());
+    }
+
+    test('CREATE: ClickHouse write failure does not leave a silently-empty Group in MongoDB', async () => {
+        const clickHouseManager = getClickHouseManager();
+        const groupId = `ea2322-create-${Date.now()}`;
+        const submittedMembers = [
+            { entity: { reference: 'Patient/ea2322-a' } },
+            { entity: { reference: 'Patient/ea2322-b' } },
+            { entity: { reference: 'Patient/ea2322-c' } }
+        ];
+
+        injectClickHouseWriteFailure();
+
+        const response = await postGroup({
+            id: groupId,
+            type: 'person',
+            actual: true,
+            member: submittedMembers
+        });
+
+        // 1. The operation must NOT report success: the ClickHouse half of the dual write failed.
+        expect(response.status).toBeGreaterThanOrEqual(400);
+
+        // Confirm the failure was the injected ClickHouse error, not something incidental.
+        expect(appendEventsSpy).toHaveBeenCalled();
+
+        // 2. ClickHouse must have no events for this group (the write failed).
+        const events = await clickHouseManager.queryAsync({
+            query: `SELECT count() as count FROM fhir.Group_4_0_0_MemberEvents WHERE group_id = '${groupId}'`
+        });
+        expect(parseInt(events[0].count)).toBe(0);
+
+        // 3. The committed MongoDB document must NOT be a silently-empty Group.
+        //    Compensation restores the original members onto the Mongo document so no data is lost.
+        const stored = await readRawMongoGroupById(groupId);
+
+        expect(stored).toBeTruthy(); // a Group document exists for this id
+        expect(Array.isArray(stored.member)).toBe(true);
+        expect(stored.member).toHaveLength(submittedMembers.length);
+        const storedRefs = stored.member.map(m => m.entity.reference).sort();
+        expect(storedRefs).toEqual(
+            submittedMembers.map(m => m.entity.reference).sort()
+        );
+    });
+
+    test('PUT/UPDATE: ClickHouse write failure preserves submitted members in MongoDB', async () => {
+        const clickHouseManager = getClickHouseManager();
+        const request = getSharedRequest();
+        const groupId = `ea2322-put-${Date.now()}`;
+
+        // First create succeeds (no failure injected yet).
+        const createResponse = await postGroup({
+            id: groupId,
+            type: 'person',
+            actual: true,
+            member: [{ entity: { reference: 'Patient/ea2322-initial' } }]
+        });
+        expect(createResponse.status).toBe(201);
+
+        // Now inject failure and PUT a new membership.
+        injectClickHouseWriteFailure();
+
+        const putMembers = [
+            { entity: { reference: 'Patient/ea2322-put-1' } },
+            { entity: { reference: 'Patient/ea2322-put-2' } }
+        ];
+
+        const putResponse = await request
+            .put(`/4_0_0/Group/${groupId}`)
+            .send({
+                resourceType: 'Group',
+                id: groupId,
+                type: 'person',
+                actual: true,
+                meta: defaultMeta,
+                member: putMembers
+            })
+            .set(getTestHeadersWithExternalStorage());
+
+        // Operation must fail (ClickHouse half failed).
+        expect(putResponse.status).toBeGreaterThanOrEqual(400);
+        expect(appendEventsSpy).toHaveBeenCalled();
+
+        // The committed Mongo document must retain the submitted PUT members (no silent loss),
+        // and must NOT be a silently-empty Group.
+        const stored = await readRawMongoGroupById(groupId);
+
+        expect(stored).toBeTruthy();
+        expect(Array.isArray(stored.member)).toBe(true);
+        expect(stored.member.length).toBeGreaterThan(0);
+        const storedRefs = stored.member.map(m => m.entity.reference).sort();
+        expect(storedRefs).toEqual(putMembers.map(m => m.entity.reference).sort());
+
+        // ClickHouse holds no events from the failed write.
+        const events = await clickHouseManager.queryAsync({
+            query: `SELECT count() as count FROM fhir.Group_4_0_0_MemberEvents WHERE group_id = '${groupId}'`
+        });
+        expect(parseInt(events[0].count)).toBe(0);
+    });
+
+    test('CREATE with no members: ClickHouse failure is irrelevant (empty Group is consistent)', async () => {
+        // With no submitted members there is nothing to write to ClickHouse, so the post-save
+        // handler short-circuits before appendEvents. The create should succeed and the Group is
+        // legitimately empty (not a split-brain).
+        injectClickHouseWriteFailure();
+
+        const response = await postGroup({
+            type: 'person',
+            actual: true,
+            name: 'EA-2322 empty group'
+        });
+
+        expect(response.status).toBe(201);
+        expect(appendEventsSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/utils/clickHouseGroupPreSave.js
+++ b/src/utils/clickHouseGroupPreSave.js
@@ -55,12 +55,79 @@ function addExternalStorageTagIfNeeded(doc, contextData) {
  * @param {Object|null} contextData - Context data with flags
  */
 function stripMembersIfNeeded(doc, contextData) {
-    if (contextData?.useExternalStorage &&
-        !contextData?.groupMemberEventsWritten &&
-        !contextData?.smartMerge &&
+    if (wasMemberStrippedForExternalStorage(contextData) &&
         doc.resourceType === 'Group') {
         delete doc.member;
     }
+}
+
+/**
+ * Returns true when, for this write, Group.member was (or would be) stripped from the
+ * MongoDB document because ClickHouse is the authoritative store for membership.
+ *
+ * This is the exact precondition used by {@link stripMembersIfNeeded}. It is exported so the
+ * dual-write executor can recognise the split-brain case (members stripped from Mongo, but the
+ * ClickHouse member write failed) and run the inverse compensation. Keeping the predicate next
+ * to the strip keeps the two halves of the invariant in one place.
+ *
+ * Note: PATCH (groupMemberEventsWritten) and smartMerge $merge are excluded because those paths
+ * never strip members from Mongo, so there is nothing to lose if their ClickHouse write fails.
+ *
+ * @param {Object|null} contextData - Context data with flags
+ * @returns {boolean}
+ */
+function wasMemberStrippedForExternalStorage(contextData) {
+    return Boolean(
+        contextData?.useExternalStorage &&
+        !contextData?.groupMemberEventsWritten &&
+        !contextData?.smartMerge
+    );
+}
+
+/**
+ * Compensation for a failed ClickHouse member write on the Group dual-write path.
+ *
+ * Context: For a Group create/PUT with useExternalStorage, MongoDB is committed first with
+ * member[] stripped, then member events are written to ClickHouse in the post-save handler.
+ * If that ClickHouse write fails, MongoDB already holds a Group with no members and ClickHouse
+ * holds no events: a silently-empty (orphaned) Group. (EA-2322)
+ *
+ * This restores the original member array onto the just-committed MongoDB document so the
+ * submitted membership is not lost. The caller still surfaces the original error to the client
+ * (HTTP 500) so the operation is reported as failed and can be retried.
+ *
+ * Why restore-into-Mongo rather than delete/rollback the document:
+ * - It is uniformly safe for both CREATE and PUT. Deleting would be acceptable for a brand-new
+ *   CREATE, but for a PUT it would destroy a pre-existing Group (a worse outcome than the bug).
+ * - It never discards data the client already submitted and we already acknowledged to Mongo.
+ *
+ * Known limitation (flagged for human review): after compensation the Group has members inline
+ * in MongoDB while meta.tag still marks membership as ClickHouse-managed, so a member-scoped read
+ * sent with useExternalStorage will still route to the (empty) ClickHouse store. Compensation
+ * therefore prevents data loss, not read availability. Replaying the restored members back into
+ * ClickHouse (full reconciliation) is intentionally out of scope here to avoid building a saga.
+ *
+ * @param {Object} params
+ * @param {import('mongodb').Collection} params.collection - Open collection for the Group's resource table
+ * @param {string} params.uuid - _uuid of the committed document
+ * @param {Array<Object>} params.members - Original Group.member entries (FHIR class instances or plain objects)
+ * @returns {Promise<boolean>} true if a document was updated, false if there was nothing to restore
+ */
+async function restoreStrippedMembersInMongo({ collection, uuid, members }) {
+    if (!collection || !uuid || !Array.isArray(members) || members.length === 0) {
+        return false;
+    }
+
+    // Serialize to the internal JSON shape that MongoDB stores (members may be FHIR class
+    // instances captured in contextData before the strip).
+    const memberDocs = members.map(m => (typeof m?.toJSONInternal === 'function' ? m.toJSONInternal() : m));
+
+    const result = await collection.updateOne(
+        { _uuid: uuid },
+        { $set: { member: memberDocs } }
+    );
+
+    return Boolean(result?.matchedCount);
 }
 
 /**
@@ -84,6 +151,8 @@ module.exports = {
     handleClickHouseGroupPreSave,
     addExternalStorageTagIfNeeded,
     stripMembersIfNeeded,
+    wasMemberStrippedForExternalStorage,
+    restoreStrippedMembersInMongo,
     EXTERNAL_STORAGE_TAG_SYSTEM,
     EXTERNAL_STORAGE_TAG_CODE
 };


### PR DESCRIPTION
Adds compensation so a ClickHouse write failure can no longer leave a committed Group with silently-missing members (Mongo-first + strip, then CH). Includes a write-failure integration test and a compensation unit test. Draft pending adversarial review; CI runs the suite (local worktree testcontainer runs blocked by harness). Refs EA-2322.