### PR TITLE
Bai sql on fhir/viewdefinition run

### DIFF
--- a/docs/superpowers/plans/2026-07-09-sql-on-fhir-run.md
+++ b/docs/superpowers/plans/2026-07-09-sql-on-fhir-run.md
@@ -1,0 +1,1560 @@
+# SQL on FHIR — `ViewDefinition/$run` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a spec-conformant HL7 SQL-on-FHIR v2 `$run` operation that evaluates an inline `ViewDefinition` (FHIRPath columns/filters) over stored or inline FHIR resources and streams a flat table as NDJSON or CSV.
+
+**Architecture:** A pure streaming engine (`ViewRunner`) ports medplum's `evalSqlOnFhir` row-expansion algorithm but yields rows lazily (`AsyncIterable`) instead of materializing them. A thin `FhirPathEvaluator` wraps the `fhirpath` npm library and adds the SQL-on-FHIR helper functions. The orchestrator (`SqlOnFhirRunOperation`) fetches stored resources through the **same** secured query path as `$search` (`searchManager.constructQueryAsync`) — never a hand-rolled Mongo query — and pipes engine output to NDJSON/CSV row writers. Wiring mirrors the existing `$export`/`$everything` operations.
+
+**Tech Stack:** Node.js (CommonJS), Express, MongoDB, `fhirpath` (new dep), `@json2csv/node` (already present), Jest + MongoDB Memory Server.
+
+**Reference spec:** `docs/superpowers/specs/2026-07-09-sql-on-fhir-run-design.md`
+
+## Global Constraints
+
+- Node >= 24.14; CommonJS (`require`/`module.exports`); Prettier: 100-char width, semicolons, single quotes, 4-space indent, ES5 trailing commas.
+- Logging via `logInfo`/`logDebug`/`logError`/`logWarn` from `src/operations/common/logging.js`.
+- New classes MUST be registered in `src/createContainer.js`; test overrides in `src/tests/createTestContainer.js`.
+- New dependencies: edit `package.json`, then run `make update` (do NOT hand-edit `yarn.lock`).
+- Tests run with `--runInBand`; use MongoDB Memory Server (no external DB); custom matcher `toHaveResponse` available.
+- **Security (non-negotiable):** stored `$run` MUST build its Mongo query via `searchManager.constructQueryAsync(...)`. Never query a collection directly for stored resources.
+- **Decision D1:** a per-resource FHIRPath runtime error fails the whole request (do not silently skip rows).
+- **Decision D2:** stored `$run` with no filter and no explicit `_count` is rejected with 400 before streaming.
+- **Decision D3 (CSV collections):** a `collection: true` column value is JSON-encoded into its cell (`JSON.stringify(array)`).
+
+---
+
+## File Structure
+
+**New files:**
+- `src/utils/fhirPathEvaluator.js` — wraps `fhirpath`; binds `constant`s; registers SoF functions. One job: `(expression, node, variables) → values[]`.
+- `src/fhir/classes/4_0_0/custom_resources/viewDefinition.js` — `ViewDefinition` custom resource class (typing/validation only).
+- `src/operations/sqlOnFhir/viewDefinitionValidator.js` — structural validation, fail-fast.
+- `src/operations/sqlOnFhir/viewRunner.js` — pure streaming engine `(view, asyncResources, {fhirPathEvaluator}) → AsyncIterable<row>`.
+- `src/operations/sqlOnFhir/viewResolver.js` — the seam; phase 1 returns the inline view + inline resources parsed from the request `Parameters`.
+- `src/operations/sqlOnFhir/rowNdJsonWriter.js` — `Transform` (object → `JSON.stringify(row)+'\n'`).
+- `src/operations/sqlOnFhir/rowCsvWriter.js` — `Transform` wrapping `@json2csv/node` with explicit `fields`.
+- `src/operations/sqlOnFhir/sqlOnFhirRunOperation.js` — orchestrator.
+- `src/middleware/fhir/sqlOnFhir/sqlOnFhir.config.js` — route config.
+- Tests under `src/tests/sqlOnFhir/` (unit + conformance + integration) and fixtures under `src/tests/sqlOnFhir/fixtures/`.
+
+**Modified files:**
+- `src/fhir/classes/4_0_0/custom_resources/index.js` — register `viewdefinition`.
+- `src/operations/fhirOperationsManager.js` — add `run` method + constructor param.
+- `src/createContainer.js` — register new services + inject into `fhirOperationsManager`.
+- `src/middleware/fhir/router.js` — add `enableSqlOnFhirRoutes` + call in `setRoutes`.
+- `package.json` — add `fhirpath`.
+
+---
+
+## Task 1: `fhirpath` dependency + `FhirPathEvaluator` service
+
+**Files:**
+- Modify: `package.json`
+- Create: `src/utils/fhirPathEvaluator.js`
+- Test: `src/tests/sqlOnFhir/fhirPathEvaluator.test.js`
+
+**Interfaces:**
+- Produces:
+  - `class FhirPathEvaluator` with `evaluate({ node, expression, variables = {} }) => any[]` — returns the FHIRPath result as an array (possibly empty).
+  - Registers SoF functions `getResourceKey()` and `getReferenceKey(resourceType?)` so they are callable inside expressions.
+
+- [ ] **Step 1: Add the dependency**
+
+Edit `package.json` `dependencies`, add (pin the version):
+```json
+"fhirpath": "3.15.2"
+```
+Then run:
+```bash
+nvm use && make update
+```
+Expected: `yarn.lock` updated, `node_modules/fhirpath` present.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/tests/sqlOnFhir/fhirPathEvaluator.test.js`:
+```javascript
+const { FhirPathEvaluator } = require('../../utils/fhirPathEvaluator');
+
+describe('FhirPathEvaluator', () => {
+    const evaluator = new FhirPathEvaluator();
+    const patient = {
+        resourceType: 'Patient',
+        id: 'p1',
+        name: [{ use: 'official', family: 'Smith', given: ['Jane'] }],
+        managingOrganization: { reference: 'Organization/o1' }
+    };
+
+    test('evaluates a simple path to a scalar array', () => {
+        expect(evaluator.evaluate({ node: patient, expression: 'name.family' })).toEqual(['Smith']);
+    });
+
+    test('returns empty array when path yields nothing', () => {
+        expect(evaluator.evaluate({ node: patient, expression: 'birthDate' })).toEqual([]);
+    });
+
+    test('binds constants as %variables', () => {
+        expect(
+            evaluator.evaluate({ node: patient, expression: "name.where(use = %u).family", variables: { u: 'official' } })
+        ).toEqual(['Smith']);
+    });
+
+    test('getResourceKey returns the resource id', () => {
+        expect(evaluator.evaluate({ node: patient, expression: 'getResourceKey()' })).toEqual(['p1']);
+    });
+
+    test('getReferenceKey extracts the id from a reference', () => {
+        expect(
+            evaluator.evaluate({ node: patient, expression: 'managingOrganization.getReferenceKey()' })
+        ).toEqual(['o1']);
+    });
+
+    test('getReferenceKey with matching type returns id, non-matching returns empty', () => {
+        expect(
+            evaluator.evaluate({ node: patient, expression: "managingOrganization.getReferenceKey('Organization')" })
+        ).toEqual(['o1']);
+        expect(
+            evaluator.evaluate({ node: patient, expression: "managingOrganization.getReferenceKey('Patient')" })
+        ).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/fhirPathEvaluator.test.js -v`
+Expected: FAIL — `Cannot find module '../../utils/fhirPathEvaluator'`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+Create `src/utils/fhirPathEvaluator.js`:
+```javascript
+const fhirpath = require('fhirpath');
+const fhirpathR4Model = require('fhirpath/fhir-context/r4');
+
+/**
+ * Parses a FHIR reference string like "Organization/o1" or a full URL into its logical id.
+ * @param {string} reference
+ * @returns {{ resourceType: string|undefined, id: string }|undefined}
+ */
+function parseReference(reference) {
+    if (!reference || typeof reference !== 'string') {
+        return undefined;
+    }
+    const parts = reference.split('/');
+    if (parts.length < 2) {
+        return { resourceType: undefined, id: reference };
+    }
+    const id = parts[parts.length - 1];
+    const resourceType = parts[parts.length - 2];
+    return { resourceType, id };
+}
+
+/**
+ * SQL-on-FHIR helper functions registered into the fhirpath userInvocationTable.
+ * See https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/#getResourceKey
+ */
+const sqlOnFhirFunctions = {
+    getResourceKey: {
+        fn: (nodes) => nodes.map((n) => (n && n.id !== undefined ? n.id : n)).filter((v) => v !== undefined),
+        arity: { 0: [] }
+    },
+    getReferenceKey: {
+        fn: (nodes, resourceTypeNode) => {
+            const wantedType = Array.isArray(resourceTypeNode) ? resourceTypeNode[0] : resourceTypeNode;
+            const out = [];
+            for (const n of nodes) {
+                const ref = n && (typeof n === 'object' ? n.reference : n);
+                const parsed = parseReference(ref);
+                if (!parsed) {
+                    continue;
+                }
+                if (wantedType && parsed.resourceType && parsed.resourceType !== wantedType) {
+                    continue;
+                }
+                out.push(parsed.id);
+            }
+            return out;
+        },
+        arity: { 0: [], 1: ['String'] }
+    }
+};
+
+class FhirPathEvaluator {
+    constructor() {
+        this.options = { userInvocationTable: sqlOnFhirFunctions };
+    }
+
+    /**
+     * @param {{ node: Object, expression: string, variables?: Object }} params
+     * @returns {any[]} FHIRPath result, always an array (possibly empty)
+     */
+    evaluate({ node, expression, variables = {} }) {
+        const result = fhirpath.evaluate(node, expression, variables, fhirpathR4Model, this.options);
+        return Array.isArray(result) ? result : [result];
+    }
+}
+
+module.exports = { FhirPathEvaluator };
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/fhirPathEvaluator.test.js -v`
+Expected: PASS (6 tests). If `getResourceKey`/`getReferenceKey` semantics differ from the pinned `fhirpath` version's built-ins, adjust `sqlOnFhirFunctions`; the conformance suite in Task 4 is the source of truth.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json yarn.lock src/utils/fhirPathEvaluator.js src/tests/sqlOnFhir/fhirPathEvaluator.test.js
+git commit -m "feat(sql-on-fhir): add FhirPathEvaluator wrapping fhirpath with SoF functions"
+```
+
+---
+
+## Task 2: `ViewDefinition` custom resource class
+
+**Files:**
+- Create: `src/fhir/classes/4_0_0/custom_resources/viewDefinition.js`
+- Modify: `src/fhir/classes/4_0_0/custom_resources/index.js`
+- Test: `src/tests/sqlOnFhir/viewDefinition.test.js`
+
+**Interfaces:**
+- Produces: a `ViewDefinition` resource class instantiable via `FhirResourceCreator.create({ resourceType: 'ViewDefinition', ... })`, with `resourceType` getter returning `'ViewDefinition'` and a `toJSON()` round-trip.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/sqlOnFhir/viewDefinition.test.js`:
+```javascript
+const { FhirResourceCreator } = require('../../fhir/fhirResourceCreator');
+
+describe('ViewDefinition custom resource', () => {
+    const raw = {
+        resourceType: 'ViewDefinition',
+        id: 'v1',
+        status: 'active',
+        resource: 'Patient',
+        select: [{ column: [{ name: 'id', path: 'getResourceKey()' }] }]
+    };
+
+    test('is created as a ViewDefinition instance', () => {
+        const view = FhirResourceCreator.create(raw);
+        expect(view.resourceType).toBe('ViewDefinition');
+        expect(view.resource).toBe('Patient');
+    });
+
+    test('toJSON round-trips core fields', () => {
+        const view = FhirResourceCreator.create(raw);
+        const json = view.toJSON();
+        expect(json.resourceType).toBe('ViewDefinition');
+        expect(json.select[0].column[0].name).toBe('id');
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/viewDefinition.test.js -v`
+Expected: FAIL — resourceType `ViewDefinition` not resolvable (`BadRequestError`) or `resource` undefined.
+
+- [ ] **Step 3: Write the resource class**
+
+Create `src/fhir/classes/4_0_0/custom_resources/viewDefinition.js` (mirror the `exportStatus.js` `Object.defineProperty` pattern; store nested `select`/`constant`/`where` as plain objects — they are FHIRPath payloads, not typed FHIR elements):
+```javascript
+const Resource = require('../resources/resource');
+
+class ViewDefinition extends Resource {
+    constructor({
+        id,
+        meta,
+        url,
+        name,
+        title,
+        status,
+        resource,
+        constant,
+        select,
+        where,
+        _access,
+        _sourceAssigningAuthority,
+        _sourceId,
+        _uuid
+    }) {
+        super({});
+
+        const defineStringLike = (key, initial) => {
+            Object.defineProperty(this, key, {
+                enumerable: true,
+                configurable: true,
+                get: () => this.__data[key],
+                set: (valueProvided) => {
+                    if (
+                        valueProvided === undefined ||
+                        valueProvided === null ||
+                        (Array.isArray(valueProvided) && valueProvided.length === 0)
+                    ) {
+                        this.__data[key] = undefined;
+                        return;
+                    }
+                    this.__data[key] = valueProvided;
+                }
+            });
+        };
+
+        this.__data = this.__data || {};
+        defineStringLike('id', id);
+        defineStringLike('meta', meta);
+        defineStringLike('url', url);
+        defineStringLike('name', name);
+        defineStringLike('title', title);
+        defineStringLike('status', status);
+        defineStringLike('resource', resource);
+        defineStringLike('constant', constant);
+        defineStringLike('select', select);
+        defineStringLike('where', where);
+        defineStringLike('_access', _access);
+        defineStringLike('_sourceAssigningAuthority', _sourceAssigningAuthority);
+        defineStringLike('_sourceId', _sourceId);
+        defineStringLike('_uuid', _uuid);
+
+        Object.defineProperty(this, 'resourceType', {
+            value: 'ViewDefinition',
+            enumerable: true,
+            writable: false,
+            configurable: true
+        });
+
+        this.id = id;
+        this.meta = meta;
+        this.url = url;
+        this.name = name;
+        this.title = title;
+        this.status = status;
+        this.resource = resource;
+        this.constant = constant;
+        this.select = select;
+        this.where = where;
+        this._access = _access;
+        this._sourceAssigningAuthority = _sourceAssigningAuthority;
+        this._sourceId = _sourceId;
+        this._uuid = _uuid;
+    }
+
+    toJSON() {
+        const { removeNull } = require('../../../../utils/nullRemover.js');
+        return removeNull({
+            id: this.id,
+            resourceType: this.resourceType,
+            meta: this.meta && (this.meta.toJSON ? this.meta.toJSON() : this.meta),
+            url: this.url,
+            name: this.name,
+            title: this.title,
+            status: this.status,
+            resource: this.resource,
+            constant: this.constant,
+            select: this.select,
+            where: this.where
+        });
+    }
+}
+
+module.exports = ViewDefinition;
+```
+
+- [ ] **Step 4: Register in the index**
+
+Modify `src/fhir/classes/4_0_0/custom_resources/index.js`:
+```javascript
+const exportstatusentry = require('./exportStatusEntry');
+const exportstatus = require('./exportStatus');
+const viewdefinition = require('./viewDefinition');
+
+module.exports = {
+    exportstatusentry,
+    exportstatus,
+    viewdefinition
+};
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/viewDefinition.test.js -v`
+Expected: PASS (2 tests). If `Resource` base import path differs, match the path used at the top of `exportStatus.js`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/fhir/classes/4_0_0/custom_resources/viewDefinition.js src/fhir/classes/4_0_0/custom_resources/index.js src/tests/sqlOnFhir/viewDefinition.test.js
+git commit -m "feat(sql-on-fhir): add ViewDefinition custom resource class"
+```
+
+---
+
+## Task 3: `ViewDefinitionValidator`
+
+**Files:**
+- Create: `src/operations/sqlOnFhir/viewDefinitionValidator.js`
+- Test: `src/tests/sqlOnFhir/viewDefinitionValidator.test.js`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `class ViewDefinitionValidator` with `validate(view) => void` — throws `BadRequestError` (from `src/utils/httpErrors.js`) with a clear message on the first structural problem. Checks: `view.resource` is a non-empty string; `view.select` is a non-empty array; every column has a non-empty `name` and `path`; column `name`s are unique across the whole view (including nested `select`/`unionAll`/`forEach`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/sqlOnFhir/viewDefinitionValidator.test.js`:
+```javascript
+const { ViewDefinitionValidator } = require('../../operations/sqlOnFhir/viewDefinitionValidator');
+
+describe('ViewDefinitionValidator', () => {
+    const validator = new ViewDefinitionValidator();
+
+    test('accepts a valid view', () => {
+        expect(() =>
+            validator.validate({
+                resource: 'Patient',
+                select: [{ column: [{ name: 'id', path: 'getResourceKey()' }] }]
+            })
+        ).not.toThrow();
+    });
+
+    test('rejects a missing resource', () => {
+        expect(() => validator.validate({ select: [{ column: [{ name: 'id', path: 'id' }] }] })).toThrow(/resource/i);
+    });
+
+    test('rejects an empty select', () => {
+        expect(() => validator.validate({ resource: 'Patient', select: [] })).toThrow(/select/i);
+    });
+
+    test('rejects a column missing name or path', () => {
+        expect(() =>
+            validator.validate({ resource: 'Patient', select: [{ column: [{ path: 'id' }] }] })
+        ).toThrow(/name/i);
+    });
+
+    test('rejects duplicate column names across nested selects', () => {
+        expect(() =>
+            validator.validate({
+                resource: 'Patient',
+                select: [
+                    { column: [{ name: 'id', path: 'getResourceKey()' }] },
+                    { select: [{ column: [{ name: 'id', path: 'id' }] }] }
+                ]
+            })
+        ).toThrow(/duplicate/i);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/viewDefinitionValidator.test.js -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/operations/sqlOnFhir/viewDefinitionValidator.js`:
+```javascript
+const { BadRequestError } = require('../../utils/httpErrors');
+
+class ViewDefinitionValidator {
+    /**
+     * @param {Object} view a ViewDefinition (plain object or resource instance)
+     * @throws {BadRequestError}
+     */
+    validate(view) {
+        if (!view || typeof view !== 'object') {
+            throw new BadRequestError(new Error('ViewDefinition is required'));
+        }
+        if (!view.resource || typeof view.resource !== 'string') {
+            throw new BadRequestError(new Error('ViewDefinition.resource (a FHIR resource type) is required'));
+        }
+        if (!Array.isArray(view.select) || view.select.length === 0) {
+            throw new BadRequestError(new Error('ViewDefinition.select must be a non-empty array'));
+        }
+        const seen = new Set();
+        this._walkSelections(view.select, seen);
+    }
+
+    _walkSelections(selections, seen) {
+        for (const selection of selections) {
+            for (const col of selection.column || []) {
+                if (!col.name || typeof col.name !== 'string') {
+                    throw new BadRequestError(new Error('Each ViewDefinition column requires a non-empty name'));
+                }
+                if (!col.path || typeof col.path !== 'string') {
+                    throw new BadRequestError(new Error(`Column "${col.name}" requires a non-empty path`));
+                }
+                if (seen.has(col.name)) {
+                    throw new BadRequestError(new Error(`Duplicate column name "${col.name}"`));
+                }
+                seen.add(col.name);
+            }
+            if (Array.isArray(selection.select)) {
+                this._walkSelections(selection.select, seen);
+            }
+            if (Array.isArray(selection.unionAll)) {
+                // unionAll branches share the same column names by design — validate each branch
+                // against a fresh copy so branch columns are consistent but not flagged as dupes of each other.
+                for (const branch of selection.unionAll) {
+                    this._walkSelections([branch], new Set(seen));
+                }
+            }
+        }
+    }
+}
+
+module.exports = { ViewDefinitionValidator };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/viewDefinitionValidator.test.js -v`
+Expected: PASS (5 tests). If `BadRequestError`'s constructor signature differs, match the usage in `src/operations/search/` (it typically wraps an `Error`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/operations/sqlOnFhir/viewDefinitionValidator.js src/tests/sqlOnFhir/viewDefinitionValidator.test.js
+git commit -m "feat(sql-on-fhir): add ViewDefinitionValidator"
+```
+
+---
+
+## Task 4: `ViewRunner` (core streaming engine) + conformance fixtures
+
+**Files:**
+- Create: `src/operations/sqlOnFhir/viewRunner.js`
+- Create: `src/tests/sqlOnFhir/fixtures/` (vendored official test cases)
+- Test: `src/tests/sqlOnFhir/viewRunner.test.js`
+- Test: `src/tests/sqlOnFhir/viewRunner.conformance.test.js`
+
+**Interfaces:**
+- Consumes: `FhirPathEvaluator` (Task 1).
+- Produces: `async function *runView(view, resourceIterable, { fhirPathEvaluator })` yielding plain row objects `{ [columnName]: scalarOrArrayOrNull }`. Row-expansion mirrors medplum `eval.ts`: `where` gate → per selection: determine `foci` (`forEach`/`forEachOrNull`/self) → cartesian product of column partial-rows, nested `select` rows, and `unionAll` rows. A `collection:false` column path yielding >1 value throws (D1). Constants are passed to the evaluator as `variables`.
+
+- [ ] **Step 1: Vendor a small set of official conformance cases**
+
+Download 3 canonical case files from the HL7 SQL-on-FHIR v2 test suite (`https://github.com/FHIR/sql-on-fhir-v2/tree/master/tests`) into `src/tests/sqlOnFhir/fixtures/`: `basic.json`, `where.json`, `fn_reference_keys.json`. (medplum vendors the same suite at `packages/core/src/sql-on-fhir/tests/` — use it as a cross-check.) Each file has shape `{ resources: [...], tests: [{ title, view, expect: [...] }] }`.
+
+```bash
+mkdir -p src/tests/sqlOnFhir/fixtures
+# fetch the three files via the plan executor's web/gh tooling into that directory
+```
+
+- [ ] **Step 2: Write the failing unit test (hand-written cases)**
+
+Create `src/tests/sqlOnFhir/viewRunner.test.js`:
+```javascript
+const { runView } = require('../../operations/sqlOnFhir/viewRunner');
+const { FhirPathEvaluator } = require('../../utils/fhirPathEvaluator');
+
+const fhirPathEvaluator = new FhirPathEvaluator();
+
+async function collect(view, resources) {
+    const rows = [];
+    for await (const row of runView(view, resources, { fhirPathEvaluator })) {
+        rows.push(row);
+    }
+    return rows;
+}
+
+const patients = [
+    { resourceType: 'Patient', id: 'p1', active: true, name: [{ family: 'Smith', given: ['Jane', 'Q'] }] },
+    { resourceType: 'Patient', id: 'p2', active: false, name: [{ family: 'Jones' }] }
+];
+
+describe('runView', () => {
+    test('one row per resource with scalar columns', async () => {
+        const view = {
+            resource: 'Patient',
+            select: [{ column: [{ name: 'id', path: 'getResourceKey()' }, { name: 'family', path: 'name.family.first()' }] }]
+        };
+        expect(await collect(view, patients)).toEqual([
+            { id: 'p1', family: 'Smith' },
+            { id: 'p2', family: 'Jones' }
+        ]);
+    });
+
+    test('where filters resources', async () => {
+        const view = {
+            resource: 'Patient',
+            where: [{ path: 'active = true' }],
+            select: [{ column: [{ name: 'id', path: 'getResourceKey()' }] }]
+        };
+        expect(await collect(view, patients)).toEqual([{ id: 'p1' }]);
+    });
+
+    test('collection column yields an array', async () => {
+        const view = {
+            resource: 'Patient',
+            select: [{ column: [{ name: 'given', path: 'name.given', collection: true }] }]
+        };
+        expect(await collect(view, [patients[0]])).toEqual([{ given: ['Jane', 'Q'] }]);
+    });
+
+    test('forEach produces one row per element', async () => {
+        const view = {
+            resource: 'Patient',
+            select: [
+                { column: [{ name: 'id', path: 'getResourceKey()' }] },
+                { forEach: 'name.given', column: [{ name: 'given', path: '$this' }] }
+            ]
+        };
+        expect(await collect(view, [patients[0]])).toEqual([
+            { id: 'p1', given: 'Jane' },
+            { id: 'p1', given: 'Q' }
+        ]);
+    });
+
+    test('scalar column with multiple values throws (D1)', async () => {
+        const view = { resource: 'Patient', select: [{ column: [{ name: 'given', path: 'name.given' }] }] };
+        await expect(collect(view, [patients[0]])).rejects.toThrow(/single|collection/i);
+    });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/viewRunner.test.js -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Write the engine**
+
+Create `src/operations/sqlOnFhir/viewRunner.js`:
+```javascript
+/**
+ * Streaming port of medplum's evalSqlOnFhir (packages/core/src/sql-on-fhir/eval.ts).
+ * Yields one plain row object at a time instead of materializing OutputRow[].
+ */
+
+function buildConstants(view, fhirPathEvaluator) {
+    const variables = {};
+    for (const c of view.constant || []) {
+        // constant value is stored as value[x]; take the first defined value* key
+        const valueKey = Object.keys(c).find((k) => k.startsWith('value'));
+        variables[c.name] = valueKey ? c[valueKey] : undefined;
+    }
+    return variables;
+}
+
+function columnValue(col, focus, variables, fhirPathEvaluator) {
+    const result = fhirPathEvaluator.evaluate({ node: focus, expression: col.path, variables });
+    if (col.collection) {
+        return result;
+    }
+    if (result.length > 1) {
+        throw new Error(`Column "${col.name}" returned multiple values but is not marked collection:true`);
+    }
+    return result.length === 1 ? result[0] : null;
+}
+
+function cartesian(parts) {
+    // parts: Array<Array<row>>; returns Array<row> combining one row from each part
+    return parts.reduce(
+        (acc, part) => {
+            const next = [];
+            for (const a of acc) {
+                for (const b of part) {
+                    next.push({ ...a, ...b });
+                }
+            }
+            return next;
+        },
+        [{}]
+    );
+}
+
+function processSelection(selection, node, variables, fhirPathEvaluator) {
+    let foci;
+    if (selection.forEach) {
+        foci = fhirPathEvaluator.evaluate({ node, expression: selection.forEach, variables });
+    } else if (selection.forEachOrNull) {
+        foci = fhirPathEvaluator.evaluate({ node, expression: selection.forEachOrNull, variables });
+    } else {
+        foci = [node];
+    }
+
+    if (foci.length === 0 && selection.forEachOrNull) {
+        // emit a single row with nulls for this selection's own columns
+        const nullRow = {};
+        for (const col of selection.column || []) {
+            nullRow[col.name] = col.collection ? [] : null;
+        }
+        return [nullRow];
+    }
+
+    const rows = [];
+    for (const focus of foci) {
+        const parts = [];
+
+        if (selection.column && selection.column.length > 0) {
+            const colRow = {};
+            for (const col of selection.column) {
+                colRow[col.name] = columnValue(col, focus, variables, fhirPathEvaluator);
+            }
+            parts.push([colRow]);
+        }
+
+        for (const nested of selection.select || []) {
+            parts.push(processSelection(nested, focus, variables, fhirPathEvaluator));
+        }
+
+        if (Array.isArray(selection.unionAll) && selection.unionAll.length > 0) {
+            const unionRows = [];
+            for (const branch of selection.unionAll) {
+                unionRows.push(...processSelection(branch, focus, variables, fhirPathEvaluator));
+            }
+            parts.push(unionRows);
+        }
+
+        rows.push(...cartesian(parts));
+    }
+    return rows;
+}
+
+/**
+ * @param {Object} view ViewDefinition
+ * @param {AsyncIterable<Object>|Iterable<Object>} resourceIterable
+ * @param {{ fhirPathEvaluator: import('../../utils/fhirPathEvaluator').FhirPathEvaluator }} deps
+ * @returns {AsyncGenerator<Object>} rows
+ */
+async function *runView(view, resourceIterable, { fhirPathEvaluator }) {
+    const variables = buildConstants(view, fhirPathEvaluator);
+    for await (const resource of resourceIterable) {
+        // where gate: every clause must evaluate to a single boolean true
+        let included = true;
+        for (const clause of view.where || []) {
+            const r = fhirPathEvaluator.evaluate({ node: resource, expression: clause.path, variables });
+            if (!(r.length === 1 && r[0] === true)) {
+                included = false;
+                break;
+            }
+        }
+        if (!included) {
+            continue;
+        }
+        const topRows = cartesian(
+            (view.select || []).map((s) => processSelection(s, resource, variables, fhirPathEvaluator))
+        );
+        for (const row of topRows) {
+            yield row;
+        }
+    }
+}
+
+module.exports = { runView };
+```
+
+- [ ] **Step 5: Run the unit test to verify it passes**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/viewRunner.test.js -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Write the conformance test over vendored fixtures**
+
+Create `src/tests/sqlOnFhir/viewRunner.conformance.test.js`:
+```javascript
+const fs = require('fs');
+const path = require('path');
+const { runView } = require('../../operations/sqlOnFhir/viewRunner');
+const { FhirPathEvaluator } = require('../../utils/fhirPathEvaluator');
+
+const fhirPathEvaluator = new FhirPathEvaluator();
+const fixturesDir = path.join(__dirname, 'fixtures');
+
+async function collect(view, resources) {
+    const rows = [];
+    for await (const row of runView(view, resources, { fhirPathEvaluator })) {
+        rows.push(row);
+    }
+    return rows;
+}
+
+const files = fs.readdirSync(fixturesDir).filter((f) => f.endsWith('.json'));
+
+describe('SQL-on-FHIR v2 conformance fixtures', () => {
+    for (const file of files) {
+        const suite = JSON.parse(fs.readFileSync(path.join(fixturesDir, file), 'utf8'));
+        describe(file, () => {
+            for (const t of suite.tests) {
+                // Some official cases assert errors; those are covered by unit tests. Skip and log here.
+                const runner = t.expect ? test : test.skip;
+                runner(t.title, async () => {
+                    const rows = await collect(t.view, suite.resources);
+                    expect(rows).toEqual(t.expect);
+                });
+            }
+        });
+    }
+});
+```
+
+- [ ] **Step 7: Run the conformance test**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/viewRunner.conformance.test.js -v`
+Expected: PASS for the vendored cases. Any failure is either an evaluator gap (fix `FhirPathEvaluator`) or an engine gap (fix `viewRunner.js`) — do not edit the fixtures. Document any case intentionally skipped.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/operations/sqlOnFhir/viewRunner.js src/tests/sqlOnFhir/viewRunner.test.js src/tests/sqlOnFhir/viewRunner.conformance.test.js src/tests/sqlOnFhir/fixtures
+git commit -m "feat(sql-on-fhir): add streaming ViewRunner engine + conformance fixtures"
+```
+
+---
+
+## Task 5: Row writers (NDJSON + CSV)
+
+**Files:**
+- Create: `src/operations/sqlOnFhir/rowNdJsonWriter.js`
+- Create: `src/operations/sqlOnFhir/rowCsvWriter.js`
+- Test: `src/tests/sqlOnFhir/rowWriters.test.js`
+
+**Interfaces:**
+- Produces:
+  - `class RowNdJsonWriter extends stream.Transform` — objectMode in, `JSON.stringify(row)+'\n'` out.
+  - `class RowCsvWriter extends stream.Transform` — objectMode in; constructor `{ columns }` (ordered column names for the header); emits a header line then one CSV line per row; `collection:true`/array/object cells are `JSON.stringify`-encoded (D3).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/sqlOnFhir/rowWriters.test.js`:
+```javascript
+const { Readable } = require('stream');
+const { RowNdJsonWriter } = require('../../operations/sqlOnFhir/rowNdJsonWriter');
+const { RowCsvWriter } = require('../../operations/sqlOnFhir/rowCsvWriter');
+
+async function drain(rows, writer) {
+    let out = '';
+    const src = Readable.from(rows);
+    writer.on('data', (c) => (out += c.toString()));
+    src.pipe(writer);
+    await new Promise((resolve, reject) => {
+        writer.on('end', resolve);
+        writer.on('error', reject);
+    });
+    return out;
+}
+
+describe('row writers', () => {
+    test('NDJSON writes one JSON object per line', async () => {
+        const out = await drain([{ id: 'p1' }, { id: 'p2' }], new RowNdJsonWriter());
+        expect(out).toBe('{"id":"p1"}\n{"id":"p2"}\n');
+    });
+
+    test('CSV writes header then rows, JSON-encoding array cells', async () => {
+        const out = await drain(
+            [{ id: 'p1', given: ['Jane', 'Q'] }, { id: 'p2', given: [] }],
+            new RowCsvWriter({ columns: ['id', 'given'] })
+        );
+        expect(out.split('\n')[0]).toBe('id,given');
+        expect(out).toContain('p1,"[""Jane"",""Q""]"');
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/rowWriters.test.js -v`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Implement the NDJSON writer**
+
+Create `src/operations/sqlOnFhir/rowNdJsonWriter.js`:
+```javascript
+const { Transform } = require('stream');
+
+class RowNdJsonWriter extends Transform {
+    constructor(options = {}) {
+        super({ ...options, writableObjectMode: true, readableObjectMode: false });
+    }
+
+    _transform(row, _encoding, callback) {
+        try {
+            this.push(JSON.stringify(row) + '\n');
+            callback();
+        } catch (err) {
+            callback(err);
+        }
+    }
+}
+
+module.exports = { RowNdJsonWriter };
+```
+
+- [ ] **Step 4: Implement the CSV writer**
+
+Create `src/operations/sqlOnFhir/rowCsvWriter.js` (encode array/object cells to a JSON string so `@json2csv` treats them as scalars — satisfies D3):
+```javascript
+const { Transform } = require('@json2csv/node');
+
+class RowCsvWriter extends Transform {
+    /**
+     * @param {{ columns: string[] }} params ordered column names for header + field order
+     */
+    constructor({ columns }) {
+        super(
+            { fields: columns },
+            {},
+            { objectMode: true }
+        );
+        this._columns = columns;
+    }
+
+    _transform(row, encoding, done) {
+        const encoded = {};
+        for (const key of this._columns) {
+            const value = row[key];
+            encoded[key] = value !== null && typeof value === 'object' ? JSON.stringify(value) : value;
+        }
+        return super._transform(encoded, encoding, done);
+    }
+}
+
+module.exports = { RowCsvWriter };
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/rowWriters.test.js -v`
+Expected: PASS (2 tests). If `@json2csv/node`'s `Transform` constructor signature differs, match how `src/operations/streaming/resourceWriters/fhirResourceCsvWriter.js` calls `super(opts, asyncOpts, transformOpts)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/operations/sqlOnFhir/rowNdJsonWriter.js src/operations/sqlOnFhir/rowCsvWriter.js src/tests/sqlOnFhir/rowWriters.test.js
+git commit -m "feat(sql-on-fhir): add NDJSON and CSV row writers"
+```
+
+---
+
+## Task 6: `ViewResolver` (request → view + inline resources)
+
+**Files:**
+- Create: `src/operations/sqlOnFhir/viewResolver.js`
+- Test: `src/tests/sqlOnFhir/viewResolver.test.js`
+
+**Interfaces:**
+- Produces: `class ViewResolver` with `resolve({ body }) => { view, inlineResources }`.
+  - `body` is the request body — a FHIR `Parameters` resource. Extracts the `viewResource` parameter (`.resource`) as `view`, and all `resource` parameters (`.resource`) as `inlineResources` (array, possibly empty).
+  - If `body.resourceType === 'ViewDefinition'`, treat the whole body as `view` with no inline resources (convenience form).
+  - Throws `BadRequestError` if no view can be found.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/sqlOnFhir/viewResolver.test.js`:
+```javascript
+const { ViewResolver } = require('../../operations/sqlOnFhir/viewResolver');
+
+describe('ViewResolver', () => {
+    const resolver = new ViewResolver();
+    const view = { resourceType: 'ViewDefinition', resource: 'Patient', select: [{ column: [{ name: 'id', path: 'id' }] }] };
+
+    test('extracts view + inline resources from Parameters', () => {
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [
+                { name: 'viewResource', resource: view },
+                { name: 'resource', resource: { resourceType: 'Patient', id: 'p1' } },
+                { name: 'resource', resource: { resourceType: 'Patient', id: 'p2' } }
+            ]
+        };
+        const { view: v, inlineResources } = resolver.resolve({ body });
+        expect(v.resource).toBe('Patient');
+        expect(inlineResources.map((r) => r.id)).toEqual(['p1', 'p2']);
+    });
+
+    test('accepts a bare ViewDefinition body', () => {
+        const { view: v, inlineResources } = resolver.resolve({ body: view });
+        expect(v.resource).toBe('Patient');
+        expect(inlineResources).toEqual([]);
+    });
+
+    test('throws when no view present', () => {
+        expect(() => resolver.resolve({ body: { resourceType: 'Parameters', parameter: [] } })).toThrow(/view/i);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/viewResolver.test.js -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `src/operations/sqlOnFhir/viewResolver.js`:
+```javascript
+const { BadRequestError } = require('../../utils/httpErrors');
+
+class ViewResolver {
+    /**
+     * Phase 1: inline only. Later phases add stored lookup by id/url behind this same method.
+     * @param {{ body: Object }} params
+     * @returns {{ view: Object, inlineResources: Object[] }}
+     */
+    resolve({ body }) {
+        if (body && body.resourceType === 'ViewDefinition') {
+            return { view: body, inlineResources: [] };
+        }
+        if (body && body.resourceType === 'Parameters' && Array.isArray(body.parameter)) {
+            const viewParam = body.parameter.find((p) => p.name === 'viewResource');
+            const view = viewParam && viewParam.resource;
+            const inlineResources = body.parameter
+                .filter((p) => p.name === 'resource' && p.resource)
+                .map((p) => p.resource);
+            if (!view) {
+                throw new BadRequestError(new Error('$run requires a "viewResource" parameter containing a ViewDefinition'));
+            }
+            return { view, inlineResources };
+        }
+        throw new BadRequestError(new Error('$run requires a Parameters body with a viewResource, or a ViewDefinition body'));
+    }
+}
+
+module.exports = { ViewResolver };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/viewResolver.test.js -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/operations/sqlOnFhir/viewResolver.js src/tests/sqlOnFhir/viewResolver.test.js
+git commit -m "feat(sql-on-fhir): add ViewResolver (inline view + resources)"
+```
+
+---
+
+## Task 7: `SqlOnFhirRunOperation` orchestrator
+
+**Files:**
+- Create: `src/operations/sqlOnFhir/sqlOnFhirRunOperation.js`
+- Test: `src/tests/sqlOnFhir/sqlOnFhirRunOperation.test.js`
+
+**Interfaces:**
+- Consumes: `ViewResolver`, `ViewDefinitionValidator`, `FhirPathEvaluator`, `runView`, `RowNdJsonWriter`, `RowCsvWriter`, and (for stored) `searchManager` + `databaseQueryFactory` + `configManager`.
+- Produces: `class SqlOnFhirRunOperation` with:
+  - `async runAsync({ requestInfo, parsedArgs, body, resourceType, res })` — resolves + validates the view, builds the resource source (inline or secured stored cursor), runs `runView`, and pipes rows through the chosen writer to `res`. Returns `undefined` (response written directly).
+  - `_resourceSource({ view, inlineResources, requestInfo, parsedArgs })` — returns an async iterable of resources. Stored path calls `searchManager.constructQueryAsync(...)` then iterates a `DatabaseCursor`. Applies guardrail D2.
+  - `_columnNames(view)` — ordered, de-duplicated column names for the CSV header.
+
+- [ ] **Step 1: Write the failing test (inline path + guardrail, with a fake searchManager)**
+
+Create `src/tests/sqlOnFhir/sqlOnFhirRunOperation.test.js`:
+```javascript
+const { Writable } = require('stream');
+const { SqlOnFhirRunOperation } = require('../../operations/sqlOnFhir/sqlOnFhirRunOperation');
+const { ViewResolver } = require('../../operations/sqlOnFhir/viewResolver');
+const { ViewDefinitionValidator } = require('../../operations/sqlOnFhir/viewDefinitionValidator');
+const { FhirPathEvaluator } = require('../../utils/fhirPathEvaluator');
+
+function fakeRes() {
+    const res = new Writable({
+        write(chunk, enc, cb) {
+            res._body += chunk.toString();
+            cb();
+        }
+    });
+    res._body = '';
+    res.headers = {};
+    res.setHeader = (k, v) => (res.headers[k] = v);
+    res.status = (c) => {
+        res.statusCode = c;
+        return res;
+    };
+    return res;
+}
+
+function makeOperation() {
+    return new SqlOnFhirRunOperation({
+        viewResolver: new ViewResolver(),
+        viewDefinitionValidator: new ViewDefinitionValidator(),
+        fhirPathEvaluator: new FhirPathEvaluator(),
+        searchManager: { constructQueryAsync: async () => ({ query: {} }) },
+        databaseQueryFactory: {},
+        configManager: {}
+    });
+}
+
+const view = {
+    resourceType: 'ViewDefinition',
+    resource: 'Patient',
+    select: [{ column: [{ name: 'id', path: 'getResourceKey()' }] }]
+};
+
+describe('SqlOnFhirRunOperation (inline)', () => {
+    test('streams NDJSON rows from inline resources', async () => {
+        const op = makeOperation();
+        const res = fakeRes();
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [
+                { name: 'viewResource', resource: view },
+                { name: 'resource', resource: { resourceType: 'Patient', id: 'p1' } }
+            ]
+        };
+        await op.runAsync({
+            requestInfo: { accept: ['application/x-ndjson'] },
+            parsedArgs: {},
+            body,
+            resourceType: 'Patient',
+            res
+        });
+        expect(res._body).toBe('{"id":"p1"}\n');
+        expect(res.headers['Content-Type']).toMatch(/ndjson/);
+    });
+
+    test('rejects an invalid view with 400 before streaming', async () => {
+        const op = makeOperation();
+        const res = fakeRes();
+        const badView = { resourceType: 'ViewDefinition', select: [] }; // no resource
+        await expect(
+            op.runAsync({
+                requestInfo: { accept: ['application/x-ndjson'] },
+                parsedArgs: {},
+                body: { resourceType: 'ViewDefinition', ...badView },
+                resourceType: 'Patient',
+                res
+            })
+        ).rejects.toThrow(/resource/i);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/sqlOnFhirRunOperation.test.js -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the orchestrator**
+
+Create `src/operations/sqlOnFhir/sqlOnFhirRunOperation.js`:
+```javascript
+const { pipeline } = require('stream/promises');
+const { Readable } = require('stream');
+const { runView } = require('./viewRunner');
+const { RowNdJsonWriter } = require('./rowNdJsonWriter');
+const { RowCsvWriter } = require('./rowCsvWriter');
+const { BadRequestError } = require('../../utils/httpErrors');
+
+class SqlOnFhirRunOperation {
+    /**
+     * @param {Object} deps
+     * @param {import('./viewResolver').ViewResolver} deps.viewResolver
+     * @param {import('./viewDefinitionValidator').ViewDefinitionValidator} deps.viewDefinitionValidator
+     * @param {import('../../utils/fhirPathEvaluator').FhirPathEvaluator} deps.fhirPathEvaluator
+     * @param {Object} deps.searchManager MUST expose constructQueryAsync (authorization gate)
+     * @param {Object} deps.databaseQueryFactory
+     * @param {Object} deps.configManager
+     */
+    constructor({ viewResolver, viewDefinitionValidator, fhirPathEvaluator, searchManager, databaseQueryFactory, configManager }) {
+        this.viewResolver = viewResolver;
+        this.viewDefinitionValidator = viewDefinitionValidator;
+        this.fhirPathEvaluator = fhirPathEvaluator;
+        this.searchManager = searchManager;
+        this.databaseQueryFactory = databaseQueryFactory;
+        this.configManager = configManager;
+    }
+
+    async runAsync({ requestInfo, parsedArgs, body, resourceType, res }) {
+        const { view, inlineResources } = this.viewResolver.resolve({ body });
+        this.viewDefinitionValidator.validate(view);
+
+        const wantsCsv = (requestInfo.accept || []).some((a) => String(a).includes('csv'));
+        const columns = this._columnNames(view);
+
+        // headers must be set before any bytes are written
+        res.setHeader('Content-Type', wantsCsv ? 'text/csv' : 'application/x-ndjson');
+
+        const source = await this._resourceSource({ view, inlineResources, requestInfo, parsedArgs });
+        const rows = runView(view, source, { fhirPathEvaluator: this.fhirPathEvaluator });
+        const writer = wantsCsv ? new RowCsvWriter({ columns }) : new RowNdJsonWriter();
+
+        await pipeline(Readable.from(rows), writer, res);
+        return undefined;
+    }
+
+    async _resourceSource({ view, inlineResources, requestInfo, parsedArgs }) {
+        if (inlineResources && inlineResources.length > 0) {
+            return inlineResources;
+        }
+        // stored path — guardrail D2: require a filter or an explicit _count
+        const hasFilter =
+            parsedArgs &&
+            Object.keys(parsedArgs).some(
+                (k) => !['base_version', 'resourceType', '_format', '_type'].includes(k)
+            );
+        if (!hasFilter) {
+            throw new BadRequestError(
+                new Error('stored $run requires a filter (e.g. patient, _lastUpdated) or an explicit _count')
+            );
+        }
+
+        // AUTHORIZATION GATE — never bypass this for stored resources
+        const { query } = await this.searchManager.constructQueryAsync({
+            user: requestInfo.user,
+            scope: requestInfo.scope,
+            isUser: requestInfo.isUser,
+            userType: requestInfo.userType,
+            resourceType: view.resource,
+            useAccessIndex: this.configManager.useAccessIndex,
+            personIdFromJwtToken: requestInfo.personIdFromJwtToken,
+            requestId: requestInfo.requestId,
+            parsedArgs,
+            operation: 'READ',
+            actor: requestInfo.actor
+        });
+
+        const databaseQueryManager = this.databaseQueryFactory.createQuery({
+            resourceType: view.resource,
+            base_version: '4_0_0'
+        });
+        const maxTimeMS = (this.configManager.sqlOnFhirMaxTimeMS) || 30000;
+        const cursor = await databaseQueryManager.findAsync({ query, options: { maxTimeMS } });
+
+        async function *iterate() {
+            while (await cursor.hasNext()) {
+                yield await cursor.next();
+            }
+        }
+        return iterate();
+    }
+
+    _columnNames(view) {
+        const names = [];
+        const seen = new Set();
+        const walk = (selections) => {
+            for (const s of selections || []) {
+                for (const c of s.column || []) {
+                    if (!seen.has(c.name)) {
+                        seen.add(c.name);
+                        names.push(c.name);
+                    }
+                }
+                walk(s.select);
+                for (const b of s.unionAll || []) {
+                    walk([b]);
+                }
+            }
+        };
+        walk(view.select);
+        return names;
+    }
+}
+
+module.exports = { SqlOnFhirRunOperation };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/sqlOnFhirRunOperation.test.js -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/operations/sqlOnFhir/sqlOnFhirRunOperation.js src/tests/sqlOnFhir/sqlOnFhirRunOperation.test.js
+git commit -m "feat(sql-on-fhir): add SqlOnFhirRunOperation orchestrator with secured stored source + guardrail"
+```
+
+---
+
+## Task 8: Container registration + `FhirOperationsManager.run`
+
+**Files:**
+- Modify: `src/createContainer.js`
+- Modify: `src/operations/fhirOperationsManager.js`
+
+**Interfaces:**
+- Consumes: all services from Tasks 1–7.
+- Produces: `fhirOperationsManager.run(args, { req, res }, resourceType)` reachable by the router with operation name `run`.
+
+- [ ] **Step 1: Register services in the container**
+
+In `src/createContainer.js`, add registrations near the other operations (mirror the `everythingOperation` block):
+```javascript
+container.register('fhirPathEvaluator', () => {
+    const { FhirPathEvaluator } = require('./utils/fhirPathEvaluator');
+    return new FhirPathEvaluator();
+});
+container.register('viewResolver', () => {
+    const { ViewResolver } = require('./operations/sqlOnFhir/viewResolver');
+    return new ViewResolver();
+});
+container.register('viewDefinitionValidator', () => {
+    const { ViewDefinitionValidator } = require('./operations/sqlOnFhir/viewDefinitionValidator');
+    return new ViewDefinitionValidator();
+});
+container.register('sqlOnFhirRunOperation', (c) => {
+    const { SqlOnFhirRunOperation } = require('./operations/sqlOnFhir/sqlOnFhirRunOperation');
+    return new SqlOnFhirRunOperation({
+        viewResolver: c.viewResolver,
+        viewDefinitionValidator: c.viewDefinitionValidator,
+        fhirPathEvaluator: c.fhirPathEvaluator,
+        searchManager: c.searchManager,
+        databaseQueryFactory: c.databaseQueryFactory,
+        configManager: c.configManager
+    });
+});
+```
+(Confirm the exact container names `searchManager`, `databaseQueryFactory`, `configManager` by grepping existing `container.register(` calls — they are registered elsewhere in this file.)
+
+- [ ] **Step 2: Inject the operation into `fhirOperationsManager`**
+
+In `src/createContainer.js`, add to the `fhirOperationsManager` registration object (the block at ~lines 968-998):
+```javascript
+            sqlOnFhirRunOperation: c.sqlOnFhirRunOperation,
+```
+
+- [ ] **Step 3: Add the constructor param + `run` method**
+
+In `src/operations/fhirOperationsManager.js`, add `sqlOnFhirRunOperation` to the constructor destructuring (near `exportOperation`) and store it:
+```javascript
+        this.sqlOnFhirRunOperation = sqlOnFhirRunOperation;
+        assertTypeEquals(sqlOnFhirRunOperation, SqlOnFhirRunOperation);
+```
+(Match the existing `assertTypeEquals` convention used for other operations; add the `require` for `SqlOnFhirRunOperation` at the top alongside the other operation requires. If a given operation is not asserted, follow that lighter pattern instead.)
+
+Then add the method (mirror `everything`’s streaming structure, but the operation owns the response writing):
+```javascript
+    async run(args, { req, res }, resourceType) {
+        const requestInfo = this.getRequestInfo(req);
+        this.accessManager.verifyAccess({ requestInfo, resourceType: resourceType || 'ViewDefinition', operation: 'run' });
+
+        let combined_args = get_all_args(req, args);
+        combined_args = this.parseParametersFromBody({ req, combined_args });
+
+        // The view's target resourceType drives arg parsing for the stored path.
+        const { ViewResolver } = require('./sqlOnFhir/viewResolver');
+        const { view } = new ViewResolver().resolve({ body: req.body });
+        const targetResourceType = view.resource;
+
+        const parsedArgs = await this.getParsedArgsAsync({
+            args: combined_args,
+            resourceType: targetResourceType,
+            headers: req.headers,
+            operation: READ,
+            requestInfo
+        });
+
+        return await this.sqlOnFhirRunOperation.runAsync({
+            requestInfo,
+            parsedArgs,
+            body: req.body,
+            resourceType: targetResourceType,
+            res
+        });
+    }
+```
+(`READ`, `get_all_args`, `getRequestInfo`, `getParsedArgsAsync`, `parseParametersFromBody` are already imported/defined in this file — reuse them.)
+
+- [ ] **Step 4: Run the full suite to confirm nothing regressed**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir -v`
+Expected: PASS (all sql-on-fhir unit tests). Also run a quick container smoke check:
+Run: `nvm use && node -e "require('./src/createContainer').createContainer()" && echo OK`
+Expected: `OK` (container builds without a missing-registration error).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/createContainer.js src/operations/fhirOperationsManager.js
+git commit -m "feat(sql-on-fhir): register \$run services and add FhirOperationsManager.run"
+```
+
+---
+
+## Task 9: Routes + end-to-end HTTP integration test
+
+**Files:**
+- Create: `src/middleware/fhir/sqlOnFhir/sqlOnFhir.config.js`
+- Modify: `src/middleware/fhir/router.js`
+- Test: `src/tests/sqlOnFhir/run.integration.test.js`
+
+**Interfaces:**
+- Consumes: `fhirOperationsManager.run` (Task 8), operation name `run`.
+- Produces: live routes `POST /:base_version/$run` and `POST /:base_version/ViewDefinition/$run`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `src/tests/sqlOnFhir/run.integration.test.js` (follow an existing operation integration test — e.g. under `src/tests/` for `$everything`/`$export` — for the exact `createTestRequest`/`getTestContainer` helpers and auth headers):
+```javascript
+const { commonBeforeEach, commonAfterEach, createTestRequest, getHeaders } = require('../common');
+
+describe('$run integration', () => {
+    beforeEach(async () => await commonBeforeEach());
+    afterEach(async () => await commonAfterEach());
+
+    const view = {
+        resourceType: 'ViewDefinition',
+        resource: 'Patient',
+        status: 'active',
+        select: [{ column: [{ name: 'id', path: 'getResourceKey()' }, { name: 'family', path: 'name.family.first()' }] }]
+    };
+
+    test('projects inline resources to NDJSON rows', async () => {
+        const request = await createTestRequest();
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [
+                { name: 'viewResource', resource: view },
+                { name: 'resource', resource: { resourceType: 'Patient', id: 'p1', name: [{ family: 'Smith' }] } }
+            ]
+        };
+        const resp = await request
+            .post('/4_0_0/ViewDefinition/$run')
+            .set({ ...getHeaders(), Accept: 'application/x-ndjson' })
+            .send(body);
+        expect(resp.status).toBe(200);
+        expect(resp.text.trim()).toBe('{"id":"p1","family":"Smith"}');
+    });
+});
+```
+(Import paths/helpers must match this repo’s conventions — copy them from a neighbouring integration test.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/run.integration.test.js -v`
+Expected: FAIL — 404 (route not registered).
+
+- [ ] **Step 3: Create the route config**
+
+Create `src/middleware/fhir/sqlOnFhir/sqlOnFhir.config.js` (mirror `export.config.js`):
+```javascript
+const { routeArgs } = require('../route.config.js');
+const { VERSIONS } = require('../utils/constants.js');
+
+const routes = [
+    {
+        path: '/:base_version/$run',
+        method: 'POST',
+        corsOptions: { methods: ['POST'] },
+        args: [routeArgs.BASE],
+        versions: [VERSIONS['4_0_0']],
+        operation: 'run'
+    },
+    {
+        path: '/:base_version/ViewDefinition/$run',
+        method: 'POST',
+        corsOptions: { methods: ['POST'] },
+        args: [routeArgs.BASE],
+        versions: [VERSIONS['4_0_0']],
+        operation: 'run'
+    }
+];
+
+module.exports = { routes };
+```
+
+- [ ] **Step 4: Register the routes in the router**
+
+In `src/middleware/fhir/router.js`: add the require near the other config requires:
+```javascript
+const { routes: sqlOnFhirConfig } = require('./sqlOnFhir/sqlOnFhir.config');
+```
+Add a method mirroring `enableExportRoutes` (without the `ENABLE_BULK_EXPORT` gate):
+```javascript
+    enableSqlOnFhirRoutes (app, config, corsDefaults) {
+        for (const profile of sqlOnFhirConfig) {
+            const operationName = profile.operation;
+            const corsOptions = Object.assign({}, corsDefaults, profile.corsOptions);
+            const operationsControllerRouteHandler = this.customOperationsController.operationsPost({
+                name: operationName
+            });
+            app.options(profile.path, cors(corsOptions));
+            app[profile.method.toLowerCase()](
+                profile.path,
+                cors(corsOptions),
+                versionValidationMiddleware(profile),
+                getArgsMiddleware(),
+                authenticationMiddleware(config),
+                sofScopeMiddleware({ route: profile.path, auth: config.auth, name: operationName }),
+                operationsControllerRouteHandler
+            );
+        }
+    }
+```
+Call it in `setRoutes` next to `this.enableExportRoutes(app, config, corsDefaults);`:
+```javascript
+        this.enableSqlOnFhirRoutes(app, config, corsDefaults);
+```
+Confirm that `customOperationsController.operationsPost` dispatches by matching the operation name to a `fhirOperationsManager` method — i.e. `run` → `fhirOperationsManager.run`. If dispatch uses an explicit allow-list/map, add `run` there.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/run.integration.test.js -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the whole sql-on-fhir suite + lint**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir -v && make lint`
+Expected: all PASS, lint clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/middleware/fhir/sqlOnFhir/sqlOnFhir.config.js src/middleware/fhir/router.js src/tests/sqlOnFhir/run.integration.test.js
+git commit -m "feat(sql-on-fhir): expose \$run routes and add end-to-end integration test"
+```
+
+---
+
+## Task 10: Stored-path security integration test
+
+**Files:**
+- Test: `src/tests/sqlOnFhir/run.security.integration.test.js`
+
+**Interfaces:**
+- Consumes: the live `$run` route (Task 9).
+
+- [ ] **Step 1: Write the security test**
+
+Create `src/tests/sqlOnFhir/run.security.integration.test.js`. Seed two Patients with different `meta.security` access tags (or owner tags) matching this repo's access model. Issue `$run` (no inline `resource`, with a filter so the guardrail passes) under a token scoped to only ONE of them. Assert:
+- the response contains ONLY the in-scope patient's row,
+- an unfiltered stored `$run` returns 400 (guardrail D2),
+- a request with no read scope for the target resourceType returns 403.
+
+Copy the access-tag seeding + header/scope helpers verbatim from an existing search-security integration test in `src/tests/` (search for a test that asserts scope-based filtering) so the security model matches exactly.
+
+```javascript
+// Structure (fill seeding/headers from an existing search-security test):
+// 1. create Patient A (access tag X) and Patient B (access tag Y)
+// 2. POST /4_0_0/ViewDefinition/$run with a filtered view under a token with access to X only
+// 3. expect(resp.text) to include A's id and NOT B's id
+// 4. POST unfiltered stored $run -> expect 400
+// 5. POST with a token lacking Patient read scope -> expect 403
+```
+
+- [ ] **Step 2: Run test to verify it fails, then passes**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir/run.security.integration.test.js -v`
+Expected: initially FAIL if any wiring is off; once green, the secured stored path is proven. If the scope-filtering assertion fails, the bug is that `_resourceSource` is not routing through `searchManager.constructQueryAsync` — fix the operation, never loosen the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tests/sqlOnFhir/run.security.integration.test.js
+git commit -m "test(sql-on-fhir): assert \$run stored path enforces search authorization"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full sql-on-fhir suite: `nvm use && node node_modules/.bin/jest src/tests/sqlOnFhir -v` → all PASS.
+- [ ] Run lint: `make lint` → clean.
+- [ ] Manual smoke (optional): `make up`, then `POST /4_0_0/ViewDefinition/$run` with a Parameters body containing `viewResource` + a few `resource` entries; confirm NDJSON and (with `Accept: text/csv`) CSV output.
+
+---
+
+## Notes for the implementer
+
+- **Do not bypass `searchManager.constructQueryAsync`** for stored resources. It is the single authorization gate (`src/operations/search/searchManager.js:189`). If it needs a parameter you don't have on `requestInfo`, get it the way `everything`/`search` do — don't invent a raw query.
+- **The conformance fixtures are the source of truth** for engine/evaluator correctness. When a fixture fails, fix `viewRunner.js` or `fhirPathEvaluator.js`, never the fixture.
+- **`fhirpath` version:** if the pinned version already ships `getResourceKey`/`getReferenceKey`, the `userInvocationTable` entries may collide — prefer the library's built-ins and delete the custom entries if the conformance suite passes without them.
+- **Exact container service names** (`searchManager`, `databaseQueryFactory`, `configManager`): verify by grepping `container.register(` in `src/createContainer.js` before wiring Task 8.

--- a/docs/superpowers/specs/2026-07-09-sql-on-fhir-run-design.md
+++ b/docs/superpowers/specs/2026-07-09-sql-on-fhir-run-design.md
@@ -51,6 +51,30 @@ over large stored result sets without buffering.
 
 ## 4. Architecture
 
+### 4.0 Execution model (read this first)
+
+There is **no input SQL** and **no query pushdown**. The input is a `ViewDefinition`
+(declarative JSON whose columns/filters are FHIRPath). Execution is:
+
+1. **Fetch resources** — for the stored case, query MongoDB for the target
+   `resourceType` via a **secured streaming cursor** (same auth/query-rewriter path
+   as `$search`; see §7). For the inline case, iterate the resources in the request.
+   Either way, resources are consumed one at a time — the collection is never fully
+   loaded.
+2. **Evaluate in-process** — for each resource, apply the ViewDefinition's FHIRPath
+   `where`/`column`/`forEach`/`unionAll` in Node to produce rows. This is medplum's
+   `evalSqlOnFhir` algorithm (`packages/core/src/sql-on-fhir/eval.ts`), ported
+   here but made **streaming** (`AsyncIterable<Row>`) instead of materializing the
+   whole `OutputRow[]` table in memory.
+3. **Write out** — each row is written straight to the NDJSON/CSV response stream.
+
+We do **not** translate the ViewDefinition into a Mongo aggregation. FHIRPath is far
+more expressive than Mongo aggregation maps cleanly onto, and every reference
+implementation (medplum, Aidbox, Pathling) evaluates FHIRPath in-process. Memory
+stays bounded at roughly one resource + its rows. Any future Mongo-side pushdown
+would be a niche optimization layered behind the source seam, never a replacement
+for the in-process engine.
+
 ### 4.1 Request flow
 
 ```

--- a/docs/superpowers/specs/2026-07-09-sql-on-fhir-run-design.md
+++ b/docs/superpowers/specs/2026-07-09-sql-on-fhir-run-design.md
@@ -1,0 +1,239 @@
+# SQL on FHIR — `ViewDefinition/$run` operation (Phase 1)
+
+- **Status:** Draft for review
+- **Date:** 2026-07-09
+- **Author:** Alvin Henrick (with Claude Code)
+- **Reference:** [HL7 SQL-on-FHIR v2](https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/), [medplum `evalSqlOnFhir`](https://www.medplum.com/docs/sdk/core.evalsqlonfhir)
+
+## 1. Summary
+
+Implement the HL7 **SQL-on-FHIR v2** `$run` operation in this Express.js + MongoDB
+FHIR server. `$run` takes a `ViewDefinition` — a tabular projection of a single
+FHIR resource type, with columns and row-inclusion criteria expressed as FHIRPath —
+and evaluates it over a set of FHIR resources, streaming back a flat table.
+
+This is the analytics-extraction primitive: define a projection (e.g. "one row per
+Patient with id, birthDate, and first official family name") and get NDJSON or CSV
+back, ready for a spreadsheet or a downstream Spark/Databricks load.
+
+## 2. Goals / Non-goals
+
+### Goals (Phase 1)
+- Spec-conformant `$run` with an **inline** `ViewDefinition`.
+- Project over resources that are **stored in MongoDB** or **provided inline** in the request.
+- Output **NDJSON** and **CSV**.
+- **Synchronous streaming** execution with a guardrail against runaway scans.
+- Full core `ViewDefinition` grammar: `select`, `column` (with `collection`),
+  `where`, `constant`, `forEach`, `forEachOrNull`, `unionAll`, nested `select`,
+  and the required SQL-on-FHIR FHIRPath functions
+  (`getResourceKey`, `getReferenceKey`, `ofType`, etc.).
+- Correctness validated against HL7's official SQL-on-FHIR v2 test suite.
+
+### Non-goals (deferred to later phases)
+- Stored / CRUD `ViewDefinition` resources and the instance form
+  `ViewDefinition/[id]/$run`.
+- Parquet output.
+- Asynchronous execution (202 + poll) and landing output in S3 / Delta / a lakehouse.
+- JSON-array output format.
+
+## 3. Background
+
+SQL-on-FHIR v2 defines a `ViewDefinition` logical resource. Each `ViewDefinition`
+is bound to one FHIR resource type (`resource`) and produces zero or more rows per
+resource instance. Columns and filters are FHIRPath expressions. The `$run`
+operation evaluates a `ViewDefinition` against provided or stored resources and
+returns the resulting table.
+
+medplum implements the evaluation core as
+`evalSqlOnFhir(view, resources): OutputRow[]` in `@medplum/core`. This design keeps
+that separation — a pure evaluation engine — but makes it **streaming** so it works
+over large stored result sets without buffering.
+
+## 4. Architecture
+
+### 4.1 Request flow
+
+```
+POST /4_0_0/ViewDefinition/$run     (primary, spec-aligned type-level form)
+POST /4_0_0/$run                    (system-level convenience form)
+  → sqlOnFhir.config.js route registration (new)
+  → CustomOperationsController
+  → FhirOperationsManager.run(args, { req, res })
+  → SqlOnFhirRunOperation.runAsync({ requestInfo, parsedArgs, req, res })
+```
+
+This mirrors the existing `$export` / `$everything` wiring. No changes to the
+router core — a new route config plus an `enableSqlOnFhirRoutes()` registration
+call, following the pattern in `src/middleware/fhir/`.
+
+### 4.2 Components
+
+Each is a single-purpose, independently testable unit.
+
+1. **`ViewDefinition` custom resource class**
+   - `src/fhir/classes/4_0_0/custom_resources/viewDefinition.js` + register in
+     `custom_resources/index.js`.
+   - Typing/validation only — **not** stored. Same pattern as the existing
+     `ExportStatus` custom resource.
+
+2. **`ViewResolver`** (the extension seam)
+   - Phase 1: returns the inline `ViewDefinition` supplied in the request.
+   - Later phases: resolves a stored `ViewDefinition` by id/url.
+   - Nothing downstream knows or cares where the view came from — this is what
+     lets stored/CRUD views be added later without touching the engine.
+
+3. **`ViewDefinitionValidator`**
+   - Structural validation: valid `resource` type, unique `column` names,
+     only-supported constructs, well-formed FHIRPath (best-effort compile check).
+   - Fails fast with a `400 OperationOutcome` **before** any streaming begins.
+
+4. **`FhirPathEvaluator`** (new DI service)
+   - Wraps the HL7 `fhirpath` npm library.
+   - Binds `ViewDefinition.constant`s as FHIRPath environment variables and
+     registers the SQL-on-FHIR function set.
+   - Single responsibility: `(expression, resource, context) → values`.
+
+5. **`ViewRunner`** (the core engine)
+   - Pure streaming transform:
+     `(ViewDefinition, AsyncIterable<Resource>) → AsyncIterable<Row>`.
+   - Implements the grammar: apply `where`; for passing resources, expand
+     `select` / `forEach` / `forEachOrNull` / `unionAll` / nested `select` and
+     evaluate each `column`'s FHIRPath to produce one or more rows.
+   - No DB, no HTTP, no framework knowledge — this is the medplum
+     `evalSqlOnFhir` analog, made streaming. Tested against the HL7 conformance
+     suite in isolation.
+
+6. **Resource source**
+   - *Inline:* iterate the resources provided in the request body.
+   - *Stored:* a `databaseQueryFactory` cursor **built through the same security /
+     query rewriters and access-index filtering as `$search`** (see §7), with
+     `maxTimeMS` applied.
+
+7. **Output writers**
+   - NDJSON row writer (`application/x-ndjson`) — one JSON object per row.
+   - CSV row writer (`text/csv`) — header row + one line per row.
+   - Column order follows `ViewDefinition` column order.
+   - Adapt the existing CSV / NDJSON response streamers rather than inventing new ones.
+
+8. **`SqlOnFhirRunOperation`** (orchestrator)
+   - Sequence: validate scopes → resolve view → validate view → guardrail check →
+     open source → `ViewRunner` → pipe rows to the negotiated output writer → end.
+   - Registered in `src/createContainer.js`; dispatched via
+     `FhirOperationsManager.run()`.
+
+### 4.3 Data flow
+
+```
+request
+  → scope check (read on target resourceType)
+  → resolve view (inline)
+  → validate view (400 on failure, pre-stream)
+  → guardrail check (stored + unfiltered → reject pre-stream)
+  → open source: inline iterator | secured Mongo cursor
+  → for each resource:
+        apply `where`; if it passes,
+        expand select/forEach/unionAll and evaluate columns → 1..N rows
+        write each row to the NDJSON/CSV stream
+  → end stream
+```
+
+## 5. Interfaces (sketch)
+
+```js
+// ViewRunner — pure, streaming, framework-agnostic
+async function *runView(viewDefinition, resourceIterable, { fhirPathEvaluator }) {
+    // yields plain row objects: { columnName: value, ... }
+}
+
+// ViewResolver — the seam
+async function resolveView(parsedArgs /*, requestInfo */) {
+    // Phase 1: return inline ViewDefinition from the request body / Parameters
+    // Later:   look up a stored ViewDefinition by id or url
+}
+
+// SqlOnFhirRunOperation
+async function runAsync({ requestInfo, parsedArgs, req, res }) { /* orchestrates */ }
+```
+
+Row values follow the SQL-on-FHIR column model: a `column` with `collection: true`
+yields an array; otherwise a scalar (or null when the FHIRPath yields empty).
+
+## 6. Error handling & decisions
+
+- **Invalid / unsupported `ViewDefinition`** → `400 OperationOutcome`, emitted
+  before streaming starts.
+- **Per-resource FHIRPath runtime error** → **fail the request** (deterministic).
+  *Decision D1 — reversible:* the alternative is skip-the-row-and-continue with a
+  logged warning. Fail-fast chosen so a broken projection surfaces immediately
+  rather than silently dropping rows. Flip if soft-fail is preferred.
+- **Guardrail on stored `$run`** → an unfiltered full-collection `$run` is
+  **rejected pre-stream** with a `400`.
+  *Decision D2 — reversible:* alternative is to silently apply a max-row cap.
+  Requiring an explicit filter (or a bounded `_count`) chosen so results are never
+  silently truncated. `maxTimeMS` on the cursor bounds runtime; if exceeded
+  mid-stream, the response is terminated and the error logged.
+- **Missing SMART scope** → `403`.
+
+## 7. Security (non-negotiable)
+
+Stored `$run` **must** use the identical authorization path as `$search`:
+SMART scope enforcement on the target resourceType, patient-compartment / proxy
+query rewriting, and access-index / consent filtering. `$run` must never surface a
+resource the caller could not already read via `$search`.
+
+Concretely: construct the stored query with the same `queryRewriters` +
+`ScopesManager` the search operation uses. **Do not** hand-roll a raw Mongo query
+that bypasses these layers.
+
+## 8. Testing
+
+- **Conformance:** run `ViewRunner` against HL7's **official SQL-on-FHIR v2 test
+  suite** (JSON cases) as unit tests — the gold standard for correctness. Track and
+  document any intentionally skipped cases (e.g. Parquet-only, deferred constructs).
+- **Unit:** `FhirPathEvaluator` (SQL-on-FHIR functions, `constant` binding),
+  `ViewDefinitionValidator` (rejection cases).
+- **Integration** (MongoDB Memory Server, existing jest harness + custom matchers):
+  - inline-resource path,
+  - stored-resource path **with security filtering asserted** (a caller must not
+    see resources outside their scope/compartment),
+  - NDJSON output shape,
+  - CSV output shape (header + rows, collection-column flattening rule),
+  - guardrail rejection (stored + unfiltered → 400),
+  - `403` on missing scope.
+
+## 9. Dependencies
+
+- Add `fhirpath` to `package.json`, then run `make update` to regenerate `yarn.lock`.
+- **Caution:** this repo version-locks some packages. Pin a known-good `fhirpath`
+  version and verify its SQL-on-FHIR function support (`getResourceKey`,
+  `getReferenceKey`, `ofType`) during implementation; register any missing
+  functions in `FhirPathEvaluator` if the library version lacks them.
+
+## 10. Files touched (anticipated)
+
+New:
+- `src/operations/sqlOnFhir/sqlOnFhirRunOperation.js`
+- `src/operations/sqlOnFhir/viewRunner.js`
+- `src/operations/sqlOnFhir/viewResolver.js`
+- `src/operations/sqlOnFhir/viewDefinitionValidator.js`
+- `src/utils/fhirPathEvaluator.js`
+- `src/fhir/classes/4_0_0/custom_resources/viewDefinition.js`
+- `src/middleware/fhir/sqlOnFhir/sqlOnFhir.config.js`
+- tests under `src/tests/sqlOnFhir/` (unit + integration + conformance)
+
+Modified:
+- `src/createContainer.js` (register new services)
+- `src/operations/fhirOperationsManager.js` (add `run` dispatch)
+- `src/fhir/classes/4_0_0/custom_resources/index.js` (register ViewDefinition)
+- `src/middleware/fhir/router.js` (register `$run` routes)
+- `package.json` (add `fhirpath`)
+
+## 11. Open questions for reviewer
+
+1. Confirm decisions **D1** (fail-fast on FHIRPath error) and **D2** (require a
+   filter on stored `$run`).
+2. Endpoint form: type-level `ViewDefinition/$run` only, or also the system-level
+   `/$run` convenience alias? (Design assumes both; type-level is the spec-aligned one.)
+3. CSV flattening rule for `collection: true` columns — JSON-encode the array into
+   the cell, or join with a separator? (Design leaves this to implementation;
+   flag a preference if you have one.)

--- a/docs/superpowers/specs/2026-07-09-sql-on-fhir-run-design.md
+++ b/docs/superpowers/specs/2026-07-09-sql-on-fhir-run-design.md
@@ -67,6 +67,8 @@ There is **no input SQL** and **no query pushdown**. The input is a `ViewDefinit
    here but made **streaming** (`AsyncIterable<Row>`) instead of materializing the
    whole `OutputRow[]` table in memory.
 3. **Write out** — each row is written straight to the NDJSON/CSV response stream.
+   Once this has started, the HTTP status (`200`) is already committed; see §6
+   for what happens if a later resource in the stream hits a fail-fast error.
 
 We do **not** translate the ViewDefinition into a Mongo aggregation. FHIRPath is far
 more expressive than Mongo aggregation maps cleanly onto, and every reference
@@ -197,6 +199,14 @@ yields an array; otherwise a scalar (or null when the FHIRPath yields empty).
   silently truncated. `maxTimeMS` on the cursor bounds runtime; if exceeded
   mid-stream, the response is terminated and the error logged.
 - **Missing SMART scope** → `403`.
+- **Mid-stream error contract:** once row streaming has begun (HTTP 200 headers
+  already sent), a per-resource FHIRPath runtime error (Decision D1, fail-fast)
+  **cannot change the already-sent status code**. The response stays a `200`
+  whose NDJSON/CSV body simply terminates early (aborted/truncated) — it is
+  **not** followed by an `OperationOutcome`. Clients must treat an unexpected
+  early end of the stream (e.g. NDJSON not ending on a clean line boundary, or
+  a connection reset) as a failed request, not a partial success. Pre-stream
+  errors (validation, guardrail, scope) remain clean `400`/`403` responses.
 
 ## 7. Security (non-negotiable)
 

--- a/docs/superpowers/specs/2026-07-09-sql-on-fhir-run-design.md
+++ b/docs/superpowers/specs/2026-07-09-sql-on-fhir-run-design.md
@@ -80,8 +80,7 @@ for the in-process engine.
 ### 4.1 Request flow
 
 ```
-POST /4_0_0/ViewDefinition/$run     (primary, spec-aligned type-level form)
-POST /4_0_0/$run                    (system-level convenience form)
+POST /4_0_0/ViewDefinition/$run     (spec-aligned type-level form)
   → sqlOnFhir.config.js route registration (new)
   → CustomOperationsController
   → FhirOperationsManager.run(args, { req, res })

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "fast-deep-equal": "^3.1.3",
     "fast-json-patch": "^3.1.1",
     "fflate": "^0.8.3",
+    "fhirpath": "3.15.2",
     "graphql": "^16.14.0",
     "graphql-fields": "^2.0.3",
     "graphql-parse-resolve-info": "^4.14.1",

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -156,6 +156,10 @@ const { GenericClickHouseQueryBuilder } = require('./dataLayer/builders/genericC
 const { GenericClickHouseRepository } = require('./dataLayer/repositories/genericClickHouseRepository');
 const { AccessHistoryClickHouseRepository } = require('./dataLayer/repositories/accessHistoryClickHouseRepository');
 const { AccessHistoryOperation } = require('./operations/accessHistory/accessHistory');
+const { FhirPathEvaluator } = require('./utils/fhirPathEvaluator');
+const { ViewResolver } = require('./operations/sqlOnFhir/viewResolver');
+const { ViewDefinitionValidator } = require('./operations/sqlOnFhir/viewDefinitionValidator');
+const { SqlOnFhirRunOperation } = require('./operations/sqlOnFhir/sqlOnFhirRunOperation');
 const deepcopy = require('deepcopy');
 
 /**
@@ -808,6 +812,18 @@ const createContainer = function () {
         cmsManager: c.cmsManager
     }));
 
+    container.register('fhirPathEvaluator', () => new FhirPathEvaluator());
+    container.register('viewResolver', () => new ViewResolver());
+    container.register('viewDefinitionValidator', () => new ViewDefinitionValidator());
+    container.register('sqlOnFhirRunOperation', (c) => new SqlOnFhirRunOperation({
+        viewResolver: c.viewResolver,
+        viewDefinitionValidator: c.viewDefinitionValidator,
+        fhirPathEvaluator: c.fhirPathEvaluator,
+        searchManager: c.searchManager,
+        databaseQueryFactory: c.databaseQueryFactory,
+        configManager: c.configManager
+    }));
+
     container.register('removeHelper', c => new RemoveHelper({
         databaseBulkInserter: c.databaseBulkInserter,
         resourceLocatorFactory: c.resourceLocatorFactory,
@@ -992,7 +1008,8 @@ const createContainer = function () {
                 accessManager: c.accessManager,
                 cmsManager: c.cmsManager,
                 accessHistoryOperation: c.accessHistoryOperation,
-                customTracer: c.customTracer
+                customTracer: c.customTracer,
+                sqlOnFhirRunOperation: c.sqlOnFhirRunOperation
             }
         )
     );

--- a/src/fhir/classes/4_0_0/custom_resources/index.js
+++ b/src/fhir/classes/4_0_0/custom_resources/index.js
@@ -1,7 +1,9 @@
 const exportstatusentry = require('./exportStatusEntry');
 const exportstatus = require('./exportStatus');
+const viewdefinition = require('./viewDefinition');
 
 module.exports = {
     exportstatusentry,
-    exportstatus
+    exportstatus,
+    viewdefinition
 };

--- a/src/fhir/classes/4_0_0/custom_resources/viewDefinition.js
+++ b/src/fhir/classes/4_0_0/custom_resources/viewDefinition.js
@@ -1,0 +1,445 @@
+const Resource = require('../resources/resource.js');
+
+/**
+ * ViewDefinition
+ *    Custom (non-standard-R4) resource used by the SQL-on-FHIR v2 $run operation for
+ *    typing/validation only. It is never persisted. `select`, `constant`, and `where`
+ *    are stored as plain pass-through data (FHIRPath payloads), not typed FHIR elements.
+ */
+class ViewDefinition extends Resource {
+    /**
+     * @typedef {Object} ConstructorParams
+     * @property {String} [id]
+     * @property {import('../complex_types/meta.js')} [meta]
+     * @property {string} [url]
+     * @property {string} [name]
+     * @property {string} [title]
+     * @property {code} [status]
+     * @property {string} [resource]
+     * @property {Object[]} [constant]
+     * @property {Object[]} [select]
+     * @property {Object[]} [where]
+     *
+     * @param {ConstructorParams}
+     */
+    constructor({
+        id,
+        meta,
+        url,
+        name,
+        title,
+        status,
+        resource,
+        constant,
+        select,
+        where,
+        _access,
+        _sourceAssigningAuthority,
+        _sourceId,
+        _uuid
+    }) {
+        super({});
+
+        /**
+         * @description The logical id of the resource, as used in the URL for the resource. Once
+         * assigned, this value never changes.
+         * @property {String|undefined}
+         */
+        Object.defineProperty(this, 'id', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data.id,
+            set: (valueProvided) => {
+                if (
+                    valueProvided === undefined ||
+                    valueProvided === null ||
+                    (Array.isArray(valueProvided) && valueProvided.length === 0)
+                ) {
+                    this.__data.id = undefined;
+                    return;
+                }
+                this.__data.id = valueProvided;
+            }
+        });
+
+        /**
+         * @description The metadata about the resource. This is content that is maintained by the
+         * infrastructure. Changes to the content might not always be associated with
+         * version changes to the resource.
+         * @property {import('../complex_types/meta')|undefined}
+         */
+        Object.defineProperty(this, 'meta', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data.meta,
+            set: (valueProvided) => {
+                if (
+                    valueProvided === undefined ||
+                    valueProvided === null ||
+                    (Array.isArray(valueProvided) && valueProvided.length === 0)
+                ) {
+                    this.__data.meta = undefined;
+                    return;
+                }
+                const Meta = require('../complex_types/meta.js');
+                const { FhirResourceCreator } = require('../../../fhirResourceCreator.js');
+                this.__data.meta = FhirResourceCreator.create(valueProvided, Meta);
+            }
+        });
+
+        /**
+         * @description An absolute base URL for the definition.
+         * @property {string|undefined}
+         */
+        Object.defineProperty(this, 'url', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data.url,
+            set: (valueProvided) => {
+                if (
+                    valueProvided === undefined ||
+                    valueProvided === null ||
+                    (Array.isArray(valueProvided) && valueProvided.length === 0)
+                ) {
+                    this.__data.url = undefined;
+                    return;
+                }
+                this.__data.url = valueProvided;
+            }
+        });
+
+        /**
+         * @description A machine-friendly name for the view definition.
+         * @property {string|undefined}
+         */
+        Object.defineProperty(this, 'name', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data.name,
+            set: (valueProvided) => {
+                if (
+                    valueProvided === undefined ||
+                    valueProvided === null ||
+                    (Array.isArray(valueProvided) && valueProvided.length === 0)
+                ) {
+                    this.__data.name = undefined;
+                    return;
+                }
+                this.__data.name = valueProvided;
+            }
+        });
+
+        /**
+         * @description A human-friendly title for the view definition.
+         * @property {string|undefined}
+         */
+        Object.defineProperty(this, 'title', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data.title,
+            set: (valueProvided) => {
+                if (
+                    valueProvided === undefined ||
+                    valueProvided === null ||
+                    (Array.isArray(valueProvided) && valueProvided.length === 0)
+                ) {
+                    this.__data.title = undefined;
+                    return;
+                }
+                this.__data.title = valueProvided;
+            }
+        });
+
+        /**
+         * @description The status of the view definition.
+         * @property {code|undefined}
+         */
+        Object.defineProperty(this, 'status', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data.status,
+            set: (valueProvided) => {
+                if (
+                    valueProvided === undefined ||
+                    valueProvided === null ||
+                    (Array.isArray(valueProvided) && valueProvided.length === 0)
+                ) {
+                    this.__data.status = undefined;
+                    return;
+                }
+                this.__data.status = valueProvided;
+            }
+        });
+
+        /**
+         * @description The FHIR resource type this view is based on (e.g. 'Patient').
+         * @property {string|undefined}
+         */
+        Object.defineProperty(this, 'resource', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data.resource,
+            set: (valueProvided) => {
+                if (
+                    valueProvided === undefined ||
+                    valueProvided === null ||
+                    (Array.isArray(valueProvided) && valueProvided.length === 0)
+                ) {
+                    this.__data.resource = undefined;
+                    return;
+                }
+                this.__data.resource = valueProvided;
+            }
+        });
+
+        /**
+         * @description Constant definitions usable as %variables in FHIRPath expressions. Stored
+         * as plain pass-through data (not typed FHIR elements).
+         * @property {Object[]|undefined}
+         */
+        Object.defineProperty(this, 'constant', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data.constant,
+            set: (valueProvided) => {
+                if (
+                    valueProvided === undefined ||
+                    valueProvided === null ||
+                    (Array.isArray(valueProvided) && valueProvided.length === 0)
+                ) {
+                    this.__data.constant = undefined;
+                    return;
+                }
+                this.__data.constant = valueProvided;
+            }
+        });
+
+        /**
+         * @description The column/select structure of the view. Stored as plain pass-through data
+         * (not typed FHIR elements) since it is a FHIRPath payload evaluated by the SQL-on-FHIR
+         * engine.
+         * @property {Object[]|undefined}
+         */
+        Object.defineProperty(this, 'select', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data.select,
+            set: (valueProvided) => {
+                if (
+                    valueProvided === undefined ||
+                    valueProvided === null ||
+                    (Array.isArray(valueProvided) && valueProvided.length === 0)
+                ) {
+                    this.__data.select = undefined;
+                    return;
+                }
+                this.__data.select = valueProvided;
+            }
+        });
+
+        /**
+         * @description FHIRPath-based filter conditions applied to the resource. Stored as plain
+         * pass-through data (not typed FHIR elements).
+         * @property {Object[]|undefined}
+         */
+        Object.defineProperty(this, 'where', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data.where,
+            set: (valueProvided) => {
+                if (
+                    valueProvided === undefined ||
+                    valueProvided === null ||
+                    (Array.isArray(valueProvided) && valueProvided.length === 0)
+                ) {
+                    this.__data.where = undefined;
+                    return;
+                }
+                this.__data.where = valueProvided;
+            }
+        });
+
+        /**
+         * @description _access
+         * @property {Object|undefined}
+         */
+        Object.defineProperty(this, '_access', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data._access,
+            set: (valueProvided) => {
+                this.__data._access = valueProvided;
+            }
+        });
+
+        /**
+         * @description _sourceAssigningAuthority
+         * @property {string|undefined}
+         */
+        Object.defineProperty(this, '_sourceAssigningAuthority', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data._sourceAssigningAuthority,
+            set: (valueProvided) => {
+                this.__data._sourceAssigningAuthority = valueProvided;
+            }
+        });
+
+        /**
+         * @description _uuid
+         * @property {string|undefined}
+         */
+        Object.defineProperty(this, '_uuid', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data._uuid,
+            set: (valueProvided) => {
+                this.__data._uuid = valueProvided;
+            }
+        });
+
+        /**
+         * @description _sourceId
+         * @property {string|undefined}
+         */
+        Object.defineProperty(this, '_sourceId', {
+            // https://www.w3schools.com/js/js_object_es5.asp
+            enumerable: true,
+            configurable: true,
+            get: () => this.__data._sourceId,
+            set: (valueProvided) => {
+                this.__data._sourceId = valueProvided;
+            }
+        });
+
+        Object.assign(this, {
+            id,
+            meta,
+            url,
+            name,
+            title,
+            status,
+            resource,
+            constant,
+            select,
+            where,
+            _access,
+            _sourceAssigningAuthority,
+            _sourceId,
+            _uuid
+        });
+
+        /**
+         * @description Define a default non-writable resourceType property
+         * @property {string}
+         */
+        Object.defineProperty(this, 'resourceType', {
+            value: 'ViewDefinition',
+            enumerable: true,
+            writable: false,
+            configurable: true
+        });
+    }
+
+    /**
+     * Returns JSON representation of entity
+     * @return {Object}
+     */
+    toJSON() {
+        const { removeNull } = require('../../../../utils/nullRemover.js');
+
+        return removeNull({
+            id: this.id,
+            resourceType: this.resourceType,
+            meta: this.meta && this.meta.toJSON(),
+            url: this.url,
+            name: this.name,
+            title: this.title,
+            status: this.status,
+            resource: this.resource,
+            constant: this.constant,
+            select: this.select,
+            where: this.where
+        });
+    }
+
+    /**
+     * @description Create a blank new resource
+     * @param {String} [id]
+     * @param {import('../complex_types/meta.js')} [meta]
+     * @param {string} [url]
+     * @param {string} [name]
+     * @param {string} [title]
+     * @param {code} [status]
+     * @param {string} [resource]
+     * @param {Object[]} [constant]
+     * @param {Object[]} [select]
+     * @param {Object[]} [where]
+     */
+    create({ id, meta, url, name, title, status, resource, constant, select, where }) {
+        return new ViewDefinition({
+            id,
+            meta,
+            url,
+            name,
+            title,
+            status,
+            resource,
+            constant,
+            select,
+            where
+        });
+    }
+
+    /**
+     * Returns JSON representation of entity
+     * @return {Object}
+     */
+    toJSONInternal() {
+        const { removeNull } = require('../../../../utils/nullRemover.js');
+
+        const json = removeNull({
+            id: this.id,
+            resourceType: this.resourceType,
+            meta: this.meta && this.meta.toJSONInternal(),
+            url: this.url,
+            name: this.name,
+            title: this.title,
+            status: this.status,
+            resource: this.resource,
+            constant: this.constant,
+            select: this.select,
+            where: this.where
+        });
+
+        if (this._access) {
+            json._access = this._access;
+        }
+        if (this._sourceAssigningAuthority) {
+            json._sourceAssigningAuthority = this._sourceAssigningAuthority;
+        }
+        if (this._uuid) {
+            json._uuid = this._uuid;
+        }
+        if (this._sourceId) {
+            json._sourceId = this._sourceId;
+        }
+
+        return json;
+    }
+}
+
+module.exports = ViewDefinition;

--- a/src/fhir/classes/4_0_0/custom_resources/viewDefinition.js
+++ b/src/fhir/classes/4_0_0/custom_resources/viewDefinition.js
@@ -431,11 +431,21 @@ class ViewDefinition extends Resource {
             name: this.name,
             title: this.title,
             status: this.status,
-            resource: this.resource,
-            constant: this.constant,
-            select: this.select,
-            where: this.where
+            resource: this.resource
         });
+
+        // constant/select/where are opaque FHIRPath pass-through payloads (the same
+        // object references held by the caller/validator/FHIRPath engine). Attach them
+        // as-is instead of running them through the mutating removeNull().
+        if (this.constant !== undefined) {
+            json.constant = this.constant;
+        }
+        if (this.select !== undefined) {
+            json.select = this.select;
+        }
+        if (this.where !== undefined) {
+            json.where = this.where;
+        }
 
         if (this._access) {
             json._access = this._access;

--- a/src/fhir/classes/4_0_0/custom_resources/viewDefinition.js
+++ b/src/fhir/classes/4_0_0/custom_resources/viewDefinition.js
@@ -361,7 +361,7 @@ class ViewDefinition extends Resource {
     toJSON() {
         const { removeNull } = require('../../../../utils/nullRemover.js');
 
-        return removeNull({
+        const json = removeNull({
             id: this.id,
             resourceType: this.resourceType,
             meta: this.meta && this.meta.toJSON(),
@@ -369,11 +369,23 @@ class ViewDefinition extends Resource {
             name: this.name,
             title: this.title,
             status: this.status,
-            resource: this.resource,
-            constant: this.constant,
-            select: this.select,
-            where: this.where
+            resource: this.resource
         });
+
+        // constant/select/where are opaque FHIRPath pass-through payloads (the same
+        // object references held by the caller/validator/FHIRPath engine). Attach them
+        // as-is instead of running them through the mutating removeNull().
+        if (this.constant !== undefined) {
+            json.constant = this.constant;
+        }
+        if (this.select !== undefined) {
+            json.select = this.select;
+        }
+        if (this.where !== undefined) {
+            json.where = this.where;
+        }
+
+        return json;
     }
 
     /**

--- a/src/middleware/fhir/router.js
+++ b/src/middleware/fhir/router.js
@@ -17,6 +17,10 @@ const {
 } = require('./import/import.config');
 
 const {
+    routes: sqlOnFhirConfig
+} = require('./sqlOnFhir/sqlOnFhir.config');
+
+const {
     routeArgs,
     routes
 } = require('./route.config');
@@ -374,6 +378,34 @@ class FhirRouter {
         }
     }
 
+    enableSqlOnFhirRoutes (app, config, corsDefaults) {
+        for (const profile of sqlOnFhirConfig) {
+            const operationName = profile.operation;
+
+            const corsOptions = Object.assign({}, corsDefaults, profile.corsOptions);
+
+            const operationsControllerRouteHandler = this.customOperationsController.operationsPost({
+                name: operationName
+            });
+
+            app.options(profile.path, cors(corsOptions));
+
+            app[profile.method.toLowerCase()](
+                profile.path,
+                cors(corsOptions),
+                versionValidationMiddleware(profile),
+                getArgsMiddleware(),
+                authenticationMiddleware(config),
+                sofScopeMiddleware({
+                    route: profile.path,
+                    auth: config.auth,
+                    name: operationName
+                }),
+                operationsControllerRouteHandler
+            );
+        }
+    }
+
     /**
      * @function enableProfileRoutes
      * @description Start iterating over potential routes to enable for this profile
@@ -539,6 +571,7 @@ class FhirRouter {
         this.enableMetadataRoute(app, config, corsDefaults);
         this.enableExportRoutes(app, config, corsDefaults);
         this.enableImportRoutes(app, config, corsDefaults);
+        this.enableSqlOnFhirRoutes(app, config, corsDefaults);
         this.enableResourceRoutes(app, config, corsDefaults); // Enable all routes, operations base: Batch and Transactions
 
         this.enableBaseRoute(app, config, corsDefaults);

--- a/src/middleware/fhir/sqlOnFhir/sqlOnFhir.config.js
+++ b/src/middleware/fhir/sqlOnFhir/sqlOnFhir.config.js
@@ -1,0 +1,33 @@
+const { routeArgs } = require('../route.config.js');
+const { VERSIONS } = require('../utils/constants.js');
+
+const routes = [
+    {
+        path: '/:base_version/$run',
+        method: 'POST',
+        corsOptions: {
+            methods: ['POST']
+        },
+        args: [routeArgs.BASE],
+        versions: [VERSIONS['4_0_0']],
+        operation: 'run'
+    },
+    {
+        path: '/:base_version/ViewDefinition/$run',
+        method: 'POST',
+        corsOptions: {
+            methods: ['POST']
+        },
+        args: [routeArgs.BASE],
+        versions: [VERSIONS['4_0_0']],
+        operation: 'run'
+    }
+];
+
+/**
+ * @name exports
+ * @summary SQL-on-FHIR $run config
+ */
+module.exports = {
+    routes
+};

--- a/src/middleware/fhir/sqlOnFhir/sqlOnFhir.config.js
+++ b/src/middleware/fhir/sqlOnFhir/sqlOnFhir.config.js
@@ -3,16 +3,6 @@ const { VERSIONS } = require('../utils/constants.js');
 
 const routes = [
     {
-        path: '/:base_version/$run',
-        method: 'POST',
-        corsOptions: {
-            methods: ['POST']
-        },
-        args: [routeArgs.BASE],
-        versions: [VERSIONS['4_0_0']],
-        operation: 'run'
-    },
-    {
         path: '/:base_version/ViewDefinition/$run',
         method: 'POST',
         corsOptions: {

--- a/src/operations/fhirOperationsManager.js
+++ b/src/operations/fhirOperationsManager.js
@@ -44,6 +44,8 @@ const { ResponseHandlerFactory } = require('../utils/responseHandler/responseHan
 const { CMSManager } = require('../utils/cmsManager');
 const { OperationAccessManager } = require('../utils/operationAccessManager');
 const { CustomTracer } = require('../utils/customTracer');
+const { SqlOnFhirRunOperation } = require('./sqlOnFhir/sqlOnFhirRunOperation');
+const { ViewResolver } = require('./sqlOnFhir/viewResolver');
 
 class FhirOperationsManager {
     /**
@@ -74,6 +76,7 @@ class FhirOperationsManager {
      * @param {CMSManager} cmsManager
      * @param {AccessHistoryOperation} accessHistoryOperation
      * @param {CustomTracer} customTracer
+     * @param {SqlOnFhirRunOperation} sqlOnFhirRunOperation
      */
     constructor(
         {
@@ -102,7 +105,8 @@ class FhirOperationsManager {
             accessManager,
             cmsManager,
             accessHistoryOperation,
-            customTracer
+            customTracer,
+            sqlOnFhirRunOperation
         }
     ) {
         /**
@@ -242,6 +246,12 @@ class FhirOperationsManager {
          */
         this.customTracer = customTracer;
         assertTypeEquals(customTracer, CustomTracer);
+
+        /**
+         * @type {SqlOnFhirRunOperation}
+         */
+        this.sqlOnFhirRunOperation = sqlOnFhirRunOperation;
+        assertTypeEquals(sqlOnFhirRunOperation, SqlOnFhirRunOperation);
     }
 
     /**
@@ -792,6 +802,47 @@ class FhirOperationsManager {
                 });
             return result;
         }
+    }
+
+    /**
+     * does a SQL-on-FHIR $run
+     * @param {string[]} args
+     * @param {import('http').IncomingMessage} req
+     * @param {import('express').Response} res
+     * @param {string} resourceType
+     * @returns {Promise<undefined>} response is written directly to res
+     */
+    async run(args, { req, res }, resourceType) {
+        const requestInfo = this.getRequestInfo(req);
+        this.accessManager.verifyAccess({ requestInfo, resourceType: resourceType || 'ViewDefinition', operation: 'run' });
+
+        /**
+         * combined args
+         * @type {Object}
+         */
+        let combined_args = get_all_args(req, args);
+        combined_args = this.parseParametersFromBody({ req, combined_args });
+
+        // The view's target resourceType drives arg parsing for the stored path. Resolve
+        // the body once here and pass the resolved resourceType through to the operation,
+        // which resolves the body again internally (small Parameters body, cheap).
+        const { view } = new ViewResolver().resolve({ body: req.body });
+        const targetResourceType = view.resource;
+
+        /**
+         * @type {ParsedArgs}
+         */
+        const parsedArgs = await this.getParsedArgsAsync({
+            args: combined_args, resourceType: targetResourceType, headers: req.headers, operation: READ, requestInfo
+        });
+
+        return await this.sqlOnFhirRunOperation.runAsync({
+            requestInfo,
+            parsedArgs,
+            body: req.body,
+            resourceType: targetResourceType,
+            res
+        });
     }
 
     /**

--- a/src/operations/fhirOperationsManager.js
+++ b/src/operations/fhirOperationsManager.js
@@ -827,6 +827,11 @@ class FhirOperationsManager {
         // the body once here and pass the resolved resourceType through to the operation,
         // which resolves the body again internally (small Parameters body, cheap).
         const { view } = new ViewResolver().resolve({ body: req.body });
+        if (!view || typeof view.resource !== 'string' || view.resource.length === 0) {
+            throw new BadRequestError(new Error(
+                '$run ViewDefinition requires a non-empty "resource" (target FHIR resource type)'
+            ));
+        }
         const targetResourceType = view.resource;
 
         /**

--- a/src/operations/sqlOnFhir/rowCsvWriter.js
+++ b/src/operations/sqlOnFhir/rowCsvWriter.js
@@ -1,0 +1,61 @@
+const { Transform } = require('@json2csv/node');
+
+/**
+ * String formatter that only quotes a cell when it actually contains the
+ * quote character, the field separator, or a line break -- i.e. it matches
+ * `@json2csv/formatters`' `stringQuoteOnlyIfNecessary` behavior without
+ * pulling in `@json2csv/formatters` as an extra explicit dependency (it is
+ * already a transitive dependency of `@json2csv/node`).
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function quoteOnlyIfNecessary(value) {
+    if (value.includes('"') || value.includes(',') || value.includes('\n')) {
+        return `"${value.replace(/"/g, '""')}"`;
+    }
+    return value;
+}
+
+/**
+ * Transform stream that converts plain row objects (SQL-on-FHIR $run output
+ * rows, NOT FHIR resources) into CSV bytes, wrapping `@json2csv/node`'s
+ * Transform.
+ *
+ * The `columns` array fixes both the header line and the per-row column
+ * order (D3). Array/object cell values are JSON-encoded into the cell as a
+ * scalar string so `@json2csv` never tries to flatten/expand them; `null`
+ * and `undefined` values are left as-is and render as an empty cell.
+ */
+class RowCsvWriter extends Transform {
+    /**
+     * @param {{ columns: string[] }} params ordered column names for header + field order
+     */
+    constructor({ columns }) {
+        super(
+            {
+                fields: columns,
+                formatters: { string: quoteOnlyIfNecessary, header: quoteOnlyIfNecessary }
+            },
+            {},
+            { objectMode: true }
+        );
+
+        /**
+         * @type {string[]}
+         * @private
+         */
+        this._columns = columns;
+    }
+
+    _transform(row, encoding, done) {
+        const encoded = {};
+        for (const key of this._columns) {
+            const value = row[key];
+            encoded[key] = value !== null && typeof value === 'object' ? JSON.stringify(value) : value;
+        }
+        return super._transform(encoded, encoding, done);
+    }
+}
+
+module.exports = { RowCsvWriter };

--- a/src/operations/sqlOnFhir/rowNdJsonWriter.js
+++ b/src/operations/sqlOnFhir/rowNdJsonWriter.js
@@ -1,0 +1,25 @@
+const { Transform } = require('stream');
+
+/**
+ * Transform stream that converts plain row objects (SQL-on-FHIR $run output
+ * rows, NOT FHIR resources) into newline-delimited JSON bytes.
+ *
+ * Writable side is objectMode (accepts row objects); readable side emits
+ * Buffers/strings of `JSON.stringify(row) + '\n'`.
+ */
+class RowNdJsonWriter extends Transform {
+    constructor(options = {}) {
+        super({ ...options, writableObjectMode: true, readableObjectMode: false });
+    }
+
+    _transform(row, _encoding, callback) {
+        try {
+            this.push(JSON.stringify(row) + '\n');
+            callback();
+        } catch (err) {
+            callback(err);
+        }
+    }
+}
+
+module.exports = { RowNdJsonWriter };

--- a/src/operations/sqlOnFhir/sqlOnFhirRunOperation.js
+++ b/src/operations/sqlOnFhir/sqlOnFhirRunOperation.js
@@ -96,9 +96,16 @@ class SqlOnFhirRunOperation {
         // NOTE: the real ParsedArgs (src/operations/query/parsedArgs.js) attaches search
         // params as NON-ENUMERABLE getters via Object.defineProperty, so Object.keys() on
         // the instance never sees them. The actual params live in parsedArgs.parsedArgItems.
-        const reservedArgs = ['_format', '_type', '_count'];
+        // NOTE: over the real HTTP path, parsedArgItems for a $run request ALWAYS includes
+        // base_version (injected by get_all_args from req.sanitized_args), resource (the
+        // controller always sets args.resource = req.body for POST custom operations — see
+        // operations.controller.js operationsPost), and viewResource (folded in from the
+        // Parameters body by parseParametersFromBody). These are structural/control params,
+        // always present regardless of caller input, and MUST NOT count as a user filter —
+        // otherwise an unfiltered stored $run always looks "filtered" and D2 never fires.
+        const nonFilterArgs = ['_format', '_type', '_count', 'base_version', 'resource', 'viewResource'];
         const items = (parsedArgs && parsedArgs.parsedArgItems) || [];
-        const hasFilter = items.some((a) => !reservedArgs.includes(a.queryParameter));
+        const hasFilter = items.some((a) => !nonFilterArgs.includes(a.queryParameter));
         const hasExplicitCount = !!(parsedArgs && parsedArgs.get && parsedArgs.get('_count'));
         if (!hasFilter && !hasExplicitCount) {
             throw new BadRequestError(

--- a/src/operations/sqlOnFhir/sqlOnFhirRunOperation.js
+++ b/src/operations/sqlOnFhir/sqlOnFhirRunOperation.js
@@ -1,0 +1,173 @@
+const { pipeline } = require('stream/promises');
+const { Readable } = require('stream');
+const { runView } = require('./viewRunner');
+const { RowNdJsonWriter } = require('./rowNdJsonWriter');
+const { RowCsvWriter } = require('./rowCsvWriter');
+const { BadRequestError } = require('../../utils/httpErrors');
+
+const BASE_VERSION = '4_0_0';
+
+class SqlOnFhirRunOperation {
+    /**
+     * @param {Object} deps
+     * @param {import('./viewResolver').ViewResolver} deps.viewResolver
+     * @param {import('./viewDefinitionValidator').ViewDefinitionValidator} deps.viewDefinitionValidator
+     * @param {import('../../utils/fhirPathEvaluator').FhirPathEvaluator} deps.fhirPathEvaluator
+     * @param {import('../search/searchManager').SearchManager} deps.searchManager
+     *        MUST expose constructQueryAsync (the authorization gate)
+     * @param {import('../../dataLayer/databaseQueryFactory').DatabaseQueryFactory} deps.databaseQueryFactory
+     * @param {Object} deps.configManager
+     */
+    constructor({
+        viewResolver,
+        viewDefinitionValidator,
+        fhirPathEvaluator,
+        searchManager,
+        databaseQueryFactory,
+        configManager
+    }) {
+        this.viewResolver = viewResolver;
+        this.viewDefinitionValidator = viewDefinitionValidator;
+        this.fhirPathEvaluator = fhirPathEvaluator;
+        this.searchManager = searchManager;
+        this.databaseQueryFactory = databaseQueryFactory;
+        this.configManager = configManager;
+    }
+
+    /**
+     * Orchestrates a SQL-on-FHIR $run: resolve + validate the view, build the resource
+     * source (inline or secured stored cursor), run the view, and pipe the resulting
+     * rows through the chosen writer directly to `res`.
+     * @param {Object} params
+     * @param {import('../../utils/fhirRequestInfo').FhirRequestInfo} params.requestInfo
+     * @param {Object} params.parsedArgs
+     * @param {Object} params.body request body (Parameters or a bare ViewDefinition)
+     * @param {string} params.resourceType
+     * @param {import('stream').Writable} params.res
+     * @returns {Promise<undefined>} response is written directly to `res`
+     */
+    async runAsync({ requestInfo, parsedArgs, body, resourceType, res }) {
+        const { view, inlineResources } = this.viewResolver.resolve({ body });
+        // validate BEFORE building the source or writing any headers/bytes, so a
+        // malformed view fails fast with a 400 and nothing is streamed.
+        this.viewDefinitionValidator.validate(view);
+
+        const wantsCsv = (requestInfo.accept || []).some((a) => String(a).includes('csv'));
+        const columns = this._columnNames(view);
+
+        // build the source (and enforce guardrail D2) BEFORE setting headers, so a
+        // guardrail rejection surfaces as a clean error with no bytes on the wire.
+        const source = await this._resourceSource({
+            view,
+            inlineResources,
+            requestInfo,
+            parsedArgs
+        });
+
+        // headers must be set before any bytes are written
+        res.setHeader('Content-Type', wantsCsv ? 'text/csv' : 'application/x-ndjson');
+
+        const rows = runView(view, source, { fhirPathEvaluator: this.fhirPathEvaluator });
+        const writer = wantsCsv ? new RowCsvWriter({ columns }) : new RowNdJsonWriter();
+
+        await pipeline(Readable.from(rows), writer, res);
+        return undefined;
+    }
+
+    /**
+     * Resolves the set of resources the view runs over. Inline resources are returned
+     * as-is. For the stored path this MUST route through searchManager.constructQueryAsync
+     * (the authorization gate: SMART scopes + patient compartment + access/consent filters)
+     * and then iterate a secured DatabaseCursor. A raw hand-rolled Mongo query is never used.
+     * @param {Object} params
+     * @param {Object} params.view
+     * @param {Object[]} params.inlineResources
+     * @param {import('../../utils/fhirRequestInfo').FhirRequestInfo} params.requestInfo
+     * @param {Object} params.parsedArgs
+     * @returns {Promise<Iterable<Object>|AsyncIterable<Object>>}
+     */
+    async _resourceSource({ view, inlineResources, requestInfo, parsedArgs }) {
+        if (inlineResources && inlineResources.length > 0) {
+            return inlineResources;
+        }
+
+        // Guardrail D2: a stored $run with NO filter and NO explicit _count would scan the
+        // entire collection. Reject before any query/stream/headers.
+        const reservedArgs = ['base_version', 'resourceType', '_format', '_type'];
+        const hasFilter =
+            parsedArgs &&
+            Object.keys(parsedArgs).some((k) => !reservedArgs.includes(k));
+        if (!hasFilter) {
+            throw new BadRequestError(
+                new Error(
+                    'stored $run requires a filter (e.g. patient, _lastUpdated) or an explicit _count'
+                )
+            );
+        }
+
+        // constructQueryAsync requires parsedArgs.base_version to be set.
+        if (parsedArgs && !parsedArgs.base_version) {
+            parsedArgs.base_version = BASE_VERSION;
+        }
+
+        // AUTHORIZATION GATE — never bypass this for stored resources. Returns
+        // { base_version, columns, query }; only the query drives the read.
+        const { query } = await this.searchManager.constructQueryAsync({
+            user: requestInfo.user,
+            scope: requestInfo.scope,
+            isUser: requestInfo.isUser,
+            userType: requestInfo.userType,
+            actor: requestInfo.actor,
+            resourceType: view.resource,
+            useAccessIndex: this.configManager.useAccessIndex,
+            personIdFromJwtToken: requestInfo.personIdFromJwtToken,
+            requestId: requestInfo.requestId,
+            parsedArgs,
+            operation: 'READ'
+        });
+
+        const databaseQueryManager = this.databaseQueryFactory.createQuery({
+            resourceType: view.resource,
+            base_version: BASE_VERSION
+        });
+        const maxTimeMS = this.configManager.sqlOnFhirMaxTimeMS || 30000;
+        const cursor = await databaseQueryManager.findAsync({ query, options: { maxTimeMS } });
+
+        async function* iterate() {
+            while (await cursor.hasNext()) {
+                yield await cursor.next();
+            }
+        }
+        return iterate();
+    }
+
+    /**
+     * Ordered, de-duplicated column names for the CSV header (D3). Walks columns,
+     * nested selects, and unionAll branches in declaration order, keeping the first
+     * occurrence of each name.
+     * @param {Object} view
+     * @returns {string[]}
+     */
+    _columnNames(view) {
+        const names = [];
+        const seen = new Set();
+        const walk = (selections) => {
+            for (const s of selections || []) {
+                for (const c of s.column || []) {
+                    if (!seen.has(c.name)) {
+                        seen.add(c.name);
+                        names.push(c.name);
+                    }
+                }
+                walk(s.select);
+                for (const b of s.unionAll || []) {
+                    walk([b]);
+                }
+            }
+        };
+        walk(view.select);
+        return names;
+    }
+}
+
+module.exports = { SqlOnFhirRunOperation };

--- a/src/operations/sqlOnFhir/sqlOnFhirRunOperation.js
+++ b/src/operations/sqlOnFhir/sqlOnFhirRunOperation.js
@@ -93,21 +93,19 @@ class SqlOnFhirRunOperation {
 
         // Guardrail D2: a stored $run with NO filter and NO explicit _count would scan the
         // entire collection. Reject before any query/stream/headers.
-        const reservedArgs = ['base_version', 'resourceType', '_format', '_type'];
-        const hasFilter =
-            parsedArgs &&
-            Object.keys(parsedArgs).some((k) => !reservedArgs.includes(k));
-        if (!hasFilter) {
+        // NOTE: the real ParsedArgs (src/operations/query/parsedArgs.js) attaches search
+        // params as NON-ENUMERABLE getters via Object.defineProperty, so Object.keys() on
+        // the instance never sees them. The actual params live in parsedArgs.parsedArgItems.
+        const reservedArgs = ['_format', '_type', '_count'];
+        const items = (parsedArgs && parsedArgs.parsedArgItems) || [];
+        const hasFilter = items.some((a) => !reservedArgs.includes(a.queryParameter));
+        const hasExplicitCount = !!(parsedArgs && parsedArgs.get && parsedArgs.get('_count'));
+        if (!hasFilter && !hasExplicitCount) {
             throw new BadRequestError(
                 new Error(
                     'stored $run requires a filter (e.g. patient, _lastUpdated) or an explicit _count'
                 )
             );
-        }
-
-        // constructQueryAsync requires parsedArgs.base_version to be set.
-        if (parsedArgs && !parsedArgs.base_version) {
-            parsedArgs.base_version = BASE_VERSION;
         }
 
         // AUTHORIZATION GATE — never bypass this for stored resources. Returns

--- a/src/operations/sqlOnFhir/viewDefinitionValidator.js
+++ b/src/operations/sqlOnFhir/viewDefinitionValidator.js
@@ -60,9 +60,6 @@ class ViewDefinitionValidator {
                     this._walkSelections([branch], new Set(seen));
                 }
             }
-            if (Array.isArray(selection.forEach)) {
-                this._walkSelections(selection.forEach, seen);
-            }
         }
     }
 }

--- a/src/operations/sqlOnFhir/viewDefinitionValidator.js
+++ b/src/operations/sqlOnFhir/viewDefinitionValidator.js
@@ -1,0 +1,70 @@
+const { BadRequestError } = require('../../utils/httpErrors');
+
+class ViewDefinitionValidator {
+    /**
+     * Structurally validates a ViewDefinition (plain object or resource instance),
+     * throwing on the first problem found. Fail-fast, no partial results.
+     * @param {Object} view a ViewDefinition (plain object or resource instance)
+     * @throws {BadRequestError}
+     */
+    validate(view) {
+        if (!view || typeof view !== 'object') {
+            throw new BadRequestError(new Error('ViewDefinition is required'));
+        }
+        if (!view.resource || typeof view.resource !== 'string') {
+            throw new BadRequestError(
+                new Error('ViewDefinition.resource (a FHIR resource type) is required')
+            );
+        }
+        if (!Array.isArray(view.select) || view.select.length === 0) {
+            throw new BadRequestError(new Error('ViewDefinition.select must be a non-empty array'));
+        }
+        const seen = new Set();
+        this._walkSelections(view.select, seen);
+    }
+
+    /**
+     * Recursively walks select entries, validating columns and tracking column
+     * name uniqueness via the shared `seen` set.
+     * @param {Array} selections
+     * @param {Set<string>} seen column names already used by this branch's ancestors
+     */
+    _walkSelections(selections, seen) {
+        for (const selection of selections) {
+            for (const col of selection.column || []) {
+                if (!col.name || typeof col.name !== 'string') {
+                    throw new BadRequestError(
+                        new Error('Each ViewDefinition column requires a non-empty name')
+                    );
+                }
+                if (!col.path || typeof col.path !== 'string') {
+                    throw new BadRequestError(
+                        new Error(`Column "${col.name}" requires a non-empty path`)
+                    );
+                }
+                if (seen.has(col.name)) {
+                    throw new BadRequestError(new Error(`Duplicate column name "${col.name}"`));
+                }
+                seen.add(col.name);
+            }
+            if (Array.isArray(selection.select)) {
+                this._walkSelections(selection.select, seen);
+            }
+            if (Array.isArray(selection.unionAll)) {
+                // unionAll branches legitimately share column names with each other (they're
+                // alternative rows for the same output columns), so each branch is validated
+                // against its own fresh copy of the seen-set. A duplicate within one branch
+                // (or against the branch's own ancestors) is still an error; siblings reusing
+                // the same names is not.
+                for (const branch of selection.unionAll) {
+                    this._walkSelections([branch], new Set(seen));
+                }
+            }
+            if (Array.isArray(selection.forEach)) {
+                this._walkSelections(selection.forEach, seen);
+            }
+        }
+    }
+}
+
+module.exports = { ViewDefinitionValidator };

--- a/src/operations/sqlOnFhir/viewResolver.js
+++ b/src/operations/sqlOnFhir/viewResolver.js
@@ -1,0 +1,28 @@
+const { BadRequestError } = require('../../utils/httpErrors');
+
+class ViewResolver {
+    /**
+     * Phase 1: inline only. Later phases add stored lookup by id/url behind this same method.
+     * @param {{ body: Object }} params
+     * @returns {{ view: Object, inlineResources: Object[] }}
+     */
+    resolve ({ body }) {
+        if (body && body.resourceType === 'ViewDefinition') {
+            return { view: body, inlineResources: [] };
+        }
+        if (body && body.resourceType === 'Parameters' && Array.isArray(body.parameter)) {
+            const viewParam = body.parameter.find((p) => p.name === 'viewResource');
+            const view = viewParam && viewParam.resource;
+            const inlineResources = body.parameter
+                .filter((p) => p.name === 'resource' && p.resource)
+                .map((p) => p.resource);
+            if (!view) {
+                throw new BadRequestError(new Error('$run requires a "viewResource" parameter containing a ViewDefinition'));
+            }
+            return { view, inlineResources };
+        }
+        throw new BadRequestError(new Error('$run requires a Parameters body with a viewResource, or a ViewDefinition body'));
+    }
+}
+
+module.exports = { ViewResolver };

--- a/src/operations/sqlOnFhir/viewRunner.js
+++ b/src/operations/sqlOnFhir/viewRunner.js
@@ -1,0 +1,157 @@
+/**
+ * Streaming port of medplum's evalSqlOnFhir (packages/core/src/sql-on-fhir/eval.ts).
+ * Yields one plain row object at a time instead of materializing OutputRow[].
+ */
+
+/**
+ * Collects a ViewDefinition's `constant` entries into a %variables map for FHIRPath.
+ * @param {Object} view ViewDefinition-shaped object
+ * @returns {Object} map of constant name -> value
+ */
+function buildConstants(view) {
+    const variables = {};
+    for (const c of view.constant || []) {
+        // constant value is stored as value[x]; take the first defined value* key
+        const valueKey = Object.keys(c).find((k) => k.startsWith('value'));
+        variables[c.name] = valueKey ? c[valueKey] : undefined;
+    }
+    return variables;
+}
+
+/**
+ * Evaluates a single column's path against a focus node, enforcing the
+ * collection/singleton contract (D1: a non-collection column that yields >1 value throws).
+ * @returns {*} scalar, array (collection:true), or null
+ */
+function columnValue(col, focus, variables, fhirPathEvaluator) {
+    const result = fhirPathEvaluator.evaluate({ node: focus, expression: col.path, variables });
+    if (col.collection) {
+        return result;
+    }
+    if (result.length > 1) {
+        throw new Error(
+            `Column "${col.name}" returned multiple values but is not marked collection:true; ` +
+                'expected a single value.'
+        );
+    }
+    return result.length === 1 ? result[0] : null;
+}
+
+/**
+ * Cartesian product of row-fragment groups.
+ * @param {Array<Array<Object>>} parts each part is a list of candidate partial rows
+ * @returns {Array<Object>} merged rows (one field-merged object per combination)
+ */
+function cartesian(parts) {
+    return parts.reduce(
+        (acc, part) => {
+            const next = [];
+            for (const a of acc) {
+                for (const b of part) {
+                    next.push({ ...a, ...b });
+                }
+            }
+            return next;
+        },
+        [{}]
+    );
+}
+
+/**
+ * Expands one selection into its rows: determine foci (forEach/forEachOrNull/self),
+ * then for each focus take the cartesian product of this selection's columns, its
+ * nested selects, and its unionAll branches.
+ * @returns {Array<Object>} rows contributed by this selection
+ */
+function processSelection(selection, node, variables, fhirPathEvaluator) {
+    let foci;
+    if (selection.forEach) {
+        foci = fhirPathEvaluator.evaluate({ node, expression: selection.forEach, variables });
+    } else if (selection.forEachOrNull) {
+        foci = fhirPathEvaluator.evaluate({ node, expression: selection.forEachOrNull, variables });
+    } else {
+        foci = [node];
+    }
+
+    if (foci.length === 0 && selection.forEachOrNull) {
+        // emit a single row with nulls for this selection's own columns
+        const nullRow = {};
+        for (const col of selection.column || []) {
+            nullRow[col.name] = col.collection ? [] : null;
+        }
+        return [nullRow];
+    }
+
+    const rows = [];
+    for (const focus of foci) {
+        const parts = [];
+
+        if (selection.column && selection.column.length > 0) {
+            const colRow = {};
+            for (const col of selection.column) {
+                colRow[col.name] = columnValue(col, focus, variables, fhirPathEvaluator);
+            }
+            parts.push([colRow]);
+        }
+
+        for (const nested of selection.select || []) {
+            parts.push(processSelection(nested, focus, variables, fhirPathEvaluator));
+        }
+
+        if (Array.isArray(selection.unionAll) && selection.unionAll.length > 0) {
+            const unionRows = [];
+            for (const branch of selection.unionAll) {
+                unionRows.push(...processSelection(branch, focus, variables, fhirPathEvaluator));
+            }
+            parts.push(unionRows);
+        }
+
+        rows.push(...cartesian(parts));
+    }
+    return rows;
+}
+
+/**
+ * Streams the rows produced by evaluating a ViewDefinition over a resource iterable.
+ * @param {Object} view ViewDefinition-shaped object
+ * @param {AsyncIterable<Object>|Iterable<Object>} resourceIterable
+ * @param {{ fhirPathEvaluator: import('../../utils/fhirPathEvaluator').FhirPathEvaluator }} deps
+ * @returns {AsyncGenerator<Object>} rows
+ */
+async function* runView(view, resourceIterable, { fhirPathEvaluator }) {
+    const variables = buildConstants(view);
+    for await (const resource of resourceIterable) {
+        // resource-type gate: a ViewDefinition only applies to resources of its
+        // declared type. Inputs of any other type are silently skipped (mirrors
+        // medplum's evalSqlOnFhir, which filters by resourceType before evaluating).
+        if (view.resource && resource && resource.resourceType !== view.resource) {
+            continue;
+        }
+        // where gate: every clause must evaluate to a single boolean true
+        let included = true;
+        for (const clause of view.where || []) {
+            const r = fhirPathEvaluator.evaluate({
+                node: resource,
+                expression: clause.path,
+                variables
+            });
+            if (!(r.length === 1 && r[0] === true)) {
+                included = false;
+                break;
+            }
+        }
+        if (!included) {
+            continue;
+        }
+        const topRows = cartesian(
+            (view.select || []).map((s) =>
+                processSelection(s, resource, variables, fhirPathEvaluator)
+            )
+        );
+        for (const row of topRows) {
+            yield row;
+        }
+    }
+}
+
+module.exports = { runView };

--- a/src/tests/sqlOnFhir/fhirPathEvaluator.test.js
+++ b/src/tests/sqlOnFhir/fhirPathEvaluator.test.js
@@ -9,6 +9,14 @@ describe('FhirPathEvaluator', () => {
         name: [{ use: 'official', family: 'Smith', given: ['Jane'] }],
         managingOrganization: { reference: 'Organization/o1' }
     };
+    const multiNamePatient = {
+        resourceType: 'Patient',
+        id: 'p2',
+        name: [
+            { use: 'official', family: 'Smith', given: ['Jane'] },
+            { use: 'nickname', family: 'Jones', given: ['J'] }
+        ]
+    };
 
     test('evaluates a simple path to a scalar array', () => {
         expect(evaluator.evaluate({ node: patient, expression: 'name.family' })).toEqual(['Smith']);
@@ -69,6 +77,24 @@ describe('FhirPathEvaluator', () => {
 
     test('does not rewrite $this inside a string literal', () => {
         expect(evaluator.evaluate({ node: patient, expression: "'$this'" })).toEqual(['$this']);
+    });
+
+    test('does not rewrite $this nested inside where() — fhirpath binds it natively', () => {
+        expect(
+            evaluator.evaluate({
+                node: multiNamePatient,
+                expression: "name.where($this.use = 'official').family"
+            })
+        ).toEqual(['Smith']);
+    });
+
+    test('does not rewrite $this nested inside select() — fhirpath binds it natively', () => {
+        expect(
+            evaluator.evaluate({
+                node: multiNamePatient,
+                expression: 'name.select($this.family)'
+            })
+        ).toEqual(['Smith', 'Jones']);
     });
 
     test('getReferenceKey also tolerates a quoted string type specifier', () => {

--- a/src/tests/sqlOnFhir/fhirPathEvaluator.test.js
+++ b/src/tests/sqlOnFhir/fhirPathEvaluator.test.js
@@ -43,7 +43,35 @@ describe('FhirPathEvaluator', () => {
         ).toEqual(['o1']);
     });
 
-    test('getReferenceKey with matching type returns id, non-matching returns empty', () => {
+    test('getReferenceKey with matching type identifier returns id, non-matching returns empty', () => {
+        // SQL-on-FHIR passes the type specifier as a FHIRPath identifier, not a string.
+        expect(
+            evaluator.evaluate({
+                node: patient,
+                expression: 'managingOrganization.getReferenceKey(Organization)'
+            })
+        ).toEqual(['o1']);
+        expect(
+            evaluator.evaluate({
+                node: patient,
+                expression: 'managingOrganization.getReferenceKey(Patient)'
+            })
+        ).toEqual([]);
+    });
+
+    test('resolves a top-level $this to the focus (primitive and derived paths)', () => {
+        expect(evaluator.evaluate({ node: 'Jane', expression: '$this' })).toEqual(['Jane']);
+        expect(evaluator.evaluate({ node: 42, expression: '$this' })).toEqual([42]);
+        expect(
+            evaluator.evaluate({ node: { family: 'Smith' }, expression: '$this.family' })
+        ).toEqual(['Smith']);
+    });
+
+    test('does not rewrite $this inside a string literal', () => {
+        expect(evaluator.evaluate({ node: patient, expression: "'$this'" })).toEqual(['$this']);
+    });
+
+    test('getReferenceKey also tolerates a quoted string type specifier', () => {
         expect(
             evaluator.evaluate({
                 node: patient,

--- a/src/tests/sqlOnFhir/fhirPathEvaluator.test.js
+++ b/src/tests/sqlOnFhir/fhirPathEvaluator.test.js
@@ -1,0 +1,60 @@
+const { describe, test, expect } = require('@jest/globals');
+const { FhirPathEvaluator } = require('../../utils/fhirPathEvaluator');
+
+describe('FhirPathEvaluator', () => {
+    const evaluator = new FhirPathEvaluator();
+    const patient = {
+        resourceType: 'Patient',
+        id: 'p1',
+        name: [{ use: 'official', family: 'Smith', given: ['Jane'] }],
+        managingOrganization: { reference: 'Organization/o1' }
+    };
+
+    test('evaluates a simple path to a scalar array', () => {
+        expect(evaluator.evaluate({ node: patient, expression: 'name.family' })).toEqual(['Smith']);
+    });
+
+    test('returns empty array when path yields nothing', () => {
+        expect(evaluator.evaluate({ node: patient, expression: 'birthDate' })).toEqual([]);
+    });
+
+    test('binds constants as %variables', () => {
+        expect(
+            evaluator.evaluate({
+                node: patient,
+                expression: 'name.where(use = %u).family',
+                variables: { u: 'official' }
+            })
+        ).toEqual(['Smith']);
+    });
+
+    test('getResourceKey returns the resource id', () => {
+        expect(evaluator.evaluate({ node: patient, expression: 'getResourceKey()' })).toEqual([
+            'p1'
+        ]);
+    });
+
+    test('getReferenceKey extracts the id from a reference', () => {
+        expect(
+            evaluator.evaluate({
+                node: patient,
+                expression: 'managingOrganization.getReferenceKey()'
+            })
+        ).toEqual(['o1']);
+    });
+
+    test('getReferenceKey with matching type returns id, non-matching returns empty', () => {
+        expect(
+            evaluator.evaluate({
+                node: patient,
+                expression: "managingOrganization.getReferenceKey('Organization')"
+            })
+        ).toEqual(['o1']);
+        expect(
+            evaluator.evaluate({
+                node: patient,
+                expression: "managingOrganization.getReferenceKey('Patient')"
+            })
+        ).toEqual([]);
+    });
+});

--- a/src/tests/sqlOnFhir/fixtures/basic.json
+++ b/src/tests/sqlOnFhir/fixtures/basic.json
@@ -1,0 +1,496 @@
+{
+  "title": "basic",
+  "description": "basic view definition",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "pt1",
+      "name": [
+        {
+          "family": "F1"
+        }
+      ],
+      "active": true
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt2",
+      "name": [
+        {
+          "family": "F2"
+        }
+      ],
+      "active": false
+    },
+    {
+      "resourceType": "Patient",
+      "id": "pt3"
+    }
+  ],
+  "tests": [
+    {
+      "title": "basic attribute",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        },
+        {
+          "id": "pt2"
+        },
+        {
+          "id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "boolean attribute with false",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "active",
+                "path": "active",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "active": true
+        },
+        {
+          "id": "pt2",
+          "active": false
+        },
+        {
+          "id": "pt3",
+          "active": null
+        }
+      ]
+    },
+    {
+      "title": "two columns",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              },
+              {
+                "name": "last_name",
+                "path": "name.family.first()",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "last_name": "F1"
+        },
+        {
+          "id": "pt2",
+          "last_name": "F2"
+        },
+        {
+          "id": "pt3",
+          "last_name": null
+        }
+      ]
+    },
+    {
+      "title": "two selects with columns",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          },
+          {
+            "column": [
+              {
+                "name": "last_name",
+                "path": "name.family.first()",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1",
+          "last_name": "F1"
+        },
+        {
+          "id": "pt2",
+          "last_name": "F2"
+        },
+        {
+          "id": "pt3",
+          "last_name": null
+        }
+      ]
+    },
+    {
+      "title": "where - 1",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "active.exists() and active = true"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "where - 2",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "active.exists() and active = false"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt2"
+        }
+      ]
+    },
+    {
+      "title": "where returns non-boolean for some cases",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "active"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "where as expr - 1",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.family.exists() and name.family = 'F2'"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt2"
+        }
+      ]
+    },
+    {
+      "title": "where as expr - 2",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "status": "active",
+        "select": [
+          {
+            "column": [
+              {
+                "name": "id",
+                "path": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.family.exists() and name.family = 'F1'"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "pt1"
+        }
+      ]
+    },
+    {
+      "title": "select & column",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "c_id",
+                "type": "id"
+              }
+            ],
+            "select": [
+              {
+                "column": [
+                  {
+                    "path": "id",
+                    "name": "s_id",
+                    "type": "id"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "c_id": "pt1",
+          "s_id": "pt1"
+        },
+        {
+          "c_id": "pt2",
+          "s_id": "pt2"
+        },
+        {
+          "c_id": "pt3",
+          "s_id": "pt3"
+        }
+      ]
+    },
+    {
+      "title": "column ordering",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "'A'",
+                "name": "a",
+                "type": "string"
+              },
+              {
+                "path": "'B'",
+                "name": "b",
+                "type": "string"
+              }
+            ],
+            "select": [
+              {
+                "forEach": "name",
+                "column": [
+                  {
+                    "path": "'C'",
+                    "name": "c",
+                    "type": "string"
+                  },
+                  {
+                    "path": "'D'",
+                    "name": "d",
+                    "type": "string"
+                  }
+                ]
+              }
+            ],
+            "unionAll": [
+              {
+                "column": [
+                  {
+                    "path": "'E1'",
+                    "name": "e",
+                    "type": "string"
+                  },
+                  {
+                    "path": "'F1'",
+                    "name": "f",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "column": [
+                  {
+                    "path": "'E2'",
+                    "name": "e",
+                    "type": "string"
+                  },
+                  {
+                    "path": "'F2'",
+                    "name": "f",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "column": [
+              {
+                "path": "'G'",
+                "name": "g",
+                "type": "string"
+              },
+              {
+                "path": "'H'",
+                "name": "h",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "expectColumns": ["a", "b", "c", "d", "e", "f", "g", "h"],
+      "expect": [
+        {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "d": "D",
+          "e": "E1",
+          "f": "F1",
+          "g": "G",
+          "h": "H"
+        },
+        {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "d": "D",
+          "e": "E2",
+          "f": "F2",
+          "g": "G",
+          "h": "H"
+        },
+        {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "d": "D",
+          "e": "E1",
+          "f": "F1",
+          "g": "G",
+          "h": "H"
+        },
+        {
+          "a": "A",
+          "b": "B",
+          "c": "C",
+          "d": "D",
+          "e": "E2",
+          "f": "F2",
+          "g": "G",
+          "h": "H"
+        }
+      ]
+    }
+  ]
+}

--- a/src/tests/sqlOnFhir/fixtures/fn_reference_keys.json
+++ b/src/tests/sqlOnFhir/fixtures/fn_reference_keys.json
@@ -1,0 +1,109 @@
+{
+  "title": "fn_reference_keys",
+  "description": "TBD",
+  "fhirVersion": ["5.0.0", "4.0.1", "3.0.2"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "p1",
+      "link": [
+        {
+          "other": {
+            "reference": "Patient/p1"
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p2",
+      "link": [
+        {
+          "other": {
+            "reference": "Patient/p3"
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "title": "getReferenceKey result matches getResourceKey without type specifier",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "getResourceKey() = link.other.getReferenceKey()",
+                "name": "key_equal_ref",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "key_equal_ref": true
+        },
+        {
+          "key_equal_ref": false
+        }
+      ]
+    },
+    {
+      "title": "getReferenceKey result matches getResourceKey with right type specifier",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "getResourceKey() = link.other.getReferenceKey(Patient)",
+                "name": "key_equal_ref",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "key_equal_ref": true
+        },
+        {
+          "key_equal_ref": false
+        }
+      ]
+    },
+    {
+      "title": "getReferenceKey result matches getResourceKey with wrong type specifier",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "getResourceKey() = link.other.getReferenceKey(Observation)",
+                "name": "key_equal_ref",
+                "type": "boolean"
+              }
+            ]
+          }
+        ]
+      },
+      "expect": [
+        {
+          "key_equal_ref": null
+        },
+        {
+          "key_equal_ref": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/tests/sqlOnFhir/fixtures/where.json
+++ b/src/tests/sqlOnFhir/fixtures/where.json
@@ -1,0 +1,279 @@
+{
+  "title": "where",
+  "description": "FHIRPath `where` function.",
+  "fhirVersion": ["5.0.0", "4.0.1"],
+  "resources": [
+    {
+      "resourceType": "Patient",
+      "id": "p1",
+      "name": [
+        {
+          "use": "official",
+          "family": "f1"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p2",
+      "name": [
+        {
+          "use": "nickname",
+          "family": "f2"
+        }
+      ]
+    },
+    {
+      "resourceType": "Patient",
+      "id": "p3",
+      "name": [
+        {
+          "use": "nickname",
+          "given": ["g3"],
+          "family": "f3"
+        }
+      ]
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o1",
+      "valueInteger": 12
+    },
+    {
+      "resourceType": "Observation",
+      "id": "o2",
+      "valueInteger": 10
+    }
+  ],
+  "tests": [
+    {
+      "title": "simple where path with result",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'official').exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        }
+      ]
+    },
+    {
+      "title": "where path with no results",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'maiden').exists()"
+          }
+        ]
+      },
+      "expect": []
+    },
+    {
+      "title": "where path with greater than inequality",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "where(value.ofType(integer) > 11).exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o1"
+        }
+      ]
+    },
+    {
+      "title": "where path with less than inequality",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Observation",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "where(value.ofType(integer) < 11).exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "o2"
+        }
+      ]
+    },
+    {
+      "title": "multiple where paths",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'official').exists()"
+          },
+          {
+            "path": "name.where(family = 'f1').exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        }
+      ]
+    },
+    {
+      "title": "where path with an 'and' connector",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'official' and family = 'f1').exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        }
+      ]
+    },
+    {
+      "title": "where path with an 'or' connector",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(use = 'official' or family = 'f2').exists()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        },
+        {
+          "id": "p2"
+        }
+      ]
+    },
+    {
+      "title": "where path that evaluates to true when empty",
+      "tags": ["shareable"],
+      "view": {
+        "resource": "Patient",
+        "select": [
+          {
+            "column": [
+              {
+                "path": "id",
+                "name": "id",
+                "type": "id"
+              }
+            ]
+          }
+        ],
+        "where": [
+          {
+            "path": "name.where(family = 'f2').empty()"
+          }
+        ]
+      },
+      "expect": [
+        {
+          "id": "p1"
+        },
+        {
+          "id": "p3"
+        }
+      ]
+    }
+  ]
+}

--- a/src/tests/sqlOnFhir/rowWriters.test.js
+++ b/src/tests/sqlOnFhir/rowWriters.test.js
@@ -1,0 +1,32 @@
+const { describe, test, expect } = require('@jest/globals');
+const { Readable } = require('stream');
+const { RowNdJsonWriter } = require('../../operations/sqlOnFhir/rowNdJsonWriter');
+const { RowCsvWriter } = require('../../operations/sqlOnFhir/rowCsvWriter');
+
+async function drain(rows, writer) {
+    let out = '';
+    const src = Readable.from(rows);
+    writer.on('data', (c) => (out += c.toString()));
+    src.pipe(writer);
+    await new Promise((resolve, reject) => {
+        writer.on('end', resolve);
+        writer.on('error', reject);
+    });
+    return out;
+}
+
+describe('row writers', () => {
+    test('NDJSON writes one JSON object per line', async () => {
+        const out = await drain([{ id: 'p1' }, { id: 'p2' }], new RowNdJsonWriter());
+        expect(out).toBe('{"id":"p1"}\n{"id":"p2"}\n');
+    });
+
+    test('CSV writes header then rows, JSON-encoding array cells', async () => {
+        const out = await drain(
+            [{ id: 'p1', given: ['Jane', 'Q'] }, { id: 'p2', given: [] }],
+            new RowCsvWriter({ columns: ['id', 'given'] })
+        );
+        expect(out.split('\n')[0]).toBe('id,given');
+        expect(out).toContain('p1,"[""Jane"",""Q""]"');
+    });
+});

--- a/src/tests/sqlOnFhir/run.integration.test.js
+++ b/src/tests/sqlOnFhir/run.integration.test.js
@@ -38,24 +38,4 @@ describe('$run integration', () => {
         expect(resp.status).toBe(200);
         expect(resp.text.trim()).toBe('{"id":"p1","family":"Smith"}');
     });
-
-    test('projects inline resources to NDJSON rows via the bare /$run route', async () => {
-        const request = await createTestRequest();
-        const body = {
-            resourceType: 'Parameters',
-            parameter: [
-                { name: 'viewResource', resource: view },
-                {
-                    name: 'resource',
-                    resource: { resourceType: 'Patient', id: 'p1', name: [{ family: 'Smith' }] }
-                }
-            ]
-        };
-        const resp = await request
-            .post('/4_0_0/$run')
-            .set({ ...getHeaders(), Accept: 'application/x-ndjson' })
-            .send(body);
-        expect(resp.status).toBe(200);
-        expect(resp.text.trim()).toBe('{"id":"p1","family":"Smith"}');
-    });
 });

--- a/src/tests/sqlOnFhir/run.integration.test.js
+++ b/src/tests/sqlOnFhir/run.integration.test.js
@@ -1,0 +1,41 @@
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+const { commonBeforeEach, commonAfterEach, createTestRequest, getHeaders } = require('../common');
+
+describe('$run integration', () => {
+    beforeEach(async () => await commonBeforeEach());
+    afterEach(async () => await commonAfterEach());
+
+    const view = {
+        resourceType: 'ViewDefinition',
+        resource: 'Patient',
+        status: 'active',
+        select: [
+            {
+                column: [
+                    { name: 'id', path: 'getResourceKey()' },
+                    { name: 'family', path: 'name.family.first()' }
+                ]
+            }
+        ]
+    };
+
+    test('projects inline resources to NDJSON rows', async () => {
+        const request = await createTestRequest();
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [
+                { name: 'viewResource', resource: view },
+                {
+                    name: 'resource',
+                    resource: { resourceType: 'Patient', id: 'p1', name: [{ family: 'Smith' }] }
+                }
+            ]
+        };
+        const resp = await request
+            .post('/4_0_0/ViewDefinition/$run')
+            .set({ ...getHeaders(), Accept: 'application/x-ndjson' })
+            .send(body);
+        expect(resp.status).toBe(200);
+        expect(resp.text.trim()).toBe('{"id":"p1","family":"Smith"}');
+    });
+});

--- a/src/tests/sqlOnFhir/run.integration.test.js
+++ b/src/tests/sqlOnFhir/run.integration.test.js
@@ -38,4 +38,24 @@ describe('$run integration', () => {
         expect(resp.status).toBe(200);
         expect(resp.text.trim()).toBe('{"id":"p1","family":"Smith"}');
     });
+
+    test('projects inline resources to NDJSON rows via the bare /$run route', async () => {
+        const request = await createTestRequest();
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [
+                { name: 'viewResource', resource: view },
+                {
+                    name: 'resource',
+                    resource: { resourceType: 'Patient', id: 'p1', name: [{ family: 'Smith' }] }
+                }
+            ]
+        };
+        const resp = await request
+            .post('/4_0_0/$run')
+            .set({ ...getHeaders(), Accept: 'application/x-ndjson' })
+            .send(body);
+        expect(resp.status).toBe(200);
+        expect(resp.text.trim()).toBe('{"id":"p1","family":"Smith"}');
+    });
 });

--- a/src/tests/sqlOnFhir/run.security.integration.test.js
+++ b/src/tests/sqlOnFhir/run.security.integration.test.js
@@ -136,31 +136,21 @@ describe('$run stored-path security', () => {
         expect(resp.text).not.toContain('patient-b-lf');
     });
 
-    // GUARDRAIL D2 — DEFECT DOCUMENTED, TEST SKIPPED (do not delete).
+    // GUARDRAIL D2 — FIXED.
     //
-    // Guardrail D2 (sqlOnFhirRunOperation._resourceSource) is meant to reject a stored $run
-    // that has NO filter and NO explicit _count, before any query/stream, to avoid a full
-    // collection scan. It inspects `parsedArgs.parsedArgItems` and treats any item whose
-    // queryParameter is not in reservedArgs = ['_format','_type','_count'] as a "filter".
+    // Guardrail D2 (sqlOnFhirRunOperation._resourceSource) rejects a stored $run that has NO
+    // filter and NO explicit _count, before any query/stream, to avoid a full collection scan.
+    // It inspects `parsedArgs.parsedArgItems` and treats any item whose queryParameter is not
+    // in nonFilterArgs as a "filter".
     //
-    // Via the real HTTP path this guardrail is INERT: an unfiltered stored $run always arrives
-    // with parsedArgItems = ["base_version","resource","viewResource"]. `base_version` is added
-    // by get_all_args from sanitized_args on every request; `resource`/`viewResource` are the
-    // Parameters body params folded into parsedArgs by parseParametersFromBody. None of the
-    // three are in reservedArgs, so hasFilter is ALWAYS true and D2 never fires — a truly
-    // unfiltered stored $run returns 200 instead of 400.
-    //
-    // Verified empirically: POST /4_0_0/ViewDefinition/$run with only a viewResource (no query
-    // string, full-access token) -> HTTP 200, parsedArgItems = ["base_version","resource",
-    // "viewResource"]. The D2 unit test in sqlOnFhirRunOperation.test.js passes only because it
-    // hand-builds ParsedArgs with an empty item list, which never happens over HTTP.
-    //
-    // This is a production defect in the D2 guardrail (Task 4/8/9), NOT a test problem, and NOT
-    // a data-leak (access filtering still works — see assertion #1 above). Per task constraints
-    // we do not modify production code here and we do not paper over the defect by asserting
-    // 200. The fix is to exclude the always-present params (base_version, resource,
-    // viewResource) from the guardrail's filter detection. Once fixed, unskip this test.
-    test.skip('(MUST) guardrail D2: stored $run with no filter and no _count returns 400 [BLOCKED: D2 inert over HTTP]', async () => {
+    // Over the real HTTP path an unfiltered stored $run always arrives with parsedArgItems =
+    // ["base_version","resource","viewResource"]. `base_version` is added by get_all_args from
+    // sanitized_args on every request; `resource`/`viewResource` are the Parameters body params
+    // folded into parsedArgs by parseParametersFromBody. These are structural/control params,
+    // not user filters, so nonFilterArgs now excludes all three (in addition to
+    // _format/_type/_count) — hasFilter is correctly false for an unfiltered stored $run, and
+    // D2 fires as intended.
+    test('(MUST) guardrail D2: stored $run with no filter and no _count returns 400', async () => {
         const request = await createTestRequest();
         await seedPatients(request);
 

--- a/src/tests/sqlOnFhir/run.security.integration.test.js
+++ b/src/tests/sqlOnFhir/run.security.integration.test.js
@@ -1,0 +1,200 @@
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+const { commonBeforeEach, commonAfterEach, createTestRequest, getHeaders } = require('../common');
+
+// SECURITY proof for the SQL-on-FHIR `$run` STORED path.
+//
+// The stored path (no inline `resource` params in the body) builds its Mongo query via
+// searchManager.constructQueryAsync(...) with operation: 'READ' — the SAME authorization
+// gate that `$search` uses. That gate applies the caller's `access/*` SMART scopes to the
+// `meta.security` access tags on each resource, so a caller can only read resources whose
+// access tag their token grants.
+//
+// NOTE on scope-403: `sofScopeMiddleware` is a no-op under NODE_ENV=test
+// (sof-scope.middleware.js), so it cannot itself produce a 403 in this harness. The 403 we
+// assert below is NOT from that middleware — it is produced by the search authorization gate
+// (scopesManager throws ForbiddenError "has no access scopes" from inside constructQueryAsync)
+// when the token carries no `access/*` scope. That is the same enforcement `$search` relies
+// on, and it is the meaningful, real security guarantee for the stored `$run` path.
+
+describe('$run stored-path security', () => {
+    beforeEach(async () => await commonBeforeEach());
+    afterEach(async () => await commonAfterEach());
+
+    // A caller with access to the "client" tenant only.
+    const clientScope = 'user/*.read user/*.write access/client.*';
+
+    const view = {
+        resourceType: 'ViewDefinition',
+        resource: 'Patient',
+        status: 'active',
+        select: [
+            {
+                column: [
+                    { name: 'id', path: 'getResourceKey()' },
+                    { name: 'family', path: 'name.family.first()' }
+                ]
+            }
+        ]
+    };
+
+    // Patient A lives in the "client" tenant (access tag the client token grants).
+    const patientA = {
+        resourceType: 'Patient',
+        id: 'patient-a-client',
+        meta: {
+            versionId: '1',
+            lastUpdated: '2021-08-29T00:53:01+00:00',
+            source: 'http://clienthealth.org/patient',
+            security: [
+                { system: 'https://www.icanbwell.com/access', code: 'client' },
+                { system: 'https://www.icanbwell.com/owner', code: 'client' }
+            ]
+        },
+        name: [{ family: 'InScopeAlpha' }]
+    };
+
+    // Patient B lives in the "l_and_f" tenant (access tag the client token does NOT grant).
+    const patientB = {
+        resourceType: 'Patient',
+        id: 'patient-b-lf',
+        meta: {
+            versionId: '1',
+            lastUpdated: '2021-08-29T00:53:01+00:00',
+            source: 'http://lfhealth.org/patient',
+            security: [
+                { system: 'https://www.icanbwell.com/access', code: 'l_and_f' },
+                { system: 'https://www.icanbwell.com/owner', code: 'l_and_f' }
+            ]
+        },
+        name: [{ family: 'OutOfScopeBravo' }]
+    };
+
+    async function seedPatients(request) {
+        // Seed both tenants with a full-access token; the resources carry their own access/owner
+        // tags via meta.security. Seeding is not the assertion under test — the scoped READ in
+        // each test is what proves filtering — so a full-access seed keeps setup deterministic.
+        //
+        // NOTE: in this local test harness the $merge HTTP response returns 500 from a
+        // post-write step (a known, environment-wide artifact that hits unrelated canonical
+        // merge tests too — the resource IS written before it). So we do NOT assert on the
+        // merge status code; instead we assert the seed landed by reading each patient back
+        // (GET -> 200 with the right access tag). That read-back is a stronger guarantee than
+        // the merge status anyway: it confirms the row is actually queryable.
+        await request
+            .post(`/4_0_0/Patient/${patientA.id}/$merge?validate=true`)
+            .send(patientA)
+            .set(getHeaders());
+        await request
+            .post(`/4_0_0/Patient/${patientB.id}/$merge?validate=true`)
+            .send(patientB)
+            .set(getHeaders());
+
+        // Confirm both rows are present and carry the expected access tags before we test $run.
+        const readA = await request.get(`/4_0_0/Patient/${patientA.id}`).set(getHeaders());
+        expect(readA.status).toBe(200);
+        expect(readA.body.meta.security).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    system: 'https://www.icanbwell.com/access',
+                    code: 'client'
+                })
+            ])
+        );
+        const readB = await request.get(`/4_0_0/Patient/${patientB.id}`).set(getHeaders());
+        expect(readB.status).toBe(200);
+        expect(readB.body.meta.security).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    system: 'https://www.icanbwell.com/access',
+                    code: 'l_and_f'
+                })
+            ])
+        );
+    }
+
+    test('(MUST) does NOT leak out-of-scope resources: client token sees only Patient A', async () => {
+        const request = await createTestRequest();
+        await seedPatients(request);
+
+        // A filter (`_security`) is required so guardrail D2 passes. The client token grants
+        // access/client.* only, so the authorization gate must exclude the l_and_f patient.
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [{ name: 'viewResource', resource: view }]
+        };
+        const resp = await request
+            .post('/4_0_0/ViewDefinition/$run?_security=https://www.icanbwell.com/access|client')
+            .set({ ...getHeaders(clientScope), Accept: 'application/x-ndjson' })
+            .send(body);
+
+        expect(resp.status).toBe(200);
+        // Patient A's row is present...
+        expect(resp.text).toContain('InScopeAlpha');
+        expect(resp.text).toContain('patient-a-client');
+        // ...and Patient B's row is absent. This is the core data-leak proof.
+        expect(resp.text).not.toContain('OutOfScopeBravo');
+        expect(resp.text).not.toContain('patient-b-lf');
+    });
+
+    // GUARDRAIL D2 — DEFECT DOCUMENTED, TEST SKIPPED (do not delete).
+    //
+    // Guardrail D2 (sqlOnFhirRunOperation._resourceSource) is meant to reject a stored $run
+    // that has NO filter and NO explicit _count, before any query/stream, to avoid a full
+    // collection scan. It inspects `parsedArgs.parsedArgItems` and treats any item whose
+    // queryParameter is not in reservedArgs = ['_format','_type','_count'] as a "filter".
+    //
+    // Via the real HTTP path this guardrail is INERT: an unfiltered stored $run always arrives
+    // with parsedArgItems = ["base_version","resource","viewResource"]. `base_version` is added
+    // by get_all_args from sanitized_args on every request; `resource`/`viewResource` are the
+    // Parameters body params folded into parsedArgs by parseParametersFromBody. None of the
+    // three are in reservedArgs, so hasFilter is ALWAYS true and D2 never fires — a truly
+    // unfiltered stored $run returns 200 instead of 400.
+    //
+    // Verified empirically: POST /4_0_0/ViewDefinition/$run with only a viewResource (no query
+    // string, full-access token) -> HTTP 200, parsedArgItems = ["base_version","resource",
+    // "viewResource"]. The D2 unit test in sqlOnFhirRunOperation.test.js passes only because it
+    // hand-builds ParsedArgs with an empty item list, which never happens over HTTP.
+    //
+    // This is a production defect in the D2 guardrail (Task 4/8/9), NOT a test problem, and NOT
+    // a data-leak (access filtering still works — see assertion #1 above). Per task constraints
+    // we do not modify production code here and we do not paper over the defect by asserting
+    // 200. The fix is to exclude the always-present params (base_version, resource,
+    // viewResource) from the guardrail's filter detection. Once fixed, unskip this test.
+    test.skip('(MUST) guardrail D2: stored $run with no filter and no _count returns 400 [BLOCKED: D2 inert over HTTP]', async () => {
+        const request = await createTestRequest();
+        await seedPatients(request);
+
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [{ name: 'viewResource', resource: view }]
+        };
+        const resp = await request
+            .post('/4_0_0/ViewDefinition/$run')
+            .set({ ...getHeaders(clientScope), Accept: 'application/x-ndjson' })
+            .send(body);
+
+        expect(resp.status).toBe(400);
+    });
+
+    test('(MUST) missing access scope returns 403 via the search authorization gate', async () => {
+        const request = await createTestRequest();
+        await seedPatients(request);
+
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [{ name: 'viewResource', resource: view }]
+        };
+        // Token has user read/write but NO access/* scope. constructQueryAsync (the same gate
+        // $search uses) rejects with ForbiddenError -> 403. A filter is included so the request
+        // reaches the gate rather than tripping guardrail D2 first.
+        const resp = await request
+            .post('/4_0_0/ViewDefinition/$run?_security=https://www.icanbwell.com/access|client')
+            .set({
+                ...getHeaders('user/*.read user/*.write'),
+                Accept: 'application/x-ndjson'
+            })
+            .send(body);
+
+        expect(resp.status).toBe(403);
+    });
+});

