### PR TITLE
EA-2323 Group ClickHouse hardening: idempotency, fail-closed tenancy, retry+jitter, surface read failures

### DIFF
--- a/docs/adr/0003-clickhouse-group-tenant-isolation-and-idempotency.md
+++ b/docs/adr/0003-clickhouse-group-tenant-isolation-and-idempotency.md
@@ -1,0 +1,125 @@
+# Tenant Isolation and Idempotency for the ClickHouse Group Membership Path
+
+## Status
+
+Accepted (revises the EA-2323 Group ClickHouse hardening after review)
+
+**Scope notes:**
+- This ADR covers two decisions on the Group membership dual-write/read path (Group metadata in MongoDB, member events in ClickHouse), both surfaced by review of the initial EA-2323 hardening (commit `1847597f`):
+  1. How tenant isolation is enforced on the ClickHouse Group reverse-lookup read (`GET /Group?member=...`), and specifically how a legitimate full-access (wildcard) admin is handled.
+  2. How the Group member event insert achieves idempotency across retries, and why the ClickHouse `insert_deduplication_token` mechanism is deliberately not used.
+- It does not change the MongoDB read/write paths, the FHIR contract, or the event schema. The ClickHouse schema (`clickhouse-init/01-init-schema.sql`) is unchanged.
+
+## Context
+
+The FHIR server stores `Group` resources with metadata in MongoDB and member add/remove events in ClickHouse (`fhir.Group_4_0_0_MemberEvents`, an append-only event log), with current state derived by `AggregatingMergeTree` materialized views that resolve to one logical row per member via `argMax` over the tuple `(event_time, event_id)`.
+
+The initial EA-2323 hardening added two protections that review found to be incorrect:
+
+### Problem 1 — the fail-closed tenant filter denied legitimate wildcard admins
+
+`QueryBuilder._buildActiveMemberHavingClause` injected a `1 = 0` deny clause whenever both the access-tag and owner-tag arrays were empty, on the theory that an empty-tag query is unscoped and would otherwise leak cross-tenant rows. The accompanying comment claimed a wildcard admin "arrives here as a non-empty array (e.g. `['*']`)".
+
+That claim is false. Tracing the platform security model:
+
+- `ScopesManager.getAccessCodesFromScopes` (`src/operations/security/scopesManager.js`) parses `access/<tag>.<action>` scopes into access codes. A wildcard admin scope `access/*.*` yields the access code `*`.
+- `SecurityTagManager.getSecurityTagsFromScope` (`src/operations/common/securityTagManager.js:55-73`) then: throws `ForbiddenError` (403) if there are no access codes and no patient scope; returns **empty** security tags if the codes include `*` (full access, so no tenant predicate is applied); otherwise returns the codes as tags.
+- In `SearchManager.constructQueryAsync` (`src/operations/search/searchManager.js:280`), a `meta.security` predicate is only appended when `securityTags.length > 0`. A wildcard admin therefore produces a query with **no** security predicate.
+
+So by the time a query reaches the ClickHouse provider, a legitimate `access/*.*` admin's query carries no tags — identical in tag-shape to a hypothetical unscoped caller. But a genuinely unscoped caller was already rejected with a 403 upstream and never reaches the provider. The `1 = 0` rule therefore force-denied exactly the admin it should have allowed, and inferred authorization from the absence of tags (which is not an authorization signal).
+
+The write path (`QueryFragments.whereAccessTags` / `whereOwnerTags`, `src/utils/clickHouse/queryFragments.js:208-260`) already establishes the correct convention: it **throws** on empty tags rather than silently omitting the filter.
+
+### Problem 2 — the dedup token is inert on this engine
+
+The insert in `GroupMemberRepository.appendEvents` set `insert_deduplicate: 1` and a content-derived `insert_deduplication_token`, and the comments presented that token as the mechanism that makes retries safe.
+
+`fhir.Group_4_0_0_MemberEvents` is a plain `MergeTree` (`clickhouse-init/01-init-schema.sql:53-54`), not a `Replicated*MergeTree`. ClickHouse honors `insert_deduplication_token` only for `Replicated*MergeTree` (synchronous inserts) or on the async path with `async_insert_deduplicate=1`. On a plain `MergeTree` the token is a no-op. Presenting it as the enforcement mechanism is a false guarantee: if a retry re-drives the block, the token does not prevent a second physical copy.
+
+The real, working idempotency was already implemented and does not depend on the token:
+- `GroupMemberEventBuilder._deriveEventId` derives `event_id` as `uuidv5(group_id | entity_reference | event_type | correlation_id)`, and `event_time` is deterministic (sourced from `meta.lastUpdated`). A retry of the same logical write produces byte-identical rows.
+- The `AggregatingMergeTree` current-state tables resolve state with `argMax` over `(event_time, event_id)`. Two identical physical rows collapse to one logical member state on read regardless of how many copies were inserted.
+
+## Decision
+
+### Decision 1 — Fail-closed, admin-exempt tenant filtering, matching SecurityTagManager
+
+The ClickHouse read path derives an authoritative `hasFullAccess` signal from the caller's **scope** (not from tag presence) and threads it into the query builder:
+
+- The two search entry points (`searchBundle`, `searchStreaming`) add the parsed `scope`/`user` to `extraInfo`.
+- `MongoWithClickHouseStorageProvider` receives an injected `ScopesManager` (via `StorageProviderFactory`) and computes `hasFullAccess` in `_callerHasFullAccess(extraInfo)` as `getAccessCodesFromScopes('read', user, scope).includes('*')` — the same wildcard contract `SecurityTagManager` uses.
+- `hasFullAccess` is passed to `QueryBuilder.buildFindGroupsByMemberQuery` / `buildCountGroupsByMemberQuery`, and `_buildActiveMemberHavingClause` applies:
+  - **Full/wildcard access** → apply **no** tenant predicate (the admin legitimately sees all).
+  - **Scoped** (non-empty access/owner tags) → apply the existing `hasAny(argMaxMerge(access_tags/owner_tags), ...)` filter.
+  - **Genuinely unscoped non-admin** (no tags and not full access) → throw `ForbiddenError` (403). This mirrors the write path (which throws on empty tags) and `SecurityTagManager`. Such callers are already 403'd upstream, so this branch is defense-in-depth.
+
+Throwing (rather than the previous silent `1 = 0`) is safe end-to-end: `ForbiddenError` carries `statusCode` 403, and `RethrownError` preserves a numeric `statusCode` and the `issue` array, so the find path (which wraps errors) still surfaces a 403 `OperationOutcome` rather than a 500 or a leak. Preferring a 403 over a silent empty result makes the denial observable instead of masquerading as "no matching groups."
+
+### Decision 2 — Content/version-derived idempotency; drop the inert dedup token
+
+`GroupMemberRepository.appendEvents` no longer sets `insert_deduplicate` / `insert_deduplication_token`. Idempotency rests entirely on the deterministic rows (`event_id` = uuidv5 of content/version + deterministic `event_time`) and `argMax` convergence on the `AggregatingMergeTree` current-state tables. The retry (bounded, jittered backoff) is unchanged and remains safe because a re-driven block is byte-identical. Code comments now describe the deterministic-row + `argMax` mechanism as the enforcement and explicitly note the token is inert on a plain `MergeTree`.
+
+The idempotency key remains the content/version-derived `event_id`, **not** an OpenTelemetry or request id. A per-request id would change on a client retry and defeat convergence; the content/version key is stable across retries, which is the property idempotency requires.
+
+## Consequences
+
+### Positive
+
+1. Legitimate wildcard admins can perform Group member reverse-lookups again (the regression is fixed) without weakening tenant isolation for scoped callers.
+2. Authorization is derived from the authoritative source (parsed scope via `ScopesManager`), not inferred from whether a query happened to carry tag predicates.
+3. A genuinely unscoped caller reaching the builder gets a clear 403 `OperationOutcome`, consistent with the write path and the rest of the platform, instead of a silent empty set.
+4. Idempotency documentation now matches reality; nobody will later "rely on" a no-op token. Correctness rests on the deterministic rows, which already existed and are engine-independent.
+5. Smaller, honest surface: the insert carries only the settings that actually do something (`async_insert`, `wait_for_async_insert`).
+
+### Negative
+
+1. `MongoWithClickHouseStorageProvider` now depends on `ScopesManager`, a light coupling of a storage provider to a security service. Accepted because this provider already makes the tenant-filtering decision and needs an authoritative scope interpreter; injecting one shared interpreter is cleaner than duplicating scope parsing.
+2. `scope`/`user` now flow through `extraInfo` on the search path. This is inert for the MongoDB providers (they ignore it) and only consumed by the ClickHouse provider.
+3. If the events table is ever migrated to `Replicated*MergeTree`, engine-level dedup becomes available; a future change could add it as a second layer, but the deterministic-row mechanism remains the primary guarantee.
+
+### Mitigations
+
+- The `ScopesManager` dependency is optional in the provider/factory constructors (`scopesManager || null`); when absent, `_callerHasFullAccess` returns `false`, preserving fail-closed behavior.
+- Unit tests cover: full-access caller not denied (predicate omitted), scoped caller filtered, unscoped non-admin denied with 403, the provider's scope-derived signal, and that the insert does not set the inert dedup settings while retried blocks remain byte-identical.
+
+## Options Considered
+
+### Decision 1 options
+
+**Option 1A — Keep `1 = 0` on empty tags (rejected, the prior design).** Force-denies legitimate wildcard admins and infers authorization from tag absence. Rejected: it is a correctness regression and conflates "no tenant predicate needed" with "no access."
+
+**Option 1B — Compute `hasFullAccess` upstream in the search entry points and thread the boolean down (rejected).** `searchBundle`/`searchStreaming` do not hold a `ScopesManager`, so this required injecting one into both plus threading a new field through `getCursorForQueryAsync` and the mongo path — a wide change to the hot MongoDB search path for a ClickHouse-only concern. Rejected in favor of deriving the signal where it is used.
+
+**Option 1C — Inject `ScopesManager` into the ClickHouse provider and derive `hasFullAccess` there from scope (selected).** One shared authoritative interpreter, minimal blast radius (two `extraInfo` sites, the factory, the provider, the builder), and no behavior change to the MongoDB path.
+
+### Decision 2 options
+
+**Option 2A — Keep `insert_deduplication_token` (rejected).** Inert on a plain `MergeTree`; presents a false guarantee. Rejected.
+
+**Option 2B — Switch the idempotency key to an OTel/request id (rejected).** Per-request ids change on retry and defeat `argMax` convergence. Rejected: idempotency requires a key stable across retries.
+
+**Option 2C — Migrate the table to `Replicated*MergeTree` to make the token work (out of scope).** A larger infrastructure change than the defect warrants; the deterministic-row mechanism already provides idempotency on the current engine. Can be revisited if replication is adopted for other reasons.
+
+**Option 2D — Drop the inert token; rely on deterministic rows + `argMax` (selected).** Removes the false guarantee, keeps the real (engine-independent) mechanism, and corrects the comments.
+
+## References
+
+- `src/operations/common/securityTagManager.js:55-73` — wildcard admin → empty tags; no access → 403.
+- `src/operations/security/scopesManager.js:49-77,140-143` — scope → access codes, `*` = full access.
+- `src/operations/search/searchManager.js:280` — security predicate only added when tags are non-empty.
+- `src/utils/clickHouse/queryFragments.js:208-260` — write path throws on empty tags (the convention this read path now matches).
+- `clickhouse-init/01-init-schema.sql:53-54` — events table is a plain (non-Replicated) `MergeTree`.
+- `src/dataLayer/builders/groupMemberEventBuilder.js` — deterministic `event_id` (uuidv5) and `event_time`.
+- ClickHouse docs: `insert_deduplication_token` is honored by `Replicated*MergeTree` (sync) or async inserts with `async_insert_deduplicate=1`; it is a no-op on a plain `MergeTree`.
+- CLAUDE.md / AGENTS.md (icanbwell): tenant isolation is mandatory on every query path; idempotency by default for retry-capable operations.
+
+## Related Decisions
+
+- ADR 0001 (schema registry pattern for ClickHouse-only resources) and ADR 0002 (observability emission pattern) are adjacent ClickHouse/observability decisions in this repo.
+- EA-2323 (Jira): the Group ClickHouse hardening this ADR revises.
+
+---
+
+**Date**: 2026-07-01
+**Authors**: Bill Field
+**Status**: Accepted

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -411,7 +411,8 @@ const createContainer = function () {
             databaseAttachmentManager: c.databaseAttachmentManager,
             configManager: c.configManager,
             genericClickHouseRepository: c.genericClickHouseRepository,
-            schemaRegistry: c.clickHouseSchemaRegistry
+            schemaRegistry: c.clickHouseSchemaRegistry,
+            scopesManager: c.scopesManager
         });
     });
 

