### PR TITLE
BAI-221: batch and write bulk import NDJSON resources to MongoDB

### DIFF
--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -1237,7 +1237,9 @@ const createContainer = function () {
         databaseQueryFactory: c.databaseQueryFactory,
         databaseUpdateFactory: c.databaseUpdateFactory,
         fastDatabaseBulkInserter: c.fastDatabaseBulkInserter,
-        s3NdjsonReader: c.s3NdjsonReader
+        s3NdjsonReader: c.s3NdjsonReader,
+        postRequestProcessor: c.postRequestProcessor,
+        requestSpecificCache: c.requestSpecificCache
     }));
 
     container.register('bulkImportOrchestratorRunner', (c) => new BulkImportOrchestratorRunner({

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -1236,6 +1236,7 @@ const createContainer = function () {
         configManager: c.configManager,
         databaseQueryFactory: c.databaseQueryFactory,
         databaseUpdateFactory: c.databaseUpdateFactory,
+        fastDatabaseBulkInserter: c.fastDatabaseBulkInserter,
         s3NdjsonReader: c.s3NdjsonReader
     }));
 

--- a/src/operations/import/bulkImportConsumerRunner.js
+++ b/src/operations/import/bulkImportConsumerRunner.js
@@ -11,6 +11,8 @@ const { buildContextDataForHybridStorage } = require('../../utils/contextDataBui
 const { generateUUID } = require('../../utils/uid.util');
 const { SecurityTagSystem } = require('../../utils/securityTagSystem');
 const { BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY } = require('../../constants');
+const { PostRequestProcessor } = require('../../utils/postRequestProcessor');
+const { RequestSpecificCache } = require('../../utils/requestSpecificCache');
 const { logInfo, logError } = require('../common/logging');
 
 class BulkImportConsumerRunner {
@@ -21,10 +23,20 @@ class BulkImportConsumerRunner {
      * @property {DatabaseUpdateFactory} databaseUpdateFactory
      * @property {FastDatabaseBulkInserter} fastDatabaseBulkInserter
      * @property {S3NdjsonReader} s3NdjsonReader
+     * @property {PostRequestProcessor} postRequestProcessor
+     * @property {RequestSpecificCache} requestSpecificCache
      *
      * @param {ConstructorParams}
      */
-    constructor({ configManager, databaseQueryFactory, databaseUpdateFactory, fastDatabaseBulkInserter, s3NdjsonReader }) {
+    constructor({
+        configManager,
+        databaseQueryFactory,
+        databaseUpdateFactory,
+        fastDatabaseBulkInserter,
+        s3NdjsonReader,
+        postRequestProcessor,
+        requestSpecificCache
+    }) {
         this.configManager = configManager;
         assertTypeEquals(configManager, ConfigManager);
 
@@ -39,6 +51,12 @@ class BulkImportConsumerRunner {
 
         this.s3NdjsonReader = s3NdjsonReader;
         assertTypeEquals(s3NdjsonReader, S3NdjsonReader);
+
+        this.postRequestProcessor = postRequestProcessor;
+        assertTypeEquals(postRequestProcessor, PostRequestProcessor);
+
+        this.requestSpecificCache = requestSpecificCache;
+        assertTypeEquals(requestSpecificCache, RequestSpecificCache);
     }
 
     /**
@@ -220,70 +238,80 @@ class BulkImportConsumerRunner {
         };
 
         try {
-            for await (const { lineNumber, resource } of this.s3NdjsonReader.readNdjsonAsync({
-                filepath,
-                byteRangeStart,
-                byteRangeEnd,
-                fileSize
-            })) {
-                linesRead++;
-                sinceLastFlush++;
+            try {
+                for await (const { lineNumber, resource } of this.s3NdjsonReader.readNdjsonAsync({
+                    filepath,
+                    byteRangeStart,
+                    byteRangeEnd,
+                    fileSize
+                })) {
+                    linesRead++;
+                    sinceLastFlush++;
 
-                try {
-                    const fhirResource = FhirResourceCreator.create(
-                        this.applyDefaultSecurityTagsIfMissing(resource)
-                    );
-                    const contextData = buildContextDataForHybridStorage(
-                        fhirResource.resourceType, fhirResource, requestInfo
-                    );
-                    await this.fastDatabaseBulkInserter.insertOneAsync({
-                        base_version,
-                        requestInfo,
-                        resourceType: fhirResource.resourceType,
-                        doc: fhirResource,
-                        contextData
-                    });
-                } catch (resourceError) {
-                    failed++;
-                    logError('Failed to buffer bulk import resource for write', {
-                        taskId,
-                        filepath,
-                        lineNumber,
-                        error: resourceError.message
-                    });
+                    try {
+                        const fhirResource = FhirResourceCreator.create(
+                            this.applyDefaultSecurityTagsIfMissing(resource)
+                        );
+                        const contextData = buildContextDataForHybridStorage(
+                            fhirResource.resourceType, fhirResource, requestInfo
+                        );
+                        await this.fastDatabaseBulkInserter.insertOneAsync({
+                            base_version,
+                            requestInfo,
+                            resourceType: fhirResource.resourceType,
+                            doc: fhirResource,
+                            contextData
+                        });
+                    } catch (resourceError) {
+                        failed++;
+                        logError('Failed to buffer bulk import resource for write', {
+                            taskId,
+                            filepath,
+                            lineNumber,
+                            error: resourceError.message
+                        });
+                    }
+
+                    if (sinceLastFlush >= batchSize) {
+                        await flushBatchAsync();
+                        // Rate control: yield between batches so a single range doesn't
+                        // monopolize the event loop or MongoDB's write capacity.
+                        await new Promise((resolve) => setTimeout(resolve, batchDelayMs));
+                    }
                 }
-
-                if (sinceLastFlush >= batchSize) {
+                if (sinceLastFlush > 0) {
                     await flushBatchAsync();
-                    // Rate control: yield between batches so a single range doesn't
-                    // monopolize the event loop or MongoDB's write capacity.
-                    await new Promise((resolve) => setTimeout(resolve, batchDelayMs));
                 }
+            } catch (e) {
+                logError('Error reading S3 NDJSON range', {
+                    taskId,
+                    filepath,
+                    rangeIndex,
+                    error: e.message
+                });
+                await this.updateTaskStatusAsync(task, 'failed', e.message);
+                return;
             }
-            if (sinceLastFlush > 0) {
-                await flushBatchAsync();
-            }
-        } catch (e) {
-            logError('Error reading S3 NDJSON range', {
+
+            logInfo('Bulk import range processed', {
                 taskId,
                 filepath,
                 rangeIndex,
-                error: e.message
+                totalRanges,
+                linesRead,
+                created,
+                updated,
+                failed
             });
-            await this.updateTaskStatusAsync(task, 'failed', e.message);
-            return;
+        } finally {
+            // FastDatabaseBulkInserter defers history writes onto postRequestProcessor's
+            // queue rather than writing them inline — without this, history writes for
+            // every bulk-imported resource would be silently dropped. RequestSpecificCache
+            // entries are also only ever freed by an explicit clearAsync, so skipping this
+            // would leak one entry per Kafka message in this long-running consumer.
+            await this.postRequestProcessor.executeAsync({ requestId: requestInfo.requestId });
+            await this.requestSpecificCache.clearAsync({ requestId: requestInfo.requestId });
         }
-
-        logInfo('Bulk import range processed', {
-            taskId,
-            filepath,
-            rangeIndex,
-            totalRanges,
-            linesRead,
-            created,
-            updated,
-            failed
-        });
     }
 }
 

--- a/src/operations/import/bulkImportConsumerRunner.js
+++ b/src/operations/import/bulkImportConsumerRunner.js
@@ -3,7 +3,14 @@ const { assertTypeEquals } = require('../../utils/assertType');
 const { ConfigManager } = require('../../utils/configManager');
 const { DatabaseQueryFactory } = require('../../dataLayer/databaseQueryFactory');
 const { DatabaseUpdateFactory } = require('../../dataLayer/databaseUpdateFactory');
+const { FastDatabaseBulkInserter } = require('../../dataLayer/fastDatabaseBulkInserter');
 const { S3NdjsonReader } = require('./s3NdjsonReader');
+const { FhirResourceCreator } = require('../../fhir/fhirResourceCreator');
+const { FhirRequestInfo } = require('../../utils/fhirRequestInfo');
+const { buildContextDataForHybridStorage } = require('../../utils/contextDataBuilder');
+const { generateUUID } = require('../../utils/uid.util');
+const { SecurityTagSystem } = require('../../utils/securityTagSystem');
+const { BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY } = require('../../constants');
 const { logInfo, logError } = require('../common/logging');
 
 class BulkImportConsumerRunner {
@@ -12,11 +19,12 @@ class BulkImportConsumerRunner {
      * @property {ConfigManager} configManager
      * @property {DatabaseQueryFactory} databaseQueryFactory
      * @property {DatabaseUpdateFactory} databaseUpdateFactory
+     * @property {FastDatabaseBulkInserter} fastDatabaseBulkInserter
      * @property {S3NdjsonReader} s3NdjsonReader
      *
      * @param {ConstructorParams}
      */
-    constructor({ configManager, databaseQueryFactory, databaseUpdateFactory, s3NdjsonReader }) {
+    constructor({ configManager, databaseQueryFactory, databaseUpdateFactory, fastDatabaseBulkInserter, s3NdjsonReader }) {
         this.configManager = configManager;
         assertTypeEquals(configManager, ConfigManager);
 
@@ -26,8 +34,68 @@ class BulkImportConsumerRunner {
         this.databaseUpdateFactory = databaseUpdateFactory;
         assertTypeEquals(databaseUpdateFactory, DatabaseUpdateFactory);
 
+        this.fastDatabaseBulkInserter = fastDatabaseBulkInserter;
+        assertTypeEquals(fastDatabaseBulkInserter, FastDatabaseBulkInserter);
+
         this.s3NdjsonReader = s3NdjsonReader;
         assertTypeEquals(s3NdjsonReader, S3NdjsonReader);
+    }
+
+    /**
+     * Builds a request-scoped FhirRequestInfo for a single byte-range's writes.
+     * A fresh requestId is required per range so concurrent ranges don't share
+     * the singleton FastDatabaseBulkInserter's buffered-operations map.
+     * @param {{ user: string|null, scope: string|null }} params
+     * @returns {FhirRequestInfo}
+     */
+    buildRangeRequestInfo({ user, scope }) {
+        return new FhirRequestInfo({
+            user: user || null,
+            scope: scope || null,
+            remoteIpAddress: null,
+            requestId: generateUUID(),
+            userRequestId: null,
+            protocol: 'kafka',
+            originalUrl: '$import',
+            path: '$import',
+            host: null,
+            body: null,
+            accept: 'application/fhir+json',
+            isUser: false,
+            userType: null,
+            personIdFromJwtToken: null,
+            masterPersonIdFromJwtToken: null,
+            managingOrganizationId: null,
+            headers: {},
+            method: 'POST',
+            contentTypeFromHeader: null,
+            alternateUserId: null,
+            actor: null,
+            purposeOfUse: null
+        });
+    }
+
+    /**
+     * NDJSON lines typically carry no ownership metadata. Stamp the same
+     * default owner/sourceAssigningAuthority tags $import's Task creation uses,
+     * unless the source file already provided its own security tags.
+     * @param {Object} rawResource
+     * @returns {Object}
+     */
+    applyDefaultSecurityTagsIfMissing(rawResource) {
+        if (!rawResource.meta) {
+            rawResource.meta = {};
+        }
+        if (!rawResource.meta.security || rawResource.meta.security.length === 0) {
+            rawResource.meta.security = [
+                { system: SecurityTagSystem.owner, code: BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY },
+                { system: SecurityTagSystem.sourceAssigningAuthority, code: BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY }
+            ];
+        }
+        if (!rawResource.meta.source) {
+            rawResource.meta.source = BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY;
+        }
+        return rawResource;
     }
 
     /**
@@ -105,7 +173,7 @@ class BulkImportConsumerRunner {
             return;
         }
 
-        const { taskId, filepath, byteRangeStart, byteRangeEnd, rangeIndex, totalRanges, fileSize } = eventData;
+        const { taskId, filepath, byteRangeStart, byteRangeEnd, rangeIndex, totalRanges, fileSize, user, scope } = eventData;
 
         logInfo('Processing bulk import range', {
             taskId,
@@ -126,7 +194,31 @@ class BulkImportConsumerRunner {
             await this.updateTaskStatusAsync(task, 'in-progress');
         }
 
+        const base_version = '4_0_0';
+        const requestInfo = this.buildRangeRequestInfo({ user, scope });
+        const batchSize = this.configManager.bulkImportBatchSize;
+        const batchDelayMs = this.configManager.bulkImportBatchDelayMs;
+
         let linesRead = 0;
+        let sinceLastFlush = 0;
+        let created = 0;
+        let updated = 0;
+        let failed = 0;
+
+        const flushBatchAsync = async () => {
+            const mergeResults = await this.fastDatabaseBulkInserter.executeAsync({ requestInfo, base_version });
+            for (const mergeResult of mergeResults) {
+                if (mergeResult.created) {
+                    created++;
+                } else if (mergeResult.updated) {
+                    updated++;
+                } else if (mergeResult.operationOutcome) {
+                    failed++;
+                }
+            }
+            sinceLastFlush = 0;
+        };
+
         try {
             for await (const { lineNumber, resource } of this.s3NdjsonReader.readNdjsonAsync({
                 filepath,
@@ -135,7 +227,41 @@ class BulkImportConsumerRunner {
                 fileSize
             })) {
                 linesRead++;
-                // Phase 4 (BAI-221) will add batched MongoDB writes here
+                sinceLastFlush++;
+
+                try {
+                    const fhirResource = FhirResourceCreator.create(
+                        this.applyDefaultSecurityTagsIfMissing(resource)
+                    );
+                    const contextData = buildContextDataForHybridStorage(
+                        fhirResource.resourceType, fhirResource, requestInfo
+                    );
+                    await this.fastDatabaseBulkInserter.insertOneAsync({
+                        base_version,
+                        requestInfo,
+                        resourceType: fhirResource.resourceType,
+                        doc: fhirResource,
+                        contextData
+                    });
+                } catch (resourceError) {
+                    failed++;
+                    logError('Failed to buffer bulk import resource for write', {
+                        taskId,
+                        filepath,
+                        lineNumber,
+                        error: resourceError.message
+                    });
+                }
+
+                if (sinceLastFlush >= batchSize) {
+                    await flushBatchAsync();
+                    // Rate control: yield between batches so a single range doesn't
+                    // monopolize the event loop or MongoDB's write capacity.
+                    await new Promise((resolve) => setTimeout(resolve, batchDelayMs));
+                }
+            }
+            if (sinceLastFlush > 0) {
+                await flushBatchAsync();
             }
         } catch (e) {
             logError('Error reading S3 NDJSON range', {
@@ -153,7 +279,10 @@ class BulkImportConsumerRunner {
             filepath,
             rangeIndex,
             totalRanges,
-            linesRead
+            linesRead,
+            created,
+            updated,
+            failed
         });
     }
 }

--- a/src/operations/import/bulkImportConsumerRunner.js
+++ b/src/operations/import/bulkImportConsumerRunner.js
@@ -5,7 +5,7 @@ const { DatabaseQueryFactory } = require('../../dataLayer/databaseQueryFactory')
 const { DatabaseUpdateFactory } = require('../../dataLayer/databaseUpdateFactory');
 const { FastDatabaseBulkInserter } = require('../../dataLayer/fastDatabaseBulkInserter');
 const { S3NdjsonReader } = require('./s3NdjsonReader');
-const { FhirResourceCreator } = require('../../fhir/fhirResourceCreator');
+const { FhirResourceWriteSerializer } = require('../../fhir/fhirResourceWriteSerializer');
 const { FhirRequestInfo } = require('../../utils/fhirRequestInfo');
 const { buildContextDataForHybridStorage } = require('../../utils/contextDataBuilder');
 const { generateUUID } = require('../../utils/uid.util');
@@ -249,9 +249,9 @@ class BulkImportConsumerRunner {
                     sinceLastFlush++;
 
                     try {
-                        const fhirResource = FhirResourceCreator.create(
-                            this.applyDefaultSecurityTagsIfMissing(resource)
-                        );
+                        const fhirResource = FhirResourceWriteSerializer.serialize({
+                            obj: this.applyDefaultSecurityTagsIfMissing(resource)
+                        });
                         const contextData = buildContextDataForHybridStorage(
                             fhirResource.resourceType, fhirResource, requestInfo
                         );

--- a/src/tests/import/bulkImportConsumerRunner.test.js
+++ b/src/tests/import/bulkImportConsumerRunner.test.js
@@ -1,5 +1,5 @@
 const { commonBeforeEach, commonAfterEach, getHeaders, createTestRequest } = require('../common');
-const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+const { describe, beforeEach, afterEach, test, expect, jest } = require('@jest/globals');
 
 const makeCloudEvent = (overrides = {}) => {
     const data = {
@@ -278,5 +278,41 @@ describe('BulkImportConsumerRunner', () => {
             .set(getHeaders())
             .expect(200);
         expect(taskResp.body.status).toBe('in-progress');
+    });
+
+    test('handleMessageAsync flushes postRequestProcessor and clears requestSpecificCache per range', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-cleanup' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../createTestContainer');
+        const container = createTestContainer();
+        const runner = container.bulkImportConsumerRunner;
+
+        container.s3NdjsonReader.setLinesToYield([
+            { resourceType: 'Patient', id: 'bulk-import-cleanup-1', name: [{ family: 'Cleanup' }] }
+        ]);
+
+        const executeAsyncSpy = jest.spyOn(container.postRequestProcessor, 'executeAsync');
+        const clearAsyncSpy = jest.spyOn(container.requestSpecificCache, 'clearAsync');
+        const requestIdsBefore = container.requestSpecificCache.getRequestIds().length;
+
+        await runner.handleMessageAsync({
+            key: 'import-consumer-cleanup-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-cleanup' }),
+            headers: []
+        });
+
+        expect(executeAsyncSpy).toHaveBeenCalled();
+        expect(clearAsyncSpy).toHaveBeenCalled();
+        // no leaked requestSpecificCache entry for the per-range requestId
+        expect(container.requestSpecificCache.getRequestIds().length).toBe(requestIdsBefore);
+
+        executeAsyncSpy.mockRestore();
+        clearAsyncSpy.mockRestore();
     });
 });

--- a/src/tests/import/bulkImportConsumerRunner.test.js
+++ b/src/tests/import/bulkImportConsumerRunner.test.js
@@ -162,4 +162,121 @@ describe('BulkImportConsumerRunner', () => {
             headers: []
         });
     });
+
+    test('handleMessageAsync writes valid NDJSON resources to MongoDB', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-write' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../createTestContainer');
+        const container = createTestContainer();
+        const runner = container.bulkImportConsumerRunner;
+
+        container.s3NdjsonReader.setLinesToYield([
+            { resourceType: 'Patient', id: 'bulk-import-patient-1', name: [{ family: 'Smith', given: ['John'] }] },
+            { resourceType: 'Patient', id: 'bulk-import-patient-2', name: [{ family: 'Jones', given: ['Sarah'] }] }
+        ]);
+
+        await runner.handleMessageAsync({
+            key: 'import-consumer-write-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-write' }),
+            headers: []
+        });
+
+        await request
+            .get('/4_0_0/Patient/bulk-import-patient-1')
+            .set(getHeaders())
+            .expect(200)
+            .then((res) => {
+                expect(res.body.name[0].family).toBe('Smith');
+            });
+
+        await request
+            .get('/4_0_0/Patient/bulk-import-patient-2')
+            .set(getHeaders())
+            .expect(200)
+            .then((res) => {
+                expect(res.body.name[0].family).toBe('Jones');
+            });
+    });
+
+    test('handleMessageAsync flushes across multiple batches without dropping resources', async () => {
+        process.env.BULK_IMPORT_BATCH_SIZE = '2';
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-batches' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../createTestContainer');
+        const container = createTestContainer();
+        const runner = container.bulkImportConsumerRunner;
+
+        container.s3NdjsonReader.setLinesToYield([
+            { resourceType: 'Patient', id: 'bulk-import-batch-1', name: [{ family: 'One' }] },
+            { resourceType: 'Patient', id: 'bulk-import-batch-2', name: [{ family: 'Two' }] },
+            { resourceType: 'Patient', id: 'bulk-import-batch-3', name: [{ family: 'Three' }] },
+            { resourceType: 'Patient', id: 'bulk-import-batch-4', name: [{ family: 'Four' }] },
+            { resourceType: 'Patient', id: 'bulk-import-batch-5', name: [{ family: 'Five' }] }
+        ]);
+
+        try {
+            await runner.handleMessageAsync({
+                key: 'import-consumer-batches-0',
+                value: makeCloudEvent({ taskId: 'import-consumer-batches' }),
+                headers: []
+            });
+        } finally {
+            delete process.env.BULK_IMPORT_BATCH_SIZE;
+        }
+
+        for (let i = 1; i <= 5; i++) {
+            await request
+                .get(`/4_0_0/Patient/bulk-import-batch-${i}`)
+                .set(getHeaders())
+                .expect(200);
+        }
+    });
+
+    test('handleMessageAsync counts per-resource failures without aborting the range', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-partial-fail' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../createTestContainer');
+        const container = createTestContainer();
+        const runner = container.bulkImportConsumerRunner;
+
+        container.s3NdjsonReader.setLinesToYield([
+            { id: 'missing-resource-type' },
+            { resourceType: 'Patient', id: 'bulk-import-survivor', name: [{ family: 'Survivor' }] }
+        ]);
+
+        await runner.handleMessageAsync({
+            key: 'import-consumer-partial-fail-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-partial-fail' }),
+            headers: []
+        });
+
+        await request
+            .get('/4_0_0/Patient/bulk-import-survivor')
+            .set(getHeaders())
+            .expect(200);
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-consumer-partial-fail')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('in-progress');
+    });
 });

--- a/src/tests/mocks/mockS3NdjsonReader.js
+++ b/src/tests/mocks/mockS3NdjsonReader.js
@@ -4,11 +4,25 @@ class MockS3NdjsonReader extends S3NdjsonReader {
     constructor({ configManager }) {
         super({ configManager });
         this.readCalls = [];
+        /**
+         * @type {Array<Object>}
+         */
+        this.linesToYield = [];
+    }
+
+    /**
+     * Configures the resources this mock will yield on the next readNdjsonAsync() call
+     * @param {Array<Object>} resources
+     */
+    setLinesToYield(resources) {
+        this.linesToYield = resources;
     }
 
     async *readNdjsonAsync({ filepath, byteRangeStart, byteRangeEnd, fileSize }) {
         this.readCalls.push({ filepath, byteRangeStart, byteRangeEnd, fileSize });
-        yield* [];
+        for (let i = 0; i < this.linesToYield.length; i++) {
+            yield { lineNumber: i + 1, resource: this.linesToYield[i] };
+        }
     }
 
     getReadCalls() {
@@ -17,6 +31,7 @@ class MockS3NdjsonReader extends S3NdjsonReader {
 
     clear() {
         this.readCalls = [];
+        this.linesToYield = [];
     }
 }
 

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -1358,6 +1358,24 @@ class ConfigManager {
     }
 
     /**
+     * Number of resources to buffer before flushing a Mongo bulk write during bulk import
+     * @return {number}
+     */
+    get bulkImportBatchSize() {
+        const parsed = parseInt(env.BULK_IMPORT_BATCH_SIZE, 10);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : 100;
+    }
+
+    /**
+     * Delay in milliseconds between bulk import batch flushes, to pace MongoDB write load
+     * @return {number}
+     */
+    get bulkImportBatchDelayMs() {
+        const parsed = parseInt(env.BULK_IMPORT_BATCH_DELAY_MS, 10);
+        return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+    }
+
+    /**
      * Kafka topic for bulk import task-created notifications
      * @return {string}
      */


### PR DESCRIPTION
## Summary
- Replaces the line-counting stub in `BulkImportConsumerRunner`'s read loop with real MongoDB writes, reusing the same `FastDatabaseBulkInserter`/`FhirResourceCreator` pipeline `$merge` uses.
- Batches writes (`BULK_IMPORT_BATCH_SIZE`, default 100) and flushes with a configurable delay between batches (`BULK_IMPORT_BATCH_DELAY_MS`, default 0) for write pacing/rate control.
- Stamps default `owner`/`sourceAssigningAuthority` security tags (matching `$import`'s existing Task-creation pattern) on resources that don't already carry their own — raw NDJSON lines typically won't have them.
- Per-resource failures (bad/missing `resourceType`, validation errors) are caught, logged, and counted without aborting the rest of the byte-range.

Jira: https://icanbwell.atlassian.net/browse/BAI-221

**Explicitly out of scope for this PR** (separate tickets): writing merge-result/error NDJSON to S3 (BAI-223), `ifNoneExist` dedup (BAI-225), Task completion once all ranges finish, per-record AuditEvents (BAI-224).

**Implementation decisions:**
- Resources with no ownership tags of their own default to `bwell` (matching Task-creation's existing pattern) rather than being rejected — confirm this is the right default for imported data specifically.
- Batch size (100) / pacing (0ms) are placeholder defaults — "sustainable MongoDB write TPS" (BAI-207/M0) was never benchmarked against this specific write path.
- Per-resource access tags are intentionally *not* derived from the Kafka event's `scope` field (risk of `ForbiddenError` on scope-format mismatch) — flagging in case per-resource access control is actually required here.

## Test plan
- [x] 3 new tests added: resources are actually written and readable, multi-batch flush doesn't drop resources, a malformed resource doesn't block valid ones in the same range
- [x] Full `src/tests/import/` suite passes (41/41), no regressions
- [x] Lint clean on all changed files