### PR TITLE
DCON-4644: Add --skip-database-creation to applyClickHouseDDL

### DIFF
--- a/readme/clickhouse.md
+++ b/readme/clickhouse.md
@@ -571,6 +571,16 @@ Only Groups with matching `access` or `owner` tags are returned in search result
 
 The Makefile runs all `clickhouse-init/*.sql` files in alphabetical order. If the volume persists from an older schema, `02-add-entity-reference-columns.sql` applies the migration.
 
+### Applying the Schema Without CREATE DATABASE Privileges
+
+In shared environments (e.g. dev/staging), the ClickHouse user configured for the app often only has grants on the existing `fhir` database, not `CREATE DATABASE`. Running `applyClickHouseDDL.js` there fails on the `CREATE DATABASE IF NOT EXISTS fhir;` statement in `clickhouse-init/01-init-schema.sql`.
+
+Pass `--skip-database-creation` to filter out `CREATE DATABASE` statements and apply only the `CREATE TABLE` / `CREATE MATERIALIZED VIEW` statements:
+
+```bash
+node src/admin/scripts/applyClickHouseDDL.js --dir clickhouse-init --skip-database-creation
+```
+
 ### Groups Not Appearing in Member Search
 
 **Symptom:** `GET /Group?member=Patient/X` returns empty results