--- a/src/tests/sqlOnFhir/sqlOnFhirRunOperation.test.js
+++ b/src/tests/sqlOnFhir/sqlOnFhirRunOperation.test.js
@@ -1,9 +1,12 @@
-const { describe, test, expect } = require('@jest/globals');
+const { describe, test, expect, jest: jestGlobal } = require('@jest/globals');
 const { Writable } = require('stream');
 const { SqlOnFhirRunOperation } = require('../../operations/sqlOnFhir/sqlOnFhirRunOperation');
 const { ViewResolver } = require('../../operations/sqlOnFhir/viewResolver');
 const { ViewDefinitionValidator } = require('../../operations/sqlOnFhir/viewDefinitionValidator');
 const { FhirPathEvaluator } = require('../../utils/fhirPathEvaluator');
+const { ParsedArgs } = require('../../operations/query/parsedArgs');
+const { ParsedArgsItem } = require('../../operations/query/parsedArgsItem');
+const { QueryParameterValue } = require('../../operations/query/queryParameterValue');
 
 function fakeRes() {
     const res = new Writable({
@@ -47,6 +50,30 @@ const view = {
     select: [{ column: [{ name: 'id', path: 'getResourceKey()' }] }]
 };
 
+/**
+ * Builds a real ParsedArgsItem (not a stub) for a given search param.
+ * @param {string} queryParameter
+ * @param {string} value
+ * @returns {ParsedArgsItem}
+ */
+function buildParsedArgsItem(queryParameter, value) {
+    return new ParsedArgsItem({
+        queryParameter,
+        queryParameterValue: new QueryParameterValue({ value }),
+        propertyObj: undefined,
+        modifiers: []
+    });
+}
+
+/**
+ * Builds a real ParsedArgs instance (not a stub) with the given items.
+ * @param {ParsedArgsItem[]} parsedArgItems
+ * @returns {ParsedArgs}
+ */
+function buildParsedArgs(parsedArgItems = []) {
+    return new ParsedArgs({ base_version: '4_0_0', parsedArgItems });
+}
+
 describe('SqlOnFhirRunOperation (inline)', () => {
     test('streams NDJSON rows from inline resources', async () => {
         const op = makeOperation();
@@ -83,5 +110,93 @@ describe('SqlOnFhirRunOperation (inline)', () => {
             })
         ).rejects.toThrow(/resource/i);
         expect(res._body).toBe('');
+    });
+});
+
+describe('SqlOnFhirRunOperation (stored, guardrail D2)', () => {
+    test('rejects a stored $run with no filter and no _count, writes zero bytes, never queries', async () => {
+        const createQuery = jestGlobal.fn();
+        const constructQueryAsync = jestGlobal.fn();
+        const op = new SqlOnFhirRunOperation({
+            viewResolver: new ViewResolver(),
+            viewDefinitionValidator: new ViewDefinitionValidator(),
+            fhirPathEvaluator: new FhirPathEvaluator(),
+            searchManager: { constructQueryAsync },
+            databaseQueryFactory: { createQuery },
+            configManager: {}
+        });
+        const res = fakeRes();
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [{ name: 'viewResource', resource: view }]
+        };
+        // real ParsedArgs, no search-param items at all — no filter, no _count.
+        const parsedArgs = buildParsedArgs([]);
+
+        await expect(
+            op.runAsync({
+                requestInfo: { accept: ['application/x-ndjson'] },
+                parsedArgs,
+                body,
+                resourceType: 'Patient',
+                res
+            })
+        ).rejects.toThrow(/filter|_count/i);
+
+        expect(res._body).toBe('');
+        expect(constructQueryAsync).not.toHaveBeenCalled();
+        expect(createQuery).not.toHaveBeenCalled();
+    });
+
+    test('stored $run with a real filter routes through constructQueryAsync and streams rows', async () => {
+        const fakeCursor = {
+            _returned: false,
+            async hasNext() {
+                return !this._returned;
+            },
+            async next() {
+                this._returned = true;
+                return { resourceType: 'Patient', id: 'stored-1' };
+            }
+        };
+        const findAsync = jestGlobal.fn().mockResolvedValue(fakeCursor);
+        const createQuery = jestGlobal.fn().mockReturnValue({ findAsync });
+        const constructQueryAsync = jestGlobal.fn().mockResolvedValue({
+            base_version: '4_0_0',
+            columns: new Set(),
+            query: { id: 'stored-1' }
+        });
+        const op = new SqlOnFhirRunOperation({
+            viewResolver: new ViewResolver(),
+            viewDefinitionValidator: new ViewDefinitionValidator(),
+            fhirPathEvaluator: new FhirPathEvaluator(),
+            searchManager: { constructQueryAsync },
+            databaseQueryFactory: { createQuery },
+            configManager: {}
+        });
+        const res = fakeRes();
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [{ name: 'viewResource', resource: view }]
+        };
+        // real ParsedArgs with a real search-param filter (patient), satisfying the guardrail.
+        const parsedArgs = buildParsedArgs([buildParsedArgsItem('patient', 'p1')]);
+
+        await op.runAsync({
+            requestInfo: { accept: ['application/x-ndjson'], user: 'u1', scope: 'patient/*.read' },
+            parsedArgs,
+            body,
+            resourceType: 'Patient',
+            res
+        });
+
+        expect(constructQueryAsync).toHaveBeenCalledTimes(1);
+        expect(constructQueryAsync.mock.calls[0][0].parsedArgs).toBe(parsedArgs);
+        expect(createQuery).toHaveBeenCalledTimes(1);
+        expect(findAsync).toHaveBeenCalledTimes(1);
+        // the query handed to findAsync is the one returned by constructQueryAsync — no
+        // raw hand-rolled query bypasses the authorization gate.
+        expect(findAsync.mock.calls[0][0].query).toEqual({ id: 'stored-1' });
+        expect(res._body).toBe('{"id":"stored-1"}\n');
     });
 });

