### PR TITLE
BAI-220: add HTTP health endpoint to orchestrator for K8s probes

### DIFF
--- a/src/operations/import/bulkImportOrchestrator.js
+++ b/src/operations/import/bulkImportOrchestrator.js
@@ -23,6 +23,10 @@ async function main() {
                 res.end(JSON.stringify({ status: 'starting' }));
             }
         });
+        healthServer.on('error', (err) => {
+            logError('Health server error', { error: err.message });
+            process.exit(1);
+        });
         healthServer.listen(3000);
 
         logInfo('Starting bulk import orchestrator', { topic, groupId });
@@ -36,6 +40,7 @@ async function main() {
 
         const shutdown = async (signal) => {
             logInfo(`Received ${signal}, shutting down bulk import orchestrator`);
+            isReady = false;
             try {
                 await kafkaClientV2.removeConsumerAsync({ consumer });
             } catch (e) {

--- a/src/operations/import/bulkImportOrchestrator.js
+++ b/src/operations/import/bulkImportOrchestrator.js
@@ -1,3 +1,4 @@
+const http = require('http');
 const { createContainer } = require('../../createContainer');
 const { initialize } = require('../../winstonInit');
 const { logInfo, logError } = require('../common/logging');
@@ -11,6 +12,18 @@ async function main() {
         const { kafkaClientV2, configManager, bulkImportOrchestratorRunner } = container;
         const topic = configManager.kafkaBulkImportTaskCreatedTopic;
         const groupId = configManager.bulkImportOrchestratorGroupId;
+
+        let isReady = false;
+        const healthServer = http.createServer((req, res) => {
+            if (isReady) {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ status: 'ok' }));
+            } else {
+                res.writeHead(503, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ status: 'starting' }));
+            }
+        });
+        healthServer.listen(3000);
 
         logInfo('Starting bulk import orchestrator', { topic, groupId });
 
@@ -44,6 +57,7 @@ async function main() {
         });
 
         await joinPromise;
+        isReady = true;
         logInfo('Bulk import orchestrator joined group', { groupId });
     } catch (e) {
         console.error(JSON.stringify({


### PR DESCRIPTION
## Summary
- Adds a minimal HTTP health server on port 3000 to the bulk import orchestrator
- Returns `503` while connecting to Kafka, `200` once the consumer group is joined
- Fixes deploy timeout caused by K8s liveness/readiness/startup probes failing (the orchestrator had no HTTP server)

## Test plan
- [ ] Verify orchestrator starts and health endpoint responds on port 3000
- [ ] Deploy to dev and confirm pods become ready
- [ ] Confirm Kafka consumer still joins group and logs events