### PR TITLE
PAY-2630: normalize legacy questionnaire references to UUIDs on write

### DIFF
--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -87,6 +87,7 @@ const {K8sClient} = require('./utils/k8sClient');
 const {GlobalIdEnrichmentProvider} = require('./enrich/providers/globalIdEnrichmentProvider');
 const {ReferenceGlobalIdHandler} = require('./preSaveHandlers/handlers/referenceGlobalIdHandler');
 const {OwnerColumnHandler} = require('./preSaveHandlers/handlers/ownerColumnHandler');
+const {QuestionnaireReferenceNormalizationHandler} = require('./preSaveHandlers/handlers/questionnaireReferenceNormalizationHandler');
 const {HashReferencesEnrichmentProvider} = require('./enrich/providers/hashedReferencesEnrichmentProvider');
 const {FhirResourceWriterFactory} = require('./operations/streaming/resourceWriters/fhirResourceWriterFactory');
 const {ProaConsentManager} = require('./operations/search/proaConsentManager');
@@ -220,6 +221,8 @@ const createContainer = function () {
         preSaveHandlers: [
             // Validate Group invariants early (fail fast)
             new GroupInvariantHandler({ configManager: c.configManager }),
+            // Normalize legacy human-readable questionnaire references to UUIDs (PAY-2630)
+            new QuestionnaireReferenceNormalizationHandler(),
             // Note: Group.member array stripping is now handled in databaseBulkInserter
             // before preSaveManager is called, to ensure proper write ordering with ClickHouse
             new DateColumnHandler(),

--- a/src/preSaveHandlers/handlers/questionnaireReferenceNormalizationHandler.js
+++ b/src/preSaveHandlers/handlers/questionnaireReferenceNormalizationHandler.js
@@ -1,0 +1,53 @@
+const { PreSaveHandler } = require('./preSaveHandler');
+
+const QUESTIONNAIRE_NAME_TO_UUID = {
+    'fitness-reimbursement-request': '7a7f53d3-acef-539d-b4e6-b48b79c94e72',
+    'fitness-reimbursement-request-es': '74dd3eb6-84a2-56ea-9d0d-c77a97608a4c',
+    'medical-claim-reimbursement-request': '80bf44d6-0c9a-5468-9343-080f46c8f445',
+    'medical-claim-reimbursement-request-es': '7e9afaa5-9d22-5ca1-b301-be91d2c0f64c',
+    'request-mailed-documents': 'cfcb7ee4-b4fe-509d-8381-85933766bee0',
+    'request-mailed-documents-es': 'd9020917-016d-5994-b424-bb64d3c6dbb0'
+};
+
+/**
+ * Normalizes QuestionnaireResponse.questionnaire references from legacy
+ * human-readable names to stable UUIDs. Old app versions still submit
+ * with human-readable names; this ensures all persisted references use
+ * the UUID format so downstream consumers (e.g. WellSense) can query
+ * consistently.
+ */
+class QuestionnaireReferenceNormalizationHandler extends PreSaveHandler {
+    /**
+     * @param {Object} params
+     * @param {Resource} params.resource
+     * @returns {Promise<Resource>}
+     */
+    async preSaveAsync ({ resource }) {
+        if (resource.resourceType !== 'QuestionnaireResponse') {
+            return resource;
+        }
+
+        const questionnaire = resource.questionnaire;
+        if (!questionnaire) {
+            return resource;
+        }
+
+        // Extract the reference ID from canonical URLs like
+        // "https://fhir.icanbwell.com/4_0_0/Questionnaire/fitness-reimbursement-request"
+        // or bare references like "Questionnaire/fitness-reimbursement-request"
+        const parts = questionnaire.split('/');
+        const referenceName = parts[parts.length - 1];
+
+        const uuid = QUESTIONNAIRE_NAME_TO_UUID[referenceName];
+        if (uuid) {
+            resource.questionnaire = questionnaire.replace(referenceName, uuid);
+        }
+
+        return resource;
+    }
+}
+
+module.exports = {
+    QuestionnaireReferenceNormalizationHandler,
+    QUESTIONNAIRE_NAME_TO_UUID
+};

--- a/src/tests/operations/preSave/preSaveQuestionnaireReferenceNormalization/preSaveQuestionnaireReferenceNormalization.test.js
+++ b/src/tests/operations/preSave/preSaveQuestionnaireReferenceNormalization/preSaveQuestionnaireReferenceNormalization.test.js
@@ -1,0 +1,81 @@
+const { describe, test, expect } = require('@jest/globals');
+const { QuestionnaireReferenceNormalizationHandler, QUESTIONNAIRE_NAME_TO_UUID } = require('../../../../preSaveHandlers/handlers/questionnaireReferenceNormalizationHandler');
+
+const handler = new QuestionnaireReferenceNormalizationHandler();
+
+describe('QuestionnaireReferenceNormalizationHandler', () => {
+    test('rewrites known human-readable name to UUID (full canonical URL)', async () => {
+        const resource = {
+            resourceType: 'QuestionnaireResponse',
+            questionnaire: 'https://fhir.icanbwell.com/4_0_0/Questionnaire/fitness-reimbursement-request'
+        };
+        const result = await handler.preSaveAsync({ resource });
+        expect(result.questionnaire).toBe(
+            'https://fhir.icanbwell.com/4_0_0/Questionnaire/7a7f53d3-acef-539d-b4e6-b48b79c94e72'
+        );
+    });
+
+    test('rewrites known human-readable name to UUID (bare reference)', async () => {
+        const resource = {
+            resourceType: 'QuestionnaireResponse',
+            questionnaire: 'Questionnaire/request-mailed-documents'
+        };
+        const result = await handler.preSaveAsync({ resource });
+        expect(result.questionnaire).toBe(
+            'Questionnaire/cfcb7ee4-b4fe-509d-8381-85933766bee0'
+        );
+    });
+
+    test('rewrites all 6 known mappings', async () => {
+        for (const [name, uuid] of Object.entries(QUESTIONNAIRE_NAME_TO_UUID)) {
+            const resource = {
+                resourceType: 'QuestionnaireResponse',
+                questionnaire: `https://fhir.icanbwell.com/4_0_0/Questionnaire/${name}`
+            };
+            const result = await handler.preSaveAsync({ resource });
+            expect(result.questionnaire).toBe(
+                `https://fhir.icanbwell.com/4_0_0/Questionnaire/${uuid}`
+            );
+        }
+    });
+
+    test('does not rewrite questionnaire reference that is already a UUID', async () => {
+        const resource = {
+            resourceType: 'QuestionnaireResponse',
+            questionnaire: 'https://fhir.icanbwell.com/4_0_0/Questionnaire/7a7f53d3-acef-539d-b4e6-b48b79c94e72'
+        };
+        const result = await handler.preSaveAsync({ resource });
+        expect(result.questionnaire).toBe(
+            'https://fhir.icanbwell.com/4_0_0/Questionnaire/7a7f53d3-acef-539d-b4e6-b48b79c94e72'
+        );
+    });
+
+    test('does not rewrite unknown human-readable names', async () => {
+        const resource = {
+            resourceType: 'QuestionnaireResponse',
+            questionnaire: 'https://fhir.icanbwell.com/4_0_0/Questionnaire/some-other-form'
+        };
+        const result = await handler.preSaveAsync({ resource });
+        expect(result.questionnaire).toBe(
+            'https://fhir.icanbwell.com/4_0_0/Questionnaire/some-other-form'
+        );
+    });
+
+    test('skips non-QuestionnaireResponse resources', async () => {
+        const resource = {
+            resourceType: 'Patient',
+            id: '123'
+        };
+        const result = await handler.preSaveAsync({ resource });
+        expect(result).toBe(resource);
+    });
+
+    test('skips QuestionnaireResponse with no questionnaire field', async () => {
+        const resource = {
+            resourceType: 'QuestionnaireResponse',
+            status: 'completed'
+        };
+        const result = await handler.preSaveAsync({ resource });
+        expect(result.questionnaire).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a `QuestionnaireReferenceNormalizationHandler` preSave handler that rewrites `QuestionnaireResponse.questionnaire` references from 6 known legacy human-readable names to their stable UUIDs before persisting
- References already using UUIDs or any other unknown names pass through unchanged
- Registered early in the preSaveHandlers chain in `createContainer.js`

## Context

Around June 11, a frontend change switched questionnaire references from human-readable names (e.g. `request-mailed-documents`) to UUIDs (e.g. `cfcb7ee4-b4fe-509d-8381-85933766bee0`). WellSense updated their daily pull to query by UUID. However, users on old app versions still submit with human-readable names, and we cannot force-upgrade those apps. Without this fix, those submissions are invisible to WellSense indefinitely.

## Mapping (only these 6 are rewritten)

| Old name | UUID |
|---|---|
| `fitness-reimbursement-request` | `7a7f53d3-acef-539d-b4e6-b48b79c94e72` |
| `fitness-reimbursement-request-es` | `74dd3eb6-84a2-56ea-9d0d-c77a97608a4c` |
| `medical-claim-reimbursement-request` | `80bf44d6-0c9a-5468-9343-080f46c8f445` |
| `medical-claim-reimbursement-request-es` | `7e9afaa5-9d22-5ca1-b301-be91d2c0f64c` |
| `request-mailed-documents` | `cfcb7ee4-b4fe-509d-8381-85933766bee0` |
| `request-mailed-documents-es` | `d9020917-016d-5994-b424-bb64d3c6dbb0` |

## Test plan

- [x] 7 unit tests covering: all 6 mappings, full canonical URLs, bare references, UUID pass-through, unknown names pass-through, non-QR resources skipped, missing questionnaire field skipped
- [ ] Verify in dev that a QR submitted with a human-readable name gets persisted with the UUID reference