### PR TITLE
DCON-4669: Fix missing SUBSCRIPTION_RESOURCE_TYPES import in everythingHelper

### DIFF
--- a/src/operations/everything/everythingHelper.js
+++ b/src/operations/everything/everythingHelper.js
@@ -24,6 +24,7 @@ const { PatientEverythingCacheKeyGenerator } = require('./patientEverythingCache
 const {
     GRIDFS: { RETRIEVE },
     OPERATIONS: { READ },
+    SUBSCRIPTION_RESOURCE_TYPES,
     SUBSCRIPTION_RESOURCES_REFERENCE_FIELDS,
     SUBSCRIPTION_RESOURCES_REFERENCE_KEY_MAP,
     PATIENT_REFERENCE_PREFIX,


### PR DESCRIPTION
## Summary
- The `DCON-4669` person-check change cherry-picked onto `hotfix/6.6.6-hotfix.2` uses `SUBSCRIPTION_RESOURCE_TYPES` in `everythingHelper.js` (to split subscription-family resources out of the main clinical loop) but never imports it from `../../constants` on this branch.
- This throws `ReferenceError: SUBSCRIPTION_RESOURCE_TYPES is not defined` unconditionally on every `$everything` request (Patient or Person), since the reference sits in early, ungated logic in the main processing path.
- Confirmed by diffing this branch's `everythingHelper.js` against the equivalent fix on `main` (PR #2343), where the import is present. This is the only substantive divergence between the two versions of the change.

## Fix
Add `SUBSCRIPTION_RESOURCE_TYPES` to the destructured `require('../../constants')` import list, matching what's on `main`.

## Test plan
- [ ] `node --check` passes on the modified file (verified locally)
- [ ] Run `make tests` / the `$everything` test suites on this branch to confirm `$everything` requests no longer throw