### PR TITLE
PHR-3191: Add field-level pagination to Composition.section (GraphQL v1 + v2)

### DIFF
--- a/generated.sdl/graphql_v1.graphql
+++ b/generated.sdl/graphql_v1.graphql
@@ -61731,7 +61731,7 @@ type Composition {
   event: [CompositionEvent]
 
   """The root of the sections that make up the composition."""
-  section: [CompositionSection]
+  section(_offset: Int, _count: Int): [CompositionSection]
 }
 
 type CompositionBundleEntry {

--- a/generated.sdl/graphql_v2.graphql
+++ b/generated.sdl/graphql_v2.graphql
@@ -64884,7 +64884,7 @@ type Composition implements DomainResource & Resource
   event: [CompositionEvent]
 
   """The root of the sections that make up the composition."""
-  section: [CompositionSection]
+  section(_offset: Int, _count: Int): [CompositionSection]
 }
 
 type CompositionBundleEntry {

--- a/generatorScripts/graphql/template.resource.jinja2
+++ b/generatorScripts/graphql/template.resource.jinja2
@@ -64,6 +64,7 @@ type {{fhir_entity.cleaned_name}} {
 {%- if fhir_entity.fhir_name == "CodeSystem" and property.name == "concept" -%}(code: [String]){%- endif -%}
 {%- if fhir_entity.fhir_name == "Patient" and property.name == "name" -%}(use: [String]){%- endif -%}
 {%- if fhir_entity.fhir_name == "CodeableConcept" and property.name == "coding" -%}(system: [String]){%- endif -%}
+{%- if fhir_entity.fhir_name == "Composition" and property.name == "section" -%}(_offset: Int, _count: Int){%- endif -%}
 {{- ': ' -}}
         {% if property.is_list -%}
             {{ '[' -}}

--- a/generatorScripts/graphqlv2/schema/template.resource.jinja2
+++ b/generatorScripts/graphqlv2/schema/template.resource.jinja2
@@ -108,6 +108,7 @@ type {{ fhir_entity.graphqlv2_type }} @key(fields: "id") {
     {{ property.documentation[0] | wordwrap(78) | replace('\n', '\n    ') | replace('\r', '\n    ') }}
     """
     {{ property.name -}}
+{%- if fhir_entity.fhir_name == "Composition" and property.name == "section" -%}(_offset: Int, _count: Int){%- endif -%}
 {{- ': ' -}}
         {% if property.is_list -%}
             {{ '[' -}}

--- a/src/graphql/resolvers/custom/composition.js
+++ b/src/graphql/resolvers/custom/composition.js
@@ -1,0 +1,28 @@
+// Field-level pagination for Composition.section per the FHIR GraphQL spec
+// (_offset / _count on a repeating element: https://build.fhir.org/graphql.html#searching).
+// Lets callers fetch a single page of sections instead of the whole Composition.
+// Merged into the generated Composition resolver via mergeResolvers; the generated
+// resolver does not define `section`, so this is purely additive.
+module.exports = {
+    Composition: {
+        /**
+         * @param {Object|null} parent - the Composition resource
+         * @param {{_offset: (number|undefined), _count: (number|undefined)}} args
+         * @return {Object[]|undefined}
+         */
+        section: (parent, args) => {
+            const sections = parent ? parent.section : undefined;
+            if (!Array.isArray(sections)) {
+                return sections;
+            }
+            const { _offset, _count } = args || {};
+            // No paging args -> return the full list (backwards compatible).
+            if (_offset == null && _count == null) {
+                return sections;
+            }
+            const start = _offset > 0 ? _offset : 0;
+            const end = _count != null ? start + _count : undefined;
+            return sections.slice(start, end);
+        }
+    }
+};

--- a/src/graphql/resolvers/custom/composition.js
+++ b/src/graphql/resolvers/custom/composition.js
@@ -21,7 +21,10 @@ module.exports = {
                 return sections;
             }
             const start = _offset > 0 ? _offset : 0;
-            const end = _count != null ? start + _count : undefined;
+            // Clamp a negative _count to 0 (empty page) rather than leaking Array.slice
+            // negative-index semantics; _count == null stays unbounded (return the rest).
+            const safeCount = _count != null && _count < 0 ? 0 : _count;
+            const end = safeCount != null ? start + safeCount : undefined;
             return sections.slice(start, end);
         }
     }

--- a/src/graphql/schemas/resources/composition.graphql
+++ b/src/graphql/schemas/resources/composition.graphql
@@ -316,7 +316,7 @@ type Composition {
     """
     The root of the sections that make up the composition.
     """
-    section: [CompositionSection]
+    section(_offset: Int, _count: Int): [CompositionSection]
 }
 
 type CompositionBundleEntry {

--- a/src/graphqlv2/resolvers/custom/composition.js
+++ b/src/graphqlv2/resolvers/custom/composition.js
@@ -1,0 +1,28 @@
+// Field-level pagination for Composition.section per the FHIR GraphQL spec
+// (_offset / _count on a repeating element: https://build.fhir.org/graphql.html#searching).
+// Lets callers fetch a single page of sections instead of the whole Composition.
+// Merged into the generated Composition resolver via mergeResolvers; the generated
+// resolver only defines __resolveReference, so this is purely additive.
+module.exports = {
+    Composition: {
+        /**
+         * @param {Object|null} parent - the Composition resource
+         * @param {{_offset: (number|undefined), _count: (number|undefined)}} args
+         * @return {Object[]|undefined}
+         */
+        section: (parent, args) => {
+            const sections = parent ? parent.section : undefined;
+            if (!Array.isArray(sections)) {
+                return sections;
+            }
+            const { _offset, _count } = args || {};
+            // No paging args -> return the full list (backwards compatible).
+            if (_offset == null && _count == null) {
+                return sections;
+            }
+            const start = _offset > 0 ? _offset : 0;
+            const end = _count != null ? start + _count : undefined;
+            return sections.slice(start, end);
+        }
+    }
+};

--- a/src/graphqlv2/resolvers/custom/composition.js
+++ b/src/graphqlv2/resolvers/custom/composition.js
@@ -21,7 +21,10 @@ module.exports = {
                 return sections;
             }
             const start = _offset > 0 ? _offset : 0;
-            const end = _count != null ? start + _count : undefined;
+            // Clamp a negative _count to 0 (empty page) rather than leaking Array.slice
+            // negative-index semantics; _count == null stays unbounded (return the rest).
+            const safeCount = _count != null && _count < 0 ? 0 : _count;
+            const end = safeCount != null ? start + safeCount : undefined;
             return sections.slice(start, end);
         }
     }

--- a/src/graphqlv2/schemas/resources/composition.graphql
+++ b/src/graphqlv2/schemas/resources/composition.graphql
@@ -359,7 +359,7 @@ type Composition implements DomainResource & Resource @key(fields: "id") {
     """
     The root of the sections that make up the composition.
     """
-    section: [CompositionSection]
+    section(_offset: Int, _count: Int): [CompositionSection]
 }
 
 type CompositionBundleEntry {

--- a/src/tests/graphql/compositionSectionPagination/composition_section_pagination.test.js
+++ b/src/tests/graphql/compositionSectionPagination/composition_section_pagination.test.js
@@ -111,4 +111,15 @@ describe('GraphQL Composition.section field-level pagination', () => {
         );
         expect(sections).toEqual([]);
     });
+
+    test('negative _count returns an empty page (clamped, not slice-from-end)', async () => {
+        const request = await createTestRequest();
+        await seedComposition(request);
+
+        const sections = await querySections(
+            request,
+            `query { composition { entry { resource { id section(_offset: 0, _count: -1) { id } } } } }`
+        );
+        expect(sections).toEqual([]);
+    });
 });

--- a/src/tests/graphql/compositionSectionPagination/composition_section_pagination.test.js
+++ b/src/tests/graphql/compositionSectionPagination/composition_section_pagination.test.js
@@ -1,0 +1,112 @@
+// Tests field-level pagination of Composition.section (_offset / _count) added via the
+// custom Composition resolver. See src/graphql/resolvers/custom/composition.js.
+const composition1Resource = require('./fixtures/composition1.json');
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    getGraphQLHeaders,
+    createTestRequest,
+    getTestContainer
+} = require('../../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+
+/**
+ * Merge the fixture Composition and wait for async processing to finish.
+ * @param {import('supertest').SuperTest} request
+ */
+async function seedComposition(request) {
+    const resp = await request
+        .post('/4_0_0/Composition/1/$merge')
+        .send(composition1Resource)
+        .set(getHeaders());
+    // noinspection JSUnresolvedFunction
+    expect(resp).toHaveMergeResponse({ created: true });
+
+    const testContainer = getTestContainer();
+    await testContainer.postRequestProcessor.waitTillAllRequestsDoneAsync({ timeoutInSeconds: 20 });
+    await testContainer.requestSpecificCache.clearAllAsync();
+}
+
+/**
+ * @param {import('supertest').SuperTest} request
+ * @param {string} query
+ * @return {Promise<Object[]>} the section array of the first returned Composition
+ */
+async function querySections(request, query) {
+    const resp = await request
+        .post('/$graphql')
+        .send({ operationName: null, variables: {}, query })
+        .set(getGraphQLHeaders());
+
+    expect(resp.body.errors).toBeUndefined();
+    return resp.body.data.composition[0].section;
+}
+
+describe('GraphQL Composition.section field-level pagination', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    test('returns the full list when no paging args are given', async () => {
+        const request = await createTestRequest();
+        await seedComposition(request);
+
+        const sections = await querySections(
+            request,
+            `query { composition { id section { id } } }`
+        );
+        expect(sections.map((s) => s.id)).toEqual(['section-0', 'section-1', 'section-2']);
+    });
+
+    test('_count limits the number of sections from the start', async () => {
+        const request = await createTestRequest();
+        await seedComposition(request);
+
+        const sections = await querySections(
+            request,
+            `query { composition { id section(_count: 2) { id } } }`
+        );
+        expect(sections.map((s) => s.id)).toEqual(['section-0', 'section-1']);
+    });
+
+    test('_offset skips sections from the start', async () => {
+        const request = await createTestRequest();
+        await seedComposition(request);
+
+        const sections = await querySections(
+            request,
+            `query { composition { id section(_offset: 1) { id } } }`
+        );
+        expect(sections.map((s) => s.id)).toEqual(['section-1', 'section-2']);
+    });
+
+    test('_offset + _count returns a single page (the page the UI would request)', async () => {
+        const request = await createTestRequest();
+        await seedComposition(request);
+
+        const sections = await querySections(
+            request,
+            `query { composition { id section(_offset: 1, _count: 1) { id title } } }`
+        );
+        expect(sections).toHaveLength(1);
+        expect(sections[0].id).toEqual('section-1');
+        expect(sections[0].title).toEqual('Section One');
+    });
+
+    test('_offset past the end returns an empty page', async () => {
+        const request = await createTestRequest();
+        await seedComposition(request);
+
+        const sections = await querySections(
+            request,
+            `query { composition { id section(_offset: 10, _count: 5) { id } } }`
+        );
+        expect(sections).toEqual([]);
+    });
+});

--- a/src/tests/graphql/compositionSectionPagination/composition_section_pagination.test.js
+++ b/src/tests/graphql/compositionSectionPagination/composition_section_pagination.test.js
@@ -30,6 +30,8 @@ async function seedComposition(request) {
 }
 
 /**
+ * The v1 `composition` query returns a CompositionBundle, so the resource (and its
+ * paginated section list) is reached via entry[].resource.
  * @param {import('supertest').SuperTest} request
  * @param {string} query
  * @return {Promise<Object[]>} the section array of the first returned Composition
@@ -41,7 +43,7 @@ async function querySections(request, query) {
         .set(getGraphQLHeaders());
 
     expect(resp.body.errors).toBeUndefined();
-    return resp.body.data.composition[0].section;
+    return resp.body.data.composition.entry[0].resource.section;
 }
 
 describe('GraphQL Composition.section field-level pagination', () => {
@@ -59,7 +61,7 @@ describe('GraphQL Composition.section field-level pagination', () => {
 
         const sections = await querySections(
             request,
-            `query { composition { id section { id } } }`
+            `query { composition { entry { resource { id section { id } } } } }`
         );
         expect(sections.map((s) => s.id)).toEqual(['section-0', 'section-1', 'section-2']);
     });
@@ -70,7 +72,7 @@ describe('GraphQL Composition.section field-level pagination', () => {
 
         const sections = await querySections(
             request,
-            `query { composition { id section(_count: 2) { id } } }`
+            `query { composition { entry { resource { id section(_count: 2) { id } } } } }`
         );
         expect(sections.map((s) => s.id)).toEqual(['section-0', 'section-1']);
     });
@@ -81,7 +83,7 @@ describe('GraphQL Composition.section field-level pagination', () => {
 
         const sections = await querySections(
             request,
-            `query { composition { id section(_offset: 1) { id } } }`
+            `query { composition { entry { resource { id section(_offset: 1) { id } } } } }`
         );
         expect(sections.map((s) => s.id)).toEqual(['section-1', 'section-2']);
     });
@@ -92,7 +94,7 @@ describe('GraphQL Composition.section field-level pagination', () => {
 
         const sections = await querySections(
             request,
-            `query { composition { id section(_offset: 1, _count: 1) { id title } } }`
+            `query { composition { entry { resource { id section(_offset: 1, _count: 1) { id title } } } } }`
         );
         expect(sections).toHaveLength(1);
         expect(sections[0].id).toEqual('section-1');
@@ -105,7 +107,7 @@ describe('GraphQL Composition.section field-level pagination', () => {
 
         const sections = await querySections(
             request,
-            `query { composition { id section(_offset: 10, _count: 5) { id } } }`
+            `query { composition { entry { resource { id section(_offset: 10, _count: 5) { id } } } } }`
         );
         expect(sections).toEqual([]);
     });

--- a/src/tests/graphql/compositionSectionPagination/fixtures/composition1.json
+++ b/src/tests/graphql/compositionSectionPagination/fixtures/composition1.json
@@ -1,0 +1,41 @@
+{
+    "resourceType": "Composition",
+    "id": "composition-pagination-1",
+    "meta": {
+        "source": "https://www.icanbwell.com/intelligence-layer-pipeline",
+        "security": [
+            { "system": "https://www.icanbwell.com/owner", "code": "bwell" },
+            { "system": "https://www.icanbwell.com/access", "code": "bwell" },
+            { "system": "https://www.icanbwell.com/sourceAssigningAuthority", "code": "bwell" }
+        ]
+    },
+    "status": "preliminary",
+    "type": {
+        "coding": [
+            {
+                "system": "https://fhir.icanbwell.com/4_0_0/CodeSystem/composition/",
+                "code": "condition_summary_document",
+                "display": "b.Well Condition Summary Composition Document"
+            }
+        ],
+        "text": "Condition Summary Composition Document"
+    },
+    "subject": {
+        "reference": "Patient/e8cfea6f-7051-5c11-b306-b995e6f6adf0",
+        "type": "Patient"
+    },
+    "date": "2024-03-14T16:52:11Z",
+    "author": [
+        {
+            "reference": "Organization/078cf112-f802-4e4b-9b62-ed44cdf05d27",
+            "type": "Organization",
+            "display": "bwell Connected Health"
+        }
+    ],
+    "title": "Condition Summary",
+    "section": [
+        { "id": "section-0", "title": "Section Zero" },
+        { "id": "section-1", "title": "Section One" },
+        { "id": "section-2", "title": "Section Two" }
+    ]
+}

--- a/src/tests/graphqlv2/compositionSectionPagination/composition_section_pagination.test.js
+++ b/src/tests/graphqlv2/compositionSectionPagination/composition_section_pagination.test.js
@@ -1,0 +1,91 @@
+// Tests field-level pagination of Composition.section (_offset / _count) on the v2
+// (federated) graph. See src/graphqlv2/resolvers/custom/composition.js.
+const composition1Resource = require('./fixtures/composition1.json');
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    getGraphQLHeaders,
+    createTestRequest,
+    getTestContainer
+} = require('../../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+
+/**
+ * Merge the fixture Composition and wait for async processing to finish.
+ * @param {import('supertest').SuperTest} request
+ */
+async function seedComposition(request) {
+    const resp = await request
+        .post('/4_0_0/Composition/1/$merge')
+        .send(composition1Resource)
+        .set(getHeaders());
+    // noinspection JSUnresolvedFunction
+    expect(resp).toHaveMergeResponse({ created: true });
+
+    const testContainer = getTestContainer();
+    await testContainer.postRequestProcessor.waitTillAllRequestsDoneAsync({ timeoutInSeconds: 20 });
+    await testContainer.requestSpecificCache.clearAllAsync();
+}
+
+/**
+ * @param {import('supertest').SuperTest} request
+ * @param {string} query
+ * @return {Promise<Object[]>} the section array of the first returned Composition
+ */
+async function querySections(request, query) {
+    const resp = await request
+        .post('/4_0_0/$graphqlv2')
+        .send({ operationName: null, variables: {}, query })
+        .set(getGraphQLHeaders())
+        .expect(200);
+
+    expect(resp.body.errors).toBeUndefined();
+    return resp.body.data.compositions.entry[0].resource.section;
+}
+
+describe('GraphQL v2 Composition.section field-level pagination', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    test('returns the full list when no paging args are given', async () => {
+        const request = await createTestRequest();
+        await seedComposition(request);
+
+        const sections = await querySections(
+            request,
+            `query { compositions { entry { resource { id section { id } } } } }`
+        );
+        expect(sections.map((s) => s.id)).toEqual(['section-0', 'section-1', 'section-2']);
+    });
+
+    test('_offset + _count returns a single page', async () => {
+        const request = await createTestRequest();
+        await seedComposition(request);
+
+        const sections = await querySections(
+            request,
+            `query { compositions { entry { resource { id section(_offset: 1, _count: 1) { id title } } } } }`
+        );
+        expect(sections).toHaveLength(1);
+        expect(sections[0].id).toEqual('section-1');
+        expect(sections[0].title).toEqual('Section One');
+    });
+
+    test('_offset past the end returns an empty page', async () => {
+        const request = await createTestRequest();
+        await seedComposition(request);
+
+        const sections = await querySections(
+            request,
+            `query { compositions { entry { resource { id section(_offset: 10, _count: 5) { id } } } } }`
+        );
+        expect(sections).toEqual([]);
+    });
+});

--- a/src/tests/graphqlv2/compositionSectionPagination/composition_section_pagination.test.js
+++ b/src/tests/graphqlv2/compositionSectionPagination/composition_section_pagination.test.js
@@ -88,4 +88,15 @@ describe('GraphQL v2 Composition.section field-level pagination', () => {
         );
         expect(sections).toEqual([]);
     });
+
+    test('negative _count returns an empty page (clamped, not slice-from-end)', async () => {
+        const request = await createTestRequest();
+        await seedComposition(request);
+
+        const sections = await querySections(
+            request,
+            `query { compositions { entry { resource { id section(_offset: 0, _count: -1) { id } } } } }`
+        );
+        expect(sections).toEqual([]);
+    });
 });

--- a/src/tests/graphqlv2/compositionSectionPagination/fixtures/composition1.json
+++ b/src/tests/graphqlv2/compositionSectionPagination/fixtures/composition1.json
@@ -1,0 +1,41 @@
+{
+    "resourceType": "Composition",
+    "id": "composition-pagination-1",
+    "meta": {
+        "source": "https://www.icanbwell.com/intelligence-layer-pipeline",
+        "security": [
+            { "system": "https://www.icanbwell.com/owner", "code": "bwell" },
+            { "system": "https://www.icanbwell.com/access", "code": "bwell" },
+            { "system": "https://www.icanbwell.com/sourceAssigningAuthority", "code": "bwell" }
+        ]
+    },
+    "status": "preliminary",
+    "type": {
+        "coding": [
+            {
+                "system": "https://fhir.icanbwell.com/4_0_0/CodeSystem/composition/",
+                "code": "condition_summary_document",
+                "display": "b.Well Condition Summary Composition Document"
+            }
+        ],
+        "text": "Condition Summary Composition Document"
+    },
+    "subject": {
+        "reference": "Patient/e8cfea6f-7051-5c11-b306-b995e6f6adf0",
+        "type": "Patient"
+    },
+    "date": "2024-03-14T16:52:11Z",
+    "author": [
+        {
+            "reference": "Organization/078cf112-f802-4e4b-9b62-ed44cdf05d27",
+            "type": "Organization",
+            "display": "bwell Connected Health"
+        }
+    ],
+    "title": "Condition Summary",
+    "section": [
+        { "id": "section-0", "title": "Section Zero" },
+        { "id": "section-1", "title": "Section One" },
+        { "id": "section-2", "title": "Section Two" }
+    ]
+}


### PR DESCRIPTION
## Summary

Adds spec-compliant field-level pagination to **`Composition.section`** on both GraphQL graphs, so callers can fetch a single page of sections instead of the whole Composition — reducing response payload and downstream (HDS) memory.

Ticket: [PHR-3191](https://icanbwell.atlassian.net/browse/PHR-3191) · Analysis/FDR: [PHR-3170](https://icanbwell.atlassian.net/browse/PHR-3170)

[Demo](https://drive.google.com/file/d/1iy75qqy8wgE43mUZutzQL1Mo8_5M803n/view?usp=drive_link)

## What & why

Health Summary cards (Conditions, Vitals, Immunizations, …) are backed by a single `Composition` whose `section[]` holds one record per item. Today the entire Composition is pulled into HDS and paginated in memory. This adds `_offset` / `_count` arguments to `Composition.section`, per the [FHIR GraphQL spec](https://build.fhir.org/graphql.html#searching) for repeating elements, so the FHIR server returns just the requested window.

```graphql
query {
  composition(type: "…|condition_summary_document", patient: $patient) {
    id
    section(_offset: 0, _count: 10) { id title code { coding { code display } } }
  }
}
```

## Changes

- **Schema generators** (`generatorScripts/graphql` + `generatorScripts/graphqlv2`): emit `(_offset: Int, _count: Int)` **only** for `Composition.section`, mirroring the existing per-field precedent (`Patient.name(use:)`, `CodeableConcept.coding(system:)`).
- **Generated schemas** regenerated for both graphs; **SDL snapshot** (`generated.sdl/`) regenerated to match.
- **Custom resolvers** (`src/graphql/resolvers/custom/composition.js`, `src/graphqlv2/resolvers/custom/composition.js`): slice `parent.section`; with no args the full list is returned (backwards compatible). Merged additively via `mergeResolvers` — the generated resolvers don't define `section`.
- **Tests** for both graphs: default (no args), `_count`, `_offset`, `_offset + _count`, and past-end.

## Scope

Intentionally limited to **`Composition.section`** on both v1 (`/$graphql`) and v2 (`/4_0_0/$graphqlv2`, federated). No other resource or field is affected. The total count is carried separately via a Composition extension (owned by the producers), out of scope here.

## Spec compliance

`_offset`/`_count` on a repeating element is exactly what the FHIR GraphQL spec defines — no custom fields or non-standard semantics.

## Testing

- Resolver logic verified directly (no-args → full list; `_offset`/`_count` → slice; past-end → empty; missing `section` → passthrough).
- Integration tests added under `src/tests/graphql/compositionSectionPagination` and `src/tests/graphqlv2/compositionSectionPagination`. Run locally (the jest harness needs Docker for the ClickHouse testcontainer):
  ```
  node node_modules/.bin/jest src/tests/graphql/compositionSectionPagination
  node node_modules/.bin/jest src/tests/graphqlv2/compositionSectionPagination
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PHR-3191]: https://icanbwell.atlassian.net/browse/PHR-3191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PHR-3170]: https://icanbwell.atlassian.net/browse/PHR-3170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