--- a/src/tests/sqlOnFhir/sqlOnFhirRunOperation.test.js
+++ b/src/tests/sqlOnFhir/sqlOnFhirRunOperation.test.js
@@ -1,0 +1,87 @@
+const { describe, test, expect } = require('@jest/globals');
+const { Writable } = require('stream');
+const { SqlOnFhirRunOperation } = require('../../operations/sqlOnFhir/sqlOnFhirRunOperation');
+const { ViewResolver } = require('../../operations/sqlOnFhir/viewResolver');
+const { ViewDefinitionValidator } = require('../../operations/sqlOnFhir/viewDefinitionValidator');
+const { FhirPathEvaluator } = require('../../utils/fhirPathEvaluator');
+
+function fakeRes() {
+    const res = new Writable({
+        write(chunk, enc, cb) {
+            res._body += chunk.toString();
+            cb();
+        }
+    });
+    res._body = '';
+    res.headers = {};
+    res.setHeader = (k, v) => (res.headers[k] = v);
+    res.status = (c) => {
+        res.statusCode = c;
+        return res;
+    };
+    return res;
+}
+
+function makeOperation() {
+    return new SqlOnFhirRunOperation({
+        viewResolver: new ViewResolver(),
+        viewDefinitionValidator: new ViewDefinitionValidator(),
+        fhirPathEvaluator: new FhirPathEvaluator(),
+        // matches the REAL SearchManager.constructQueryAsync return shape:
+        // { base_version, columns, query }
+        searchManager: {
+            constructQueryAsync: async () => ({
+                base_version: '4_0_0',
+                columns: new Set(),
+                query: {}
+            })
+        },
+        databaseQueryFactory: {},
+        configManager: {}
+    });
+}
+
+const view = {
+    resourceType: 'ViewDefinition',
+    resource: 'Patient',
+    select: [{ column: [{ name: 'id', path: 'getResourceKey()' }] }]
+};
+
+describe('SqlOnFhirRunOperation (inline)', () => {
+    test('streams NDJSON rows from inline resources', async () => {
+        const op = makeOperation();
+        const res = fakeRes();
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [
+                { name: 'viewResource', resource: view },
+                { name: 'resource', resource: { resourceType: 'Patient', id: 'p1' } }
+            ]
+        };
+        await op.runAsync({
+            requestInfo: { accept: ['application/x-ndjson'] },
+            parsedArgs: {},
+            body,
+            resourceType: 'Patient',
+            res
+        });
+        expect(res._body).toBe('{"id":"p1"}\n');
+        expect(res.headers['Content-Type']).toMatch(/ndjson/);
+    });
+
+    test('rejects an invalid view with 400 before streaming', async () => {
+        const op = makeOperation();
+        const res = fakeRes();
+        const badView = { resourceType: 'ViewDefinition', select: [] }; // no resource
+        await expect(
+            op.runAsync({
+                requestInfo: { accept: ['application/x-ndjson'] },
+                parsedArgs: {},
+                body: { resourceType: 'ViewDefinition', ...badView },
+                resourceType: 'Patient',
+                res
+            })
+        ).rejects.toThrow(/resource/i);
+        expect(res._body).toBe('');
+    });
+});

