### PR TITLE
DCON-4691: Fix same-tenant sibling Person consolidation in Person/$everything (WIP)

### DIFF
--- a/src/tests/data_sharing/everything/data_sharing_scenario.test.js
+++ b/src/tests/data_sharing/everything/data_sharing_scenario.test.js
@@ -711,5 +711,98 @@ describe('Data sharing test cases for different scenarios', () => {
             expect(resp.body.entry ?? []).toHaveLength(0);
             });
         });
+
+        describe('Same-tenant sibling Person consolidation via shared master', () => {
+            test('Person $everything must not include a sibling Person\'s patient when both share the same tenant via a common master', async () => {
+                const request = await createTestRequest((c) => c);
+
+                const MASTER_PERSON_ID = 'b5f6f6d2-6b7e-4b8b-9b3a-1a2b3c4d5e6f';
+                const PERSON_ALICE_1_ID = 'b7a1a111-1111-1111-1111-111111111111';
+                const PERSON_ALICE_2_ID = 'b7a2a222-2222-2222-2222-222222222222';
+                const PATIENT_ALICE_1_ID = 'b7a1p111-1111-1111-1111-111111111111';
+                const PATIENT_ALICE_2_ID = 'b7a2p222-2222-2222-2222-222222222222';
+
+                const ownerSecurity = [
+                    { system: 'https://www.icanbwell.com/access', code: 'client' },
+                    { system: 'https://www.icanbwell.com/owner', code: 'client' }
+                ];
+
+                // A "master" Person consolidating what person-matching believes are the same
+                // real-world identity - but both sibling Persons below belong to the SAME
+                // tenant (owner: client), so this is a duplicate-account scenario, not the
+                // legitimate cross-org consolidation case (which spans different owner tags).
+                const masterPerson = {
+                    resourceType: 'Person',
+                    id: MASTER_PERSON_ID,
+                    meta: { source: 'client', security: ownerSecurity },
+                    name: [{ use: 'usual', family: 'Hackett', given: ['Allison'] }],
+                    link: [
+                        { target: { reference: `Person/${PERSON_ALICE_1_ID}`, type: 'Person' }, assurance: 'level4' },
+                        { target: { reference: `Person/${PERSON_ALICE_2_ID}`, type: 'Person' }, assurance: 'level4' }
+                    ]
+                };
+
+                const personAlice1 = {
+                    resourceType: 'Person',
+                    id: PERSON_ALICE_1_ID,
+                    meta: { source: 'client', security: ownerSecurity },
+                    name: [{ use: 'usual', family: 'Hackett', given: ['Allison'] }],
+                    link: [
+                        { target: { reference: `Person/${MASTER_PERSON_ID}`, type: 'Person' }, assurance: 'level4' },
+                        { target: { reference: `Patient/${PATIENT_ALICE_1_ID}`, type: 'Patient' }, assurance: 'level4' }
+                    ]
+                };
+
+                const personAlice2 = {
+                    resourceType: 'Person',
+                    id: PERSON_ALICE_2_ID,
+                    meta: { source: 'client', security: ownerSecurity },
+                    name: [{ use: 'usual', family: 'Hackett', given: ['Allison'] }],
+                    link: [
+                        { target: { reference: `Person/${MASTER_PERSON_ID}`, type: 'Person' }, assurance: 'level4' },
+                        { target: { reference: `Patient/${PATIENT_ALICE_2_ID}`, type: 'Patient' }, assurance: 'level4' }
+                    ]
+                };
+
+                const patientAlice1 = {
+                    resourceType: 'Patient',
+                    id: PATIENT_ALICE_1_ID,
+                    meta: { source: 'client', security: ownerSecurity },
+                    name: [{ use: 'usual', family: 'Hackett', given: ['Allison'] }],
+                    gender: 'female',
+                    birthDate: '1990-01-01'
+                };
+
+                const patientAlice2 = {
+                    resourceType: 'Patient',
+                    id: PATIENT_ALICE_2_ID,
+                    meta: { source: 'client', security: ownerSecurity },
+                    name: [{ use: 'usual', family: 'Hackett', given: ['Allison'] }],
+                    gender: 'female',
+                    birthDate: '1990-01-01'
+                };
+
+                let resp = await request
+                    .post('/4_0_0/Person/1/$merge')
+                    .send([masterPerson, personAlice1, personAlice2, patientAlice1, patientAlice2])
+                    .set(getHeaders());
+                // noinspection JSUnresolvedFunction
+                expect(resp).toHaveMergeResponse({ created: true });
+
+                resp = await request
+                    .get(`/4_0_0/Person/${PERSON_ALICE_1_ID}/$everything?_type=Patient`)
+                    .set({ ...headers, prefer: 'global_id=false' });
+
+                const patientIds = (resp.body.entry ?? [])
+                    .filter((e) => e.resource?.resourceType === 'Patient')
+                    .map((e) => e.resource.id);
+
+                // Alice's own patient must be present ...
+                expect(patientIds).toContain(PATIENT_ALICE_1_ID);
+                // ... but her sibling account's patient (reached only via the shared,
+                // same-tenant master Person) must NOT be.
+                expect(patientIds).not.toContain(PATIENT_ALICE_2_ID);
+            });
+        });
     });
 });