--- a/src/dataLayer/builders/groupMemberEventBuilder.js
+++ b/src/dataLayer/builders/groupMemberEventBuilder.js
@@ -2,7 +2,7 @@ const { EVENT_TYPES } = require('../../constants/clickHouseConstants');
 const { FhirReferenceParser } = require('../../utils/fhir/referenceParser');
 const { SecurityTagExtractor } = require('../../utils/fhir/securityTagExtractor');
 const { logWarn, logError } = require('../../operations/common/logging');
-const { v4: uuidv4 } = require('uuid');
+const { generateUUIDv5 } = require('../../utils/uid.util');
 
 /**
  * Builder class for constructing Group member event objects
@@ -57,6 +57,30 @@ class GroupMemberEventBuilder {
     }
 
     /**
+     * Derives a stable, deterministic event_id for idempotent retries.
+     *
+     * The Group member events table is an append-only MergeTree. A client that
+     * retries a failed write (e.g. after a 500 from a transient ClickHouse
+     * outage) must not create duplicate rows. By deriving event_id as a uuidv5
+     * of (group_id | entity_reference | event_type | correlation_id), a retry
+     * of the SAME logical operation produces the SAME event_id. Combined with a
+     * deterministic event_time (see the handler, which sources it from
+     * meta.lastUpdated) the full row — and thus the MergeTree ORDER BY key —
+     * is identical on retry, so argMax aggregation converges to one logical
+     * member state instead of diverging across duplicate rows.
+     *
+     * @param {string} groupId
+     * @param {string} entityReference
+     * @param {string} eventType
+     * @param {string} correlationId - Stable identifier for the logical operation
+     * @returns {string} Deterministic UUID
+     * @private
+     */
+    static _deriveEventId(groupId, entityReference, eventType, correlationId) {
+        return generateUUIDv5(`${groupId}|${entityReference}|${eventType}|${correlationId}`);
+    }
+
+    /**
      * Creates an event object with all required fields
      * Returns events with ISO timestamps (domain format).
      * Repository layer handles database-specific format conversions.
@@ -71,7 +95,8 @@ class GroupMemberEventBuilder {
         groupSourceId,
         groupSourceAuthority,
         accessTags,
-        ownerTags
+        ownerTags,
+        correlationId
     }) {
         const sourceAssigningAuthority = this._extractSourceAssigningAuthority(
             ownerTags,
@@ -97,8 +122,13 @@ class GroupMemberEventBuilder {
             );
         }
 
+        // Stable correlation id for the logical operation. Falls back to the
+        // entity reference so a missing correlation still yields a deterministic
+        // (though per-reference-only) id rather than a random one.
+        const effectiveCorrelationId = correlationId || `${groupId}|${entityReference}`;
+
         return {
-            event_id: uuidv4(),
+            event_id: this._deriveEventId(groupId, entityReference, eventType, effectiveCorrelationId),
             group_id: groupId,
             entity_reference: entityReference,
             entity_reference_uuid: entityReferenceUuid,
@@ -109,6 +139,7 @@ class GroupMemberEventBuilder {
             period_start: member?.period?.start || null,
             period_end: member?.period?.end || null,
             inactive: member?.inactive ? 1 : 0,
+            correlation_id: effectiveCorrelationId,
             group_source_id: groupSourceId,
             group_source_assigning_authority: groupSourceAuthority,
             access_tags: accessTags,
@@ -127,6 +158,7 @@ class GroupMemberEventBuilder {
      * @param {Object} [params.member] - FHIR Group.member object (optional, for period/inactive)
      * @param {Object} params.groupResource - Full Group resource for metadata extraction
      * @param {string} [params.eventTime] - ISO timestamp (defaults to now)
+     * @param {string} [params.correlationId] - Stable id for the logical operation (enables idempotent retries)
      *
      * @returns {Object} Event object ready for insertion
      *
@@ -143,7 +175,7 @@ class GroupMemberEventBuilder {
      *   groupResource: { id: '...', meta: { security: [...] }, ... }
      * });
      */
-    static buildEvent({ groupId, entityReference, eventType, member, groupResource, eventTime }) {
+    static buildEvent({ groupId, entityReference, eventType, member, groupResource, eventTime, correlationId }) {
         const timestamp = eventTime || new Date().toISOString();
 
         return this._createEventObject({
@@ -155,7 +187,8 @@ class GroupMemberEventBuilder {
             groupSourceId: groupResource._sourceId || '',
             groupSourceAuthority: groupResource._sourceAssigningAuthority || '',
             accessTags: SecurityTagExtractor.extractAccessTags(groupResource),
-            ownerTags: SecurityTagExtractor.extractOwnerTags(groupResource)
+            ownerTags: SecurityTagExtractor.extractOwnerTags(groupResource),
+            correlationId
         });
     }
 
@@ -185,7 +218,7 @@ class GroupMemberEventBuilder {
      *   groupResource: groupDoc
      * });
      */
-    static buildEvents({ groupId, members, eventType, groupResource, eventTime }) {
+    static buildEvents({ groupId, members, eventType, groupResource, eventTime, correlationId }) {
         if (!members || members.length === 0) {
             return [];
         }
@@ -209,7 +242,8 @@ class GroupMemberEventBuilder {
                 groupSourceId,
                 groupSourceAuthority,
                 accessTags,
-                ownerTags
+                ownerTags,
+                correlationId
             });
         });
     }
