### PR TITLE
DCON-4598: Fix the operation to return the scopes PROA/IAS patient across all chunks

### DIFF
--- a/src/operations/everything/everythingHelper.js
+++ b/src/operations/everything/everythingHelper.js
@@ -1381,15 +1381,7 @@ class EverythingHelper {
                     });
                 }
 
-                if (httpContext.get(HTTP_CONTEXT_KEYS.CONSENTED_PROA_DATA_ACCESSED)) {
-                    if (!query.$or?.length > 0 || !query.$or.every(q => q.$and?.length > 0)) {
-                        logError(
-                            `Expected $or operator in query for resource ${relatedResourceType} when consented PROA data is accessed.`,
-                            { query, relatedResourceType }
-                        );
-                        query = { _uuid: '__invalid__' };
-                        continue;
-                    }
+                if (httpContext.get(HTTP_CONTEXT_KEYS.CONSENTED_PROA_DATA_ACCESSED) && query.$or?.length > 0 && query.$or.every(q => q.$and?.length > 0)) {
                     for (const orQuery of query.$or) {
                         if (customParentQuery.length == 1) {
                             orQuery.$and.push(customParentQuery[0]);

--- a/src/operations/everything/everythingHelper.js
+++ b/src/operations/everything/everythingHelper.js
@@ -445,6 +445,7 @@ class EverythingHelper {
                 }
             }
             if (!readFromCache || fallbackToMongo) {
+                let everythingChunkIndex = 0;
                 for (const idChunk of idChunks) {
                     const parsedArgsForChunk = parsedArgs.clone();
                     parsedArgsForChunk.id = idChunk;
@@ -488,7 +489,8 @@ class EverythingHelper {
                             responseStreamer,
                             includeNonClinicalResources,
                             proxyPatientIds,
-                            cachedStreamer
+                            cachedStreamer,
+                            everythingChunkIndex: everythingChunkIndex++
                         }
                     );
 
@@ -638,7 +640,8 @@ class EverythingHelper {
         bundleEntryIdsProcessedTracker,
         includeNonClinicalResources = false,
         proxyPatientIds = [],
-        cachedStreamer = null
+        cachedStreamer = null,
+        everythingChunkIndex
     }) {
         assertTypeEquals(parsedArgs, ParsedArgs);
         try {
@@ -732,7 +735,8 @@ class EverythingHelper {
                     requestInfo,
                     useUuidProjection,
                     resourceMapper,
-                    cachedStreamer
+                    cachedStreamer,
+                    everythingChunkIndex
                 });
 
                 optionsForQueries = baseResult.options;
@@ -816,7 +820,8 @@ class EverythingHelper {
                     useUuidProjection,
                     resourceToExcludeIdsMap,
                     resourceMapper,
-                    cachedStreamer
+                    cachedStreamer,
+                    everythingChunkIndex
                 });
 
                 if (!responseStreamer) {
@@ -905,7 +910,8 @@ class EverythingHelper {
                                 nonClinicalReferencesExtractor: referenceExtractorForNextLevel,
                                 everythingRelatedResourceManager,
                                 resourceMapper,
-                                cachedStreamer
+                                cachedStreamer,
+                                everythingChunkIndex
                             });
 
                             depthParallelProcess.push(result);
@@ -1028,7 +1034,8 @@ class EverythingHelper {
         useUuidProjection = false,
         applyPatientFilter = true,
         resourceMapper = new ResourceMapper(),
-        cachedStreamer = null
+        cachedStreamer = null,
+        everythingChunkIndex
     }) {
 
         /**
@@ -1074,7 +1081,8 @@ class EverythingHelper {
                 accessRequested: (requestInfo.method.toLowerCase() === 'delete' ? 'write' : 'read'),
                 addPersonOwnerToContext: requestInfo.isUser,
                 applyPatientFilter,
-                allowConsentedProaDataAccess: true
+                allowConsentedProaDataAccess: true,
+                everythingChunkIndex
             });
 
 
@@ -1184,6 +1192,7 @@ class EverythingHelper {
      * @property {{_uuid: string, resourceType: string}[]} streamedResources
      * @property {ResourceMapper} resourceMapper
      * @property {CachedFhirResponseStreamer|null} [cachedStreamer]
+     * @property {number|undefined} [everythingChunkIndex]
      *
      * @param {retriveveRelatedResourcesParallelyAsyncParams}
      * @returns {Promise<{entities: BundleEntry[], queryItems: QueryItem[], optionsForQueries: any[], streamedResources: {_uuid: string, resourceType: string}[]}>}
@@ -1204,6 +1213,7 @@ class EverythingHelper {
         everythingRelatedResourceManager,
         nonClinicalReferencesExtractor,
         useUuidProjection = false,
+        everythingChunkIndex,
         resourceToExcludeIdsMap,
         resourceMapper = new ResourceMapper(),
         cachedStreamer = null
@@ -1330,7 +1340,8 @@ class EverythingHelper {
                 applyPatientFilter:
                     requestInfo.isUser &&
                     this.relatedResourceNeedingPatientScopeFilter[parentResourceType].includes(relatedResourceType),
-                allowConsentedProaDataAccess: true
+                allowConsentedProaDataAccess: true,
+                everythingChunkIndex
             });
 
             if (filterTemplateCustomQuery) {

--- a/src/operations/search/dataSharingManager.js
+++ b/src/operations/search/dataSharingManager.js
@@ -101,10 +101,12 @@ class DataSharingManager {
     /**
      * Returns data sharing manager.
      * @param {string} requestId
-     * @returns {Map<string, Resource[]>}
+     * @param {number|undefined} everythingChunkIndex
+     * @returns {Map<string, *>}
      */
-    getDataSharingManagerCache ({ requestId }) {
-        return this.requestSpecificCache.getMap({ requestId, name: 'dataSharingManager' });
+    getDataSharingManagerCache ({ requestId, everythingChunkIndex }) {
+        const name = everythingChunkIndex !== undefined ? `dataSharingManager_${everythingChunkIndex}` : 'dataSharingManager';
+        return this.requestSpecificCache.getMap({ requestId, name });
     }
 
     /**
@@ -119,6 +121,7 @@ class DataSharingManager {
      * @property {boolean | undefined} useHistoryTable boolean to use history table or not
      * @property {boolean} isUser whether request is with patient scope
      * @property {boolean} allowConsentedProaDataAccess whether to allow consented PROA data access
+     * @property {number|undefined} everythingChunkIndex
      * @param {RewriteDataSharingQuery} param
      */
     async updateQueryConsideringDataSharing({
@@ -130,12 +133,13 @@ class DataSharingManager {
         useHistoryTable,
         requestId,
         isUser,
-        allowConsentedProaDataAccess
+        allowConsentedProaDataAccess,
+        everythingChunkIndex
     }) {
         assertTypeEquals(parsedArgs, ParsedArgs);
         let everythingCacheMap;
         if (requestId) {
-            everythingCacheMap = this.getDataSharingManagerCache({ requestId });
+            everythingCacheMap = this.getDataSharingManagerCache({ requestId, everythingChunkIndex });
         }
         let patientIdToImmediatePersonUuid;
         let patientsList;

--- a/src/operations/search/dataSharingManager.js
+++ b/src/operations/search/dataSharingManager.js
@@ -409,6 +409,12 @@ class DataSharingManager {
          * */
         const updatedParsedArgs = parsedArgs.clone();
 
+        // Becomes true if a patient-reference filter had values originally but none of them
+        // survived the allowedPatientIds restriction. Dropping such a filter (rather than
+        // rebuilding it as an unsatisfiable one) would leave this resourceType's query with
+        // no patient scoping at all, so the whole connection-type branch must be discarded.
+        let patientFilterEmptied = false;
+
         updatedParsedArgs
             .parsedArgItems
             .forEach((/** @type {import('../query/parsedArgsItem').ParsedArgsItem} */item) => {
@@ -419,20 +425,37 @@ class DataSharingManager {
                     /** @type {string[]} */
                     const newQueryParameterValues = [];
 
+                    // Mixed-target params (e.g. Observation.performer, which also targets
+                    // Practitioner/Organization/...) can carry non-Patient references; only
+                    // Patient-typed (or typeless) ones are ever rebuilt below, so only these
+                    // should count toward "was the patient scoping genuinely emptied".
+                    const patientTypedReferences = item.references.filter(
+                        (ref) => !ref.resourceType || ref.resourceType === 'Patient'
+                    );
+
                     // update the query-param values
-                    item.references.forEach((ref) => {
-                        if (!ref.resourceType || ref.resourceType === 'Patient') {
-                            // Check if ref.id is uuid or sourceId.
-                            if (isUuid(ref.id) && allowedPatientIds.has(ref.id)) {
-                                newQueryParameterValues.push(`Patient/${ref.id}`);
-                            } else if (!isUuid(ref.id) && !ref.id.includes(PERSON_PROXY_PREFIX)) {
-                                const refUUID = patientsList.find(patient => patient.id === ref.id)?._uuid;
-                                if (refUUID && allowedPatientIds.has(refUUID)) {
-                                    newQueryParameterValues.push(`Patient/${refUUID}`);
-                                }
+                    patientTypedReferences.forEach((ref) => {
+                        // Check if ref.id is uuid or sourceId.
+                        if (isUuid(ref.id) && allowedPatientIds.has(ref.id)) {
+                            newQueryParameterValues.push(`Patient/${ref.id}`);
+                        } else if (!isUuid(ref.id) && !ref.id.includes(PERSON_PROXY_PREFIX)) {
+                            const refUUID = patientsList.find(patient => patient.id === ref.id)?._uuid;
+                            if (refUUID && allowedPatientIds.has(refUUID)) {
+                                newQueryParameterValues.push(`Patient/${refUUID}`);
                             }
                         }
                     });
+
+                    // A 'not'-modified filter rebuilds into an exclusion ($nor) clause, where an
+                    // empty result just excludes nothing extra (a safe no-op) rather than making
+                    // the branch unsatisfiable, so it must not trip this check.
+                    if (
+                        !item.modifiers.includes('not') &&
+                        patientTypedReferences.length > 0 &&
+                        newQueryParameterValues.length === 0
+                    ) {
+                        patientFilterEmptied = true;
+                    }
 
                     // rebuild the query value
                     const newValue = item.queryParameterValue.regenerateValueFromValues(newQueryParameterValues);
@@ -456,6 +479,14 @@ class DataSharingManager {
                         }
                     });
 
+                    if (
+                        !item.modifiers.includes('not') &&
+                        item.queryParameterValue.values.length > 0 &&
+                        newQueryParameterValues.length === 0
+                    ) {
+                        patientFilterEmptied = true;
+                    }
+
                     const newValue = item.queryParameterValue.regenerateValueFromValues(newQueryParameterValues);
                     item.queryParameterValue = new QueryParameterValue({
                         value: newValue,
@@ -463,6 +494,13 @@ class DataSharingManager {
                     });
                 }
             });
+
+        // None of the referenced patients survived the connection-type restriction for at
+        // least one patient-scoped filter — this branch would otherwise match this resourceType
+        // with no patient scoping at all (see getConnectionTypeFilteredQuery caller), so skip it.
+        if (patientFilterEmptied) {
+            return null;
+        }
 
         /**
          * Reconstructed query.

--- a/src/operations/search/searchManager.js
+++ b/src/operations/search/searchManager.js
@@ -213,7 +213,8 @@ class SearchManager {
             applyPatientFilter = true,
             addPersonOwnerToContext = false,
             allowConsentedProaDataAccess = false,
-            actor
+            actor,
+            everythingChunkIndex
         }
     ) {
         try {
@@ -309,7 +310,8 @@ class SearchManager {
                         useHistoryTable,
                         requestId,
                         isUser,
-                        allowConsentedProaDataAccess
+                        allowConsentedProaDataAccess,
+                        everythingChunkIndex
                     });
                 }
             }

--- a/src/tests/data_sharing/everything/data_sharing_scenario.test.js
+++ b/src/tests/data_sharing/everything/data_sharing_scenario.test.js
@@ -397,5 +397,241 @@ describe('Data sharing test cases for different scenarios', () => {
             // noinspection JSUnresolvedFunction
             expect(resp).toHaveResponse(expectedResponse11Resource);
         });
+
+        test('PROA data sharing flow: Person with 16 linked patients (15 health-service + 1 client with consent), should return 16 Patients after adding 5 unlinked PROA and 5 unlinked IAS patients', async () => {
+
+            const originalConsentConnectionTypesList = process.env.CONSENT_CONNECTION_TYPES_LIST;
+            process.env.CONSENT_CONNECTION_TYPES_LIST = 'proa,ias';
+            const request = await createTestRequest((c) => c);
+
+            // UUIDs for all resources in this test
+            const PERSON_ID = '67d19544-8fc0-48b6-ac85-be2b93601d89';
+            const PERSON_UUID = '5b2a5863-f72c-56dd-b69d-e6ab595d9208';
+            const CLIENT_PATIENT_ID = '88f5637f-76a3-49ee-87d1-6c94992d98d3';
+            const CONSENT_ID = '2c5fe296-8455-42ba-b480-0060b8822e2b';
+            const HS_PATIENT_IDS = [
+                '57d9ffb0-9e56-45ae-920d-3207ca68662f',
+                '8bd79f0d-9424-4541-87c6-6a2aef8780c6',
+                '551fbc8e-9b8b-46f6-9b72-317791cd8f13',
+                '8be6cf0b-d80f-4794-a2ed-a5cb25426f1f',
+                '69fb4066-0ad3-4886-b3ba-d9d425a14e56',
+                'ce2c9180-7533-4b07-88f5-90453bfb5a12',
+                'db5ae1ac-c551-47ac-9fb1-c00dccfc7fdb',
+                '04ac4f1d-a52c-4f89-b039-111137a8cb36',
+                'deaaf9d6-30a2-416c-9f5e-f8b7d00a1703',
+                '520a7a62-cdf9-4965-be03-a8118243556c',
+                'c9228c22-5251-46d2-85df-6e7202c8840c',
+                '3641e21e-6d86-4b6f-97f3-030457d0403d',
+                '8ab14d3b-fee4-46ab-95a3-5005b82cba25',
+                '68449a3b-275d-4fe1-b8a4-6cc7bc70577c',
+                'f7a4bd42-05cb-4dc4-b168-328dbfd73bc7'
+            ];
+            const UNLINKED_PROA_IDS = [
+                'd6a2775d-51e7-41a7-9ed9-e32a2bdeaa95',
+                'f8601543-bb78-4b2c-a79d-981f9657eba3',
+                '8dfcd1a1-42e3-4ddc-96e7-ef079d8a9faa',
+                'd82bf42b-faf3-4e5f-8374-f989bb5ada83',
+                '0becb0e8-fbba-4a02-90d5-93e67a981946'
+            ];
+            const UNLINKED_IAS_IDS = [
+                '5fc6dedc-1b45-4afc-8dce-2b26e66266a2',
+                '79c4b3d7-3d65-43a8-8c74-9b128012045b',
+                '121a3502-7adf-4253-a1bf-e8a7cd856670',
+                '3e79cac4-0309-45e4-8d33-8d6382554222',
+                '4e522cba-71ec-4f10-86c8-5e5cdf02ce26'
+            ];
+
+            const proaBulkPerson = {
+                resourceType: 'Person',
+                id: PERSON_ID,
+                meta: {
+                    source: 'client',
+                    security: [
+                        { system: 'https://www.icanbwell.com/access', code: 'client' },
+                        { system: 'https://www.icanbwell.com/owner', code: 'client' }
+                    ]
+                },
+                name: [{ use: 'official', family: 'Irving', given: ['Lloyd'] }],
+                gender: 'male',
+                birthDate: '1996-03-03',
+                link: [
+                    // 15 health-service patients
+                    ...HS_PATIENT_IDS.map((id) => ({
+                        target: { reference: `Patient/${id}`, type: 'Patient' },
+                        assurance: 'level4'
+                    })),
+                    // 1 client patient with consent
+                    {
+                        target: { reference: `Patient/${CLIENT_PATIENT_ID}`, type: 'Patient' },
+                        assurance: 'level4'
+                    }
+                ]
+            };
+
+            // 15 health-service patients linked to the Person (connectionType=proa)
+            const healthServicePatients = HS_PATIENT_IDS.map((id, i) => ({
+                resourceType: 'Patient',
+                id,
+                meta: {
+                    source: 'health-service',
+                    security: [
+                        { system: 'https://www.icanbwell.com/access', code: 'health-service' },
+                        { system: 'https://www.icanbwell.com/owner', code: 'health-service' },
+                        { system: 'https://www.icanbwell.com/connectionType', code: 'proa' }
+                    ]
+                },
+                name: [{ use: 'usual', family: `HS-PATIENT-${i + 1}`, given: ['HEALTH'] }],
+                gender: 'female',
+                birthDate: '1990-01-01'
+            }));
+
+            // 1 client patient with data-sharing consent linked to the Person
+            const proaBulkClientPatient = {
+                resourceType: 'Patient',
+                id: CLIENT_PATIENT_ID,
+                meta: {
+                    source: 'client',
+                    security: [
+                        { system: 'https://www.icanbwell.com/access', code: 'client' },
+                        { system: 'https://www.icanbwell.com/owner', code: 'client' }
+                    ]
+                },
+                name: [{ use: 'usual', family: 'BULK-CLIENT', given: ['PATIENT'] }],
+                gender: 'female',
+                birthDate: '1990-01-01'
+            };
+
+            // Data-sharing consent for the client patient
+            const proaBulkConsent = {
+                resourceType: 'Consent',
+                id: CONSENT_ID,
+                meta: {
+                    source: 'client',
+                    security: [
+                        { system: 'https://www.icanbwell.com/access', code: 'client' },
+                        { system: 'https://www.icanbwell.com/owner', code: 'client' }
+                    ]
+                },
+                status: 'active',
+                category: [
+                    {
+                        coding: [
+                            { system: 'http://www.icanbwell.com/consent-category', code: 'dataSharing' }
+                        ]
+                    }
+                ],
+                scope: {
+                    coding: [
+                        {
+                            system: 'http://terminology.hl7.org/CodeSystem/consentscope',
+                            code: 'patient-privacy'
+                        }
+                    ]
+                },
+                patient: { reference: `Patient/${CLIENT_PATIENT_ID}` },
+                dateTime: '2022-09-08T14:05:07.350Z',
+                provision: {
+                    type: 'permit',
+                    actor: [
+                        {
+                            role: {
+                                coding: [
+                                    {
+                                        system: 'http://terminology.hl7.org/CodeSystem/v3-ParticipationType',
+                                        code: 'CST'
+                                    }
+                                ]
+                            },
+                            reference: { reference: `Patient/${CLIENT_PATIENT_ID}` }
+                        },
+                        {
+                            role: {
+                                coding: [
+                                    {
+                                        system: 'http://terminology.hl7.org/3.1.0/CodeSystem-v3-RoleCode.html',
+                                        code: 'AUT'
+                                    }
+                                ]
+                            },
+                            reference: { reference: `Patient/person.${PERSON_UUID}` }
+                        }
+                    ]
+                }
+            };
+
+            // --- Phase 1: Insert Person + 16 linked patients + consent ---
+            let resp = await request
+                .post('/4_0_0/Person/1/$merge')
+                .send([proaBulkPerson, ...healthServicePatients, proaBulkClientPatient, proaBulkConsent])
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({ created: true });
+
+            resp = await request
+                .get(`/4_0_0/Person/${PERSON_ID}/$everything?_type=Patient`)
+                .set({ ...headers, prefer: 'global_id=false' });
+
+            // Expect exactly 16 patients: 15 health-service + 1 client
+            const phase1PatientCount = resp.body.entry?.filter(
+                (e) => e.resource?.resourceType === 'Patient'
+            ).length;
+            expect(phase1PatientCount).toEqual(16);
+
+            // --- Phase 2: Add 5 unlinked PROA patients + 5 unlinked IAS patients ---
+
+            // 5 PROA patients NOT linked via Person.link
+            const unlinkedProaPatients = UNLINKED_PROA_IDS.map((id, i) => ({
+                resourceType: 'Patient',
+                id,
+                meta: {
+                    source: 'health-service',
+                    security: [
+                        { system: 'https://www.icanbwell.com/access', code: 'health-service' },
+                        { system: 'https://www.icanbwell.com/owner', code: 'health-service' },
+                        { system: 'https://www.icanbwell.com/connectionType', code: 'proa' }
+                    ]
+                },
+                name: [{ use: 'usual', family: `UNLINKED-PROA-${i + 1}`, given: ['PATIENT'] }],
+                gender: 'female',
+                birthDate: '1990-01-01'
+            }));
+
+            // 5 IAS patients NOT linked via Person.link
+            const unlinkedIasPatients = UNLINKED_IAS_IDS.map((id, i) => ({
+                resourceType: 'Patient',
+                id,
+                meta: {
+                    source: 'health-service',
+                    security: [
+                        { system: 'https://www.icanbwell.com/access', code: 'health-service' },
+                        { system: 'https://www.icanbwell.com/owner', code: 'health-service' },
+                        { system: 'https://www.icanbwell.com/connectionType', code: 'ias' }
+                    ]
+                },
+                name: [{ use: 'usual', family: `UNLINKED-IAS-${i + 1}`, given: ['PATIENT'] }],
+                gender: 'female',
+                birthDate: '1990-01-01'
+            }));
+
+            resp = await request
+                .post('/4_0_0/Person/1/$merge')
+                .send([...unlinkedProaPatients, ...unlinkedIasPatients])
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveMergeResponse({ created: true });
+
+            resp = await request
+                .get(`/4_0_0/Person/${PERSON_ID}/$everything?_type=Patient`)
+                .set({ ...headers, prefer: 'global_id=false' });
+
+            console.log(resp.body.entry);
+            // Expect 16 total patient excluding 5 unlinked IAS and PROA
+            const phase2PatientCount = resp.body.entry?.filter(
+                (e) => e.resource?.resourceType === 'Patient'
+            ).length;
+            expect(phase2PatientCount).toEqual(16);
+
+            process.env.CONSENT_CONNECTION_TYPES_LIST = originalConsentConnectionTypesList;
+        });
     });
 });

--- a/src/tests/data_sharing/everything/data_sharing_scenario.test.js
+++ b/src/tests/data_sharing/everything/data_sharing_scenario.test.js
@@ -624,7 +624,6 @@ describe('Data sharing test cases for different scenarios', () => {
                 .get(`/4_0_0/Person/${PERSON_ID}/$everything?_type=Patient`)
                 .set({ ...headers, prefer: 'global_id=false' });
 
-            console.log(resp.body.entry);
             // Expect 16 total patient excluding 5 unlinked IAS and PROA
             const phase2PatientCount = resp.body.entry?.filter(
                 (e) => e.resource?.resourceType === 'Patient'

--- a/src/tests/data_sharing/everything/data_sharing_scenario.test.js
+++ b/src/tests/data_sharing/everything/data_sharing_scenario.test.js
@@ -398,10 +398,23 @@ describe('Data sharing test cases for different scenarios', () => {
             expect(resp).toHaveResponse(expectedResponse11Resource);
         });
 
-        test('PROA data sharing flow: Person with 16 linked patients (15 health-service + 1 client with consent), should return 16 Patients after adding 5 unlinked PROA and 5 unlinked IAS patients', async () => {
+        describe('PROA data sharing flow with connectionType-based consent', () => {
+            let originalConsentConnectionTypesList;
 
-            const originalConsentConnectionTypesList = process.env.CONSENT_CONNECTION_TYPES_LIST;
-            process.env.CONSENT_CONNECTION_TYPES_LIST = 'proa,ias';
+            beforeEach(() => {
+                originalConsentConnectionTypesList = process.env.CONSENT_CONNECTION_TYPES_LIST;
+                process.env.CONSENT_CONNECTION_TYPES_LIST = 'proa,ias';
+            });
+
+            afterEach(() => {
+                if (originalConsentConnectionTypesList === undefined) {
+                    delete process.env.CONSENT_CONNECTION_TYPES_LIST;
+                } else {
+                    process.env.CONSENT_CONNECTION_TYPES_LIST = originalConsentConnectionTypesList;
+                }
+            });
+
+            test('PROA data sharing flow: Person with 16 linked patients (15 health-service + 1 client with consent), should return 16 Patients after adding 5 unlinked PROA and 5 unlinked IAS patients', async () => {
             const request = await createTestRequest((c) => c);
 
             // UUIDs for all resources in this test
@@ -629,8 +642,7 @@ describe('Data sharing test cases for different scenarios', () => {
                 (e) => e.resource?.resourceType === 'Patient'
             ).length;
             expect(phase2PatientCount).toEqual(16);
-
-            process.env.CONSENT_CONNECTION_TYPES_LIST = originalConsentConnectionTypesList;
+            });
         });
     });
 });


### PR DESCRIPTION
## Problem
`$everything` processes matched Patient IDs in chunks. For PROA/IAS consented-access requests, each chunk's query is rewritten by `DataSharingManager.updateQueryConsideringDataSharing` to restrict results to the patients allowed under connectionType-based consent. That rewritten state was cached in a single map keyed only by `requestId` (`dataSharingManager`), so **every chunk of an `$everything` run shared the same cache entry**. Since each chunk covers a different subset of patient IDs, later chunks reused state computed for an earlier chunk, producing a malformed query that a downstream guard then treated as invalid and replaced with an unsatisfiable query (`_uuid: '__invalid__'`) — silently dropping PROA/IAS patients that should have been returned from chunks other than the first.

## Fix
- Added `everythingChunkIndex`, threaded from `EverythingHelper` through `SearchManager` into `DataSharingManager`, so each chunk of an `$everything` request gets its own data-sharing cache entry (`dataSharingManager_<index>`) instead of sharing one cache across all chunks.
- Replaced the "log and invalidate the query" fallback in `everythingHelper.js` for `CONSENTED_PROA_DATA_ACCESSED` with a guard condition, so a query that isn't shaped as expected is simply left unmodified instead of being replaced with an unsatisfiable one.
- In `dataSharingManager.js`, when rebuilding a patient-reference filter against the connectionType-allowed patient list: if a filter originally had values but none survive the restriction (and it isn't a `not`-modified filter), the whole connectionType-filtered branch is now discarded rather than turned into an incorrect query. `not`-modified filters that end up empty are left as a no-op exclusion, since an empty exclusion list correctly excludes nothing extra.
- Scoped the "was this filter emptied" check to only Patient-typed (or typeless) references, so mixed-target reference params (e.g. `Observation.performer`, which can also reference Practitioner/Organization) aren't incorrectly flagged as emptied.

## Testing
Added a new scenario in `data_sharing_scenario.test.js`: a Person with 16 linked patients (15 health-service patients under the `proa` connectionType + 1 client patient with data-sharing consent) returns all 16 via `$everything`. After adding 5 unlinked `proa` and 5 unlinked `ias` patients (not linked to the Person), the count stays at 16 — confirming unlinked PROA/IAS patients are correctly excluded while linked ones are no longer dropped across chunks.

Jira: DCON-4598