--- a/src/utils/personToPatientIdsExpander.js
+++ b/src/utils/personToPatientIdsExpander.js
@@ -16,6 +16,18 @@ const personProxyPrefix = 'person.';
 const patientReferencePlusPersonProxyPrefix = `${patientReferencePrefix}${personProxyPrefix}`;
 const maximumRecursionDepth = 4;
 
+/**
+ * @param {{meta?: {security?: {system: string, code: string}[]}}} person
+ * @return {string|undefined} the resource's owner security tag code, or undefined if it has none
+ */
+function getOwnerSecurityCode (person) {
+    const security = person?.meta?.security;
+    if (!security || security.length === 0) {
+        return undefined;
+    }
+    return security.find((tag) => tag.system === SecurityTagSystem.owner)?.code;
+}
+
 class PersonToPatientIdsExpander {
     /**
      * constructor
@@ -190,12 +202,15 @@ class PersonToPatientIdsExpander {
      * @property {boolean} returnOriginalPersonId If true then returns original personId passed. By default returns person _uuid
      * @property {boolean} addPersonOwnerToContext If true then add person owner to context
      * @property {FhirRequestInfo} requestInfo
+     * @property {Map<string, string>} [parentOwnerTagByPersonId] Maps a personId being fetched at this
+     * level to the owner security tag of the Person whose link led us here. Used to detect a
+     * Person.link hop that never leaves the requester's own tenant.
      *
      * @param {getPatientIdsFromPersonAsyncArgs}
      * @return {Promise<string[] | Map<string, Set<string>>>} Will return an array if toMap is false else return an map. By default toMap is false
      */
     async getPatientIdsFromPersonAsync ({
-        personIds, totalProcessedPersonIds, databaseQueryManager, level, toMap = false, returnOriginalPersonId = false, addPersonOwnerToContext = false, requestInfo
+        personIds, totalProcessedPersonIds, databaseQueryManager, level, toMap = false, returnOriginalPersonId = false, addPersonOwnerToContext = false, requestInfo, parentOwnerTagByPersonId
     }) {
         /**
          * Final result to return
@@ -204,11 +219,10 @@ class PersonToPatientIdsExpander {
          */
         const personToLinkedPatient = new Map();
 
-        const projectionsMap = { id: 1, link: 1, _id: 0, _uuid: 1, _sourceId: 1 }
-
-        if(addPersonOwnerToContext) {
-            projectionsMap.meta = 1
-        }
+        // meta.security is always needed (not just when addPersonOwnerToContext is set) so that
+        // getOwnerSecurityCode can compare each fetched Person's owner tag against the tag of
+        // whoever linked to it, to detect a same-tenant Person.link hop.
+        const projectionsMap = { id: 1, link: 1, _id: 0, _uuid: 1, _sourceId: 1, meta: 1 }
 
         let query = FilterById.getListFilter(personIds);
 
@@ -259,15 +273,48 @@ class PersonToPatientIdsExpander {
          */
         let patientIds = [];
         let personIdsToRecurse = [];
+        /**
+         * Owner security tag of the Person being expanded, keyed by the personId of each of
+         * ITS linked Persons - passed to the next recursion level so it can tell whether that
+         * hop stayed within the same tenant.
+         * @type {Map<string, string>}
+         */
+        const nextLevelParentOwnerTagByPersonId = new Map();
         while (await personResourceCursor.hasNext()) {
             const person = await personResourceCursor.nextObject();
             let personId = person._uuid;
-            patientIds.push(`${personProxyPrefix}${personId}`);
+
+            const currentOwnerTag = getOwnerSecurityCode(person);
+            const parentOwnerTag = parentOwnerTagByPersonId?.get(person._uuid);
+            const isSameTenantHopFromParent = parentOwnerTag !== undefined && parentOwnerTag === currentOwnerTag;
+
             // at first call only, returnOriginalPersonId can be true so that we return the id map for passed personIds not their uuids
             // also, this is only have significance when we want to return map
             if (returnOriginalPersonId && toMap) {
                 personId = personIds.find((id) => id === person._uuid || id === person._sourceId);
             }
+
+            if (addPersonOwnerToContext && person.meta && person.meta.security && person.meta.security.length > 0) {
+                person.meta.security.forEach((security) => {
+                    if (security.system === SecurityTagSystem.owner) {
+                        httpContext.set(
+                            `${HTTP_CONTEXT_KEYS.PERSON_OWNER_PREFIX}${personId}`,
+                            security.code
+                        );
+                    }
+                });
+            }
+
+            // A Person reached only via a Person.link hop that never leaves the tenant of
+            // whoever linked to it is a duplicate/sibling account, not the legitimate
+            // cross-org consolidation case (see RNGR-38) - treat it as a dead end: don't
+            // surface its own proxy patient or linked patients, and don't recurse into its
+            // own Person links.
+            if (isSameTenantHopFromParent) {
+                continue;
+            }
+
+            patientIds.push(`${personProxyPrefix}${personId}`);
             const uuidKey = '_uuid';
 
             if (person && person.link && person.link.length > 0 && !totalProcessedPersonIds.has(personId)) {
@@ -296,20 +343,12 @@ class PersonToPatientIdsExpander {
                     });
 
                 personIdsToRecurse = personIdsToRecurse.concat(personResourceWithPersonReferenceLink);
+                personResourceWithPersonReferenceLink.forEach((linkedPersonId) => {
+                    nextLevelParentOwnerTagByPersonId.set(linkedPersonId, currentOwnerTag);
+                });
 
                 // finally update the sets
                 personToLinkedPatient.set(personId, linkedPatients);
-            }
-
-            if (addPersonOwnerToContext && person.meta && person.meta.security && person.meta.security.length > 0) {
-                person.meta.security.forEach((security) => {
-                    if (security.system === SecurityTagSystem.owner) {
-                        httpContext.set(
-                            `${HTTP_CONTEXT_KEYS.PERSON_OWNER_PREFIX}${personId}`,
-                            security.code
-                        );
-                    }
-                });
             }
         }
 
@@ -334,7 +373,8 @@ class PersonToPatientIdsExpander {
                     level: level + 1,
                     toMap,
                     returnOriginalPersonId: false, // always return _uuid map for it
-                    requestInfo
+                    requestInfo,
+                    parentOwnerTagByPersonId: nextLevelParentOwnerTagByPersonId
                 });
 
                 // add all patients to current person
@@ -355,7 +395,8 @@ class PersonToPatientIdsExpander {
                 databaseQueryManager,
                 level: level + 1,
                 toMap,
-                requestInfo
+                requestInfo,
+                parentOwnerTagByPersonId: nextLevelParentOwnerTagByPersonId
             });
             return patientIds.concat(patientIdsFromPersons);
         }