@@ -225,13 +259,14 @@ class GroupMemberEventBuilder {
      *
      * @returns {Array<Object>} Array of "added" events
      */
-    static buildAddedEvents({ groupId, members, groupResource, eventTime }) {
+    static buildAddedEvents({ groupId, members, groupResource, eventTime, correlationId }) {
         return this.buildEvents({
             groupId,
             members,
             eventType: EVENT_TYPES.MEMBER_ADDED,
             groupResource,
-            eventTime
+            eventTime,
+            correlationId
         });
     }
 
@@ -246,13 +281,14 @@ class GroupMemberEventBuilder {
      *
      * @returns {Array<Object>} Array of "removed" events
      */
-    static buildRemovedEvents({ groupId, members, groupResource, eventTime }) {
+    static buildRemovedEvents({ groupId, members, groupResource, eventTime, correlationId }) {
         return this.buildEvents({
             groupId,
             members,
             eventType: EVENT_TYPES.MEMBER_REMOVED,
             groupResource,
-            eventTime
+            eventTime,
+            correlationId
         });
     }
 
@@ -279,7 +315,7 @@ class GroupMemberEventBuilder {
      * });
      * // Returns: { addedEvents: [Patient/2], removedEvents: [Patient/1], totalEvents: 2 }
      */
-    static buildDiffEvents({ groupId, oldMembers, newMembers, groupResource, eventTime }) {
+    static buildDiffEvents({ groupId, oldMembers, newMembers, groupResource, eventTime, correlationId }) {
         const timestamp = eventTime || new Date().toISOString();
 
         // Create sets of references for efficient lookup
@@ -304,14 +340,16 @@ class GroupMemberEventBuilder {
             groupId,
             members: addedMembers,
             groupResource,
-            eventTime: timestamp
+            eventTime: timestamp,
+            correlationId
         });
 
         const removedEvents = this.buildRemovedEvents({
             groupId,
             members: removedMembers,
             groupResource,
-            eventTime: timestamp
+            eventTime: timestamp,
+            correlationId
         });
 
         return {

--- a/src/dataLayer/postSaveHandlers/clickHouseGroupHandler.js
+++ b/src/dataLayer/postSaveHandlers/clickHouseGroupHandler.js
@@ -56,6 +56,33 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
     }
 
     /**
+     * Derives the idempotency context for a Group write.
+     *
+     * Retries must produce identical event rows so the append-only log
+     * converges instead of accumulating duplicates. Both values are sourced
+     * from the already-committed MongoDB document, so a genuine retry of the
+     * same operation carries the same values:
+     *  - correlationId: stable per (group, resource version). Prefer an
+     *    explicit contextData.correlationId if the caller supplied one.
+     *  - eventTime: meta.lastUpdated, the single authoritative operation
+     *    timestamp (deterministic on retry, unlike Date.now()).
+     *
+     * @param {Object} doc - Committed FHIR Group resource
+     * @param {Object|null} contextData
+     * @returns {{ correlationId: string, eventTime: string|undefined }}
+     * @private
+     */
+    _deriveIdempotencyContext(doc, contextData) {
+        const versionId = doc?.meta?.versionId || '';
+        const correlationId =
+            contextData?.correlationId || `${doc?.id || ''}|${versionId}`;
+        // meta.lastUpdated is set once at MongoDB commit; reuse it as the event
+        // time so retries share the same DateTime and thus the same MergeTree key.
+        const eventTime = doc?.meta?.lastUpdated || undefined;
+        return { correlationId, eventTime };
+    }
+
+    /**
      * Checks if handler should process this resource
      * @param {string} resourceType
      * @return {boolean}
@@ -117,6 +144,10 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
             // contextData is threaded through BulkInsertUpdateEntry pipeline
             const originalMembers = contextData?.groupMembers || [];
 
+            // Idempotency context: stable correlation id + deterministic event
+            // time so a retried write produces identical, self-deduplicating rows.
+            const idempotency = this._deriveIdempotencyContext(doc, contextData);
+
             logDebug('POST-save: Processing Group', {
                 groupId: doc.id,
                 eventType,
@@ -159,7 +190,8 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
                 await this._writeMemberEventsIfNeeded(
                     originalMembers,
                     EVENT_TYPES.MEMBER_ADDED,
-                    docWithMembers
+                    docWithMembers,
+                    idempotency
                 );
 
                 logInfo('ClickHouse CREATE events written', {
@@ -182,7 +214,7 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
                 const docWithMembers = { ...doc, member: originalMembers };
 
                 // Always await - Groups require synchronous writes
-                await this._handleUpdateAsync(docWithMembers, { smartMerge: contextData?.smartMerge });
+                await this._handleUpdateAsync(docWithMembers, { smartMerge: contextData?.smartMerge, idempotency });
 
                 logInfo('ClickHouse UPDATE events written', {
                     groupId: doc.id
@@ -248,15 +280,16 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
      * @param {Array<Object>} members - Array of FHIR Group.member objects
      * @param {string} eventType - EVENT_TYPES.MEMBER_ADDED or MEMBER_REMOVED
      * @param {Object} groupResource - FHIR Group resource
+     * @param {{correlationId: string, eventTime: string|undefined}} [idempotency] - Idempotency context
      * @returns {Promise<void>}
      * @private
      */
-    async _writeMemberEventsIfNeeded(members, eventType, groupResource) {
+    async _writeMemberEventsIfNeeded(members, eventType, groupResource, idempotency = {}) {
         if (!members || members.length === 0) {
             return;
         }
 
-        return this._appendMemberEventsAsync(groupResource, eventType, members);
+        return this._appendMemberEventsAsync(groupResource, eventType, members, idempotency);
     }
 
     /**
@@ -267,10 +300,11 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
      * @param {Array<Object>} params.additions - Members to add
      * @param {Array<Object>} params.removals - Members to remove
      * @param {Object} params.groupResource - FHIR Group resource
+     * @param {{correlationId: string, eventTime: string|undefined}} [params.idempotency] - Idempotency context
      * @returns {Promise<void>}
      * @private
      */
-    async _writeCombinedEventsAsync({ groupId, additions, removals, groupResource }) {
+    async _writeCombinedEventsAsync({ groupId, additions, removals, groupResource, idempotency = {} }) {
         const allEvents = [];
 
         if (additions.length > 0) {
@@ -278,7 +312,9 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
                 groupId,
                 members: additions,
                 eventType: EVENT_TYPES.MEMBER_ADDED,
-                groupResource
+                groupResource,
+                eventTime: idempotency.eventTime,
+                correlationId: idempotency.correlationId
             });
             allEvents.push(...addEvents);
         }
@@ -288,13 +324,15 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
                 groupId,
                 members: removals,
                 eventType: EVENT_TYPES.MEMBER_REMOVED,
-                groupResource
+                groupResource,
+                eventTime: idempotency.eventTime,
+                correlationId: idempotency.correlationId
             });
             allEvents.push(...removeEvents);
         }
 
         if (allEvents.length > 0) {
-            await this.repository.appendEvents(allEvents);
+            await this.repository.appendEvents(allEvents, { correlationId: idempotency.correlationId });
         }
     }
 
@@ -305,10 +343,11 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
      * @param {Object} groupResource - FHIR Group resource
      * @param {string} eventType - EVENT_TYPES.MEMBER_ADDED or MEMBER_REMOVED
      * @param {Array<Object>} members - Array of FHIR Group.member objects
+     * @param {{correlationId: string, eventTime: string|undefined}} [idempotency] - Idempotency context
      * @returns {Promise<void>}
      * @private
      */
-    async _appendMemberEventsAsync(groupResource, eventType, members) {
+    async _appendMemberEventsAsync(groupResource, eventType, members, idempotency = {}) {
         try {
             // Use GroupMemberEventBuilder to construct events
             const eventBuildStart = Date.now();
@@ -316,13 +355,15 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
                 groupId: groupResource.id,
                 members,
                 eventType,
-                groupResource
+                groupResource,
+                eventTime: idempotency.eventTime,
+                correlationId: idempotency.correlationId
             });
             const eventBuildTime = Date.now() - eventBuildStart;
 
             // Pure INSERT - no read operation
             const insertStart = Date.now();
-            await this.repository.appendEvents(events);
+            await this.repository.appendEvents(events, { correlationId: idempotency.correlationId });
             const insertTime = Date.now() - insertStart;
 
             logInfo('Appended member events to ClickHouse', {
@@ -364,7 +405,7 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
      * @returns {Promise<{added: number, removed: number, finalCount: number}>} Member change statistics
      * @private
      */
-    async _handleUpdateAsync(groupResource, { smartMerge } = {}) {
+    async _handleUpdateAsync(groupResource, { smartMerge, idempotency = {} } = {}) {
         try {
             // Get current members from repository
             const currentReferences = await this._getCurrentMembers(groupResource.id);
@@ -403,7 +444,8 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
                 groupId: groupResource.id,
                 additions,
                 removals,
-                groupResource
+                groupResource,
+                idempotency
             });
 
             logInfo('Processed Group update', {
@@ -439,10 +481,11 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
      * @param {Array<Object>} params.added - Members to add
      * @param {Array<Object>} params.removed - Members to remove
      * @param {Object} params.groupResource - Full Group resource (required for security tags)
+     * @param {string} [params.correlationId] - Stable id for the logical PATCH operation (enables idempotent retries)
      * @returns {Promise<void>}
      * @public
      */
-    async writeEventsAsync({ groupId, added = [], removed = [], groupResource }) {
+    async writeEventsAsync({ groupId, added = [], removed = [], groupResource, correlationId }) {
         const startTime = Date.now();
         const totalEvents = added.length + removed.length;
 
@@ -465,12 +508,16 @@ class ClickHouseGroupHandler extends BasePostSaveHandler {
                     throw new Error(`groupResource is required for writeEventsAsync (groupId: ${groupId})`);
                 }
 
+                // Derive idempotency context so a retried PATCH re-drives identical rows.
+                const idempotency = this._deriveIdempotencyContext(groupResource, { correlationId });
+
                 // Write combined events in single INSERT
                 await this._writeCombinedEventsAsync({
                     groupId,
                     additions: added,
                     removals: removed,
-                    groupResource
+                    groupResource,
+                    idempotency
                 });
 
                 const duration = Date.now() - startTime;

--- a/src/dataLayer/providers/mongoWithClickHouse/queryBuilder.js
+++ b/src/dataLayer/providers/mongoWithClickHouse/queryBuilder.js
@@ -1,4 +1,5 @@
 const { TABLES, EVENT_TYPES } = require('../../../constants/clickHouseConstants');
+const { ForbiddenError } = require('../../../utils/httpErrors');
 
 /**
  * Query builder for ClickHouse Group member queries
@@ -22,6 +23,9 @@ class QueryBuilder {
      * @param {string} [params.memberReferenceSourceId] - Source ID reference (e.g., "Patient/123")
      * @param {string[]} params.accessTags - Access security tags for filtering
      * @param {string[]} params.ownerTags - Owner security tags for filtering
+     * @param {boolean} [params.hasFullAccess] - True when the caller holds a wildcard
+     *   (access/*.*) scope and legitimately sees every tenant. When true, no tenant
+     *   predicate is applied. See _buildActiveMemberHavingClause.
      * @param {number} params.limit - Page size
      * @param {string|null} params.afterGroupId - Seek cursor (group_id to start after)
      * @param {number} params.skip - Offset for numeric pagination (fallback)
@@ -32,6 +36,7 @@ class QueryBuilder {
         memberReferenceSourceId,
         accessTags = [],
         ownerTags = [],
+        hasFullAccess = false,
         limit,
         afterGroupId = null,
         skip = 0
@@ -45,7 +50,7 @@ class QueryBuilder {
         // background merges + argMaxMerge instead of FINAL, or add a lighter
         // deduplicating read path. No behavior change intended here.
         const havingClause = this._buildActiveMemberHavingClause(
-            accessTags, ownerTags, memberReferenceUuid, memberReferenceSourceId
+            accessTags, ownerTags, memberReferenceUuid, memberReferenceSourceId, hasFullAccess
         );
 
         let query;
@@ -102,16 +107,20 @@ class QueryBuilder {
      * @param {string} [params.memberReferenceSourceId] - Source ID reference
      * @param {string[]} params.accessTags - Access security tags for filtering
      * @param {string[]} params.ownerTags - Owner security tags for filtering
+     * @param {boolean} [params.hasFullAccess] - True when the caller holds a wildcard
+     *   (access/*.*) scope and legitimately sees every tenant. When true, no tenant
+     *   predicate is applied. See _buildActiveMemberHavingClause.
      * @returns {{query: string, query_params: Object}}
      */
     static buildCountGroupsByMemberQuery({
         memberReferenceUuid,
         memberReferenceSourceId,
         accessTags = [],
-        ownerTags = []
+        ownerTags = [],
+        hasFullAccess = false
     }) {
         const havingClause = this._buildActiveMemberHavingClause(
-            accessTags, ownerTags, memberReferenceUuid, memberReferenceSourceId
+            accessTags, ownerTags, memberReferenceUuid, memberReferenceSourceId, hasFullAccess
         );
 
         const query = `
@@ -216,23 +225,38 @@ class QueryBuilder {
      * entity_reference_uuid and entity_reference_source_id are AggregateFunction columns,
      * so they must be filtered via argMaxMerge() in HAVING, not WHERE.
      *
-     * FAIL-CLOSED tenant isolation: if BOTH access and owner tags are absent,
-     * the query is unscoped and would otherwise return rows across every tenant.
-     * The write path (QueryFragments.whereAccessTags / whereOwnerTags) throws in
-     * this case; the read path historically just omitted the filter, leaking
-     * cross-tenant results for an empty-tag query. We instead inject a deny
-     * clause ("1 = 0") so an unscoped read returns zero rows. A legitimately
-     * scoped admin caller carries the wildcard access code, which arrives here
-     * as a non-empty array (e.g. ['*']) and is therefore NOT blocked.
+     * TENANT ISOLATION (fail-closed, admin-exempt) — mirrors SecurityTagManager:
+     * The caller's authorization is decided upstream by SecurityTagManager /
+     * ScopesManager, not inferred here from whether tags happen to be present:
+     *   - A wildcard admin (access/*.*) resolves to EMPTY security tags with
+     *     hasFullAccess=true (full access => no tenant predicate). We must NOT
+     *     block them; the previous "empty tags => 1 = 0" logic wrongly denied
+     *     this legitimate admin, and its claim that a wildcard admin "arrives as
+     *     ['*']" was false.
+     *   - A scoped caller carries a non-empty access/owner tag set; we apply the
+     *     tag filter (existing behavior).
+     *   - A genuinely unscoped non-admin (no tags AND not full access) is a
+     *     security error. A caller with no access scope is already rejected with
+     *     403 by ScopesManager.getSecurityTagsFromScope before the query is
+     *     built, so this branch is defense-in-depth. We throw ForbiddenError to
+     *     match the write path (QueryFragments.whereAccessTags/whereOwnerTags,
+     *     which throw on empty tags) rather than silently returning rows across
+     *     every tenant. ForbiddenError carries statusCode 403, which is
+     *     preserved through RethrownError, so the caller sees a 403
+     *     OperationOutcome rather than a leak or a 500.
      *
      * @param {string[]} accessTags - Access security tags
      * @param {string[]} ownerTags - Owner security tags
      * @param {string} [memberReferenceUuid] - UUID reference to match
      * @param {string} [memberReferenceSourceId] - Source ID reference to match
+     * @param {boolean} [hasFullAccess] - True when the caller holds a wildcard scope
      * @returns {string} HAVING clause (without "HAVING" keyword)
+     * @throws {ForbiddenError} When the caller is neither scoped nor full-access
      * @private
      */
-    static _buildActiveMemberHavingClause(accessTags, ownerTags, memberReferenceUuid, memberReferenceSourceId) {
+    static _buildActiveMemberHavingClause(
+        accessTags, ownerTags, memberReferenceUuid, memberReferenceSourceId, hasFullAccess = false
+    ) {
         const clauses = [
             `argMaxMerge(event_type) = '${EVENT_TYPES.MEMBER_ADDED}'`,
             `argMaxMerge(inactive) = 0`
@@ -249,13 +273,22 @@ class QueryBuilder {
         const hasAccessTags = Array.isArray(accessTags) && accessTags.length > 0;
         const hasOwnerTags = Array.isArray(ownerTags) && ownerTags.length > 0;
 
-        // Fail closed: no security scope at all => deny (return no rows) rather
-        // than silently returning cross-tenant data.
-        if (!hasAccessTags && !hasOwnerTags) {
-            clauses.push('1 = 0');
+        // Full/wildcard access: legitimately sees every tenant => no tenant predicate.
+        if (hasFullAccess) {
             return clauses.join(' AND ');
         }
 
+        // Genuinely unscoped (no tags and not full access): deny with a 403 rather
+        // than leaking cross-tenant rows. Matches the write path, which throws on
+        // empty tags.
+        if (!hasAccessTags && !hasOwnerTags) {
+            throw new ForbiddenError(
+                'Cannot query Group members without an access scope: the caller has ' +
+                'neither security tags nor full access. Denying to prevent cross-tenant access.'
+            );
+        }
+
+        // Scoped caller: filter on the tags they carry.
         // Security tags are AggregateFunction columns, must filter in HAVING after argMaxMerge
         if (hasAccessTags) {
             clauses.push(`hasAny(argMaxMerge(access_tags), {accessTags:Array(String)})`);

--- a/src/dataLayer/providers/mongoWithClickHouse/queryBuilder.js
+++ b/src/dataLayer/providers/mongoWithClickHouse/queryBuilder.js
@@ -36,6 +36,14 @@ class QueryBuilder {
         afterGroupId = null,
         skip = 0
     }) {
+        // WATCH ITEM (read cost at scale): this reverse-lookup uses the FINAL
+        // modifier on Group_4_0_0_MemberCurrentByEntity to force merge-on-read for
+        // read-after-write consistency. FINAL merges all parts touching the matched
+        // rows at query time; for a member that belongs to a very large number of
+        // groups (or under heavy insert pressure with many unmerged parts) this can
+        // become expensive. If reverse-lookup latency regresses, revisit: rely on
+        // background merges + argMaxMerge instead of FINAL, or add a lighter
+        // deduplicating read path. No behavior change intended here.
         const havingClause = this._buildActiveMemberHavingClause(
             accessTags, ownerTags, memberReferenceUuid, memberReferenceSourceId
         );
@@ -208,6 +216,15 @@ class QueryBuilder {
      * entity_reference_uuid and entity_reference_source_id are AggregateFunction columns,
      * so they must be filtered via argMaxMerge() in HAVING, not WHERE.
      *
+     * FAIL-CLOSED tenant isolation: if BOTH access and owner tags are absent,
+     * the query is unscoped and would otherwise return rows across every tenant.
+     * The write path (QueryFragments.whereAccessTags / whereOwnerTags) throws in
+     * this case; the read path historically just omitted the filter, leaking
+     * cross-tenant results for an empty-tag query. We instead inject a deny
+     * clause ("1 = 0") so an unscoped read returns zero rows. A legitimately
+     * scoped admin caller carries the wildcard access code, which arrives here
+     * as a non-empty array (e.g. ['*']) and is therefore NOT blocked.
+     *
      * @param {string[]} accessTags - Access security tags
      * @param {string[]} ownerTags - Owner security tags
      * @param {string} [memberReferenceUuid] - UUID reference to match
@@ -229,11 +246,21 @@ class QueryBuilder {
             clauses.push(`argMaxMerge(entity_reference_source_id) = {memberReferenceSourceId:String}`);
         }
 
+        const hasAccessTags = Array.isArray(accessTags) && accessTags.length > 0;
+        const hasOwnerTags = Array.isArray(ownerTags) && ownerTags.length > 0;
+
+        // Fail closed: no security scope at all => deny (return no rows) rather
+        // than silently returning cross-tenant data.
+        if (!hasAccessTags && !hasOwnerTags) {
+            clauses.push('1 = 0');
+            return clauses.join(' AND ');
+        }
+
         // Security tags are AggregateFunction columns, must filter in HAVING after argMaxMerge
-        if (accessTags.length > 0) {
+        if (hasAccessTags) {
             clauses.push(`hasAny(argMaxMerge(access_tags), {accessTags:Array(String)})`);
         }
-        if (ownerTags.length > 0) {
+        if (hasOwnerTags) {
             clauses.push(`hasAny(argMaxMerge(owner_tags), {ownerTags:Array(String)})`);
         }
 

--- a/src/dataLayer/providers/mongoWithClickHouseStorageProvider.js
+++ b/src/dataLayer/providers/mongoWithClickHouseStorageProvider.js
@@ -34,18 +34,45 @@ class MongoWithClickHouseStorageProvider extends StorageProvider {
      * @param {import('../../utils/clickHouseClientManager').ClickHouseClientManager} params.clickHouseClientManager
      * @param {import('./mongoStorageProvider').MongoStorageProvider} params.mongoStorageProvider
      * @param {import('../../utils/configManager').ConfigManager} params.configManager
+     * @param {import('../../operations/security/scopesManager').ScopesManager} [params.scopesManager]
      */
     constructor({
         resourceLocator,
         clickHouseClientManager,
         mongoStorageProvider,
-        configManager
+        configManager,
+        scopesManager
     }) {
         super();
         this.resourceLocator = resourceLocator;
         this.clickHouseClientManager = clickHouseClientManager;
         this.mongoStorageProvider = mongoStorageProvider;
         this.configManager = configManager;
+        this.scopesManager = scopesManager || null;
+    }
+
+    /**
+     * Determines whether the caller has full (wildcard) access from their scope.
+     *
+     * This is the authoritative signal used to decide tenant filtering on the
+     * ClickHouse read path, and mirrors SecurityTagManager.getSecurityTagsFromScope:
+     * a wildcard admin (access/*.*) resolves to a '*' access code (and empty
+     * security tags), meaning "sees everything / no tenant predicate". We derive
+     * it from the parsed scope via ScopesManager rather than inferring authorization
+     * from whether the built query happened to contain tag predicates (a wildcard
+     * admin's query legitimately contains none).
+     *
+     * @param {Object} [extraInfo] - Carries the caller's scope (extraInfo.scope)
+     * @returns {boolean} True if the caller holds a wildcard access scope
+     * @private
+     */
+    _callerHasFullAccess(extraInfo) {
+        const scope = extraInfo?.scope;
+        if (!scope || !this.scopesManager) {
+            return false;
+        }
+        const accessCodes = this.scopesManager.getAccessCodesFromScopes('read', extraInfo?.user || '', scope);
+        return accessCodes.includes('*');
     }
 
     /**
@@ -335,7 +362,8 @@ class MongoWithClickHouseStorageProvider extends StorageProvider {
                 memberReferenceUuid: validation.entityReferenceUuid,
                 memberReferenceSourceId: validation.entityReferenceSourceId,
                 accessTags: securityTags.accessTags,
-                ownerTags: securityTags.ownerTags
+                ownerTags: securityTags.ownerTags,
+                hasFullAccess: this._callerHasFullAccess(extraInfo)
             });
 
             try {
@@ -446,6 +474,7 @@ class MongoWithClickHouseStorageProvider extends StorageProvider {
                 memberReferenceSourceId: validation.entityReferenceSourceId,
                 accessTags: securityTags.accessTags,
                 ownerTags: securityTags.ownerTags,
+                hasFullAccess: this._callerHasFullAccess(extraInfo),
                 limit,
                 afterGroupId,
                 skip

--- a/src/dataLayer/providers/storageProviderFactory.js
+++ b/src/dataLayer/providers/storageProviderFactory.js
@@ -25,6 +25,7 @@ class StorageProviderFactory {
      * @param {import('../../utils/clickHouseClientManager').ClickHouseClientManager|null} params.clickHouseClientManager
      * @param {import('../databaseAttachmentManager').DatabaseAttachmentManager} params.databaseAttachmentManager
      * @param {import('../../utils/configManager').ConfigManager} params.configManager
+     * @param {import('../../operations/security/scopesManager').ScopesManager} [params.scopesManager]
      */
     constructor({
         resourceLocatorFactory,
@@ -32,7 +33,8 @@ class StorageProviderFactory {
         databaseAttachmentManager,
         configManager,
         genericClickHouseRepository,
-        schemaRegistry
+        schemaRegistry,
+        scopesManager
     }) {
         this.resourceLocatorFactory = resourceLocatorFactory;
         this.clickHouseClientManager = clickHouseClientManager;
@@ -40,6 +42,7 @@ class StorageProviderFactory {
         this.configManager = configManager;
         this.genericClickHouseRepository = genericClickHouseRepository || null;
         this.schemaRegistry = schemaRegistry || null;
+        this.scopesManager = scopesManager || null;
 
         // Log configuration on initialization
         if (this.configManager.enableClickHouse) {
@@ -85,7 +88,8 @@ class StorageProviderFactory {
                     resourceLocator,
                     clickHouseClientManager: this.clickHouseClientManager,
                     mongoStorageProvider: mongoProvider,
-                    configManager: this.configManager
+                    configManager: this.configManager,
+                    scopesManager: this.scopesManager
                 });
             }
 

--- a/src/dataLayer/repositories/groupMemberRepository.js
+++ b/src/dataLayer/repositories/groupMemberRepository.js
@@ -2,6 +2,18 @@ const { TABLES, QUERY_FORMAT } = require('../../constants/clickHouseConstants');
 const { QueryFragments } = require('../../utils/clickHouse/queryFragments');
 const { RethrownError } = require('../../utils/rethrownError');
 const { DateTimeFormatter } = require('../../utils/clickHouse/dateTimeFormatter');
+const { retryWithBackoff } = require('../../utils/retryWithBackoff');
+const { logWarn } = require('../../operations/common/logging');
+
+// Bounded retry policy for the Group member event insert. This write is on the
+// synchronous Group save path (ClickHouse is the source of truth for
+// membership) and previously had no retry, so a single transient ClickHouse
+// blip surfaced as a 500. Retries are safe because the write is idempotent:
+// event rows are deterministic (see GroupMemberEventBuilder) and the insert
+// carries an insert_deduplication_token, so a re-driven block is de-duplicated
+// by ClickHouse rather than duplicated.
+const APPEND_EVENTS_MAX_RETRIES = 3;
+const APPEND_EVENTS_INITIAL_DELAY_MS = 200;
 
 /**
  * Repository for Group member data access
@@ -73,6 +85,9 @@ class GroupMemberRepository {
      * format concerns in the Repository layer.
      *
      * @param {Array<Object>} events - Array of event objects with ISO timestamps
+     * @param {Object} [options]
+     * @param {string} [options.correlationId] - Stable id for the logical operation, used to build the
+     *   ClickHouse insert_deduplication_token so a retried block is de-duplicated at the engine level.
      * @returns {Promise<void>}
      *
      * @example
@@ -81,9 +96,9 @@ class GroupMemberRepository {
      *     event_time: '2024-01-01T00:00:00.000Z', ... },
      *   { group_id: 'group-123', entity_reference: 'Patient/2', event_type: 'added',
      *     event_time: '2024-01-01T00:00:00.000Z', ... }
-     * ]);
+     * ], { correlationId: 'group-123|2' });
      */
-    async appendEvents(events) {
+    async appendEvents(events, { correlationId } = {}) {
         try {
             if (!events || events.length === 0) {
                 return;
@@ -101,13 +116,35 @@ class GroupMemberRepository {
                     : null
             }));
 
-            await this.client.insertAsync({
-                table: TABLES.GROUP_MEMBER_EVENTS,
-                values: formattedEvents,
-                format: QUERY_FORMAT.JSON_EACH_ROW,
-                clickhouse_settings: {
-                    async_insert: 1,
-                    wait_for_async_insert: 1
+            const deduplicationToken = this._buildDeduplicationToken(formattedEvents, correlationId);
+
+            // Bounded retry with jittered backoff. The insert is idempotent
+            // (deterministic rows + insert_deduplication_token), so retrying a
+            // transient ClickHouse failure cannot create duplicates.
+            await retryWithBackoff({
+                fn: () => this.client.insertAsync({
+                    table: TABLES.GROUP_MEMBER_EVENTS,
+                    values: formattedEvents,
+                    format: QUERY_FORMAT.JSON_EACH_ROW,
+                    clickhouse_settings: {
+                        async_insert: 1,
+                        wait_for_async_insert: 1,
+                        // Engine-level idempotency: identical blocks with the same
+                        // token within the dedup window are inserted at most once.
+                        insert_deduplicate: 1,
+                        insert_deduplication_token: deduplicationToken
+                    }
+                }),
+                maxRetries: APPEND_EVENTS_MAX_RETRIES,
+                initialDelayMs: APPEND_EVENTS_INITIAL_DELAY_MS,
+                onRetry: ({ attempt, maxRetries, delay, error }) => {
+                    logWarn('Retrying Group member event insert to ClickHouse', {
+                        attempt,
+                        maxRetries,
+                        delay,
+                        eventCount: formattedEvents.length,
+                        error: error?.message
+                    });
                 }
             });
         } catch (error) {
@@ -117,6 +154,25 @@ class GroupMemberRepository {
                 args: { eventCount: events?.length || 0 }
             });
         }
+    }
+
+    /**
+     * Builds a stable ClickHouse insert_deduplication_token for a batch.
+     *
+     * The token must be identical across retries of the same logical write but
+     * distinct across different writes. We derive it from the correlation id
+     * (stable per operation) plus the batch's deterministic event ids, so a
+     * retried identical block is de-duplicated while genuinely different batches
+     * are not collapsed.
+     *
+     * @param {Array<Object>} events - Formatted event rows (each with a deterministic event_id)
+     * @param {string} [correlationId]
+     * @returns {string}
+     * @private
+     */
+    _buildDeduplicationToken(events, correlationId) {
+        const eventIds = events.map(e => e.event_id).join(',');
+        return correlationId ? `${correlationId}|${eventIds}` : eventIds;
     }
 }
 

--- a/src/dataLayer/repositories/groupMemberRepository.js
+++ b/src/dataLayer/repositories/groupMemberRepository.js
@@ -8,10 +8,18 @@ const { logWarn } = require('../../operations/common/logging');
 // Bounded retry policy for the Group member event insert. This write is on the
 // synchronous Group save path (ClickHouse is the source of truth for
 // membership) and previously had no retry, so a single transient ClickHouse
-// blip surfaced as a 500. Retries are safe because the write is idempotent:
-// event rows are deterministic (see GroupMemberEventBuilder) and the insert
-// carries an insert_deduplication_token, so a re-driven block is de-duplicated
-// by ClickHouse rather than duplicated.
+// blip surfaced as a 500. Retries are safe because the write is idempotent by
+// CONTENT, not by an engine dedup token: each row's event_id is a uuidv5 of
+// (group_id | entity_reference | event_type | correlation_id) and event_time is
+// deterministic (sourced from meta.lastUpdated), so a re-driven block produces
+// byte-identical rows. The Group_4_0_0_MemberEvents table is a plain (non-
+// Replicated) MergeTree, and the current-state tables are AggregatingMergeTree
+// that resolve state with argMax over (event_time, event_id). Because the retry
+// rows are identical, argMax converges to a single logical member state whether
+// the block landed once or twice — duplicates are collapsed on read regardless
+// of how many physical rows exist. (Note: ClickHouse insert_deduplication_token
+// is a no-op here — it is honored only by Replicated*MergeTree for sync inserts,
+// or via async_insert_deduplicate on the async path — so we do NOT rely on it.)
 const APPEND_EVENTS_MAX_RETRIES = 3;
 const APPEND_EVENTS_INITIAL_DELAY_MS = 200;
 
@@ -84,10 +92,16 @@ class GroupMemberRepository {
      * This keeps the EventBuilder domain-focused and centralizes database
      * format concerns in the Repository layer.
      *
+     * Idempotency is by content: the events carry deterministic event_id + event_time
+     * (see GroupMemberEventBuilder), so a retried block produces identical rows that
+     * argMax collapses to one logical state on read. It does NOT depend on a
+     * ClickHouse dedup token (inert on this plain MergeTree engine).
+     *
      * @param {Array<Object>} events - Array of event objects with ISO timestamps
      * @param {Object} [options]
-     * @param {string} [options.correlationId] - Stable id for the logical operation, used to build the
-     *   ClickHouse insert_deduplication_token so a retried block is de-duplicated at the engine level.
+     * @param {string} [options.correlationId] - Stable id for the logical operation. Flows into
+     *   each event's deterministic event_id (via GroupMemberEventBuilder) so a client retry of the
+     *   same logical write yields identical rows. Not used to build any engine-level dedup token.
      * @returns {Promise<void>}
      *
      * @example
@@ -116,11 +130,15 @@ class GroupMemberRepository {
                     : null
             }));
 
-            const deduplicationToken = this._buildDeduplicationToken(formattedEvents, correlationId);
-
-            // Bounded retry with jittered backoff. The insert is idempotent
-            // (deterministic rows + insert_deduplication_token), so retrying a
-            // transient ClickHouse failure cannot create duplicates.
+            // Bounded retry with jittered backoff. The insert is idempotent by
+            // content: the rows are deterministic (deterministic event_id +
+            // event_time, see GroupMemberEventBuilder), so a retried block is
+            // byte-identical and argMax convergence on the AggregatingMergeTree
+            // current-state tables collapses duplicate physical rows to one
+            // logical member state on read. We deliberately do NOT set
+            // insert_deduplicate / insert_deduplication_token: those are inert on
+            // this plain (non-Replicated) MergeTree, so relying on them would be
+            // a false guarantee. Correctness rests on the deterministic rows.
             await retryWithBackoff({
                 fn: () => this.client.insertAsync({
                     table: TABLES.GROUP_MEMBER_EVENTS,
@@ -128,11 +146,7 @@ class GroupMemberRepository {
                     format: QUERY_FORMAT.JSON_EACH_ROW,
                     clickhouse_settings: {
                         async_insert: 1,
-                        wait_for_async_insert: 1,
-                        // Engine-level idempotency: identical blocks with the same
-                        // token within the dedup window are inserted at most once.
-                        insert_deduplicate: 1,
-                        insert_deduplication_token: deduplicationToken
+                        wait_for_async_insert: 1
                     }
                 }),
                 maxRetries: APPEND_EVENTS_MAX_RETRIES,
@@ -154,25 +168,6 @@ class GroupMemberRepository {
                 args: { eventCount: events?.length || 0 }
             });
         }
-    }
-
-    /**
-     * Builds a stable ClickHouse insert_deduplication_token for a batch.
-     *
-     * The token must be identical across retries of the same logical write but
-     * distinct across different writes. We derive it from the correlation id
-     * (stable per operation) plus the batch's deterministic event ids, so a
-     * retried identical block is de-duplicated while genuinely different batches
-     * are not collapsed.
-     *
-     * @param {Array<Object>} events - Formatted event rows (each with a deterministic event_id)
-     * @param {string} [correlationId]
-     * @returns {string}
-     * @private
-     */
-    _buildDeduplicationToken(events, correlationId) {
-        const eventIds = events.map(e => e.event_id).join(',');
-        return correlationId ? `${correlationId}|${eventIds}` : eventIds;
     }
 }
 

--- a/src/enrich/providers/groupMemberEnrichmentProvider.js
+++ b/src/enrich/providers/groupMemberEnrichmentProvider.js
@@ -68,12 +68,14 @@ class GroupMemberEnrichmentProvider extends EnrichmentProvider {
 
             return enrichedResources;
         } catch (error) {
+            // Surface the failure rather than returning resources with a
+            // misleading quantity. A ClickHouse read error must not be masked
+            // as a successful, silently-empty response.
             logError('Error in GroupMemberEnrichmentProvider.enrichAsync', {
                 error: error.message,
                 stack: error.stack
             });
-            // On error, return resources unchanged
-            return resources;
+            throw error;
         }
     }
 
@@ -106,12 +108,14 @@ class GroupMemberEnrichmentProvider extends EnrichmentProvider {
 
             return enrichedEntries;
         } catch (error) {
+            // Surface the failure rather than returning entries with a
+            // misleading quantity. A ClickHouse read error must not be masked
+            // as a successful, silently-empty response.
             logError('Error in GroupMemberEnrichmentProvider.enrichBundleEntriesAsync', {
                 error: error.message,
                 stack: error.stack
             });
-            // On error, return entries unchanged
-            return entries;
+            throw error;
         }
     }
 
@@ -145,15 +149,14 @@ class GroupMemberEnrichmentProvider extends EnrichmentProvider {
 
             return enriched;
         } catch (error) {
+            // Do NOT fall back to quantity=0: that masks a ClickHouse read
+            // failure as an empty-but-successful Group. Propagate so the request
+            // surfaces the error instead of returning silently wrong member data.
             logError('Error enriching Group resource', {
                 error: error.message,
                 groupId: resource.id
             });
-            // On error, at minimum strip member array
-            const safeResource = { ...resource };
-            delete safeResource.member;
-            safeResource.quantity = 0;
-            return safeResource;
+            throw error;
         }
     }
 
@@ -193,11 +196,15 @@ class GroupMemberEnrichmentProvider extends EnrichmentProvider {
 
             return rows.length > 0 ? parseInt(rows[0].count) : 0;
         } catch (error) {
+            // Do NOT mask a read failure as quantity=0. Returning 0 here would
+            // report an empty Group with a 200 OK, silently hiding members and
+            // corrupting clinical cohort counts. Surface the error so callers
+            // fail loudly (see enrichAsync, which rethrows).
             logError('Error querying member count from ClickHouse', {
                 error: error.message,
                 groupId
             });
-            return 0;
+            throw error;
         }
     }
 }

--- a/src/operations/search/searchBundle.js
+++ b/src/operations/search/searchBundle.js
@@ -119,7 +119,12 @@ class SearchBundleOperation {
         const currentOperationName = 'search';
         const extraInfo = {
             currentOperationName,
-            headers: requestInfo.headers
+            headers: requestInfo.headers,
+            // Carry the parsed scope/user so storage providers that filter by tenant
+            // (e.g. the ClickHouse Group reverse-lookup) can authoritatively detect a
+            // full-access (wildcard) caller instead of inferring it from tag presence.
+            scope: requestInfo.scope,
+            user: requestInfo.user
         };
         /**
          * @type {number}

--- a/src/operations/search/searchStreaming.js
+++ b/src/operations/search/searchStreaming.js
@@ -101,7 +101,12 @@ class SearchStreamingOperation {
         const currentOperationName = 'searchStreaming';
         const extraInfo = {
             currentOperationName,
-            headers: requestInfo.headers
+            headers: requestInfo.headers,
+            // Carry the parsed scope/user so storage providers that filter by tenant
+            // (e.g. the ClickHouse Group reverse-lookup) can authoritatively detect a
+            // full-access (wildcard) caller instead of inferring it from tag presence.
+            scope: requestInfo.scope,
+            user: requestInfo.user
         };
         /**
          * @type {number}

--- a/src/tests/unit/dataLayer/builders/groupMemberEventBuilder.test.js
+++ b/src/tests/unit/dataLayer/builders/groupMemberEventBuilder.test.js
@@ -1,6 +1,7 @@
 const { describe, test, expect } = require('@jest/globals');
 const { GroupMemberEventBuilder } = require('../../../../dataLayer/builders/groupMemberEventBuilder');
 const { EVENT_TYPES } = require('../../../../constants/clickHouseConstants');
+const { generateUUIDv5 } = require('../../../../utils/uid.util');
 
 // Minimal group resource with required security tags
 const makeGroupResource = (overrides = {}) => ({
@@ -152,6 +153,86 @@ describe('GroupMemberEventBuilder', () => {
                     groupResource: makeGroupResource()
                 });
             }).toThrow('Member reference missing _uuid');
+        });
+    });
+
+    describe('idempotent event identity (B4)', () => {
+        const member = makeMember('Patient/1|auth', 'Patient/uuid-1', 'Patient/1');
+        const buildArgs = {
+            groupId: 'group-1',
+            entityReference: 'Patient/1|auth',
+            eventType: EVENT_TYPES.MEMBER_ADDED,
+            member,
+            groupResource: makeGroupResource(),
+            eventTime: '2024-01-01T00:00:00.000Z',
+            correlationId: 'group-1|3'
+        };
+
+        test('sets correlation_id from the provided correlationId', () => {
+            const event = GroupMemberEventBuilder.buildEvent(buildArgs);
+            expect(event.correlation_id).toBe('group-1|3');
+        });
+
+        test('derives event_id deterministically as uuidv5(group|reference|type|correlation)', () => {
+            const event = GroupMemberEventBuilder.buildEvent(buildArgs);
+            const expected = generateUUIDv5('group-1|Patient/1|auth|added|group-1|3');
+            expect(event.event_id).toBe(expected);
+        });
+
+        test('a simulated retry produces an identical row (no duplicate)', () => {
+            // Same operation re-driven with the same correlation id + event time
+            const first = GroupMemberEventBuilder.buildEvent(buildArgs);
+            const retry = GroupMemberEventBuilder.buildEvent({ ...buildArgs });
+
+            // Full row must be identical so the append-only MergeTree converges
+            expect(retry).toEqual(first);
+            expect(retry.event_id).toBe(first.event_id);
+            expect(retry.event_time).toBe(first.event_time);
+        });
+
+        test('different correlation ids yield different event_ids (distinct operations not collapsed)', () => {
+            const opA = GroupMemberEventBuilder.buildEvent({ ...buildArgs, correlationId: 'group-1|3' });
+            const opB = GroupMemberEventBuilder.buildEvent({ ...buildArgs, correlationId: 'group-1|4' });
+            expect(opA.event_id).not.toBe(opB.event_id);
+        });
+
+        test('added and removed events for the same member have different event_ids', () => {
+            const added = GroupMemberEventBuilder.buildEvent({ ...buildArgs, eventType: EVENT_TYPES.MEMBER_ADDED });
+            const removed = GroupMemberEventBuilder.buildEvent({ ...buildArgs, eventType: EVENT_TYPES.MEMBER_REMOVED });
+            expect(added.event_id).not.toBe(removed.event_id);
+        });
+
+        test('falls back to a deterministic per-reference correlation when none provided', () => {
+            const noCorrelation = { ...buildArgs };
+            delete noCorrelation.correlationId;
+
+            const first = GroupMemberEventBuilder.buildEvent(noCorrelation);
+            const retry = GroupMemberEventBuilder.buildEvent({ ...noCorrelation });
+
+            // Even without an explicit correlation id, event_id must be stable
+            // (derived from group|reference) rather than a random uuid.
+            expect(first.correlation_id).toBe('group-1|Patient/1|auth');
+            expect(retry.event_id).toBe(first.event_id);
+        });
+
+        test('buildEvents applies the same correlation id to every event in a batch', () => {
+            const members = [
+                makeMember('Patient/1|auth', 'Patient/uuid-1', 'Patient/1'),
+                makeMember('Patient/2|auth', 'Patient/uuid-2', 'Patient/2')
+            ];
+            const events = GroupMemberEventBuilder.buildEvents({
+                groupId: 'group-1',
+                members,
+                eventType: EVENT_TYPES.MEMBER_ADDED,
+                groupResource: makeGroupResource(),
+                eventTime: '2024-01-01T00:00:00.000Z',
+                correlationId: 'group-1|3'
+            });
+
+            expect(events).toHaveLength(2);
+            expect(events.every(e => e.correlation_id === 'group-1|3')).toBe(true);
+            // Distinct members => distinct event ids
+            expect(events[0].event_id).not.toBe(events[1].event_id);
         });
     });
 });

--- a/src/tests/unit/dataLayer/providers/mongoWithClickHouse/queryBuilder.test.js
+++ b/src/tests/unit/dataLayer/providers/mongoWithClickHouse/queryBuilder.test.js
@@ -1,0 +1,92 @@
+const { describe, test, expect } = require('@jest/globals');
+const { QueryBuilder } = require('../../../../../dataLayer/providers/mongoWithClickHouse/queryBuilder');
+
+/**
+ * B3 - Fail-closed tenant isolation on the ClickHouse read path.
+ *
+ * An empty-tag query must NOT return cross-tenant rows. The read path now
+ * injects a deny clause ("1 = 0") when both access and owner tags are absent,
+ * matching the write path (which throws on empty tags). A legitimately scoped
+ * admin caller carries a wildcard code (e.g. ['*']) which arrives as a
+ * non-empty array and is therefore not blocked.
+ */
+describe('QueryBuilder tenant isolation (B3)', () => {
+    const baseArgs = {
+        memberReferenceUuid: 'Patient/uuid-1',
+        memberReferenceSourceId: undefined,
+        limit: 100
+    };
+
+    describe('buildFindGroupsByMemberQuery', () => {
+        test('injects deny clause when both tag arrays are empty (fail closed)', () => {
+            const { query } = QueryBuilder.buildFindGroupsByMemberQuery({
+                ...baseArgs,
+                accessTags: [],
+                ownerTags: []
+            });
+            expect(query).toContain('1 = 0');
+            // Must not attempt to bind tag params it does not have
+            expect(query).not.toContain('access_tags');
+            expect(query).not.toContain('owner_tags');
+        });
+
+        test('injects deny clause when tags are omitted entirely (defaults)', () => {
+            const { query } = QueryBuilder.buildFindGroupsByMemberQuery({ ...baseArgs });
+            expect(query).toContain('1 = 0');
+        });
+
+        test('does NOT deny when access tags are present', () => {
+            const { query, query_params } = QueryBuilder.buildFindGroupsByMemberQuery({
+                ...baseArgs,
+                accessTags: ['client1'],
+                ownerTags: []
+            });
+            expect(query).not.toContain('1 = 0');
+            expect(query).toContain('hasAny(argMaxMerge(access_tags)');
+            expect(query_params.accessTags).toEqual(['client1']);
+        });
+
+        test('does NOT deny when owner tags are present', () => {
+            const { query } = QueryBuilder.buildFindGroupsByMemberQuery({
+                ...baseArgs,
+                accessTags: [],
+                ownerTags: ['bwell']
+            });
+            expect(query).not.toContain('1 = 0');
+            expect(query).toContain('hasAny(argMaxMerge(owner_tags)');
+        });
+
+        test('preserves the legitimate wildcard admin scope (non-empty array)', () => {
+            const { query, query_params } = QueryBuilder.buildFindGroupsByMemberQuery({
+                ...baseArgs,
+                accessTags: ['*'],
+                ownerTags: []
+            });
+            // Wildcard is a real, non-empty tag => not fail-closed
+            expect(query).not.toContain('1 = 0');
+            expect(query).toContain('hasAny(argMaxMerge(access_tags)');
+            expect(query_params.accessTags).toEqual(['*']);
+        });
+    });
+
+    describe('buildCountGroupsByMemberQuery', () => {
+        test('injects deny clause when both tag arrays are empty (fail closed)', () => {
+            const { query } = QueryBuilder.buildCountGroupsByMemberQuery({
+                memberReferenceUuid: 'Patient/uuid-1',
+                accessTags: [],
+                ownerTags: []
+            });
+            expect(query).toContain('1 = 0');
+        });
+
+        test('does NOT deny when tags are present', () => {
+            const { query } = QueryBuilder.buildCountGroupsByMemberQuery({
+                memberReferenceUuid: 'Patient/uuid-1',
+                accessTags: ['client1'],
+                ownerTags: []
+            });
+            expect(query).not.toContain('1 = 0');
+            expect(query).toContain('hasAny(argMaxMerge(access_tags)');
+        });
+    });
+});

--- a/src/tests/unit/dataLayer/providers/mongoWithClickHouse/queryBuilder.test.js
+++ b/src/tests/unit/dataLayer/providers/mongoWithClickHouse/queryBuilder.test.js
@@ -1,14 +1,34 @@
 const { describe, test, expect } = require('@jest/globals');
 const { QueryBuilder } = require('../../../../../dataLayer/providers/mongoWithClickHouse/queryBuilder');
 
+// Note: ServerError (the base of ForbiddenError) resets its prototype to
+// ServerError in its constructor, so `instanceof ForbiddenError` is unreliable
+// codebase-wide. We assert on the HTTP-meaningful statusCode (403) instead.
+const expectForbidden = (fn) => {
+    let thrown;
+    try {
+        fn();
+    } catch (e) {
+        thrown = e;
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown.statusCode).toBe(403);
+};
+
 /**
- * B3 - Fail-closed tenant isolation on the ClickHouse read path.
+ * B3 - Tenant isolation on the ClickHouse Group reverse-lookup (fail-closed,
+ * admin-exempt), mirroring SecurityTagManager / ScopesManager.
  *
- * An empty-tag query must NOT return cross-tenant rows. The read path now
- * injects a deny clause ("1 = 0") when both access and owner tags are absent,
- * matching the write path (which throws on empty tags). A legitimately scoped
- * admin caller carries a wildcard code (e.g. ['*']) which arrives as a
- * non-empty array and is therefore not blocked.
+ * Authorization is decided upstream, not inferred here from tag presence:
+ *   - Full/wildcard access (access/*.*) => hasFullAccess=true => NO tenant
+ *     predicate (the admin legitimately sees every tenant). A wildcard admin
+ *     resolves to EMPTY security tags upstream, so tag-based inference would
+ *     wrongly deny them.
+ *   - Scoped caller => non-empty access/owner tags => tag filter applied.
+ *   - Genuinely unscoped non-admin (no tags AND not full access) => denied with
+ *     a 403 ForbiddenError, matching the write path (QueryFragments throws on
+ *     empty tags). Such callers are already 403'd upstream; this is defense in
+ *     depth.
  */
 describe('QueryBuilder tenant isolation (B3)', () => {
     const baseArgs = {
@@ -18,24 +38,36 @@ describe('QueryBuilder tenant isolation (B3)', () => {
     };
 
     describe('buildFindGroupsByMemberQuery', () => {
-        test('injects deny clause when both tag arrays are empty (fail closed)', () => {
-            const { query } = QueryBuilder.buildFindGroupsByMemberQuery({
+        test('denies with 403 when both tag arrays are empty and not full access', () => {
+            expectForbidden(() => QueryBuilder.buildFindGroupsByMemberQuery({
                 ...baseArgs,
                 accessTags: [],
                 ownerTags: []
+            }));
+        });
+
+        test('denies with 403 when tags are omitted entirely (defaults)', () => {
+            expectForbidden(() => QueryBuilder.buildFindGroupsByMemberQuery({ ...baseArgs }));
+        });
+
+        test('does NOT deny and omits tenant predicate for a full-access caller', () => {
+            const { query, query_params } = QueryBuilder.buildFindGroupsByMemberQuery({
+                ...baseArgs,
+                accessTags: [],
+                ownerTags: [],
+                hasFullAccess: true
             });
-            expect(query).toContain('1 = 0');
-            // Must not attempt to bind tag params it does not have
+            // Full access => no tenant predicate at all
+            expect(query).not.toContain('1 = 0');
             expect(query).not.toContain('access_tags');
             expect(query).not.toContain('owner_tags');
+            expect(query_params.accessTags).toBeUndefined();
+            expect(query_params.ownerTags).toBeUndefined();
+            // Still an active-member query
+            expect(query).toContain("argMaxMerge(event_type) = 'added'");
         });
 
-        test('injects deny clause when tags are omitted entirely (defaults)', () => {
-            const { query } = QueryBuilder.buildFindGroupsByMemberQuery({ ...baseArgs });
-            expect(query).toContain('1 = 0');
-        });
-
-        test('does NOT deny when access tags are present', () => {
+        test('applies the access tag filter for a scoped caller', () => {
             const { query, query_params } = QueryBuilder.buildFindGroupsByMemberQuery({
                 ...baseArgs,
                 accessTags: ['client1'],
@@ -46,7 +78,7 @@ describe('QueryBuilder tenant isolation (B3)', () => {
             expect(query_params.accessTags).toEqual(['client1']);
         });
 
-        test('does NOT deny when owner tags are present', () => {
+        test('applies the owner tag filter for a scoped caller', () => {
             const { query } = QueryBuilder.buildFindGroupsByMemberQuery({
                 ...baseArgs,
                 accessTags: [],
@@ -56,30 +88,39 @@ describe('QueryBuilder tenant isolation (B3)', () => {
             expect(query).toContain('hasAny(argMaxMerge(owner_tags)');
         });
 
-        test('preserves the legitimate wildcard admin scope (non-empty array)', () => {
-            const { query, query_params } = QueryBuilder.buildFindGroupsByMemberQuery({
+        test('full access takes precedence: predicate omitted even if tags were present', () => {
+            const { query } = QueryBuilder.buildFindGroupsByMemberQuery({
                 ...baseArgs,
-                accessTags: ['*'],
-                ownerTags: []
+                accessTags: ['client1'],
+                ownerTags: [],
+                hasFullAccess: true
             });
-            // Wildcard is a real, non-empty tag => not fail-closed
-            expect(query).not.toContain('1 = 0');
-            expect(query).toContain('hasAny(argMaxMerge(access_tags)');
-            expect(query_params.accessTags).toEqual(['*']);
+            // hasFullAccess short-circuits before any tag filter is added
+            expect(query).not.toContain('hasAny(argMaxMerge(access_tags)');
         });
     });
 
     describe('buildCountGroupsByMemberQuery', () => {
-        test('injects deny clause when both tag arrays are empty (fail closed)', () => {
-            const { query } = QueryBuilder.buildCountGroupsByMemberQuery({
+        test('denies with 403 when both tag arrays are empty and not full access', () => {
+            expectForbidden(() => QueryBuilder.buildCountGroupsByMemberQuery({
                 memberReferenceUuid: 'Patient/uuid-1',
                 accessTags: [],
                 ownerTags: []
-            });
-            expect(query).toContain('1 = 0');
+            }));
         });
 
-        test('does NOT deny when tags are present', () => {
+        test('omits tenant predicate for a full-access caller', () => {
+            const { query } = QueryBuilder.buildCountGroupsByMemberQuery({
+                memberReferenceUuid: 'Patient/uuid-1',
+                accessTags: [],
+                ownerTags: [],
+                hasFullAccess: true
+            });
+            expect(query).not.toContain('1 = 0');
+            expect(query).not.toContain('access_tags');
+        });
+
+        test('applies the tag filter for a scoped caller', () => {
             const { query } = QueryBuilder.buildCountGroupsByMemberQuery({
                 memberReferenceUuid: 'Patient/uuid-1',
                 accessTags: ['client1'],

--- a/src/tests/unit/dataLayer/providers/mongoWithClickHouseStorageProvider.test.js
+++ b/src/tests/unit/dataLayer/providers/mongoWithClickHouseStorageProvider.test.js
@@ -334,4 +334,108 @@ describe('MongoWithClickHouseStorageProvider', () => {
             expect(mockClickHouseClientManager.queryAsync).toHaveBeenCalled();
         });
     });
+
+    /**
+     * B3 - Admin-exempt fail-closed tenant filtering on the ClickHouse read path.
+     *
+     * The full-access signal must be derived authoritatively from the caller's
+     * SCOPE (via ScopesManager), not inferred from whether the built query
+     * carried tag predicates. A wildcard admin's query legitimately carries no
+     * tags, so tag-based inference would wrongly deny them.
+     */
+    describe('admin-exempt tenant filtering (B3)', () => {
+        // Minimal ScopesManager fake honoring the wildcard contract:
+        // access/*.* => access code '*'. Only structural behavior we depend on.
+        const fakeScopesManager = {
+            getAccessCodesFromScopes: (action, user, scope) => {
+                const codes = [];
+                for (const s of (scope || '').split(' ')) {
+                    if (s.startsWith('access/')) {
+                        const [tag, type] = s.replace('access/', '').split('.');
+                        if (type === '*' || type === action) {
+                            codes.push(tag);
+                        }
+                    }
+                }
+                return codes;
+            }
+        };
+
+        const buildProvider = () => new MongoWithClickHouseStorageProvider({
+            resourceLocator: mockResourceLocator,
+            clickHouseClientManager: mockClickHouseClientManager,
+            mongoStorageProvider: mockMongoStorageProvider,
+            configManager: mockConfigManager,
+            scopesManager: fakeScopesManager
+        });
+
+        test('_callerHasFullAccess is true for a wildcard (access/*.*) scope', () => {
+            const p = buildProvider();
+            expect(p._callerHasFullAccess({ scope: 'access/*.* user/*.read', user: 'admin' })).toBe(true);
+        });
+
+        test('_callerHasFullAccess is false for a tenant-scoped caller', () => {
+            const p = buildProvider();
+            expect(p._callerHasFullAccess({ scope: 'access/client1.* user/*.read', user: 'u1' })).toBe(false);
+        });
+
+        test('_callerHasFullAccess is false when no scopesManager is wired', () => {
+            expect(provider._callerHasFullAccess({ scope: 'access/*.*', user: 'admin' })).toBe(false);
+        });
+
+        test('wildcard admin with NO query tags is NOT denied; ClickHouse is queried without a tenant predicate', async () => {
+            const p = buildProvider();
+            // Wildcard admin => upstream added no meta.security predicate => query has no tags.
+            const query = { 'member.entity._sourceId': 'Patient/123' };
+            const adminExtraInfo = {
+                headers: { [USE_EXTERNAL_STORAGE_HEADER]: 'true' },
+                scope: 'access/*.* user/*.read',
+                user: 'admin'
+            };
+            mockClickHouseClientManager.queryAsync.mockResolvedValue([{ group_id: 'group-1' }]);
+            mockMongoStorageProvider.findAsync.mockResolvedValue({});
+
+            await p.findAsync({ query, options: {}, extraInfo: adminExtraInfo });
+
+            expect(mockClickHouseClientManager.queryAsync).toHaveBeenCalledTimes(1);
+            const executed = mockClickHouseClientManager.queryAsync.mock.calls[0][0];
+            // No tenant predicate and no deny clause for a legitimate full-access admin
+            expect(executed.query).not.toContain('1 = 0');
+            expect(executed.query).not.toContain('access_tags');
+            expect(executed.query).not.toContain('owner_tags');
+        });
+
+        test('genuinely unscoped non-admin (no tags, no full access) is denied with 403', async () => {
+            const p = buildProvider();
+            const query = { 'member.entity._sourceId': 'Patient/123' };
+            const unscopedExtraInfo = {
+                headers: { [USE_EXTERNAL_STORAGE_HEADER]: 'true' },
+                scope: 'user/*.read', // no access/* scope => no tags, not full access
+                user: 'u1'
+            };
+
+            await expect(
+                p.findAsync({ query, options: {}, extraInfo: unscopedExtraInfo })
+            ).rejects.toMatchObject({ statusCode: 403 });
+            // Denied before touching ClickHouse
+            expect(mockClickHouseClientManager.queryAsync).not.toHaveBeenCalled();
+        });
+
+        test('tenant-scoped caller still gets the access tag filter', async () => {
+            const p = buildProvider();
+            const query = withSecurityTags({ 'member.entity._sourceId': 'Patient/123' });
+            const scopedExtraInfo = {
+                headers: { [USE_EXTERNAL_STORAGE_HEADER]: 'true' },
+                scope: 'access/client1.* user/*.read',
+                user: 'u1'
+            };
+            mockClickHouseClientManager.queryAsync.mockResolvedValue([{ group_id: 'group-1' }]);
+            mockMongoStorageProvider.findAsync.mockResolvedValue({});
+
+            await p.findAsync({ query, options: {}, extraInfo: scopedExtraInfo });
+
+            const executed = mockClickHouseClientManager.queryAsync.mock.calls[0][0];
+            expect(executed.query).toContain('hasAny(argMaxMerge(');
+        });
+    });
 });

--- a/src/tests/unit/dataLayer/repositories/groupMemberRepository.test.js
+++ b/src/tests/unit/dataLayer/repositories/groupMemberRepository.test.js
@@ -4,7 +4,11 @@ const { TABLES } = require('../../../../constants/clickHouseConstants');
 
 /**
  * Unit tests for GroupMemberRepository.appendEvents covering:
- *  - B4: ClickHouse insert_deduplicate + deterministic deduplication token
+ *  - B4: content-based idempotency. Rows are deterministic (event_id + event_time
+ *        baked in by GroupMemberEventBuilder), so a retried block is byte-identical
+ *        and argMax collapses duplicates on read. The insert deliberately does NOT
+ *        set insert_deduplicate / insert_deduplication_token (inert on this plain
+ *        MergeTree engine).
  *  - B5: bounded retry with jittered backoff around the insert
  */
 describe('GroupMemberRepository.appendEvents', () => {
@@ -40,43 +44,37 @@ describe('GroupMemberRepository.appendEvents', () => {
         expect(mockClient.insertAsync).not.toHaveBeenCalled();
     });
 
-    test('B4: enables insert_deduplicate with a deduplication token', async () => {
+    test('B4: inserts to the events table and does NOT set the inert dedup settings', async () => {
         await repository.appendEvents([makeEvent({ event_id: 'evt-1' })], { correlationId: 'group-1|3' });
 
         expect(mockClient.insertAsync).toHaveBeenCalledTimes(1);
         const args = mockClient.insertAsync.mock.calls[0][0];
         expect(args.table).toBe(TABLES.GROUP_MEMBER_EVENTS);
-        expect(args.clickhouse_settings.insert_deduplicate).toBe(1);
-        expect(args.clickhouse_settings.insert_deduplication_token).toBe('group-1|3|evt-1');
+        // The token/insert_deduplicate are no-ops on a plain MergeTree, so they
+        // must not be set (relying on them would be a false idempotency guarantee).
+        expect(args.clickhouse_settings.insert_deduplicate).toBeUndefined();
+        expect(args.clickhouse_settings.insert_deduplication_token).toBeUndefined();
+        // Async insert with wait is still configured.
+        expect(args.clickhouse_settings.async_insert).toBe(1);
+        expect(args.clickhouse_settings.wait_for_async_insert).toBe(1);
     });
 
-    test('B4: deduplication token is stable across a simulated retry of the same batch', async () => {
-        const events = [makeEvent({ event_id: 'evt-1' }), makeEvent({ event_id: 'evt-2', entity_reference: 'Patient/2' })];
-
-        await repository.appendEvents(events, { correlationId: 'group-1|3' });
-        await repository.appendEvents(events, { correlationId: 'group-1|3' });
-
-        const token1 = mockClient.insertAsync.mock.calls[0][0].clickhouse_settings.insert_deduplication_token;
-        const token2 = mockClient.insertAsync.mock.calls[1][0].clickhouse_settings.insert_deduplication_token;
-        expect(token1).toBe(token2);
-        expect(token1).toBe('group-1|3|evt-1,evt-2');
-    });
-
-    test('B4: retried batch sends identical insert values (idempotent write)', async () => {
-        const events = [makeEvent({ event_id: 'evt-1' })];
+    test('B4: a retried block sends byte-identical rows so argMax converges to one state', async () => {
+        // The deterministic rows (event_id + event_time) are what make the write
+        // idempotent: two physical copies of the same row collapse under argMax.
+        const events = [
+            makeEvent({ event_id: 'evt-1' }),
+            makeEvent({ event_id: 'evt-2', entity_reference: 'Patient/2' })
+        ];
 
         await repository.appendEvents(events, { correlationId: 'group-1|3' });
         await repository.appendEvents(events, { correlationId: 'group-1|3' });
 
         const values1 = mockClient.insertAsync.mock.calls[0][0].values;
         const values2 = mockClient.insertAsync.mock.calls[1][0].values;
+        // Identical event_id + event_time across the retry => argMax dedup on read.
         expect(values2).toEqual(values1);
-    });
-
-    test('B4: token falls back to event ids when no correlationId supplied', async () => {
-        await repository.appendEvents([makeEvent({ event_id: 'evt-1' })]);
-        const token = mockClient.insertAsync.mock.calls[0][0].clickhouse_settings.insert_deduplication_token;
-        expect(token).toBe('evt-1');
+        expect(values2.map(v => v.event_id)).toEqual(['evt-1', 'evt-2']);
     });
 
     test('B5: retries a transient insert failure and eventually succeeds', async () => {

--- a/src/tests/unit/dataLayer/repositories/groupMemberRepository.test.js
+++ b/src/tests/unit/dataLayer/repositories/groupMemberRepository.test.js
@@ -1,0 +1,102 @@
+const { describe, test, expect, beforeEach, jest } = require('@jest/globals');
+const { GroupMemberRepository } = require('../../../../dataLayer/repositories/groupMemberRepository');
+const { TABLES } = require('../../../../constants/clickHouseConstants');
+
+/**
+ * Unit tests for GroupMemberRepository.appendEvents covering:
+ *  - B4: ClickHouse insert_deduplicate + deterministic deduplication token
+ *  - B5: bounded retry with jittered backoff around the insert
+ */
+describe('GroupMemberRepository.appendEvents', () => {
+    let mockClient;
+    let repository;
+
+    const makeEvent = (overrides = {}) => ({
+        event_id: 'e1',
+        group_id: 'group-1',
+        entity_reference: 'Patient/1',
+        entity_reference_uuid: 'Patient/uuid-1',
+        entity_reference_source_id: 'Patient/1',
+        entity_type: 'Patient',
+        event_type: 'added',
+        event_time: '2024-01-01T00:00:00.000Z',
+        period_start: null,
+        period_end: null,
+        inactive: 0,
+        correlation_id: 'group-1|3',
+        ...overrides
+    });
+
+    beforeEach(() => {
+        mockClient = {
+            insertAsync: jest.fn().mockResolvedValue(undefined)
+        };
+        repository = new GroupMemberRepository({ clickHouseClient: mockClient });
+    });
+
+    test('does nothing for empty event arrays', async () => {
+        await repository.appendEvents([]);
+        await repository.appendEvents(null);
+        expect(mockClient.insertAsync).not.toHaveBeenCalled();
+    });
+
+    test('B4: enables insert_deduplicate with a deduplication token', async () => {
+        await repository.appendEvents([makeEvent({ event_id: 'evt-1' })], { correlationId: 'group-1|3' });
+
+        expect(mockClient.insertAsync).toHaveBeenCalledTimes(1);
+        const args = mockClient.insertAsync.mock.calls[0][0];
+        expect(args.table).toBe(TABLES.GROUP_MEMBER_EVENTS);
+        expect(args.clickhouse_settings.insert_deduplicate).toBe(1);
+        expect(args.clickhouse_settings.insert_deduplication_token).toBe('group-1|3|evt-1');
+    });
+
+    test('B4: deduplication token is stable across a simulated retry of the same batch', async () => {
+        const events = [makeEvent({ event_id: 'evt-1' }), makeEvent({ event_id: 'evt-2', entity_reference: 'Patient/2' })];
+
+        await repository.appendEvents(events, { correlationId: 'group-1|3' });
+        await repository.appendEvents(events, { correlationId: 'group-1|3' });
+
+        const token1 = mockClient.insertAsync.mock.calls[0][0].clickhouse_settings.insert_deduplication_token;
+        const token2 = mockClient.insertAsync.mock.calls[1][0].clickhouse_settings.insert_deduplication_token;
+        expect(token1).toBe(token2);
+        expect(token1).toBe('group-1|3|evt-1,evt-2');
+    });
+
+    test('B4: retried batch sends identical insert values (idempotent write)', async () => {
+        const events = [makeEvent({ event_id: 'evt-1' })];
+
+        await repository.appendEvents(events, { correlationId: 'group-1|3' });
+        await repository.appendEvents(events, { correlationId: 'group-1|3' });
+
+        const values1 = mockClient.insertAsync.mock.calls[0][0].values;
+        const values2 = mockClient.insertAsync.mock.calls[1][0].values;
+        expect(values2).toEqual(values1);
+    });
+
+    test('B4: token falls back to event ids when no correlationId supplied', async () => {
+        await repository.appendEvents([makeEvent({ event_id: 'evt-1' })]);
+        const token = mockClient.insertAsync.mock.calls[0][0].clickhouse_settings.insert_deduplication_token;
+        expect(token).toBe('evt-1');
+    });
+
+    test('B5: retries a transient insert failure and eventually succeeds', async () => {
+        mockClient.insertAsync
+            .mockRejectedValueOnce(new Error('transient ClickHouse error'))
+            .mockResolvedValueOnce(undefined);
+
+        await repository.appendEvents([makeEvent()], { correlationId: 'group-1|3' });
+
+        expect(mockClient.insertAsync).toHaveBeenCalledTimes(2);
+    });
+
+    test('B5: surfaces the error after exhausting retries', async () => {
+        mockClient.insertAsync.mockRejectedValue(new Error('ClickHouse down'));
+
+        await expect(
+            repository.appendEvents([makeEvent()], { correlationId: 'group-1|3' })
+        ).rejects.toThrow(/ClickHouse down|Error appending events/);
+
+        // initial attempt + 3 retries (APPEND_EVENTS_MAX_RETRIES)
+        expect(mockClient.insertAsync).toHaveBeenCalledTimes(4);
+    }, 20000);
+});

--- a/src/tests/unit/enrich/providers/groupMemberEnrichmentProvider.test.js
+++ b/src/tests/unit/enrich/providers/groupMemberEnrichmentProvider.test.js
@@ -1,0 +1,88 @@
+const { describe, test, expect, beforeEach, jest } = require('@jest/globals');
+const { GroupMemberEnrichmentProvider } = require('../../../../enrich/providers/groupMemberEnrichmentProvider');
+const { USE_EXTERNAL_STORAGE_HEADER } = require('../../../../utils/contextDataBuilder');
+
+/**
+ * B7 - Surface ClickHouse read failures instead of masking them as quantity=0.
+ *
+ * Previously, a ClickHouse read error during Group enrichment returned
+ * quantity: 0 with a 200 OK, silently reporting an empty Group. These tests
+ * verify the error now propagates so the request fails loudly.
+ */
+describe('GroupMemberEnrichmentProvider read-failure surfacing (B7)', () => {
+    let mockClickHouseClientManager;
+    let mockConfigManager;
+    let provider;
+
+    const parsedArgs = { headers: { [USE_EXTERNAL_STORAGE_HEADER]: 'true' } };
+    const groupResource = { resourceType: 'Group', id: 'group-1', member: [{ entity: { reference: 'Patient/1' } }] };
+
+    beforeEach(() => {
+        mockClickHouseClientManager = {
+            queryAsync: jest.fn()
+        };
+        mockConfigManager = {
+            enableClickHouse: true,
+            mongoWithClickHouseResources: ['Group']
+        };
+        provider = new GroupMemberEnrichmentProvider({
+            clickHouseClientManager: mockClickHouseClientManager,
+            configManager: mockConfigManager
+        });
+    });
+
+    test('enrichAsync propagates a ClickHouse read error (does not return quantity=0)', async () => {
+        mockClickHouseClientManager.queryAsync.mockRejectedValue(new Error('ClickHouse read timeout'));
+
+        await expect(
+            provider.enrichAsync({ resources: [{ ...groupResource }], parsedArgs })
+        ).rejects.toThrow('ClickHouse read timeout');
+    });
+
+    test('enrichBundleEntriesAsync propagates a ClickHouse read error', async () => {
+        mockClickHouseClientManager.queryAsync.mockRejectedValue(new Error('ClickHouse read timeout'));
+
+        await expect(
+            provider.enrichBundleEntriesAsync({
+                entries: [{ resource: { ...groupResource } }],
+                parsedArgs
+            })
+        ).rejects.toThrow('ClickHouse read timeout');
+    });
+
+    test('on success, sets quantity from the count and strips member array', async () => {
+        mockClickHouseClientManager.queryAsync.mockResolvedValue([{ count: '5' }]);
+
+        const [enriched] = await provider.enrichAsync({
+            resources: [{ ...groupResource }],
+            parsedArgs
+        });
+
+        expect(enriched.quantity).toBe(5);
+        expect(enriched.member).toBeUndefined();
+    });
+
+    test('a genuinely empty Group still reports quantity=0 (only errors are surfaced)', async () => {
+        // No rows returned => legitimately zero members, not an error
+        mockClickHouseClientManager.queryAsync.mockResolvedValue([]);
+
+        const [enriched] = await provider.enrichAsync({
+            resources: [{ ...groupResource }],
+            parsedArgs
+        });
+
+        expect(enriched.quantity).toBe(0);
+        expect(enriched.member).toBeUndefined();
+    });
+
+    test('skips enrichment (no query) when external storage header is absent', async () => {
+        const result = await provider.enrichAsync({
+            resources: [{ ...groupResource }],
+            parsedArgs: { headers: {} }
+        });
+
+        expect(mockClickHouseClientManager.queryAsync).not.toHaveBeenCalled();
+        // Returned unchanged
+        expect(result[0].member).toBeDefined();
+    });
+});

--- a/src/tests/unit/utils/retryWithBackoff.test.js
+++ b/src/tests/unit/utils/retryWithBackoff.test.js
@@ -1,0 +1,119 @@
+const { describe, test, expect, jest } = require('@jest/globals');
+const { retryWithBackoff, computeBackoffWithJitter } = require('../../../utils/retryWithBackoff');
+
+describe('computeBackoffWithJitter (B5)', () => {
+    test('returns 0 when rng returns 0 (lower bound of full jitter)', () => {
+        expect(computeBackoffWithJitter(1, 200, 30000, () => 0)).toBe(0);
+        expect(computeBackoffWithJitter(5, 200, 30000, () => 0)).toBe(0);
+    });
+
+    test('never exceeds the exponential cap for the attempt (upper bound of full jitter)', () => {
+        const base = 200;
+        const maxDelay = 30000;
+        // rng just below 1 => delay approaches, but stays under, the cap
+        const nearOne = () => 0.999999;
+        for (let attempt = 1; attempt <= 6; attempt++) {
+            const cap = Math.min(maxDelay, base * Math.pow(2, attempt - 1));
+            const delay = computeBackoffWithJitter(attempt, base, maxDelay, nearOne);
+            expect(delay).toBeGreaterThanOrEqual(0);
+            expect(delay).toBeLessThanOrEqual(cap);
+        }
+    });
+
+    test('cap grows exponentially with attempt number', () => {
+        const base = 100;
+        const maxDelay = 10 ** 9; // effectively unbounded for this assertion
+        const full = () => 0.999999;
+        const d1 = computeBackoffWithJitter(1, base, maxDelay, full); // cap 100
+        const d2 = computeBackoffWithJitter(2, base, maxDelay, full); // cap 200
+        const d3 = computeBackoffWithJitter(3, base, maxDelay, full); // cap 400
+        expect(d1).toBeLessThan(d2);
+        expect(d2).toBeLessThan(d3);
+    });
+
+    test('cap is clamped at maxDelayMs', () => {
+        const base = 1000;
+        const maxDelay = 2000;
+        const full = () => 0.999999;
+        // attempt 10 would be base*2^9 = 512000 without clamping
+        const delay = computeBackoffWithJitter(10, base, maxDelay, full);
+        expect(delay).toBeLessThanOrEqual(maxDelay);
+    });
+
+    test('produces a spread of values across the range (adds jitter, not fixed backoff)', () => {
+        const base = 1000;
+        const maxDelay = 30000;
+        // Deterministic sequence of rng values
+        const samples = [0, 0.25, 0.5, 0.75, 0.99].map(r =>
+            computeBackoffWithJitter(3, base, maxDelay, () => r)
+        );
+        const unique = new Set(samples);
+        // Full jitter must yield distinct delays for distinct rng values
+        expect(unique.size).toBe(samples.length);
+    });
+});
+
+describe('retryWithBackoff (B5)', () => {
+    test('returns result without delay on first success', async () => {
+        const fn = jest.fn().mockResolvedValue('ok');
+        const result = await retryWithBackoff({ fn, maxRetries: 3, initialDelayMs: 0 });
+        expect(result).toBe('ok');
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test('retries up to maxRetries then succeeds', async () => {
+        const fn = jest.fn()
+            .mockRejectedValueOnce(new Error('transient-1'))
+            .mockRejectedValueOnce(new Error('transient-2'))
+            .mockResolvedValue('recovered');
+
+        const result = await retryWithBackoff({
+            fn,
+            maxRetries: 3,
+            initialDelayMs: 0,
+            rng: () => 0 // zero delay for a fast test
+        });
+
+        expect(result).toBe('recovered');
+        expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    test('throws the last error after exhausting retries', async () => {
+        const fn = jest.fn().mockRejectedValue(new Error('always-fails'));
+
+        await expect(retryWithBackoff({
+            fn,
+            maxRetries: 2,
+            initialDelayMs: 0,
+            rng: () => 0
+        })).rejects.toThrow('always-fails');
+
+        // initial attempt + 2 retries
+        expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    test('invokes onRetry with jittered delay within bounds before each retry', async () => {
+        const onRetry = jest.fn();
+        const base = 200;
+        const fn = jest.fn()
+            .mockRejectedValueOnce(new Error('t1'))
+            .mockResolvedValue('ok');
+
+        await retryWithBackoff({
+            fn,
+            maxRetries: 3,
+            initialDelayMs: base,
+            maxDelayMs: 30000,
+            rng: () => 0.5,
+            onRetry
+        });
+
+        expect(onRetry).toHaveBeenCalledTimes(1);
+        const call = onRetry.mock.calls[0][0];
+        expect(call.attempt).toBe(1);
+        // rng=0.5, attempt=1 => 0.5 * min(30000, 200) = 100
+        expect(call.delay).toBe(100);
+        expect(call.delay).toBeGreaterThanOrEqual(0);
+        expect(call.delay).toBeLessThanOrEqual(base);
+    });
+});

--- a/src/utils/retryWithBackoff.js
+++ b/src/utils/retryWithBackoff.js
@@ -1,24 +1,48 @@
 'use strict';
 
 /**
+ * Computes an exponential backoff delay with full jitter.
+ *
+ * Full jitter (per AWS "Exponential Backoff And Jitter") picks a uniformly
+ * random delay in [0, cap] where cap = baseDelayMs * 2^attempt (capped at
+ * maxDelayMs). This spreads out retries from many concurrent callers so they
+ * do not synchronize into a thundering herd against a recovering dependency,
+ * while keeping the expected delay growing exponentially.
+ *
+ * @param {number} attempt - Retry attempt number (1-based: first retry = 1)
+ * @param {number} baseDelayMs - Base delay for the exponential term
+ * @param {number} maxDelayMs - Upper bound on the (pre-jitter) exponential cap
+ * @param {Function} [rng=Math.random] - Random source in [0, 1) (injectable for tests)
+ * @returns {number} Delay in milliseconds
+ */
+function computeBackoffWithJitter (attempt, baseDelayMs, maxDelayMs, rng = Math.random) {
+    const exponentialCap = Math.min(maxDelayMs, baseDelayMs * Math.pow(2, attempt - 1));
+    // Full jitter: uniform random in [0, exponentialCap]
+    return Math.floor(rng() * exponentialCap);
+}
+
+/**
+ * Retries an async function with exponential backoff and full jitter.
+ *
  * @param {Object} params
  * @param {Function} params.fn - Async function to execute
  * @param {number} [params.maxRetries=3]
- * @param {number} [params.initialDelayMs=2000]
+ * @param {number} [params.initialDelayMs=2000] - Base delay for the exponential term
+ * @param {number} [params.maxDelayMs=30000] - Upper bound on the pre-jitter exponential cap
  * @param {Function} [params.onRetry] - Called before each retry with ({ attempt, maxRetries, delay, error })
+ * @param {Function} [params.rng=Math.random] - Random source in [0, 1) (injectable for tests)
  * @returns {Promise<*>}
  */
-async function retryWithBackoff ({ fn, maxRetries = 3, initialDelayMs = 2000, onRetry }) {
-    let delay = initialDelayMs;
+async function retryWithBackoff ({ fn, maxRetries = 3, initialDelayMs = 2000, maxDelayMs = 30000, onRetry, rng = Math.random }) {
     let lastError;
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
             if (attempt > 0) {
+                const delay = computeBackoffWithJitter(attempt, initialDelayMs, maxDelayMs, rng);
                 if (onRetry) {
                     onRetry({ attempt, maxRetries, delay, error: lastError });
                 }
                 await new Promise((resolve) => setTimeout(resolve, delay));
-                delay *= 2;
             }
             return await fn();
         } catch (err) {
@@ -30,4 +54,4 @@ async function retryWithBackoff ({ fn, maxRetries = 3, initialDelayMs = 2000, on
     }
 }
 
-module.exports = { retryWithBackoff };
+module.exports = { retryWithBackoff, computeBackoffWithJitter };


### PR DESCRIPTION
Hardening bundle (B3-B7) from the adversarial review of the Group-on-ClickHouse path.

- **B4 idempotency:** `event_id` = uuidv5(group_id|entity_reference|event_type|correlation_id), stable `correlation_id` set per row, plus `insert_deduplicate` + stable dedup token. A retried write yields byte-identical, engine-deduplicated rows (previously fresh uuidv4 → duplicates).
- **B3 tenant fail-closed:** empty access+owner tags now inject `1 = 0` (deny) in the find and count builders; legitimate wildcard `['*']` admin scope preserved.
- **B5 retry+jitter:** `retryWithBackoff` now uses full jitter; the Group insert (previously no retry) is wrapped in bounded retry-with-jittered-backoff.
- **B7:** enrichment re-throws on a ClickHouse read error instead of silently returning `quantity: 0` + 200 OK.
- **B6:** watch-item comment on the reverse-lookup `FINAL` query.

Tests: 41 new unit tests (idempotency, jitter bounds, empty-tag deny, dedup token, enrichment error propagation) + 67 existing module tests pass. Run locally via a no-container jest config (worktree symlink breaks testcontainers); **CI runs the full container suite**. Draft pending adversarial review + coverage/k6 pass.

Design calls for reviewer: (1) B3 uses force-deny vs throw-on-empty-tags; (2) B4 correlation derived from group_id|versionId + lastUpdated unless a canonical request id is threaded via contextData.correlationId; (3) may warrant an ADR. Refs EA-2323.