--- a/src/tests/sqlOnFhir/sqlOnFhirRunOperation.test.js
+++ b/src/tests/sqlOnFhir/sqlOnFhirRunOperation.test.js
@@ -148,6 +148,54 @@ describe('SqlOnFhirRunOperation (stored, guardrail D2)', () => {
         expect(createQuery).not.toHaveBeenCalled();
     });
 
+    test('rejects a stored $run whose parsedArgItems contain ONLY the structural params ' +
+        'present on every real HTTP request (base_version, resource, viewResource), ' +
+        'writes zero bytes, never queries', async () => {
+        // This mirrors the REAL HTTP shape: over the actual request path, parsedArgItems is
+        // NEVER empty for a $run request — get_all_args always injects base_version, the
+        // POST operations controller always sets args.resource = req.body, and
+        // parseParametersFromBody always folds in viewResource from the Parameters body.
+        // None of these are user-supplied filters, so the guardrail must not treat them as
+        // one. Before the fix, hasFilter was computed from a reservedArgs list that only
+        // excluded _format/_type/_count, so this exact shape was wrongly treated as
+        // "filtered" and the guardrail never fired (RED). After the fix, base_version,
+        // resource, and viewResource are also excluded, so this rejects as expected (GREEN).
+        const createQuery = jestGlobal.fn();
+        const constructQueryAsync = jestGlobal.fn();
+        const op = new SqlOnFhirRunOperation({
+            viewResolver: new ViewResolver(),
+            viewDefinitionValidator: new ViewDefinitionValidator(),
+            fhirPathEvaluator: new FhirPathEvaluator(),
+            searchManager: { constructQueryAsync },
+            databaseQueryFactory: { createQuery },
+            configManager: {}
+        });
+        const res = fakeRes();
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [{ name: 'viewResource', resource: view }]
+        };
+        const parsedArgs = buildParsedArgs([
+            buildParsedArgsItem('base_version', '4_0_0'),
+            buildParsedArgsItem('resource', body),
+            buildParsedArgsItem('viewResource', view)
+        ]);
+
+        await expect(
+            op.runAsync({
+                requestInfo: { accept: ['application/x-ndjson'] },
+                parsedArgs,
+                body,
+                resourceType: 'Patient',
+                res
+            })
+        ).rejects.toThrow(/filter|_count/i);
+
+        expect(res._body).toBe('');
+        expect(constructQueryAsync).not.toHaveBeenCalled();
+        expect(createQuery).not.toHaveBeenCalled();
+    });
+
     test('stored $run with a real filter routes through constructQueryAsync and streams rows', async () => {
         const fakeCursor = {
             _returned: false,

--- a/src/tests/sqlOnFhir/viewDefinition.test.js
+++ b/src/tests/sqlOnFhir/viewDefinition.test.js
@@ -22,4 +22,30 @@ describe('ViewDefinition custom resource', () => {
         expect(json.resourceType).toBe('ViewDefinition');
         expect(json.select[0].column[0].name).toBe('id');
     });
+
+    test('toJSON does not mutate the instance pass-through select/where payloads', () => {
+        const rawWithNulls = {
+            resourceType: 'ViewDefinition',
+            id: 'v2',
+            status: 'active',
+            resource: 'Patient',
+            select: [
+                {
+                    column: [{ name: 'id', path: 'getResourceKey()', description: null }]
+                }
+            ],
+            where: [{ path: 'active', tag: null }]
+        };
+        const view = FhirResourceCreator.create(rawWithNulls);
+
+        const selectSnapshot = JSON.stringify(view.select);
+        const whereSnapshot = JSON.stringify(view.where);
+
+        view.toJSON();
+
+        expect(JSON.stringify(view.select)).toBe(selectSnapshot);
+        expect(JSON.stringify(view.where)).toBe(whereSnapshot);
+        expect(view.select[0].column[0]).toHaveProperty('description', null);
+        expect(view.where[0]).toHaveProperty('tag', null);
+    });
 });

--- a/src/tests/sqlOnFhir/viewDefinition.test.js
+++ b/src/tests/sqlOnFhir/viewDefinition.test.js
@@ -1,0 +1,25 @@
+const { describe, test, expect } = require('@jest/globals');
+const { FhirResourceCreator } = require('../../fhir/fhirResourceCreator');
+
+describe('ViewDefinition custom resource', () => {
+    const raw = {
+        resourceType: 'ViewDefinition',
+        id: 'v1',
+        status: 'active',
+        resource: 'Patient',
+        select: [{ column: [{ name: 'id', path: 'getResourceKey()' }] }]
+    };
+
+    test('is created as a ViewDefinition instance', () => {
+        const view = FhirResourceCreator.create(raw);
+        expect(view.resourceType).toBe('ViewDefinition');
+        expect(view.resource).toBe('Patient');
+    });
+
+    test('toJSON round-trips core fields', () => {
+        const view = FhirResourceCreator.create(raw);
+        const json = view.toJSON();
+        expect(json.resourceType).toBe('ViewDefinition');
+        expect(json.select[0].column[0].name).toBe('id');
+    });
+});

--- a/src/tests/sqlOnFhir/viewDefinition.test.js
+++ b/src/tests/sqlOnFhir/viewDefinition.test.js
@@ -48,4 +48,61 @@ describe('ViewDefinition custom resource', () => {
         expect(view.select[0].column[0]).toHaveProperty('description', null);
         expect(view.where[0]).toHaveProperty('tag', null);
     });
+
+    test('toJSONInternal does not mutate the instance pass-through select/where/constant payloads', () => {
+        const rawWithNulls = {
+            resourceType: 'ViewDefinition',
+            id: 'v3',
+            status: 'active',
+            resource: 'Patient',
+            select: [
+                {
+                    column: [{ name: 'id', path: 'getResourceKey()', description: null }]
+                }
+            ],
+            where: [{ path: 'active', tag: null }],
+            constant: [{ name: 'someConstant', valueString: 'foo', meta: { tag: null } }]
+        };
+        const view = FhirResourceCreator.create(rawWithNulls);
+
+        const selectSnapshot = JSON.stringify(view.select);
+        const whereSnapshot = JSON.stringify(view.where);
+        const constantSnapshot = JSON.stringify(view.constant);
+
+        view.toJSONInternal();
+
+        expect(JSON.stringify(view.select)).toBe(selectSnapshot);
+        expect(JSON.stringify(view.where)).toBe(whereSnapshot);
+        expect(JSON.stringify(view.constant)).toBe(constantSnapshot);
+        expect(view.select[0].column[0]).toHaveProperty('description', null);
+        expect(view.where[0]).toHaveProperty('tag', null);
+        expect(view.constant[0].meta).toHaveProperty('tag', null);
+    });
+
+    test('Resource.clone() (which calls toJSONInternal) does not mutate select/where/constant', () => {
+        const rawWithNulls = {
+            resourceType: 'ViewDefinition',
+            id: 'v4',
+            status: 'active',
+            resource: 'Patient',
+            select: [
+                {
+                    column: [{ name: 'id', path: 'getResourceKey()', description: null }]
+                }
+            ],
+            where: [{ path: 'active', tag: null }],
+            constant: [{ name: 'someConstant', valueString: 'foo', meta: { tag: null } }]
+        };
+        const view = FhirResourceCreator.create(rawWithNulls);
+
+        const selectSnapshot = JSON.stringify(view.select);
+        const whereSnapshot = JSON.stringify(view.where);
+        const constantSnapshot = JSON.stringify(view.constant);
+
+        view.clone();
+
+        expect(JSON.stringify(view.select)).toBe(selectSnapshot);
+        expect(JSON.stringify(view.where)).toBe(whereSnapshot);
+        expect(JSON.stringify(view.constant)).toBe(constantSnapshot);
+    });
 });

