### PR TITLE
DCON-4598: Fix the  operation to return the scopes PROA/IAS patient across all chunks

### DIFF
--- a/src/operations/everything/everythingHelper.js
+++ b/src/operations/everything/everythingHelper.js
@@ -445,6 +445,7 @@ class EverythingHelper {
                 }
             }
             if (!readFromCache || fallbackToMongo) {
+                let everythingChunkIndex = 0;
                 for (const idChunk of idChunks) {
                     const parsedArgsForChunk = parsedArgs.clone();
                     parsedArgsForChunk.id = idChunk;
@@ -488,7 +489,8 @@ class EverythingHelper {
                             responseStreamer,
                             includeNonClinicalResources,
                             proxyPatientIds,
-                            cachedStreamer
+                            cachedStreamer,
+                            everythingChunkIndex: everythingChunkIndex++
                         }
                     );
 
@@ -638,7 +640,8 @@ class EverythingHelper {
         bundleEntryIdsProcessedTracker,
         includeNonClinicalResources = false,
         proxyPatientIds = [],
-        cachedStreamer = null
+        cachedStreamer = null,
+        everythingChunkIndex
     }) {
         assertTypeEquals(parsedArgs, ParsedArgs);
         try {
@@ -732,7 +735,8 @@ class EverythingHelper {
                     requestInfo,
                     useUuidProjection,
                     resourceMapper,
-                    cachedStreamer
+                    cachedStreamer,
+                    everythingChunkIndex
                 });
 
                 optionsForQueries = baseResult.options;
@@ -816,7 +820,8 @@ class EverythingHelper {
                     useUuidProjection,
                     resourceToExcludeIdsMap,
                     resourceMapper,
-                    cachedStreamer
+                    cachedStreamer,
+                    everythingChunkIndex
                 });
 
                 if (!responseStreamer) {
@@ -905,7 +910,8 @@ class EverythingHelper {
                                 nonClinicalReferencesExtractor: referenceExtractorForNextLevel,
                                 everythingRelatedResourceManager,
                                 resourceMapper,
-                                cachedStreamer
+                                cachedStreamer,
+                                everythingChunkIndex
                             });
 
                             depthParallelProcess.push(result);
