### PR TITLE
SEC-1580: Fix PUT-by-uuid cross-tenant existence

### DIFF
--- a/src/operations/update/update.js
+++ b/src/operations/update/update.js
@@ -22,7 +22,6 @@ const { isTrue } = require('../../utils/isTrue');
 const { SearchManager } = require('../search/searchManager');
 const { IdParser } = require('../../utils/idParser');
 const { GRIDFS: { RETRIEVE }, OPERATIONS: { WRITE }, ACCESS_LOGS_ENTRY_DATA, BLOB_OP } = require('../../constants');
-const { isUuid } = require('../../utils/uid.util');
 const { buildContextDataForHybridStorage } = require('../../utils/contextDataBuilder');
 const { IdentifierEnrichmentProvider } = require('../../enrich/providers/identifierEnrichmentProvider');
 const { FhirResourceSerializer } = require('../../fhir/fhirResourceSerializer');
@@ -220,32 +219,30 @@ class UpdateOperation {
              * @type {import('mongodb').Document}
              */
             let query;
-            if (isUuid(rawId)) {
-                query = { _uuid: rawId };
-            } else {
-                /**
-                 * @type {boolean}
-                 */
-                const useAccessIndex =
-                    this.configManager.useAccessIndex || isTrue(parsedArgs._useAccessIndex);
+            /**
+             * @type {boolean}
+             */
+            const useAccessIndex =
+                this.configManager.useAccessIndex || isTrue(parsedArgs._useAccessIndex);
 
-                /**
-                 * @type {{base_version, columns: Set, query: import('mongodb').Document}}
-                 */
-                (
-                    { query } = await this.searchManager.constructQueryAsync({
-                        user,
-                        scope,
-                        isUser,
-                        resourceType,
-                        useAccessIndex,
-                        personIdFromJwtToken,
-                        parsedArgs,
-                        operation: WRITE,
-                        accessRequested: 'write'
-                    })
-                );
-            }
+            // Always resolve via the tenant/access-scoped query builder, same as
+            // patch.js/remove.js, even for uuid ids.
+            /**
+             * @type {{base_version, columns: Set, query: import('mongodb').Document}}
+             */
+            (
+                { query } = await this.searchManager.constructQueryAsync({
+                    user,
+                    scope,
+                    isUser,
+                    resourceType,
+                    useAccessIndex,
+                    personIdFromJwtToken,
+                    parsedArgs,
+                    operation: WRITE,
+                    accessRequested: 'write'
+                })
+            );
 
             // Get current record
             const databaseQueryManager = this.databaseQueryFactory.createQuery(

--- a/src/tests/update/put_uuid_cross_tenant_oracle/fixtures/Patient/patient1.json
+++ b/src/tests/update/put_uuid_cross_tenant_oracle/fixtures/Patient/patient1.json
@@ -1,0 +1,23 @@
+{
+  "resourceType": "Patient",
+  "id": "1",
+  "meta": {
+    "source": "test",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "clientA"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "clientA"
+      }
+    ]
+  },
+  "name": [
+    {
+      "family": "Smith",
+      "given": ["John"]
+    }
+  ]
+}

--- a/src/tests/update/put_uuid_cross_tenant_oracle/fixtures/Patient/patient_clientB.json
+++ b/src/tests/update/put_uuid_cross_tenant_oracle/fixtures/Patient/patient_clientB.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "Patient",
+  "meta": {
+    "source": "test",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "clientB"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "clientB"
+      }
+    ]
+  },
+  "name": [
+    {
+      "family": "Jones",
+      "given": ["Bob"]
+    }
+  ]
+}