--- a/src/tests/sqlOnFhir/viewDefinitionValidator.test.js
+++ b/src/tests/sqlOnFhir/viewDefinitionValidator.test.js
@@ -1,0 +1,43 @@
+const { describe, test, expect } = require('@jest/globals');
+const { ViewDefinitionValidator } = require('../../operations/sqlOnFhir/viewDefinitionValidator');
+
+describe('ViewDefinitionValidator', () => {
+    const validator = new ViewDefinitionValidator();
+
+    test('accepts a valid view', () => {
+        expect(() =>
+            validator.validate({
+                resource: 'Patient',
+                select: [{ column: [{ name: 'id', path: 'getResourceKey()' }] }]
+            })
+        ).not.toThrow();
+    });
+
+    test('rejects a missing resource', () => {
+        expect(() =>
+            validator.validate({ select: [{ column: [{ name: 'id', path: 'id' }] }] })
+        ).toThrow(/resource/i);
+    });
+
+    test('rejects an empty select', () => {
+        expect(() => validator.validate({ resource: 'Patient', select: [] })).toThrow(/select/i);
+    });
+
+    test('rejects a column missing name or path', () => {
+        expect(() =>
+            validator.validate({ resource: 'Patient', select: [{ column: [{ path: 'id' }] }] })
+        ).toThrow(/name/i);
+    });
+
+    test('rejects duplicate column names across nested selects', () => {
+        expect(() =>
+            validator.validate({
+                resource: 'Patient',
+                select: [
+                    { column: [{ name: 'id', path: 'getResourceKey()' }] },
+                    { select: [{ column: [{ name: 'id', path: 'id' }] }] }
+                ]
+            })
+        ).toThrow(/duplicate/i);
+    });
+});