### PR DESCRIPTION
## Summary

`Person/$everything` resolves a consolidated view by recursively following `Person.link` entries (`personToPatientIdsExpander.js`). DCON-4669 added a tenant/owner check to this traversal, but it only guards against *different*-tenant leakage. When multiple distinct Person records under the *same* tenant are linked to one shared master (e.g. duplicate accounts, or a person-matching false positive), the traversal still merges their linked Patients into the response.

This is the customer-facing issue Stew Dunn reported in the INC-332 thread after DCON-4669 shipped: `Person/$everything` returned connections belonging to sibling Person accounts under the same client slug.

Jira: [DCON-4691](https://icanbwell.atlassian.net/browse/DCON-4691) (companion: [DCON-4690](https://icanbwell.atlassian.net/browse/DCON-4690))

## Changes

- Added a regression test reproducing the reported scenario: a shared "master" Person with two same-tenant sibling Persons, each linked to their own Patient. Confirmed it fails against pre-fix code before implementing anything.
- `personToPatientIdsExpander.js`: track the owner security tag of whoever linked to a Person during the recursive traversal. If a Person is reached via a link that never leaves that tenant, treat it as a dead end - don't include its patients, don't recurse further into its own Person links.

## ⚠️ Open question blocking this PR

This fix conflicts with an existing test: `src/tests/utils/personToPatientIdsExpander/personToPatientIdsExpander.test.js` (EFS-350) expects a `bwell`-owned Person to recursively merge patients from two other `bwell`-owned linked Persons - same owner tag on all three, structurally identical to the bug this PR fixes.

Asked Mintu (original author of EFS-350) whether same-owner-tag Person-to-Person hub consolidation is real, intentional behavior, or whether that fixture just reused a placeholder security tag without modeling an actual tenant boundary. Depending on the answer:
- **If real:** owner-tag equality isn't a safe signal on its own - need a different discriminator (e.g. explicit identifier, matching-confidence field) before this can merge.
- **If stale:** update that fixture to use distinct owner tags per Person, and this PR should be ready to finish.

Opening as draft so the diff is visible while that question is outstanding.

## Test plan

- [x] New regression test fails against pre-fix code (RED)
- [x] New regression test passes with the fix (GREEN)
- [x] `data_sharing_scenario.test.js` full suite passes
- [ ] `personToPatientIdsExpander.test.js` (EFS-350) - currently failing, blocked on open question above
- [ ] Full regression suite once resolved

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

[DCON-4691]: https://icanbwell.atlassian.net/browse/DCON-4691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DCON-4690]: https://icanbwell.atlassian.net/browse/DCON-4690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