### PR TITLE
DCON-3463: Connect to Redis Cloud using CA cert bundle

### DIFF
--- a/src/utils/redisClient.js
+++ b/src/utils/redisClient.js
@@ -16,7 +16,8 @@ class RedisClient {
                 port: parseInt(env.REDIS_PORT) || 6379,
                 tls: isTrueWithFallback(env.REDIS_ENABLE_TLS, true),
                 reconnectStrategy: false,
-                rejectUnauthorized: isTrueWithFallback(env.REDIS_REJECT_UNAUTHORIZED_FLAG, false)
+                ca: env.REDIS_CA_CERT || undefined,
+                rejectUnauthorized: isTrueWithFallback(env.REDIS_REJECT_UNAUTHORIZED_FLAG, true)
             }
         };
         if (env.REDIS_USERNAME !== undefined) {
@@ -185,4 +186,3 @@ class RedisClient {
 module.exports = {
     RedisClient
 };
-


### PR DESCRIPTION
## Summary
Updates the Redis client to connect to Redis Cloud using the new **private DNS + CA-certificate** method, per [DCON-3463](https://icanbwell.atlassian.net/browse/DCON-3463) and the CIE Redis Cloud update ([Slack](https://icanbwell.slack.com/archives/CDWT99YQZ/p1774550006283309)). The old workaround (skipping CA validation / `rejectUnauthorized: false`) is being deprecated.

## Changes (`src/utils/redisClient.js`)
- Pass `env.REDIS_CA_CERT` as the TLS `ca` socket option, so the connection can be validated against the Redis Cloud CA bundle.
- Flip the `REDIS_REJECT_UNAUTHORIZED_FLAG` **default from `false` to `true`** — certificate/hostname validation is now on by default and only disabled when the flag is explicitly set to `false`.

```js
tls: isTrueWithFallback(env.REDIS_ENABLE_TLS, true),
reconnectStrategy: false,
ca: env.REDIS_CA_CERT || undefined,                                    // NEW
rejectUnauthorized: isTrueWithFallback(env.REDIS_REJECT_UNAUTHORIZED_FLAG, true)  // default false -> true
```

## Behavior notes
- **Local dev (`docker-compose.yml`)** runs with `REDIS_ENABLE_TLS: 'false'` and `REDIS_REJECT_UNAUTHORIZED_FLAG: 'false'` — TLS is off, so this change has no effect locally. No docker-compose change needed.
- When `REDIS_CA_CERT` is unset, `ca` is `undefined` (falls back to the system CA store) — no change for anyone not on Redis Cloud private DNS.

## Paired deployment change
The `REDIS_CA_CERT` value + private-DNS hosts are supplied via Helm in **bwell-fhir-server PR [#107](https://github.com/icanbwell/bwell-fhir-server/pull/107)**. These should ship together (or this app change first): with `rejectUnauthorized: true` the deployment must also provide the CA bundle, or Redis connections will fail to verify the private CA chain.

## Verification
Local dev runs Redis TLS-off, and the cert-validation path requires a live Redis Cloud private-DNS endpoint, so it can't be meaningfully exercised on a laptop — verification is via CI on this PR plus deploy to the dev environment (paired with the Helm PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DCON-3463]: https://icanbwell.atlassian.net/browse/DCON-3463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