--- a/src/tests/sqlOnFhir/viewResolver.test.js
+++ b/src/tests/sqlOnFhir/viewResolver.test.js
@@ -1,0 +1,31 @@
+const { describe, test, expect } = require('@jest/globals');
+const { ViewResolver } = require('../../operations/sqlOnFhir/viewResolver');
+
+describe('ViewResolver', () => {
+    const resolver = new ViewResolver();
+    const view = { resourceType: 'ViewDefinition', resource: 'Patient', select: [{ column: [{ name: 'id', path: 'id' }] }] };
+
+    test('extracts view + inline resources from Parameters', () => {
+        const body = {
+            resourceType: 'Parameters',
+            parameter: [
+                { name: 'viewResource', resource: view },
+                { name: 'resource', resource: { resourceType: 'Patient', id: 'p1' } },
+                { name: 'resource', resource: { resourceType: 'Patient', id: 'p2' } }
+            ]
+        };
+        const { view: v, inlineResources } = resolver.resolve({ body });
+        expect(v.resource).toBe('Patient');
+        expect(inlineResources.map((r) => r.id)).toEqual(['p1', 'p2']);
+    });
+
+    test('accepts a bare ViewDefinition body', () => {
+        const { view: v, inlineResources } = resolver.resolve({ body: view });
+        expect(v.resource).toBe('Patient');
+        expect(inlineResources).toEqual([]);
+    });
+
+    test('throws when no view present', () => {
+        expect(() => resolver.resolve({ body: { resourceType: 'Parameters', parameter: [] } })).toThrow(/view/i);
+    });
+});

