### PR TITLE
DCON-4266: Add summary in access-history

### DIFF
--- a/src/constants/clickHouseConstants.js
+++ b/src/constants/clickHouseConstants.js
@@ -46,6 +46,11 @@ module.exports = {
         JSON_EACH_ROW: 'JSONEachRow'
     },
 
+    // Rolling window (in days) covered by the $access-history operation.
+    // Shared between the ClickHouse aggregation query and the summary section
+    // of the Parameters response so the two never drift apart.
+    ACCESS_HISTORY_WINDOW_DAYS: 90,
+
     // DateTime conversion patterns
     DATETIME_CONVERSION: {
         // ISO 8601 to ClickHouse DateTime64 format

--- a/src/dataLayer/repositories/accessHistoryClickHouseRepository.js
+++ b/src/dataLayer/repositories/accessHistoryClickHouseRepository.js
@@ -1,4 +1,4 @@
-const { TABLES } = require('../../constants/clickHouseConstants');
+const { TABLES, ACCESS_HISTORY_WINDOW_DAYS } = require('../../constants/clickHouseConstants');
 const { assertIsValid } = require('../../utils/assertType');
 
 class AccessHistoryClickHouseRepository {
@@ -28,7 +28,7 @@ class AccessHistoryClickHouseRepository {
                 groupUniqArrayMerge(purpose_of_events) AS purposes
             FROM ${TABLES.AUDIT_ACCESS_AGG}
             WHERE entity_ref IN {entity_refs:Array(String)}
-            AND recorded_month >= toStartOfMonth(now() - INTERVAL 90 DAY)
+            AND recorded_month >= toStartOfMonth(now() - INTERVAL ${ACCESS_HISTORY_WINDOW_DAYS} DAY)
             GROUP BY accessor_uuid, entity_resource_type
             ORDER BY last_accessed DESC
         `;

--- a/src/operations/accessHistory/accessHistory.js
+++ b/src/operations/accessHistory/accessHistory.js
@@ -8,6 +8,7 @@ const { NotFoundError, BadRequestError, ForbiddenError } = require('../../utils/
 const { PERSON_PROXY_PREFIX } = require('../../constants');
 const { sliceIntoChunks } = require('../../utils/list.util');
 const { logInfo } = require('../common/logging');
+const { ACCESS_HISTORY_WINDOW_DAYS } = require('../../constants/clickHouseConstants');
 
 class AccessHistoryOperation {
     /**
@@ -125,7 +126,7 @@ class AccessHistoryOperation {
         }
 
         if (allRows.length === 0) {
-            return { resourceType: 'Parameters', parameter: [] };
+            return { resourceType: 'Parameters', parameter: [this._buildSummaryParameter()] };
         }
 
         // 4. Group by accessor (preserving per-resource-type counts)
@@ -238,7 +239,7 @@ class AccessHistoryOperation {
      * @param {Object} params
      * @param {string[]} params.accessorRefs
      * @param {string} params.base_version
-     * @returns {Promise<Object<string, {display: string, organizations: Array<{reference: string, display: string}>}>>}
+     * @returns {Promise<Object<string, {display: string, organizations: Array<{reference: string, display: string, name: string, sourceId: string}>}>>}
      */
     async _resolveAccessorDetails({ accessorRefs, base_version }) {
         const details = {};
@@ -330,9 +331,12 @@ class AccessHistoryOperation {
                     projection: { _uuid: 1, name: 1 }
                 });
                 for (const org of orgs) {
+                    const orgName = typeof org.name === 'string' ? org.name : '';
                     orgDetails[org._uuid] = {
                         reference: `Organization/${org._uuid}`,
-                        display: typeof org.name === 'string' ? org.name : ''
+                        display: orgName,
+                        name: orgName,
+                        sourceId: org._uuid
                     };
                 }
             }
@@ -431,6 +435,27 @@ class AccessHistoryOperation {
     }
 
     /**
+     * Builds the top-level `summary` parameter containing response-level metadata.
+     * Emitted on every response path (including the empty/no-results case) per RFC §4.1.2.
+     * @returns {Object}
+     */
+    _buildSummaryParameter() {
+        return {
+            name: 'summary',
+            part: [
+                {
+                    name: 'generatedAt',
+                    valueDateTime: new Date().toISOString()
+                },
+                {
+                    name: 'windowDays',
+                    valueInteger: ACCESS_HISTORY_WINDOW_DAYS
+                }
+            ]
+        };
+    }
+
+    /**
      * Builds the FHIR Parameters response per the FDR spec.
      * @param {Object} params
      * @param {Object} params.accessorMap
@@ -438,7 +463,7 @@ class AccessHistoryOperation {
      * @returns {Object}
      */
     _buildParametersResponse({ accessorMap, accessorDetails }) {
-        const parameter = [];
+        const parameter = [this._buildSummaryParameter()];
 
         for (const [accessorRef, data] of Object.entries(accessorMap)) {
             const detail = accessorDetails[accessorRef] || { display: accessorRef, organizations: [] };
@@ -461,15 +486,30 @@ class AccessHistoryOperation {
                 }
             ];
 
-            // Organization parts (for proxy patient accessors)
+            // Organization parts (for proxy patient accessors).
+            // Per FDR, each `organization` is a `part` container with `reference`,
+            // `name`, and `sourceId` sub-parts.
             if (detail.organizations) {
                 for (const org of detail.organizations) {
                     parts.push({
                         name: 'organization',
-                        valueReference: {
-                            reference: org.reference,
-                            display: org.display
-                        }
+                        part: [
+                            {
+                                name: 'reference',
+                                valueReference: {
+                                    reference: org.reference,
+                                    display: org.display
+                                }
+                            },
+                            {
+                                name: 'name',
+                                valueString: org.name
+                            },
+                            {
+                                name: 'sourceId',
+                                valueString: org.sourceId
+                            }
+                        ]
                     });
                 }
             }

--- a/src/tests/accessHistory/access_history/access_history.test.js
+++ b/src/tests/accessHistory/access_history/access_history.test.js
@@ -3,6 +3,8 @@ const person1Resource = require('./fixtures/Person/person1.json');
 const patient1Resource = require('./fixtures/Patient/patient1.json');
 const observation1Resource = require('./fixtures/Observation/observation1.json');
 const activeConsentResource = require('./fixtures/Consent/activeConsent.json');
+const org1Resource = require('./fixtures/Organization/org1.json');
+const accessorPersonWithOrgResource = require('./fixtures/Person/accessorPersonWithOrg.json');
 
 const expectedEmptyParameters = require('./fixtures/expected/expected_empty_parameters.json');
 const expectedSingleAccessor = require('./fixtures/expected/expected_single_accessor.json');
@@ -61,6 +63,26 @@ function daysAgo(days) {
     const d = new Date();
     d.setDate(d.getDate() - days);
     return toClickHouseDateTime(d);
+}
+
+/**
+ * Returns only the `accessor` parameters, skipping the top-level `summary` block.
+ */
+function getAccessors(body) {
+    return body.parameter.filter((p) => p.name === 'accessor');
+}
+
+/**
+ * Copies the dynamic `generatedAt` timestamp from the actual response into the
+ * expected fixture so the summary block can be asserted with an exact match.
+ */
+function syncGeneratedAt(expected, respBody) {
+    const expectedSummary = expected.parameter.find((p) => p.name === 'summary');
+    const respSummary = respBody.parameter.find((p) => p.name === 'summary');
+    if (expectedSummary && respSummary) {
+        expectedSummary.part.find((p) => p.name === 'generatedAt').valueDateTime =
+            respSummary.part.find((p) => p.name === 'generatedAt').valueDateTime;
+    }
 }
 
 describe('Person $access-history Tests', () => {
@@ -124,7 +146,34 @@ describe('Person $access-history Tests', () => {
             .get(`/4_0_0/Person/${personUuid}/$access-history`)
             .set(getHeaders());
 
-        expect(resp).toHaveResponse(expectedEmptyParameters);
+        const expected = deepcopy(expectedEmptyParameters);
+        syncGeneratedAt(expected, resp.body);
+        expect(resp).toHaveResponse(expected);
+    });
+
+    test('$access-history includes a summary block with generatedAt and windowDays', async () => {
+        const request = sharedRequest;
+
+        let resp = await request
+            .post('/4_0_0/Person/1/$merge?validate=true')
+            .send(person1Resource)
+            .set(getHeaders());
+        expect(resp).toHaveMergeResponse({ created: true });
+        const personUuid = resp.body.uuid;
+
+        resp = await request
+            .get(`/4_0_0/Person/${personUuid}/$access-history`)
+            .set(getHeaders());
+
+        const summary = resp.body.parameter.find((p) => p.name === 'summary');
+        expect(summary).toBeDefined();
+
+        const generatedAt = summary.part.find((p) => p.name === 'generatedAt').valueDateTime;
+        const windowDays = summary.part.find((p) => p.name === 'windowDays').valueInteger;
+
+        expect(windowDays).toBe(90);
+        // generatedAt must be a valid ISO-8601 timestamp
+        expect(Number.isNaN(Date.parse(generatedAt))).toBe(false);
     });
 
     test('$access-history returns empty parameters when no access records exist', async () => {
@@ -147,7 +196,9 @@ describe('Person $access-history Tests', () => {
             .get(`/4_0_0/Person/${personUuid}/$access-history`)
             .set(getHeaders());
 
-        expect(resp).toHaveResponse(expectedEmptyParameters);
+        const expected = deepcopy(expectedEmptyParameters);
+        syncGeneratedAt(expected, resp.body);
+        expect(resp).toHaveResponse(expected);
     });
 
     test('$access-history returns accessor details after a resource is read', async () => {
@@ -185,8 +236,9 @@ describe('Person $access-history Tests', () => {
             .set(getHeaders());
 
         const expected = deepcopy(expectedSingleAccessor);
-        expected.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
-            resp.body.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        getAccessors(expected)[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
+            getAccessors(resp.body)[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        syncGeneratedAt(expected, resp.body);
         expect(resp).toHaveResponse(expected);
     });
 
@@ -238,11 +290,12 @@ describe('Person $access-history Tests', () => {
 
         const expected = deepcopy(expectedE2ePatientRead);
         const accessorRefValue = `Patient/person.${personUuid}`;
-        const respRefPart = resp.body.parameter[0].part.find((p) => p.name === 'reference');
-        expected.parameter[0].part.find((p) => p.name === 'reference').valueReference.reference = accessorRefValue;
-        expected.parameter[0].part.find((p) => p.name === 'reference').valueReference.display = respRefPart.valueReference.display;
-        expected.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
-            resp.body.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        const respRefPart = getAccessors(resp.body)[0].part.find((p) => p.name === 'reference');
+        getAccessors(expected)[0].part.find((p) => p.name === 'reference').valueReference.reference = accessorRefValue;
+        getAccessors(expected)[0].part.find((p) => p.name === 'reference').valueReference.display = respRefPart.valueReference.display;
+        getAccessors(expected)[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
+            getAccessors(resp.body)[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        syncGeneratedAt(expected, resp.body);
         expect(resp).toHaveResponse(expected);
     });
 
@@ -309,11 +362,12 @@ describe('Person $access-history Tests', () => {
             .set(getHeaders());
 
         const expected = deepcopy(expectedDelegatedUserAccess);
-        const respRefPart = resp.body.parameter[0].part.find((p) => p.name === 'reference');
-        expected.parameter[0].part.find((p) => p.name === 'reference').valueReference.reference = respRefPart.valueReference.reference;
-        expected.parameter[0].part.find((p) => p.name === 'reference').valueReference.display = respRefPart.valueReference.display;
-        expected.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
-            resp.body.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        const respRefPart = getAccessors(resp.body)[0].part.find((p) => p.name === 'reference');
+        getAccessors(expected)[0].part.find((p) => p.name === 'reference').valueReference.reference = respRefPart.valueReference.reference;
+        getAccessors(expected)[0].part.find((p) => p.name === 'reference').valueReference.display = respRefPart.valueReference.display;
+        getAccessors(expected)[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
+            getAccessors(resp.body)[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        syncGeneratedAt(expected, resp.body);
         expect(resp).toHaveResponse(expected);
     });
 
@@ -372,14 +426,15 @@ describe('Person $access-history Tests', () => {
             .set(getHeaders());
 
         const expected = deepcopy(expectedResourceTypeBreakdown);
-        expected.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
-            resp.body.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
-        const respRtParts = resp.body.parameter[0].part.filter((p) => p.name === 'resourceType');
-        const expectedRtParts = expected.parameter[0].part.filter((p) => p.name === 'resourceType');
+        getAccessors(expected)[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
+            getAccessors(resp.body)[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        const respRtParts = getAccessors(resp.body)[0].part.filter((p) => p.name === 'resourceType');
+        const expectedRtParts = getAccessors(expected)[0].part.filter((p) => p.name === 'resourceType');
         expectedRtParts[0].part.find((p) => p.name === 'type').valueCode =
             respRtParts[0].part.find((p) => p.name === 'type').valueCode;
         expectedRtParts[1].part.find((p) => p.name === 'type').valueCode =
             respRtParts[1].part.find((p) => p.name === 'type').valueCode;
+        syncGeneratedAt(expected, resp.body);
         expect(resp).toHaveResponse(expected);
     });
 
@@ -536,17 +591,20 @@ describe('Person $access-history Tests', () => {
             .set(getHeaders());
 
         const expected = deepcopy(expectedMultipleAccessors);
+        const respAccessors = getAccessors(resp.body);
+        const expectedAccessors = getAccessors(expected);
         // Match expected parameter order to actual response order
-        const respParam0Ref = resp.body.parameter[0].part.find((p) => p.name === 'reference').valueReference.reference;
-        const respParam1Ref = resp.body.parameter[1].part.find((p) => p.name === 'reference').valueReference.reference;
-        expected.parameter[0].part.find((p) => p.name === 'reference').valueReference.reference = respParam0Ref;
-        expected.parameter[0].part.find((p) => p.name === 'reference').valueReference.display = respParam0Ref;
-        expected.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
-            resp.body.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
-        expected.parameter[1].part.find((p) => p.name === 'reference').valueReference.reference = respParam1Ref;
-        expected.parameter[1].part.find((p) => p.name === 'reference').valueReference.display = respParam1Ref;
-        expected.parameter[1].part.find((p) => p.name === 'lastAccessed').valueDateTime =
-            resp.body.parameter[1].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        const respParam0Ref = respAccessors[0].part.find((p) => p.name === 'reference').valueReference.reference;
+        const respParam1Ref = respAccessors[1].part.find((p) => p.name === 'reference').valueReference.reference;
+        expectedAccessors[0].part.find((p) => p.name === 'reference').valueReference.reference = respParam0Ref;
+        expectedAccessors[0].part.find((p) => p.name === 'reference').valueReference.display = respParam0Ref;
+        expectedAccessors[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
+            respAccessors[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        expectedAccessors[1].part.find((p) => p.name === 'reference').valueReference.reference = respParam1Ref;
+        expectedAccessors[1].part.find((p) => p.name === 'reference').valueReference.display = respParam1Ref;
+        expectedAccessors[1].part.find((p) => p.name === 'lastAccessed').valueDateTime =
+            respAccessors[1].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        syncGeneratedAt(expected, resp.body);
         expect(resp).toHaveResponse(expected);
     });
 
@@ -612,8 +670,9 @@ describe('Person $access-history Tests', () => {
             .set(getHeaders());
 
         const expected = deepcopy(expectedAggregatedCounts);
-        expected.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
-            resp.body.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        getAccessors(expected)[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
+            getAccessors(resp.body)[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        syncGeneratedAt(expected, resp.body);
         expect(resp).toHaveResponse(expected);
     });
 
@@ -656,9 +715,80 @@ describe('Person $access-history Tests', () => {
             .set(getHeaders());
 
         const expected = deepcopy(expectedPurposeOfEvent);
-        expected.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
-            resp.body.parameter[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        getAccessors(expected)[0].part.find((p) => p.name === 'lastAccessed').valueDateTime =
+            getAccessors(resp.body)[0].part.find((p) => p.name === 'lastAccessed').valueDateTime;
+        syncGeneratedAt(expected, resp.body);
         expect(resp).toHaveResponse(expected);
+    });
+
+    test('$access-history returns organization block per FDR for a proxy patient accessor', async () => {
+        const request = sharedRequest;
+
+        let resp = await request
+            .post('/4_0_0/Person/1/$merge?validate=true')
+            .send(person1Resource)
+            .set(getHeaders());
+        expect(resp).toHaveMergeResponse({ created: true });
+        const personUuid = resp.body.uuid;
+
+        resp = await request
+            .post('/4_0_0/Patient/1/$merge?validate=true')
+            .send(patient1Resource)
+            .set(getHeaders());
+        expect(resp).toHaveMergeResponse({ created: true });
+        const patientUuid = resp.body.uuid;
+
+        resp = await request
+            .post('/4_0_0/Organization/1/$merge?validate=true')
+            .send(org1Resource)
+            .set(getHeaders());
+        expect(resp).toHaveMergeResponse({ created: true });
+        const orgUuid = resp.body.uuid;
+
+        // The accessor is a proxy patient whose Person has a managingOrganization,
+        // which is the only path that surfaces an `organization` block.
+        resp = await request
+            .post('/4_0_0/Person/1/$merge?validate=true')
+            .send(accessorPersonWithOrgResource)
+            .set(getHeaders());
+        expect(resp).toHaveMergeResponse({ created: true });
+        const accessorPersonUuid = resp.body.uuid;
+
+        const accessorRef = `Patient/person.${accessorPersonUuid}`;
+        await insertAuditEvents([{
+            id: 'ae-org',
+            _uuid: 'ae-uuid-org',
+            recorded: daysAgo(1),
+            action: 'R',
+            agent_who: [accessorRef],
+            agent_altid: [],
+            entity_what: [`Patient/${patientUuid}`],
+            agent_requestor_who: accessorRef
+        }]);
+
+        resp = await request
+            .get(`/4_0_0/Person/${personUuid}/$access-history`)
+            .set(getHeaders());
+
+        const accessor = getAccessors(resp.body)
+            .find((a) => a.part.find((p) => p.name === 'reference').valueReference.reference === accessorRef);
+        expect(accessor).toBeDefined();
+
+        const orgPart = accessor.part.find((p) => p.name === 'organization');
+        expect(orgPart).toBeDefined();
+        // Per FDR the organization is a `part` container, not a flat valueReference.
+        expect(orgPart.valueReference).toBeUndefined();
+        expect(Array.isArray(orgPart.part)).toBe(true);
+
+        const orgReference = orgPart.part.find((p) => p.name === 'reference').valueReference;
+        const orgName = orgPart.part.find((p) => p.name === 'name').valueString;
+        const orgSourceId = orgPart.part.find((p) => p.name === 'sourceId').valueString;
+
+        expect(orgReference.reference).toBe(`Organization/${orgUuid}`);
+        expect(orgReference.display).toBe('HealthSystem One');
+        expect(orgName).toBe('HealthSystem One');
+        // Per FDR, sourceId is the bwell Organization id — same value as in the reference.
+        expect(orgSourceId).toBe(orgUuid);
     });
 
     test('$access-history returns 404 when ClickHouse is not enabled', async () => {

--- a/src/tests/accessHistory/access_history/fixtures/Person/accessorPersonWithOrg.json
+++ b/src/tests/accessHistory/access_history/fixtures/Person/accessorPersonWithOrg.json
@@ -1,0 +1,31 @@
+{
+    "resourceType": "Person",
+    "id": "accessorPersonWithOrg",
+    "meta": {
+        "source": "http://healthsystem1.org/provider",
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "healthsystem1"
+            },
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "healthsystem1"
+            },
+            {
+                "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+                "code": "healthsystem1"
+            }
+        ]
+    },
+    "name": [
+        {
+            "use": "usual",
+            "family": "Alvarez",
+            "given": ["Maria"]
+        }
+    ],
+    "managingOrganization": {
+        "reference": "Organization/org1"
+    }
+}

--- a/src/tests/accessHistory/access_history/fixtures/expected/expected_aggregated_counts.json
+++ b/src/tests/accessHistory/access_history/fixtures/expected/expected_aggregated_counts.json
@@ -2,6 +2,19 @@
     "resourceType": "Parameters",
     "parameter": [
         {
+            "name": "summary",
+            "part": [
+                {
+                    "name": "generatedAt",
+                    "valueDateTime": "${generatedAt}"
+                },
+                {
+                    "name": "windowDays",
+                    "valueInteger": 90
+                }
+            ]
+        },
+        {
             "name": "accessor",
             "part": [
                 {

--- a/src/tests/accessHistory/access_history/fixtures/expected/expected_delegated_user_access.json
+++ b/src/tests/accessHistory/access_history/fixtures/expected/expected_delegated_user_access.json
@@ -2,6 +2,19 @@
     "resourceType": "Parameters",
     "parameter": [
         {
+            "name": "summary",
+            "part": [
+                {
+                    "name": "generatedAt",
+                    "valueDateTime": "${generatedAt}"
+                },
+                {
+                    "name": "windowDays",
+                    "valueInteger": 90
+                }
+            ]
+        },
+        {
             "name": "accessor",
             "part": [
                 {

--- a/src/tests/accessHistory/access_history/fixtures/expected/expected_e2e_patient_read.json
+++ b/src/tests/accessHistory/access_history/fixtures/expected/expected_e2e_patient_read.json
@@ -2,6 +2,19 @@
     "resourceType": "Parameters",
     "parameter": [
         {
+            "name": "summary",
+            "part": [
+                {
+                    "name": "generatedAt",
+                    "valueDateTime": "${generatedAt}"
+                },
+                {
+                    "name": "windowDays",
+                    "valueInteger": 90
+                }
+            ]
+        },
+        {
             "name": "accessor",
             "part": [
                 {

--- a/src/tests/accessHistory/access_history/fixtures/expected/expected_empty_parameters.json
+++ b/src/tests/accessHistory/access_history/fixtures/expected/expected_empty_parameters.json
@@ -1,4 +1,18 @@
 {
     "resourceType": "Parameters",
-    "parameter": []
+    "parameter": [
+        {
+            "name": "summary",
+            "part": [
+                {
+                    "name": "generatedAt",
+                    "valueDateTime": "${generatedAt}"
+                },
+                {
+                    "name": "windowDays",
+                    "valueInteger": 90
+                }
+            ]
+        }
+    ]
 }

--- a/src/tests/accessHistory/access_history/fixtures/expected/expected_multiple_accessors.json
+++ b/src/tests/accessHistory/access_history/fixtures/expected/expected_multiple_accessors.json
@@ -2,6 +2,19 @@
     "resourceType": "Parameters",
     "parameter": [
         {
+            "name": "summary",
+            "part": [
+                {
+                    "name": "generatedAt",
+                    "valueDateTime": "${generatedAt}"
+                },
+                {
+                    "name": "windowDays",
+                    "valueInteger": 90
+                }
+            ]
+        },
+        {
             "name": "accessor",
             "part": [
                 {

--- a/src/tests/accessHistory/access_history/fixtures/expected/expected_purpose_of_event.json
+++ b/src/tests/accessHistory/access_history/fixtures/expected/expected_purpose_of_event.json
@@ -2,6 +2,19 @@
     "resourceType": "Parameters",
     "parameter": [
         {
+            "name": "summary",
+            "part": [
+                {
+                    "name": "generatedAt",
+                    "valueDateTime": "${generatedAt}"
+                },
+                {
+                    "name": "windowDays",
+                    "valueInteger": 90
+                }
+            ]
+        },
+        {
             "name": "accessor",
             "part": [
                 {

--- a/src/tests/accessHistory/access_history/fixtures/expected/expected_resource_type_breakdown.json
+++ b/src/tests/accessHistory/access_history/fixtures/expected/expected_resource_type_breakdown.json
@@ -2,6 +2,19 @@
     "resourceType": "Parameters",
     "parameter": [
         {
+            "name": "summary",
+            "part": [
+                {
+                    "name": "generatedAt",
+                    "valueDateTime": "${generatedAt}"
+                },
+                {
+                    "name": "windowDays",
+                    "valueInteger": 90
+                }
+            ]
+        },
+        {
             "name": "accessor",
             "part": [
                 {

--- a/src/tests/accessHistory/access_history/fixtures/expected/expected_single_accessor.json
+++ b/src/tests/accessHistory/access_history/fixtures/expected/expected_single_accessor.json
@@ -2,6 +2,19 @@
     "resourceType": "Parameters",
     "parameter": [
         {
+            "name": "summary",
+            "part": [
+                {
+                    "name": "generatedAt",
+                    "valueDateTime": "${generatedAt}"
+                },
+                {
+                    "name": "windowDays",
+                    "valueInteger": 90
+                }
+            ]
+        },
+        {
             "name": "accessor",
             "part": [
                 {


### PR DESCRIPTION
## Summary

[DCON-4266](https://icanbwell.atlassian.net/browse/DCON-4266) — brings the `GET /4_0_0/Person/{id}/$access-history` response into conformance with the [FDR: Access History Response Format](https://icanbwell.atlassian.net/wiki/spaces/HEL/pages/6300270625/FDR+Access+History+Response+Format).

Two gaps against the FDR are addressed:

1. **Missing top-level `summary` block.** The response now includes response-level metadata as the first parameter.
2. **`organization` shape mismatch.** It was emitted as a flat `valueReference`; the FDR requires a `part` container.

## Changes

**`summary` block**
- Added `_buildSummaryParameter()` producing a `summary` parameter with:
  - `generatedAt` (`valueDateTime`) — request time
  - `windowDays` (`valueInteger`) — the rolling window (90)
- Emitted on **every** response path, including the empty/no-results case (previously `{ resourceType: 'Parameters', parameter: [] }`).
- Introduced a shared `ACCESS_HISTORY_WINDOW_DAYS` constant (`clickHouseConstants.js`) used by both the ClickHouse aggregation query and the reported `windowDays`, so the query window and the summary can't drift apart.

**`organization` block**
- Restructured the per-accessor `organization` entry into a `part` container with:
  - `reference` (`valueReference`) — `Organization/{uuid}` with `display` = org name
  - `name` (`valueString`) — organization name
  - `sourceId` (`valueString`) — the bwell Organization id (same value as the id in `reference`; **not** an upstream source-system identifier)
- `_resolveAccessorDetails` now gathers `name`/`sourceId` alongside `reference`/`display`.

## Tests

- Updated all expected fixtures to include the `summary` block.
- Refactored assertions to be order-independent via `getAccessors()` / `syncGeneratedAt()` helpers (filter by `name` instead of positional indexing).
- Added a focused test asserting `windowDays === 90` and a valid `generatedAt`.
- Added a new test + fixture (`accessorPersonWithOrg.json`) covering the FDR `organization` structure — a path that was previously untested.

All 17 tests in the suite pass; lint clean.


[DCON-4266]: https://icanbwell.atlassian.net/browse/DCON-4266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