@@ -1028,7 +1034,8 @@ class EverythingHelper {
         useUuidProjection = false,
         applyPatientFilter = true,
         resourceMapper = new ResourceMapper(),
-        cachedStreamer = null
+        cachedStreamer = null,
+        everythingChunkIndex
     }) {
 
         /**
@@ -1074,7 +1081,8 @@ class EverythingHelper {
                 accessRequested: (requestInfo.method.toLowerCase() === 'delete' ? 'write' : 'read'),
                 addPersonOwnerToContext: requestInfo.isUser,
                 applyPatientFilter,
-                allowConsentedProaDataAccess: true
+                allowConsentedProaDataAccess: true,
+                everythingChunkIndex
             });
 
 
@@ -1184,6 +1192,7 @@ class EverythingHelper {
      * @property {{_uuid: string, resourceType: string}[]} streamedResources
      * @property {ResourceMapper} resourceMapper
      * @property {CachedFhirResponseStreamer|null} [cachedStreamer]
+     * @property {number|undefined} [everythingChunkIndex]
      *
      * @param {retriveveRelatedResourcesParallelyAsyncParams}
      * @returns {Promise<{entities: BundleEntry[], queryItems: QueryItem[], optionsForQueries: any[], streamedResources: {_uuid: string, resourceType: string}[]}>}
@@ -1204,6 +1213,7 @@ class EverythingHelper {
         everythingRelatedResourceManager,
         nonClinicalReferencesExtractor,
         useUuidProjection = false,
+        everythingChunkIndex,
         resourceToExcludeIdsMap,
         resourceMapper = new ResourceMapper(),
         cachedStreamer = null
@@ -1330,7 +1340,8 @@ class EverythingHelper {
                 applyPatientFilter:
                     requestInfo.isUser &&
                     this.relatedResourceNeedingPatientScopeFilter[parentResourceType].includes(relatedResourceType),
-                allowConsentedProaDataAccess: true
+                allowConsentedProaDataAccess: true,
+                everythingChunkIndex
             });
 
             if (filterTemplateCustomQuery) {

--- a/src/operations/search/dataSharingManager.js
+++ b/src/operations/search/dataSharingManager.js
@@ -101,10 +101,12 @@ class DataSharingManager {
     /**
      * Returns data sharing manager.
      * @param {string} requestId
-     * @returns {Map<string, Resource[]>}
+     * @param {number|undefined} everythingChunkIndex
+     * @returns {Map<string, *>}
      */
-    getDataSharingManagerCache ({ requestId }) {
-        return this.requestSpecificCache.getMap({ requestId, name: 'dataSharingManager' });
+    getDataSharingManagerCache ({ requestId, everythingChunkIndex }) {
+        const name = everythingChunkIndex !== undefined ? `dataSharingManager_${everythingChunkIndex}` : 'dataSharingManager';
+        return this.requestSpecificCache.getMap({ requestId, name });
     }
 
     /**
@@ -119,6 +121,7 @@ class DataSharingManager {
      * @property {boolean | undefined} useHistoryTable boolean to use history table or not
      * @property {boolean} isUser whether request is with patient scope
      * @property {boolean} allowConsentedProaDataAccess whether to allow consented PROA data access
+     * @property {number|undefined} everythingChunkIndex
      * @param {RewriteDataSharingQuery} param
      */
     async updateQueryConsideringDataSharing({
@@ -130,12 +133,13 @@ class DataSharingManager {
         useHistoryTable,
         requestId,
         isUser,
-        allowConsentedProaDataAccess
+        allowConsentedProaDataAccess,
+        everythingChunkIndex
     }) {
         assertTypeEquals(parsedArgs, ParsedArgs);
         let everythingCacheMap;
         if (requestId) {
-            everythingCacheMap = this.getDataSharingManagerCache({ requestId });
+            everythingCacheMap = this.getDataSharingManagerCache({ requestId, everythingChunkIndex });
         }
         let patientIdToImmediatePersonUuid;
         let patientsList;

--- a/src/operations/search/searchManager.js
+++ b/src/operations/search/searchManager.js
@@ -213,7 +213,8 @@ class SearchManager {
             applyPatientFilter = true,
             addPersonOwnerToContext = false,
             allowConsentedProaDataAccess = false,
-            actor
+            actor,
+            everythingChunkIndex
         }
     ) {
         try {
@@ -309,7 +310,8 @@ class SearchManager {
                         useHistoryTable,
                         requestId,
                         isUser,
-                        allowConsentedProaDataAccess
+                        allowConsentedProaDataAccess,
+                        everythingChunkIndex
                     });
                 }
             }

--- a/src/tests/data_sharing/everything/data_sharing_scenario.test.js
+++ b/src/tests/data_sharing/everything/data_sharing_scenario.test.js
@@ -397,5 +397,122 @@ describe('Data sharing test cases for different scenarios', () => {
             // noinspection JSUnresolvedFunction
             expect(resp).toHaveResponse(expectedResponse11Resource);
         });
+
+        test('With consent given and batch size 1, each chunk query is scoped to patient UUIDs — not unbounded', async () => {
+            // Force batch size = 1 so each patient is processed in its own chunk.
+            // This exercises the everythingChunkIndex cache-scoping fix.
+            // Without the fix, chunks 2+ reuse chunk 1's allowedPatientIds, producing
+            // a bare { meta.tag: NOT hidden, connectionType: proa } query with no patient scoping.
+            // With the fix, every $or arm must contain patient-specific filters.
+            const request = await createTestRequest((c) => {
+                Object.defineProperty(c.configManager, 'everythingBatchSize', {
+                    get: () => 1,
+                    configurable: true
+                });
+                return c;
+            });
+
+            let resp = await request
+                .post('/4_0_0/Person/1/$merge')
+                .send([masterPersonResource, masterPatientResource, clientPersonResource, clientPatientResource,
+                    clientObservationResource, client1PersonResource, client1PatientResource, client1ObservationResource,
+                    proaPatient1Resource, proaObservation1Resource, proaPatient2Resource, proaObservation2Resource,
+                    hieTreatmentPatientResource, hieTreatmentObservationResource, clientConsentGivenResource])
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({ created: true });
+
+            resp = await request
+                .get('/4_0_0/Person/c12345/$everything?_debug=true')
+                .set({
+                    ...headers,
+                    prefer: 'global_id=false'
+                });
+
+            expect(resp.status).toBe(200);
+
+            // Extract all query strings from debug meta tags
+            const metaTags = resp.body?.meta?.tag || [];
+            const queryDisplays = metaTags
+                .filter((t) => t.system === 'https://www.icanbwell.com/query')
+                .flatMap((t) => t.display.split('|'));
+
+            // Every $or query must have at least one arm that scopes to patient UUIDs or connectionType.
+            // A bare { meta.tag: NOT hidden } only query (no _uuid, no connectionType) indicates
+            // the unbounded scan bug is present.
+            for (const queryStr of queryDisplays) {
+                let parsedQuery;
+                try {
+                    const firstParen = queryStr.indexOf('(');
+                    const lastCommaOutside = (() => {
+                        let depth = 0, last = -1;
+                        for (let i = firstParen + 1; i < queryStr.length; i++) {
+                            if (queryStr[i] === '{') depth++;
+                            else if (queryStr[i] === '}') depth--;
+                            else if (queryStr[i] === ',' && depth === 0) last = i;
+                        }
+                        return last;
+                    })();
+                    parsedQuery = JSON.parse(
+                        queryStr.substring(firstParen + 1, lastCommaOutside).replace(/'/g, '"')
+                    );
+                } catch {
+                    continue;
+                }
+                if (!parsedQuery?.$or) {
+                    continue;
+                }
+                // Each arm of the $or must contain something beyond just meta.tag
+                for (const arm of parsedQuery.$or) {
+                    const armStr = JSON.stringify(arm);
+                    const hasPatientScope = armStr.includes('_uuid');
+                    expect(hasPatientScope).toBe(true);
+                }
+            }
+        });
+
+        test('Without consent and batch size 1, PROA observations do not appear from any chunk', async () => {
+            // Force batch size = 1 so each patient is its own chunk.
+            // Without consent, the patientFilterEmptied guard must return null for PROA arms
+            // in every chunk — no PROA observations should leak across chunk boundaries.
+            const request = await createTestRequest((c) => {
+                Object.defineProperty(c.configManager, 'everythingBatchSize', {
+                    get: () => 1,
+                    configurable: true
+                });
+                return c;
+            });
+
+            let resp = await request
+                .post('/4_0_0/Person/1/$merge')
+                .send([masterPersonResource, masterPatientResource, clientPersonResource, clientPatientResource,
+                    clientObservationResource, proaPatient1Resource, proaObservation1Resource,
+                    proaPatient2Resource, proaObservation2Resource,
+                    hieTreatmentPatientResource, hieTreatmentObservationResource])
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({ created: true });
+
+            resp = await request
+                .get('/4_0_0/Person/c12345/$everything')
+                .set({
+                    ...headers,
+                    prefer: 'global_id=false'
+                });
+
+            expect(resp.status).toBe(200);
+
+            const entries = resp.body.entry || [];
+            const observationIds = entries
+                .filter((e) => e.resource?.resourceType === 'Observation')
+                .map((e) => e.resource.id);
+
+            // PROA observations must not appear without consent — in any chunk
+            expect(observationIds).not.toContain(proaObservation1Resource.id);
+            expect(observationIds).not.toContain(proaObservation2Resource.id);
+
+            // Client observation must still be returned
+            expect(observationIds).toContain(clientObservationResource.id);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- `$everything` processes patient IDs in chunks, but `DataSharingManager`'s PROA/IAS consent data-sharing cache was keyed only by `requestId`, so it was shared across all chunks of a request
- This meant PROA/IAS scoped patients in chunks after the first were never looked up for data-sharing consent and were silently dropped from the response
- Adds `everythingChunkIndex`, threaded through `EverythingHelper` -> `SearchManager` -> `DataSharingManager`, so the data-sharing cache is now keyed per chunk instead of shared across the whole request