--- a/src/tests/sqlOnFhir/viewRunner.conformance.test.js
+++ b/src/tests/sqlOnFhir/viewRunner.conformance.test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const { describe, test, expect } = require('@jest/globals');
+const { runView } = require('../../operations/sqlOnFhir/viewRunner');
+const { FhirPathEvaluator } = require('../../utils/fhirPathEvaluator');
+
+const fhirPathEvaluator = new FhirPathEvaluator();
+const fixturesDir = path.join(__dirname, 'fixtures');
+
+async function collect(view, resources) {
+    const rows = [];
+    for await (const row of runView(view, resources, { fhirPathEvaluator })) {
+        rows.push(row);
+    }
+    return rows;
+}
+
+const files = fs.readdirSync(fixturesDir).filter((f) => f.endsWith('.json'));
+
+describe('SQL-on-FHIR v2 conformance fixtures', () => {
+    for (const file of files) {
+        const suite = JSON.parse(fs.readFileSync(path.join(fixturesDir, file), 'utf8'));
+        describe(file, () => {
+            for (const t of suite.tests) {
+                // Some official cases assert errors (expectError) or counts (expectCount);
+                // those are exercised by the hand-written unit tests. Skip and log here.
+                const runner = t.expect ? test : test.skip;
+                runner(t.title, async () => {
+                    const rows = await collect(t.view, suite.resources);
+                    expect(rows).toEqual(t.expect);
+                });
+            }
+        });
+    }
+});

--- a/src/tests/sqlOnFhir/viewRunner.conformance.test.js
+++ b/src/tests/sqlOnFhir/viewRunner.conformance.test.js
@@ -1,3 +1,10 @@
+// Fixture provenance: the JSON files under ./fixtures/ (basic.json,
+// fn_reference_keys.json, where.json) are vendored verbatim from the upstream
+// HL7 SQL-on-FHIR v2 conformance test suite, repo `FHIR/sql-on-fhir-v2`, from
+// branch `intro-update` at the time of vendoring, which resolved to immutable
+// commit `e5345f64ff7df8214f9c39cdfa82841630d9f78b`
+// (https://github.com/FHIR/sql-on-fhir-v2/commit/e5345f64ff7df8214f9c39cdfa82841630d9f78b).
+// Re-vendor from that SHA (not the branch) if the fixtures ever need refreshing.
 const fs = require('fs');
 const path = require('path');
 const { describe, test, expect } = require('@jest/globals');

--- a/src/tests/sqlOnFhir/viewRunner.test.js
+++ b/src/tests/sqlOnFhir/viewRunner.test.js
@@ -1,0 +1,82 @@
+const { describe, test, expect } = require('@jest/globals');
+const { runView } = require('../../operations/sqlOnFhir/viewRunner');
+const { FhirPathEvaluator } = require('../../utils/fhirPathEvaluator');
+
+const fhirPathEvaluator = new FhirPathEvaluator();
+
+async function collect(view, resources) {
+    const rows = [];
+    for await (const row of runView(view, resources, { fhirPathEvaluator })) {
+        rows.push(row);
+    }
+    return rows;
+}
+
+const patients = [
+    {
+        resourceType: 'Patient',
+        id: 'p1',
+        active: true,
+        name: [{ family: 'Smith', given: ['Jane', 'Q'] }]
+    },
+    { resourceType: 'Patient', id: 'p2', active: false, name: [{ family: 'Jones' }] }
+];
+
+describe('runView', () => {
+    test('one row per resource with scalar columns', async () => {
+        const view = {
+            resource: 'Patient',
+            select: [
+                {
+                    column: [
+                        { name: 'id', path: 'getResourceKey()' },
+                        { name: 'family', path: 'name.family.first()' }
+                    ]
+                }
+            ]
+        };
+        expect(await collect(view, patients)).toEqual([
+            { id: 'p1', family: 'Smith' },
+            { id: 'p2', family: 'Jones' }
+        ]);
+    });
+
+    test('where filters resources', async () => {
+        const view = {
+            resource: 'Patient',
+            where: [{ path: 'active = true' }],
+            select: [{ column: [{ name: 'id', path: 'getResourceKey()' }] }]
+        };
+        expect(await collect(view, patients)).toEqual([{ id: 'p1' }]);
+    });
+
+    test('collection column yields an array', async () => {
+        const view = {
+            resource: 'Patient',
+            select: [{ column: [{ name: 'given', path: 'name.given', collection: true }] }]
+        };
+        expect(await collect(view, [patients[0]])).toEqual([{ given: ['Jane', 'Q'] }]);
+    });
+
+    test('forEach produces one row per element', async () => {
+        const view = {
+            resource: 'Patient',
+            select: [
+                { column: [{ name: 'id', path: 'getResourceKey()' }] },
+                { forEach: 'name.given', column: [{ name: 'given', path: '$this' }] }
+            ]
+        };
+        expect(await collect(view, [patients[0]])).toEqual([
+            { id: 'p1', given: 'Jane' },
+            { id: 'p1', given: 'Q' }
+        ]);
+    });
+
+    test('scalar column with multiple values throws (D1)', async () => {
+        const view = {
+            resource: 'Patient',
+            select: [{ column: [{ name: 'given', path: 'name.given' }] }]
+        };
+        await expect(collect(view, [patients[0]])).rejects.toThrow(/single|collection/i);
+    });
+});

--- a/src/tests/sqlOnFhir/viewRunner.test.js
+++ b/src/tests/sqlOnFhir/viewRunner.test.js
@@ -79,4 +79,28 @@ describe('runView', () => {
         };
         await expect(collect(view, [patients[0]])).rejects.toThrow(/single|collection/i);
     });
+
+    test('D1 fail-fast is mid-stream: rows already yielded are not swallowed by a later error', async () => {
+        const view = {
+            resource: 'Patient',
+            select: [{ column: [{ name: 'family', path: 'name.family' }] }]
+        };
+        const goodPatient = {
+            resourceType: 'Patient',
+            id: 'good',
+            name: [{ family: 'Solo' }]
+        };
+        const badPatient = {
+            resourceType: 'Patient',
+            id: 'bad',
+            name: [{ family: 'Skywalker' }, { family: 'Vader' }]
+        };
+        const iterator = runView(view, [goodPatient, badPatient], { fhirPathEvaluator });
+
+        const first = await iterator.next();
+        expect(first.done).toBe(false);
+        expect(first.value).toEqual({ family: 'Solo' });
+
+        await expect(iterator.next()).rejects.toThrow(/single|collection/i);
+    });
 });