--- a/src/tests/update/put_uuid_cross_tenant_oracle/put_uuid_cross_tenant_oracle.test.js
+++ b/src/tests/update/put_uuid_cross_tenant_oracle/put_uuid_cross_tenant_oracle.test.js
@@ -1,0 +1,70 @@
+const patient1Resource = require('./fixtures/Patient/patient1.json');
+const patientClientBResource = require('./fixtures/Patient/patient_clientB.json');
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    createTestRequest
+} = require('../../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+
+// A PUT by uuid must not let a caller with no access to a resource's tenant
+// tell "this uuid belongs to someone else" apart from "this uuid doesn't
+// exist anywhere".
+describe('PUT by uuid must not leak cross-tenant existence', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    test('PUT by uuid for a uuid that does not exist anywhere still succeeds as a create', async () => {
+        const request = await createTestRequest();
+        const unusedUuid = '11111111-2222-3333-4444-555555555555';
+
+        const resp = await request
+            .put(`/4_0_0/Patient/${unusedUuid}`)
+            .send({ ...patientClientBResource, id: unusedUuid })
+            .set(getHeaders('access/clientB.* user/*.*'))
+            .expect(201);
+
+        expect(resp.body.id).toBe(unusedUuid);
+    });
+
+    test('PUT by uuid belonging to another tenant does not confirm the resource exists', async () => {
+        const request = await createTestRequest();
+
+        // clientA creates a resource. Capture its server-assigned uuid.
+        const createResp = await request
+            .post('/4_0_0/Patient/1/$merge')
+            .send(patient1Resource)
+            .set(getHeaders())
+            .expect(200);
+        expect(createResp).toHaveMergeResponse({ created: true });
+        const clientAUuid = createResp._body.uuid;
+        expect(clientAUuid).toBeDefined();
+
+        // clientB has zero owner/access overlap with clientA and sends a PUT
+        // for the exact uuid clientA's resource was assigned.
+        const crossTenantUpdateResp = await request
+            .put(`/4_0_0/Patient/${clientAUuid}`)
+            .send({ ...patientClientBResource, id: clientAUuid })
+            .set(getHeaders('access/clientB.* user/*.*'));
+
+        // The response must not be the tenant-confirming forbidden error that
+        // names the resource (e.g. "... has no write access to resource
+        // Patient with id 1").
+        const bodyText = JSON.stringify(crossTenantUpdateResp.body);
+        expect(bodyText).not.toMatch(/no write access to resource/);
+
+        // clientB must not have been able to overwrite clientA's resource.
+        const verifyResp = await request
+            .get(`/4_0_0/Patient/${clientAUuid}`)
+            .set(getHeaders('access/clientA.* user/*.*'))
+            .expect(200);
+        expect(verifyResp.body.name[0].family).toBe('Smith');
+    });
+});


### PR DESCRIPTION
## Summary
- `PUT /<ResourceType>/<uuid>` resolved the target resource via a bare `{_uuid: rawId}` query with no tenant/access filter, unlike every other write path (`patch.js`, `remove.js`) which already scope by tenant/access via `constructQueryAsync`.
- This let a write-scoped caller with zero access-tag overlap on a given tenant distinguish "this uuid belongs to another tenant" (403 forbidden, naming the resource) from "this uuid doesn't exist anywhere" (201 created) — a cross-tenant existence oracle, especially notable given `_uuid` is a deterministic, computable hash (finding F6).
- Fix: route the uuid branch through the same `searchManager.constructQueryAsync(...)` call already used for non-uuid ids, so a uuid outside the caller's scope simply doesn't match and falls through to the ordinary not-found path.

Addresses finding F5 from SEC-1580 only.

## Test plan
- [x] New regression test `src/tests/update/put_uuid_cross_tenant_oracle/put_uuid_cross_tenant_oracle.test.js`:
  - PUT by a uuid that doesn't exist anywhere still succeeds as a create (no regression).
  - PUT by a uuid belonging to another tenant no longer returns the tenant-confirming `"...has no write access to resource..."` message, and the other tenant's resource is verified unchanged afterward.
- [x] Verified the test fails against the pre-fix code (reproduces the oracle) and passes against the fix.
- [ ] `make lint` / `make tests` (please run locally / in CI)