--- a/src/admin/runners/applyClickHouseDDLRunner.js
+++ b/src/admin/runners/applyClickHouseDDLRunner.js
@@ -7,7 +7,9 @@ const { ClickHouseClientManager } = require('../../utils/clickHouseClientManager
 /**
  * @classdesc Applies ClickHouse DDL (CREATE DATABASE / CREATE TABLE / CREATE MATERIALIZED VIEW)
  * from .sql files to the configured ClickHouse instance. Idempotent when the DDL uses
- * `IF NOT EXISTS`.
+ * `IF NOT EXISTS`. Pass `skipDatabaseCreation: true` in environments (e.g. dev/staging)
+ * where the configured ClickHouse user lacks `CREATE DATABASE` privileges and the
+ * target database is expected to already exist.
  */
 class ApplyClickHouseDDLRunner extends BaseScriptRunner {
     /**
@@ -17,10 +19,19 @@ class ApplyClickHouseDDLRunner extends BaseScriptRunner {
      *   clickHouseClientManager: ClickHouseClientManager | null,
      *   dir?: string,
      *   file?: string,
-     *   dryRun?: boolean
+     *   dryRun?: boolean,
+     *   skipDatabaseCreation?: boolean
      * }} params
      */
-    constructor({ adminLogger, mongoDatabaseManager, clickHouseClientManager, dir, file, dryRun = false }) {
+    constructor({
+        adminLogger,
+        mongoDatabaseManager,
+        clickHouseClientManager,
+        dir,
+        file,
+        dryRun = false,
+        skipDatabaseCreation = false
+    }) {
         super({ adminLogger, mongoDatabaseManager });
 
         if (clickHouseClientManager) {
@@ -31,6 +42,7 @@ class ApplyClickHouseDDLRunner extends BaseScriptRunner {
         this.dir = dir;
         this.file = file;
         this.dryRun = Boolean(dryRun);
+        this.skipDatabaseCreation = Boolean(skipDatabaseCreation);
     }
 
     async processAsync() {
@@ -99,8 +111,19 @@ class ApplyClickHouseDDLRunner extends BaseScriptRunner {
      */
     async _applyFile(filePath) {
         const sqlText = fs.readFileSync(filePath, 'utf8');
-        const statements = this._parseStatements(sqlText);
+        let statements = this._parseStatements(sqlText);
         const name = path.basename(filePath);
+
+        if (this.skipDatabaseCreation) {
+            const skipped = statements.filter((stmt) => /^CREATE\s+DATABASE\b/i.test(stmt));
+            if (skipped.length > 0) {
+                statements = statements.filter((stmt) => !/^CREATE\s+DATABASE\b/i.test(stmt));
+                this.adminLogger.logInfo('Skipping CREATE DATABASE statement(s)', {
+                    file: name,
+                    count: skipped.length
+                });
+            }
+        }
 
         this.adminLogger.logInfo('Applying DDL file', { file: name, statements: statements.length });
 

--- a/src/admin/scripts/applyClickHouseDDL.js
+++ b/src/admin/scripts/applyClickHouseDDL.js
@@ -16,20 +16,25 @@ const { AdminLogger } = require('../adminLogger');
  *   CLICKHOUSE_PASSWORD (default: empty)
  *
  * Options:
- *   --dir <path>    Directory of .sql files to apply in lexical order (default: clickhouse-init)
- *   --file <path>   Apply a single .sql file (overrides --dir)
- *   --dry-run       Log statements without executing
+ *   --dir <path>              Directory of .sql files to apply in lexical order (default: clickhouse-init)
+ *   --file <path>             Apply a single .sql file (overrides --dir)
+ *   --dry-run                 Log statements without executing
+ *   --skip-database-creation  Skip `CREATE DATABASE` statements. Use in environments (e.g.
+ *                             dev/staging) where the configured ClickHouse user lacks
+ *                             CREATE DATABASE privileges and the database already exists.
  *
  * Examples:
  *   ENABLE_CLICKHOUSE=1 CLICKHOUSE_HOST=http://localhost CLICKHOUSE_PORT=8123 \
  *     node src/admin/scripts/applyClickHouseDDL.js --dir clickhouse-init
  *   node src/admin/scripts/applyClickHouseDDL.js --file clickhouse-init/02-audit-event.sql --dry-run
+ *   node src/admin/scripts/applyClickHouseDDL.js --dir clickhouse-init --skip-database-creation
  */
 async function main() {
     const args = CommandLineParser.parseCommandLine();
     const dir = args.dir || 'clickhouse-init';
     const file = args.file;
     const dryRun = Boolean(args.dryRun);
+    const skipDatabaseCreation = Boolean(args.skipDatabaseCreation);
 
     const container = createContainer();
 
@@ -42,7 +47,8 @@ async function main() {
                 clickHouseClientManager: c.clickHouseClientManager,
                 dir,
                 file,
-                dryRun
+                dryRun,
+                skipDatabaseCreation
             })
     );
 

--- a/src/tests/scripts/applyClickHouseDDL.test.js
+++ b/src/tests/scripts/applyClickHouseDDL.test.js
@@ -7,7 +7,7 @@
 process.env.ENABLE_CLICKHOUSE = '1';
 
 const path = require('path');
-const { describe, test, beforeAll, beforeEach, afterAll, expect } = require('@jest/globals');
+const { describe, test, beforeAll, beforeEach, afterAll, expect, jest } = require('@jest/globals');
 
 const { ClickHouseClientManager } = require('../../utils/clickHouseClientManager');
 const { ConfigManager } = require('../../utils/configManager');
@@ -43,14 +43,23 @@ const DROP_ORDER = [
     'fhir.AUDIT_ACCESS_AGG'
 ];
 
-function makeRunner({ clickHouseClientManager, mongoDatabaseManager, dir, file, dryRun }) {
+function makeRunner({
+    clickHouseClientManager,
+    mongoDatabaseManager,
+    dir,
+    file,
+    dryRun,
+    skipDatabaseCreation,
+    adminLogger = new AdminLogger()
+}) {
     return new ApplyClickHouseDDLRunner({
-        adminLogger: new AdminLogger(),
+        adminLogger,
         mongoDatabaseManager,
         clickHouseClientManager,
         dir,
         file,
-        dryRun
+        dryRun,
+        skipDatabaseCreation
     });
 }
 
@@ -170,4 +179,27 @@ describe('applyClickHouseDDL admin runner', () => {
             expect(await clickHouseClientManager.tableExistsAsync(table)).toBe(false);
         }
     }, 120000);
+
+    test('--skip-database-creation skips CREATE DATABASE statements but still applies the rest', async () => {
+        const adminLogger = new AdminLogger();
+        const logInfoSpy = jest.spyOn(adminLogger, 'logInfo');
+
+        const runner = makeRunner({
+            clickHouseClientManager,
+            mongoDatabaseManager,
+            dir: DDL_DIR,
+            skipDatabaseCreation: true,
+            adminLogger
+        });
+        await runner.processAsync();
+
+        expect(logInfoSpy).toHaveBeenCalledWith(
+            'Skipping CREATE DATABASE statement(s)',
+            expect.objectContaining({ file: '01-init-schema.sql' })
+        );
+
+        for (const table of EXPECTED_TABLES) {
+            expect(await clickHouseClientManager.tableExistsAsync(table)).toBe(true);
+        }
+    }, 60000);
 });


### PR DESCRIPTION
## Summary
- Dev/staging ClickHouse users lack `CREATE DATABASE` privileges, so `applyClickHouseDDL.js` aborted on the first statement in `clickhouse-init/01-init-schema.sql`
- Adds a `--skip-database-creation` flag (`skipDatabaseCreation` on `ApplyClickHouseDDLRunner`) that filters out `CREATE DATABASE` statements and logs what was skipped, applying the rest of the DDL as normal
- Documents the new flag in `readme/clickhouse.md`

Jira: DCON-4644

## Test plan
- [x] `node node_modules/.bin/jest src/tests/scripts/applyClickHouseDDL.test.js` — 5/5 passing, including new `--skip-database-creation` test
- [x] `eslint` clean on changed files