### PR TITLE
Codify Observation and VerificationResult indexes to fix drift

### DIFF
--- a/src/indexes/customIndexes.js
+++ b/src/indexes/customIndexes.js
@@ -536,6 +536,28 @@ module.exports = {
                 options: {
                     name: 'category_coding_code.effectiveDateTime._uuid_1'
                 }
+            },
+            {
+                keys: {
+                    'method.coding.system': 1,
+                    'method.coding.code': 1,
+                    'subject._uuid': 1,
+                    _uuid: 1
+                },
+                options: {
+                    name: 'method.coding.system_1_method.coding.code_1_subject._uuid_1__uuid_1'
+                }
+            },
+            {
+                keys: {
+                    'category.coding.code': 1,
+                    'subject._uuid': 1,
+                    effectiveDateTime: -1,
+                    _uuid: 1
+                },
+                options: {
+                    name: 'category.coding.code_1_subject._uuid_1_effectiveDateTime_-1__uuid_1'
+                }
             }
         ],
         Organization_4_0_0: [
@@ -1122,6 +1144,17 @@ module.exports = {
                 }
             }
        ],
+        VerificationResult_4_0_0: [
+            {
+                keys: {
+                    'target._uuid': 1,
+                    _uuid: 1
+                },
+                options: {
+                    name: 'target._uuid_1__uuid_1'
+                }
+            }
+        ],
         Vitals_4_0_0: [
             {
                 keys: {


### PR DESCRIPTION
Three indexes existed in prod MongoDB but were missing from customIndexes.js, so they showed as 'extra' in the index-drift report and would be dropped by synchronizeIndexes / dropExtraIndexesOnly.

Add them with their exact existing names and key order so the compare matches by name + keys (no rebuild):

- Observation_4_0_0: {method.coding.system, method.coding.code, subject._uuid, _uuid} — supports the CodeSystem/cluster-model Observation search (p99 ~1s -> ~7.6ms after this index).
- Observation_4_0_0: {category.coding.code, subject._uuid, effectiveDateTime:-1, _uuid}.
- VerificationResult_4_0_0 (new section): {target._uuid, _uuid}.