--- a/src/utils/fhirPathEvaluator.js
+++ b/src/utils/fhirPathEvaluator.js
@@ -1,0 +1,91 @@
+const fhirpath = require('fhirpath');
+const fhirpathR4Model = require('fhirpath/fhir-context/r4');
+
+/**
+ * Parses a FHIR reference string like "Organization/o1" or a full URL into its logical id.
+ * @param {string} reference
+ * @returns {{ resourceType: string|undefined, id: string }|undefined}
+ */
+function parseReference(reference) {
+    if (!reference || typeof reference !== 'string') {
+        return undefined;
+    }
+    const parts = reference.split('/');
+    if (parts.length < 2) {
+        return { resourceType: undefined, id: reference };
+    }
+    const id = parts[parts.length - 1];
+    const resourceType = parts[parts.length - 2];
+    return { resourceType, id };
+}
+
+/**
+ * Unwraps a fhirpath ResourceNode (or plain value) to its underlying data.
+ * @param {*} node
+ * @returns {*}
+ */
+function unwrap(node) {
+    return node && typeof node === 'object' && 'data' in node && node.data !== undefined
+        ? node.data
+        : node;
+}
+
+/**
+ * SQL-on-FHIR helper functions registered into the fhirpath userInvocationTable.
+ * See https://build.fhir.org/ig/FHIR/sql-on-fhir-v2/#getResourceKey
+ */
+const sqlOnFhirFunctions = {
+    getResourceKey: {
+        fn: (nodes) =>
+            nodes
+                .map((n) => unwrap(n))
+                .map((v) => (v && v.id !== undefined ? v.id : v))
+                .filter((v) => v !== undefined),
+        arity: { 0: [] }
+    },
+    getReferenceKey: {
+        fn: (nodes, resourceTypeNode) => {
+            const wantedType = Array.isArray(resourceTypeNode)
+                ? resourceTypeNode[0]
+                : resourceTypeNode;
+            const out = [];
+            for (const n of nodes) {
+                const v = unwrap(n);
+                const ref = v && typeof v === 'object' ? v.reference : v;
+                const parsed = parseReference(ref);
+                if (!parsed) {
+                    continue;
+                }
+                if (wantedType && parsed.resourceType && parsed.resourceType !== wantedType) {
+                    continue;
+                }
+                out.push(parsed.id);
+            }
+            return out;
+        },
+        arity: { 0: [], 1: ['String'] }
+    }
+};
+
+class FhirPathEvaluator {
+    constructor() {
+        this.options = { userInvocationTable: sqlOnFhirFunctions };
+    }
+
+    /**
+     * @param {{ node: Object, expression: string, variables?: Object }} params
+     * @returns {any[]} FHIRPath result, always an array (possibly empty)
+     */
+    evaluate({ node, expression, variables = {} }) {
+        const result = fhirpath.evaluate(
+            node,
+            expression,
+            variables,
+            fhirpathR4Model,
+            this.options
+        );
+        return Array.isArray(result) ? result : [result];
+    }
+}
+
+module.exports = { FhirPathEvaluator };

--- a/src/utils/fhirPathEvaluator.js
+++ b/src/utils/fhirPathEvaluator.js
@@ -76,17 +76,26 @@ const sqlOnFhirFunctions = {
 };
 
 /**
- * Rewrites a bare top-level `$this` token to `%context`.
+ * Rewrites a bare root-level `$this` token to `%context`.
  *
  * The npm `fhirpath` engine does not bind `ctx.$this` at the root of an evaluation,
- * so a top-level `$this` throws (and `$this.foo` silently returns empty), even though
+ * so a root-level `$this` throws (and `$this.foo` silently returns empty), even though
  * the FHIRPath spec defines the root `$this` to be identical to the input focus (which
  * the engine *does* expose as `%context`). SQL-on-FHIR views routinely use `$this` as a
  * column path when iterating a primitive collection via `forEach` (e.g. `forEach:
  * name.given`, `column path: $this`), so we normalize it here.
  *
+ * Crucially, fhirpath.js DOES correctly bind `$this` natively inside macro
+ * sub-expressions such as `where(...)`, `select(...)`, `exists(...)`, `all(...)`, and
+ * `iif(...)` — there it refers to the item currently being iterated, not the evaluation
+ * root. Rewriting those nested occurrences to `%context` would silently replace the
+ * per-item focus with the root node, producing wrong (but not erroring) results. To
+ * avoid that, only tokens at parenthesis depth 0 (i.e. not lexically inside any `(...)`)
+ * are rewritten.
+ *
  * The substitution only touches `$this` tokens outside of quoted string literals so it
- * cannot corrupt a literal that happens to contain the text `$this`.
+ * cannot corrupt a literal that happens to contain the text `$this`, and parens inside
+ * string literals do not affect the depth count either.
  * @param {string} expression
  * @returns {string}
  */
@@ -96,6 +105,7 @@ function normalizeThis(expression) {
     }
     let out = '';
     let quote = null; // active string-literal delimiter, or null
+    let depth = 0; // parenthesis nesting depth outside of string literals
     for (let i = 0; i < expression.length; i++) {
         const ch = expression[i];
         if (quote) {
@@ -113,7 +123,21 @@ function normalizeThis(expression) {
             out += ch;
             continue;
         }
-        if (expression.startsWith('$this', i) && !/[A-Za-z0-9_]/.test(expression[i + 5] || '')) {
+        if (ch === '(') {
+            depth++;
+            out += ch;
+            continue;
+        }
+        if (ch === ')') {
+            depth--;
+            out += ch;
+            continue;
+        }
+        if (
+            depth === 0 &&
+            expression.startsWith('$this', i) &&
+            !/[A-Za-z0-9_]/.test(expression[i + 5] || '')
+        ) {
             out += '%context';
             i += 4; // skip the remaining chars of "$this"
             continue;

--- a/src/utils/fhirPathEvaluator.js
+++ b/src/utils/fhirPathEvaluator.js
@@ -1,6 +1,18 @@
 const fhirpath = require('fhirpath');
 const fhirpathR4Model = require('fhirpath/fhir-context/r4');
 
+// fhirpath monkey-patches String.prototype with *enumerable* `hashCode` and `seed`.
+// Enumerable properties on String.prototype leak into every `for...in` over a string,
+// including Express's res.set/res.header, which then tries to emit them as HTTP headers
+// and throws "Invalid character in header content" — 500ing all FHIR write responses.
+// Make them non-enumerable while keeping fhirpath's functionality intact.
+for (const prop of ['hashCode', 'seed']) {
+    const descriptor = Object.getOwnPropertyDescriptor(String.prototype, prop);
+    if (descriptor && descriptor.enumerable) {
+        Object.defineProperty(String.prototype, prop, { ...descriptor, enumerable: false });
+    }
+}
+
 /**
  * Parses a FHIR reference string like "Organization/o1" or a full URL into its logical id.
  * @param {string} reference

--- a/src/utils/fhirPathEvaluator.js
+++ b/src/utils/fhirPathEvaluator.js
@@ -45,9 +45,17 @@ const sqlOnFhirFunctions = {
     },
     getReferenceKey: {
         fn: (nodes, resourceTypeNode) => {
-            const wantedType = Array.isArray(resourceTypeNode)
+            let wantedType = Array.isArray(resourceTypeNode)
                 ? resourceTypeNode[0]
                 : resourceTypeNode;
+            // The type specifier is a FHIRPath identifier (e.g. getReferenceKey(Patient)).
+            // With `Identifier` arity, fhirpath.js hands us the raw source text of the
+            // argument node, so a quoted string literal arrives with its quotes intact
+            // (e.g. "'Patient'"). Strip surrounding quotes so both the identifier and
+            // string-literal forms resolve to the same bare type name.
+            if (typeof wantedType === 'string') {
+                wantedType = wantedType.replace(/^(['"])(.*)\1$/, '$2');
+            }
             const out = [];
             for (const n of nodes) {
                 const v = unwrap(n);
@@ -63,9 +71,57 @@ const sqlOnFhirFunctions = {
             }
             return out;
         },
-        arity: { 0: [], 1: ['String'] }
+        arity: { 0: [], 1: ['Identifier'] }
     }
 };
+
+/**
+ * Rewrites a bare top-level `$this` token to `%context`.
+ *
+ * The npm `fhirpath` engine does not bind `ctx.$this` at the root of an evaluation,
+ * so a top-level `$this` throws (and `$this.foo` silently returns empty), even though
+ * the FHIRPath spec defines the root `$this` to be identical to the input focus (which
+ * the engine *does* expose as `%context`). SQL-on-FHIR views routinely use `$this` as a
+ * column path when iterating a primitive collection via `forEach` (e.g. `forEach:
+ * name.given`, `column path: $this`), so we normalize it here.
+ *
+ * The substitution only touches `$this` tokens outside of quoted string literals so it
+ * cannot corrupt a literal that happens to contain the text `$this`.
+ * @param {string} expression
+ * @returns {string}
+ */
+function normalizeThis(expression) {
+    if (typeof expression !== 'string' || !expression.includes('$this')) {
+        return expression;
+    }
+    let out = '';
+    let quote = null; // active string-literal delimiter, or null
+    for (let i = 0; i < expression.length; i++) {
+        const ch = expression[i];
+        if (quote) {
+            out += ch;
+            if (ch === '\\' && i + 1 < expression.length) {
+                // preserve escaped character verbatim
+                out += expression[++i];
+            } else if (ch === quote) {
+                quote = null;
+            }
+            continue;
+        }
+        if (ch === "'" || ch === '"' || ch === '`') {
+            quote = ch;
+            out += ch;
+            continue;
+        }
+        if (expression.startsWith('$this', i) && !/[A-Za-z0-9_]/.test(expression[i + 5] || '')) {
+            out += '%context';
+            i += 4; // skip the remaining chars of "$this"
+            continue;
+        }
+        out += ch;
+    }
+    return out;
+}
 
 class FhirPathEvaluator {
     constructor() {
@@ -79,7 +135,7 @@ class FhirPathEvaluator {
     evaluate({ node, expression, variables = {} }) {
         const result = fhirpath.evaluate(
             node,
-            expression,
+            normalizeThis(expression),
             variables,
             fhirpathR4Model,
             this.options

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,6 +2428,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lhncbc/ucum-lhc@npm:^5.0.0":
+  version: 5.0.4
+  resolution: "@lhncbc/ucum-lhc@npm:5.0.4"
+  dependencies:
+    coffeescript: "npm:^2.7.0"
+    csv-parse: "npm:^4.4.6"
+    csv-stringify: "npm:^1.0.4"
+    escape-html: "npm:^1.0.3"
+    is-integer: "npm:^1.0.6"
+    jsonfile: "npm:^2.2.3"
+    stream: "npm:0.0.2"
+    stream-transform: "npm:^0.1.1"
+    string-to-stream: "npm:^1.1.0"
+    xmldoc: "npm:^0.4.0"
+  checksum: 10c0/a5e73e97fd029014ed4b59ed76639e1b78f09f6516d65c462c0c8d7280acf191e3bbe97c73ee044b00b3da7d8e9e7a881a62f9d931a14120d5303c8b9fca11ef
+  languageName: node
+  linkType: hard
+
 "@mixmark-io/domino@npm:^2.2.0":
   version: 2.2.0
   resolution: "@mixmark-io/domino@npm:2.2.0"
@@ -4999,6 +5017,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"antlr4@npm:~4.9.3":
+  version: 4.9.3
+  resolution: "antlr4@npm:4.9.3"
+  checksum: 10c0/5ea44aadf8f0d74022f249c683535d1e66c644f0e719594b7f840452315388f128f1bbf80f0957a144fc92232a309d2ddb25cddab2b29f40426eb0b23c692652
+  languageName: node
+  linkType: hard
+
 "anymatch@npm:^3.1.3":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
@@ -5613,6 +5638,7 @@ __metadata:
     fast-deep-equal: "npm:^3.1.3"
     fast-json-patch: "npm:^3.1.1"
     fflate: "npm:^0.8.3"
+    fhirpath: "npm:3.15.2"
     graphql: "npm:^16.14.0"
     graphql-fields: "npm:^2.0.3"
     graphql-parse-resolve-info: "npm:^4.14.1"
@@ -5883,6 +5909,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"coffeescript@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "coffeescript@npm:2.7.0"
+  bin:
+    cake: bin/cake
+    coffee: bin/coffee
+  checksum: 10c0/c98e4086e5cc26d669949a1b7ca6a14cd9d515885f397ab19a5a6ad1eee0c84a526f7d78b6368c7007adafafb9549b334597a7798bec3f08b218363a97f9685b
+  languageName: node
+  linkType: hard
+
 "collect-v8-coverage@npm:^1.0.2":
   version: 1.0.3
   resolution: "collect-v8-coverage@npm:1.0.3"
@@ -5983,7 +6019,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.20.0, commander@npm:^2.20.3":
+"commander@npm:^2.18.0, commander@npm:^2.20.0, commander@npm:^2.20.3":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
@@ -6234,6 +6270,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"csv-parse@npm:^4.4.6":
+  version: 4.16.3
+  resolution: "csv-parse@npm:4.16.3"
+  checksum: 10c0/40771fda105b10c3e44551fa4dbeab462315400deb572f2918c19d5848addd95ea3479aaaeaaf3bbd9235593a6d798dd90b9e6ba5c4ce570979bafc4bb1ba5f0
+  languageName: node
+  linkType: hard
+
+"csv-stringify@npm:^1.0.4":
+  version: 1.1.2
+  resolution: "csv-stringify@npm:1.1.2"
+  dependencies:
+    lodash.get: "npm:~4.4.2"
+  checksum: 10c0/e65b251fe4e5d85dd43f2d49fba4154cb07bb6aec1b48c545d13786c62f7e7af3ca85db44ddc298228ddfe21b2dc09d532d3f8871df3c01bbde09713fd2e63fc
+  languageName: node
+  linkType: hard
+
 "csv42@npm:^5.0.3":
   version: 5.0.3
   resolution: "csv42@npm:5.0.3"
@@ -6252,6 +6304,13 @@ __metadata:
   version: 2.2.3
   resolution: "dataloader@npm:2.2.3"
   checksum: 10c0/9b9a056fbc863ca86da87d59e053e871e263b4966aa4d55e40d61a65e96815fae5530ca220629064ca5f8e3000c0c4ec93292e170c38ff393fb34256b4d7c1aa
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^1.30.1":
+  version: 1.30.1
+  resolution: "date-fns@npm:1.30.1"
+  checksum: 10c0/bad6ad7c15180121e15d61ad62a4a214c108d66f35b35f5eeb6ade837a3c29aa4444b9528a93a5374b95ba11231c142276351bf52f4d168676f9a1e17ce3726a
   languageName: node
   linkType: hard
 
@@ -6484,6 +6543,13 @@ __metadata:
   version: 1.5.378
   resolution: "electron-to-chromium@npm:1.5.378"
   checksum: 10c0/bb8cc9632b6e47aa7458d6f270145ef10a51a5da0c82605ae6f7cabfc851c3792e21db25caab7e3bd9434380e6afd404ee8999cdf5fa5faa3e2468456df11f5c
+  languageName: node
+  linkType: hard
+
+"emitter-component@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "emitter-component@npm:1.1.2"
+  checksum: 10c0/0f5e2240689783ca8e9118a68f10f5111a06a073bc4ab58159ebaf18482bfc41d9d8d2787a0bc57bda129698717f0724cee5dde7fe967b494daba4f98e0c54dd
   languageName: node
   linkType: hard
 
@@ -7010,6 +7076,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fhirpath@npm:3.15.2":
+  version: 3.15.2
+  resolution: "fhirpath@npm:3.15.2"
+  dependencies:
+    "@lhncbc/ucum-lhc": "npm:^5.0.0"
+    antlr4: "npm:~4.9.3"
+    commander: "npm:^2.18.0"
+    date-fns: "npm:^1.30.1"
+    js-yaml: "npm:^3.13.1"
+  bin:
+    fhirpath: bin/fhirpath
+  checksum: 10c0/f68f6d2f560ed30e32c38a293e36eaff013dd2ff51940792bdd18d60f8c83ed1b705d6d35acdf7c88c98578d59e9a09a127ee7aae83ee8758e1fbedc6e904086
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^8.0.0":
   version: 8.0.0
   resolution: "file-entry-cache@npm:8.0.0"
@@ -7406,7 +7487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -7721,7 +7802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
+"inherits@npm:2, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -7787,6 +7868,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-finite@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "is-finite@npm:1.1.0"
+  checksum: 10c0/ca6bc7a0321b339f098e657bd4cbf4bb2410f5a11f1b9adb1a1a9ab72288b64368e8251326cb1f74e985f2779299cec3e1f1e558b68ce7e1e2c9be17b7cfd626
+  languageName: node
+  linkType: hard
+
 "is-fullwidth-code-point@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
@@ -7820,6 +7908,15 @@ __metadata:
   dependencies:
     is-extglob: "npm:^2.1.1"
   checksum: 10c0/17fb4014e22be3bbecea9b2e3a76e9e34ff645466be702f1693e8f1ee1adac84710d0be0bd9f967d6354036fd51ab7c2741d954d6e91dae6bb69714de92c197a
+  languageName: node
+  linkType: hard
+
+"is-integer@npm:^1.0.6":
+  version: 1.0.7
+  resolution: "is-integer@npm:1.0.7"
+  dependencies:
+    is-finite: "npm:^1.0.0"
+  checksum: 10c0/4f4835ee63b826e050a246efe97b4bfbe8e23d5cba86399ac2df32bfd347cf64d6438dd1811a6f6f6cf5a9a21f7d20c1940658e7c6fc0f4fa2fb7e467a8907f0
   languageName: node
   linkType: hard
 
@@ -8574,6 +8671,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonfile@npm:^2.2.3":
+  version: 2.4.0
+  resolution: "jsonfile@npm:2.4.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.6"
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 10c0/02ad746d9490686519b3369bc9572694076eb982e1b4982c5ad9b91bc3c0ad30d10c866bb26b7a87f0c4025a80222cd2962cb57083b5a6a475a9031eab8c8962
+  languageName: node
+  linkType: hard
+
 "jsonpath-plus@npm:^10.3.0":
   version: 10.4.0
   resolution: "jsonpath-plus@npm:10.4.0"
@@ -8733,6 +8842,13 @@ __metadata:
   version: 4.5.0
   resolution: "lodash.clonedeep@npm:4.5.0"
   checksum: 10c0/2caf0e4808f319d761d2939ee0642fa6867a4bbf2cfce43276698828380756b99d4c4fa226d881655e6ac298dd453fe12a5ec8ba49861777759494c534936985
+  languageName: node
+  linkType: hard
+
+"lodash.get@npm:~4.4.2":
+  version: 4.4.2
+  resolution: "lodash.get@npm:4.4.2"
+  checksum: 10c0/48f40d471a1654397ed41685495acb31498d5ed696185ac8973daef424a749ca0c7871bf7b665d5c14f5cc479394479e0307e781f61d5573831769593411be6e
   languageName: node
   linkType: hard
 
@@ -10068,7 +10184,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.0.5":
+"readable-stream@npm:^2.0.5, readable-stream@npm:^2.1.0":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
   dependencies:
@@ -10294,6 +10410,13 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
+  languageName: node
+  linkType: hard
+
+"sax@npm:~1.1.1":
+  version: 1.1.6
+  resolution: "sax@npm:1.1.6"
+  checksum: 10c0/984b9aedacaa8c69c7e046be5c3c203377d9e0b6451d1e925e18a09b68555b29fef943f4c148e12fb2041999584bc9098ceb3c7f2b0edd262eb8c5732c941758
   languageName: node
   linkType: hard
 
@@ -10635,6 +10758,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stream-transform@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "stream-transform@npm:0.1.2"
+  checksum: 10c0/a1abdfd131a5059a7d2304c57dfd5c11412abc4355ffd62043670559fd7ab2731fff073baa552a1d2772d5503fb3f91b9d3bdbdb12642ff0c4ee5acef5865206
+  languageName: node
+  linkType: hard
+
+"stream@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stream@npm:0.0.2"
+  dependencies:
+    emitter-component: "npm:^1.1.1"
+  checksum: 10c0/2b2a196218afcd61fa48366318cdbc4a496d7141ec21f616e5f75290428daff9d0e1ac109a39e63c6d07f1187db055ca2b04e188232cca21595b85f282d7ad28
+  languageName: node
+  linkType: hard
+
 "streamx@npm:^2.12.5, streamx@npm:^2.15.0, streamx@npm:^2.25.0":
   version: 2.28.0
   resolution: "streamx@npm:2.28.0"
@@ -10667,6 +10806,16 @@ __metadata:
     char-regex: "npm:^1.0.2"
     strip-ansi: "npm:^6.0.0"
   checksum: 10c0/1cd77409c3d7db7bc59406f6bcc9ef0783671dcbabb23597a1177c166906ef2ee7c8290f78cae73a8aec858768f189d2cb417797df5e15ec4eb5e16b3346340c
+  languageName: node
+  linkType: hard
+
+"string-to-stream@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "string-to-stream@npm:1.1.1"
+  dependencies:
+    inherits: "npm:^2.0.1"
+    readable-stream: "npm:^2.1.0"
+  checksum: 10c0/e50b2f698ada33af1ccf3729ab4c6e20ba12bc7ae5398a5da836d84dc416681f5df2c4f449b5c68c4d572188cd215fb80087e96b30bcb37e7809dca6f6ee9822
   languageName: node
   linkType: hard
 
@@ -11613,6 +11762,15 @@ __metadata:
   bin:
     xlsx: ./bin/xlsx.njs
   checksum: 10c0/eb20749e56ffa23ffc4a5a6fd983524e0406308e53992e24112424de9f30ec64d7dd80e8e56363e39c3853687f7b4151f97a6f5373050b23c0c2758796803b6b
+  languageName: node
+  linkType: hard
+
+"xmldoc@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "xmldoc@npm:0.4.0"
+  dependencies:
+    sax: "npm:~1.1.1"
+  checksum: 10c0/8f70f5f8ad2ee51a7db491ceafff85f16eb4e7c4570f59826eaf7ecf9afd0072e7621d04e8e4e4285cb7abe396ada6b3b84ba244ba0021f2c1d9cf5aea4551ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Implements the HL7 **SQL-on-FHIR v2** `ViewDefinition/$run` operation (Phase 1). `$run` takes a `ViewDefinition` — a tabular projection of one FHIR resource type whose columns and row-inclusion rules are FHIRPath expressions — and evaluates it over stored (MongoDB) or inline resources, streaming back a flat table as **NDJSON or CSV**.

This is the analytics-extraction primitive: define a projection once, get a table you can drop into a spreadsheet or load into a warehouse (Spark/Databricks), without exporting whole resources.

```
POST /4_0_0/ViewDefinition/$run
Accept: application/x-ndjson        # or text/csv

{
  "resourceType": "Parameters",
  "parameter": [
    { "name": "viewResource", "resource": {
        "resourceType": "ViewDefinition",
        "resource": "Patient",
        "status": "active",
        "select": [{ "column": [
          { "name": "id",     "path": "getResourceKey()" },
          { "name": "family", "path": "name.family.first()" }
        ]}]
    }},
    { "name": "resource", "resource": { "resourceType": "Patient", "id": "p1", "name": [{ "family": "Smith" }] } }
  ]
}
→ 200  {"id":"p1","family":"Smith"}
```

Omit the inline `resource` params (and add a search filter) to project over resources already in Mongo.

## How it works

- **No SQL, no query pushdown.** The input is a declarative `ViewDefinition` (FHIRPath), not SQL. Rows are generated **in-process**, one resource at a time — a streaming port of medplum's `evalSqlOnFhir` algorithm (`AsyncIterable<Row>` instead of materializing the whole table).
- **Stored resources** are read through a **secured streaming cursor** — the same `searchManager.constructQueryAsync` path as `$search` (SMART scopes + patient compartment + access/consent filtering). There is no branch that reads stored data outside that gate.
- **Inline resources** are projected directly from the request body.
- **Output** is negotiated via `Accept`: NDJSON (`application/x-ndjson`) or CSV (`text/csv`). Collection columns are JSON-encoded into the CSV cell.
- **Execution is synchronous streaming** with a guardrail: a stored `$run` with no filter and no explicit `_count` is rejected `400` before streaming, to prevent a runaway full-collection scan.

Full core `ViewDefinition` grammar is supported: `select`, `column` (incl. `collection`), `where`, `constant`, `forEach`, `forEachOrNull`, `unionAll`, nested `select`, plus the SQL-on-FHIR functions `getResourceKey`/`getReferenceKey`.

## Security

For a healthcare server this is the load-bearing property, so it has a dedicated test:

- Stored `$run` cannot surface resources the caller couldn't already read via `$search` — proven by `run.security.integration.test.js`: a token scoped to one access tenant sees only its own patient, never the other tenant's. The positive assertion (its own patient **is** present) forces the query to actually run, so the negative assertion is a real proof of filtering, not a vacuous empty result.
- A caller with no access scope gets `403` from the authorization gate (`constructQueryAsync`).
- All fail-fast paths (invalid view `400`, guardrail `400`, missing scope `403`) throw **before** any header/byte is sent, so the client gets a clean `OperationOutcome`.

## Testing

- Full `src/tests/sqlOnFhir` suite: **10 suites / 63 tests / 0 skipped**.
- Engine validated against **HL7's official SQL-on-FHIR v2 conformance fixtures** — 22/22 (basic, where, fn_reference_keys), vendored verbatim and pinned to an immutable upstream commit SHA.
- Coverage spans unit (evaluator, validator, writers, resolver, engine), the orchestrator (inline + secured stored paths + guardrail), and end-to-end HTTP integration.

## Scope (Phase 1) / non-goals

**In:** inline `ViewDefinition`; stored + inline resource sources; NDJSON + CSV; synchronous streaming.

**Deferred (not in this PR):**
- Stored / CRUD `ViewDefinition` resources and the instance form `ViewDefinition/[id]/$run` (a `ViewResolver` seam is in place so this drops in without touching the engine).
- Parquet output; asynchronous execution (202 + poll) and landing output in S3/Delta/a lakehouse.
- The conformance suite here is a representative 3-file subset, not the full HL7 suite.

## Known limitation

A per-resource FHIRPath runtime error (Decision D1, fail-fast) **after** streaming has begun cannot change the already-sent `200` — the NDJSON/CSV stream simply terminates early. Clients should treat an unexpected early end as failure. Documented in the design spec; pre-stream errors remain clean `4xx`.

## Notable fixes surfaced during review

Incremental review caught and fixed several real defects before merge: in-place mutation of shared `ViewDefinition` payloads via `toJSON`/`toJSONInternal`; a FHIRPath `$this` rewrite that corrupted nested `where()/select()` sub-expressions (now paren-depth-0 only); and the D2 guardrail being inert (first against the non-enumerable `ParsedArgs` shape, then against the structural params every HTTP request carries).

## Design docs

- Spec: `docs/superpowers/specs/2026-07-09-sql-on-fhir-run-design.md`
- Plan: `docs/superpowers/plans/2026-07-09-sql-on-fhir-run.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
