### PR TITLE
DCON-4753: Add adversarial PR review checklist for access-control/tenant isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 R4-compliant FHIR server built with Express.js, MongoDB, and an IoC container pattern. Supports REST and GraphQL APIs, Kafka event streaming, Redis caching, and OAuth 2.0 / SMART on FHIR authentication.
 
+## Security-Sensitive Changes
+
+Before reviewing or approving any PR that touches resource search/read, Person/Patient link
+traversal (`$everything`, `$graph`, proxy-patient), resource writes (create/update/merge/patch/
+remove), OAuth scope/token parsing, request-scoped caching, or any cross-resource join on a
+shared identifier — read `review.md` at the repo root and adversarially review the diff against
+it.
+
 ## Essential Commands
 
 ```bash

--- a/review.md
+++ b/review.md
@@ -1,0 +1,154 @@
+# Adversarial PR Review — Access Control & Tenant Isolation
+
+## Purpose
+
+This file is a standing checklist for adversarially reviewing every PR to this repo for
+cross-tenant / cross-client / cross-user data-access regressions — i.e. could this change let a
+service account or user belonging to one client read, infer the existence of, or write data
+belonging to another client, another user, or a Person/Patient they are not authorized for.
+
+It is scoped narrowly to the access-control / tenant-isolation / security-model surface. It is
+not a substitute for general code review (style, tests, performance) — use the repo's other
+review tooling for that.
+
+## How to use this file
+
+For every PR:
+
+1. **Identify touch points** — does the diff touch any of: resource search/read, Person/Patient
+   link traversal or expansion, resource write (create/update/merge/patch/remove), OAuth
+   scope/token parsing, caching of anything derived from a request, or a join/lookup keyed by an
+   identifier shared across tenants (e.g. a source-system patient id, an internal UUID)? If none,
+   this checklist doesn't apply — say so and stop.
+2. **Walk the relevant checklist section(s) below** against the actual diff, not just the PR
+   description. Read the surrounding code, not only the changed lines — regressions here are
+   usually about what a change *removes or fails to add*, not what's visibly wrong in isolation.
+3. **For every candidate issue, construct a concrete attack scenario** before flagging it: name
+   the caller (scope, tenant, user vs. service account), the target resource/tenant, and the
+   exact request that would trigger it. If you can't state a concrete scenario, say so explicitly
+   and mark it lower-confidence rather than omitting it.
+4. **Report both ways** — list what you checked and found clean, not only problems found. A
+   review that only lists findings is indistinguishable from one that didn't look.
+
+Report findings as:
+
+| Severity | Area | Attack scenario | Recommendation |
+|---|---|---|---|
+
+plus a "Checked, no issues found" list of the touch points reviewed.
+
+## 1. The data model (primer)
+
+- **Main Person** — a real human; the cross-tenant hub concept. Every `Person` resource has the
+  same shape today; there's no dedicated schema-level marker for this role.
+- **Client Person** — one `Person` resource per tenant/client a human has an account with (e.g.
+  one for their Samsung account, one for their Walgreens account). Carries an owner tag for that
+  tenant.
+- **Patient** — one `Patient` resource per data source (health system, payor, pharmacy, lab).
+  Patients belong to a *source*, never directly to a client.
+- **Clinical/other resources** — reference a Patient (or, via the `Patient/person.<id>`
+  proxy-patient convention, a Person).
+- **Link** — `Person.link` connects Main Person → Client Person → Patient, via an `assurance`
+  (match confidence) field only — it does not carry a relationship-type/category.
+- **Owner tag** (`meta.security`, system `.../owner`) — exactly one per resource; declares the
+  authoritative tenant.
+- **Access tag(s)** (`meta.security`, system `.../access`) — one or more; declare which
+  tenant(s) may read the resource. This is what every tenant-isolation check should ultimately
+  be filtering on.
+
+Any query, traversal, or write that doesn't ultimately reduce to "is every access tag on this
+resource one the caller is authorized for" is worth a closer look.
+
+## 2. Caller / scope types (primer)
+
+- **Tenant/service-account scope** — authorizes access to resources tagged for that tenant.
+- **Resource-type read/write scope** — combined with the tenant scope to determine what's
+  allowed.
+- **Patient-scoped tokens** — anchored to a specific Person/Patient id, and distinguishable in
+  code from tenant/service-account tokens. **A check that branches only on "is this a
+  patient-scoped user token" is worth extra scrutiny** — confirm the non-patient-scoped
+  (service-account) path still gets an equivalent tenant/access check, rather than skipping it.
+- **Admin scope** — typically bypasses tenant filtering by design; changes here need explicit
+  reasoning for why the bypass is safe.
+- Patient-scope checks and tenant/access-scope checks tend to live in different code paths — a
+  PR that adds a new authorization branch should be checked for whether it's mutually exclusive
+  with the *other* scope type's check (a common bug shape in multi-tenant systems generally: one
+  scope type's caller bypassing the other scope type's filtering entirely because the two checks
+  live in an if/else rather than both being required to pass).
+
+## 3. Checklist by touch point
+
+### A. Search / read / query construction
+
+- Does every new or modified query path build its filter through the shared tenant-scoping
+  mechanism, rather than querying by a raw internal id/uuid/source-id first and checking access
+  afterward? Fetch-then-check-afterward can still leak existence/timing/error-detail through
+  response-code differences even when the response body is correctly withheld.
+- Is an internal id/uuid ever treated as if it were secret or unguessable? Confirm whether it
+  could be derived or brute-forced from other information available to a caller. Any "check by
+  exact id" gate needs a real access-tag check behind it, not just id-matching.
+- Do all resolvers/query builders (including any GraphQL layer) reuse the same tenant-scoped
+  search path, or does any of them construct an independent query outside that shared mechanism?
+
+### B. Person/Patient link traversal & expansion
+
+- Does every resource surfaced through link traversal get the *same* per-resource access-tag
+  check it would get if fetched directly by id? Reachability via a link is never itself
+  authorization.
+- Does a traversal/expansion path apply its access check consistently across every URL form or
+  entry point that can reach the same conceptual operation? A fix applied to one entry point does
+  not necessarily cover an equivalent one.
+- When a traversal step decides whether to follow a link further (e.g., one record pointing to
+  another), verify that decision is based on an explicit, intentional relationship the data model
+  actually defines — not an incidental attribute the two records happen to share. Two records
+  sharing an attribute is not the same as one being an authorized extension of the other, and
+  code should not treat it as license to combine their data without confirming that's deliberate.
+
+### C. Write path (create / update / merge / patch / remove)
+
+- Authorization checks over a multi-valued attribute (like a list of access tags) can require
+  either "at least one value matches" or "every value matches," and the correct choice usually
+  differs between read and write. Verify which quantifier a given check actually uses, and
+  whether it's the right one for what it's gating — getting this backwards in either direction is
+  a classic access-control pitfall (too permissive on write, or too restrictive on read).
+- If a merge/update path maintains a list of fields a caller cannot override (to protect resource
+  identity, versioning, or ownership), verify that list is actually complete for every field that
+  could change who is allowed to access the resource. Protected-field lists are easy to leave
+  incomplete as a schema gains new security-relevant fields over time — or re-run the access
+  check against the fully-merged document before persisting, instead of relying on the list alone.
+- Does any internal-field/patch blocklist match on the actual field name (an explicit
+  allowlist/denylist), rather than a naming convention (like a prefix character)? A
+  convention-based blocklist can be bypassed by any field that doesn't happen to follow the
+  convention.
+
+### D. Consent / allow-list caching, and anything request-scoped
+
+- A cache or memoized value derived from a request should be re-derived (or clearly invalidated)
+  whenever the scope of what's being asked for changes during that request's lifecycle — not just
+  computed once at the start and trusted for the rest of it. If a single logical request can be
+  processed in multiple internal steps that each have a different effective scope, confirm the
+  cache can't quietly carry an earlier step's answer into a later, differently-scoped step. Treat
+  any new or modified per-request cache as high-scrutiny by default.
+- When an authorization-derived filter ends up matching nothing, verify the code treats that as
+  "return nothing," not "have no filter, so return everything." A function that represents "no
+  restriction" and "no matches" the same way is an easy way to fail open by accident — confirm
+  the emptied-filter case explicitly rather than assuming it's handled.
+- Is any of this state held on a process-wide singleton service? If so, confirm request-scoped
+  data is being passed in per-call, not accidentally cached on shared instance state across
+  requests/tenants.
+
+### E. Cross-tenant joins on a shared identifier
+
+- Any join/match on an identifier that exists independent of tenant (e.g. a source-system patient
+  id, an MRN, a shared upstream identity key) — does the query also include a tenant/client
+  discriminator in the join condition itself, not just in a later filter step? Two tenants
+  sharing the same underlying real-world patient at a health system is a normal, expected case —
+  the join must not let them see each other's records, connection status, or other metadata as a
+  side effect.
+
+## 4. Maintenance
+
+- If review under this checklist surfaces a new risk pattern worth remembering, add it to the
+  relevant checklist section above so future reviewers benefit.
+- Keep this checklist's language general and pattern-based rather than tied to one specific
+  instance, so it stays useful as the codebase evolves.


### PR DESCRIPTION
## Summary
- Adds `review.md` at the repo root: a checklist for reviewing PRs for cross-tenant/cross-client/cross-user data-access regressions — covering read/write query scoping, Person/Patient link traversal & expansion, request-scoped caching, and cross-tenant joins on shared identifiers.
- Updates `CLAUDE.md` to point any Claude Code session at `review.md` when a PR touches a security-sensitive area.

Jira: [DCON-4753](https://icanbwell.atlassian.net/browse/DCON-4753) (under epic DCON-4654)

## Test plan
- [ ] FHIR team reviews `review.md` for accuracy and completeness of the checklist
- [ ] Confirm the `CLAUDE.md` pointer section reads correctly in context
- [ ] No code changes in this PR — documentation/process only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DCON-4753]: https://icanbwell.atlassian.net/browse/DCON-4753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