### PR TITLE
SEC-1580 F5: Fix cross-tenant UUID existence oracle on PUT

### DIFF
--- a/src/operations/update/update.js
+++ b/src/operations/update/update.js
@@ -1,6 +1,6 @@
 const httpContext = require('express-http-context');
 const moment = require('moment-timezone');
-const { NotValidatedError, BadRequestError, PreconditionFailedError } = require('../../utils/httpErrors');
+const { NotValidatedError, BadRequestError, PreconditionFailedError, NotFoundError } = require('../../utils/httpErrors');
 const { assertTypeEquals, assertIsValid } = require('../../utils/assertType');
 const { AuditLogger } = require('../../utils/auditLogger');
 const { PostRequestProcessor } = require('../../utils/postRequestProcessor');
@@ -22,6 +22,7 @@ const { isTrue } = require('../../utils/isTrue');
 const { SearchManager } = require('../search/searchManager');
 const { IdParser } = require('../../utils/idParser');
 const { GRIDFS: { RETRIEVE }, OPERATIONS: { WRITE }, ACCESS_LOGS_ENTRY_DATA, BLOB_OP } = require('../../constants');
+const { isUuid } = require('../../utils/uid.util');
 const { buildContextDataForHybridStorage } = require('../../utils/contextDataBuilder');
 const { IdentifierEnrichmentProvider } = require('../../enrich/providers/identifierEnrichmentProvider');
 const { FhirResourceSerializer } = require('../../fhir/fhirResourceSerializer');
@@ -272,6 +273,27 @@ class UpdateOperation {
              * @type {Resource | null}
              */
             const data = resources[0];
+
+            // A uuid identifies a specific, already-existing resource (unlike a source id, it is
+            // never chosen by the client for a new resource). If a uuid didn't match under the
+            // caller's tenant-scoped query, treat it as not-found rather than falling through to
+            // the create-new path below: since UuidColumnHandler reuses resource.id verbatim as
+            // _uuid whenever it is already a valid uuid, creating "new" here would collide with
+            // whatever resource actually owns that uuid instead of creating a distinct resource.
+            // Only applies when the query was actually narrowed by a tenant/access-tag filter
+            // (a specific, non-'*' access/<tenant> scope, and not a patient-scoped token, which
+            // resolves access via linked patient/person ids rather than security tags) — for a
+            // caller with unrestricted ('*') access, or patient-scoped access, no tenant filter
+            // was applied to the query at all, so "not found" already unambiguously means the
+            // uuid doesn't exist anywhere, and legitimate create-with-explicit-uuid must proceed.
+            if (!data && isUuid(rawId) && !isUser) {
+                const accessCodes = this.scopesValidator.scopesManager.getAccessCodesFromScopes(
+                    'write', user, scope
+                );
+                if (!accessCodes.includes('*')) {
+                    throw new NotFoundError(`Resource not found: ${resourceType}/${rawId}`);
+                }
+            }
             /**
              * @type {OperationOutcome|null}
              */

--- a/src/operations/update/update.js
+++ b/src/operations/update/update.js
@@ -22,7 +22,6 @@ const { isTrue } = require('../../utils/isTrue');
 const { SearchManager } = require('../search/searchManager');
 const { IdParser } = require('../../utils/idParser');
 const { GRIDFS: { RETRIEVE }, OPERATIONS: { WRITE }, ACCESS_LOGS_ENTRY_DATA, BLOB_OP } = require('../../constants');
-const { isUuid } = require('../../utils/uid.util');
 const { buildContextDataForHybridStorage } = require('../../utils/contextDataBuilder');
 const { IdentifierEnrichmentProvider } = require('../../enrich/providers/identifierEnrichmentProvider');
 const { FhirResourceSerializer } = require('../../fhir/fhirResourceSerializer');
@@ -220,32 +219,28 @@ class UpdateOperation {
              * @type {import('mongodb').Document}
              */
             let query;
-            if (isUuid(rawId)) {
-                query = { _uuid: rawId };
-            } else {
-                /**
-                 * @type {boolean}
-                 */
-                const useAccessIndex =
-                    this.configManager.useAccessIndex || isTrue(parsedArgs._useAccessIndex);
+            /**
+             * @type {boolean}
+             */
+            const useAccessIndex =
+                this.configManager.useAccessIndex || isTrue(parsedArgs._useAccessIndex);
 
-                /**
-                 * @type {{base_version, columns: Set, query: import('mongodb').Document}}
-                 */
-                (
-                    { query } = await this.searchManager.constructQueryAsync({
-                        user,
-                        scope,
-                        isUser,
-                        resourceType,
-                        useAccessIndex,
-                        personIdFromJwtToken,
-                        parsedArgs,
-                        operation: WRITE,
-                        accessRequested: 'write'
-                    })
-                );
-            }
+            /**
+             * @type {{base_version, columns: Set, query: import('mongodb').Document}}
+             */
+            (
+                { query } = await this.searchManager.constructQueryAsync({
+                    user,
+                    scope,
+                    isUser,
+                    resourceType,
+                    useAccessIndex,
+                    personIdFromJwtToken,
+                    parsedArgs,
+                    operation: WRITE,
+                    accessRequested: 'write'
+                })
+            );
 
             // Get current record
             const databaseQueryManager = this.databaseQueryFactory.createQuery(

--- a/src/tests/update/put_cross_tenant_uuid/fixtures/Observation/observation1.json
+++ b/src/tests/update/put_cross_tenant_uuid/fixtures/Observation/observation1.json
@@ -1,0 +1,43 @@
+{
+    "meta": {
+        "source": "http://clienthealth.org/provider",
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "clientA"
+            },
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "clientA"
+            }
+        ]
+    },
+    "category": [
+        {
+            "coding": [
+                {
+                    "code": "vital-signs",
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "code": "8302-2",
+                "display": "Body height",
+                "system": "http://loinc.org"
+            }
+        ]
+    },
+    "id": "1",
+    "resourceType": "Observation",
+    "status": "final",
+    "valueQuantity": {
+        "code": "[in_i]",
+        "system": "http://unitsofmeasure.org",
+        "unit": "inch",
+        "value": 70.00000000000001
+    }
+}

--- a/src/tests/update/put_cross_tenant_uuid/fixtures/Observation/observation1_attacker_put.json
+++ b/src/tests/update/put_cross_tenant_uuid/fixtures/Observation/observation1_attacker_put.json
@@ -1,0 +1,43 @@
+{
+    "meta": {
+        "source": "http://clienthealth.org/provider",
+        "security": [
+            {
+                "system": "https://www.icanbwell.com/access",
+                "code": "clientB"
+            },
+            {
+                "system": "https://www.icanbwell.com/owner",
+                "code": "clientB"
+            }
+        ]
+    },
+    "category": [
+        {
+            "coding": [
+                {
+                    "code": "vital-signs",
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category"
+                }
+            ]
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "code": "8302-2",
+                "display": "Body height",
+                "system": "http://loinc.org"
+            }
+        ]
+    },
+    "id": "1",
+    "resourceType": "Observation",
+    "status": "final",
+    "valueQuantity": {
+        "code": "[in_i]",
+        "system": "http://unitsofmeasure.org",
+        "unit": "inch",
+        "value": 99.0
+    }
+}

--- a/src/tests/update/put_cross_tenant_uuid/put_cross_tenant_uuid.test.js
+++ b/src/tests/update/put_cross_tenant_uuid/put_cross_tenant_uuid.test.js
@@ -39,8 +39,11 @@ describe('PUT by UUID cross-tenant tests', () => {
                 .send(observation1AttackerPut)
                 .set(getHeaders('access/clientB.* user/*.*'));
 
-            // Must not be a 403 (that would confirm the uuid belongs to someone else's tenant)
-            expect(attackerResp.status).not.toBe(403);
+            // Must not be a 403 (that would confirm the uuid belongs to someone else's tenant,
+            // distinguishing it from a uuid that doesn't exist anywhere) and must not silently
+            // create-and-collide with the existing resource (a uuid is never a client-chosen id
+            // for a new resource) — a plain 404 is the only response that leaks nothing.
+            expect(attackerResp.status).toStrictEqual(404);
 
             // The original clientA resource must be untouched by the attacker's PUT
             const readBackResp = await request
@@ -82,6 +85,19 @@ describe('PUT by UUID cross-tenant tests', () => {
 
             expect(readBackResp._body.meta.versionId).toStrictEqual('2');
             expect(readBackResp._body.valueQuantity.value).toStrictEqual(72.0);
+        });
+
+        test('PUT by a uuid that does not exist anywhere also returns 404, matching the cross-tenant case', async () => {
+            const request = await createTestRequest();
+
+            const nonExistentUuid = '11111111-2222-5333-8444-555555555555';
+
+            const resp = await request
+                .put('/4_0_0/Observation/' + nonExistentUuid)
+                .send(observation1AttackerPut)
+                .set(getHeaders('access/clientB.* user/*.*'));
+
+            expect(resp.status).toStrictEqual(404);
         });
     });
 });

--- a/src/tests/update/put_cross_tenant_uuid/put_cross_tenant_uuid.test.js
+++ b/src/tests/update/put_cross_tenant_uuid/put_cross_tenant_uuid.test.js
@@ -1,0 +1,87 @@
+const observation1Resource = require('./fixtures/Observation/observation1.json');
+const observation1AttackerPut = require('./fixtures/Observation/observation1_attacker_put.json');
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    createTestRequest
+} = require('../../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+
+describe('PUT by UUID cross-tenant tests', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    describe('update Tests', () => {
+        test('PUT by _uuid for a resource in another tenant does not confirm existence or overwrite it (F5)', async () => {
+            const request = await createTestRequest();
+
+            // clientA creates its own Observation
+            const createResp = await request
+                .post('/4_0_0/Observation/$merge')
+                .send(observation1Resource)
+                .set(getHeaders())
+                .expect(200);
+
+            expect(createResp).toHaveMergeResponse({ created: true });
+            const clientAUuid = createResp._body.uuid;
+            expect(clientAUuid).toBeDefined();
+
+            // clientB, with no scope for clientA at all, PUTs to clientA's exact _uuid
+            const attackerResp = await request
+                .put('/4_0_0/Observation/' + clientAUuid)
+                .send(observation1AttackerPut)
+                .set(getHeaders('access/clientB.* user/*.*'));
+
+            // Must not be a 403 (that would confirm the uuid belongs to someone else's tenant)
+            expect(attackerResp.status).not.toBe(403);
+
+            // The original clientA resource must be untouched by the attacker's PUT
+            const readBackResp = await request
+                .get('/4_0_0/Observation/' + clientAUuid)
+                .set(getHeaders('access/clientA.* user/*.*'))
+                .expect(200);
+
+            expect(readBackResp._body.meta.versionId).toStrictEqual('1');
+            expect(readBackResp._body.valueQuantity.value).toStrictEqual(70.00000000000001);
+        });
+
+        test('PUT by _uuid within the same tenant still updates the resource', async () => {
+            const request = await createTestRequest();
+
+            const createResp = await request
+                .post('/4_0_0/Observation/$merge')
+                .send(observation1Resource)
+                .set(getHeaders())
+                .expect(200);
+
+            expect(createResp).toHaveMergeResponse({ created: true });
+            const clientAUuid = createResp._body.uuid;
+
+            const updatedObservation = {
+                ...observation1Resource,
+                valueQuantity: { ...observation1Resource.valueQuantity, value: 72.0 }
+            };
+
+            await request
+                .put('/4_0_0/Observation/' + clientAUuid)
+                .send(updatedObservation)
+                .set(getHeaders('access/clientA.* user/*.*'))
+                .expect(200);
+
+            const readBackResp = await request
+                .get('/4_0_0/Observation/' + clientAUuid)
+                .set(getHeaders('access/clientA.* user/*.*'))
+                .expect(200);
+
+            expect(readBackResp._body.meta.versionId).toStrictEqual('2');
+            expect(readBackResp._body.valueQuantity.value).toStrictEqual(72.0);
+        });
+    });
+});

--- a/src/tests/update/put_without_access/put_without_access.test.js
+++ b/src/tests/update/put_without_access/put_without_access.test.js
@@ -183,6 +183,9 @@ describe('Patient Tests', () => {
                 .set(getHeaders())
                 .expect(200);
 
+            // PUT-by-uuid is tenant-scoped at the query level (SEC-1580 F5), so a caller without
+            // access to this resource's tenant gets a plain not-found rather than a 403 that would
+            // confirm the uuid belongs to someone else's tenant.
             let resp = await request
                 .put('/4_0_0/Observation/' + createResp._body.uuid)
                 .send(observation2Resource)
@@ -191,12 +194,10 @@ describe('Patient Tests', () => {
             expect(resp).toHaveResponse({
                 issue: [
                     {
-                        code: 'forbidden',
+                        code: 'not-found',
                         details: {
-                            text: 'user imran with scopes [access/access.* user/*.*] has no write access to resource Observation with id 1'
+                            text: `Resource not found: Observation/${createResp._body.uuid}`
                         },
-                        diagnostics:
-                            'user imran with scopes [access/access.* user/*.*] has no write access to resource Observation with id 1',
                         severity: 'error'
                     }
                 ],


### PR DESCRIPTION
## Summary
- `update.js`'s PUT-by-uuid path queried `{_uuid: rawId}` directly, unscoped by tenant, then checked access afterward — a write-scoped caller with no access to another tenant's resource could distinguish "exists in another tenant" (403) from "doesn't exist anywhere" (201) using only a uuid, which is a deterministic, publicly-computable hash (SEC-1580 F6), not a secret.
- Routes the uuid lookup through the same tenant-scoped `constructQueryAsync` that `patch.js`/`remove.js` already use, so a cross-tenant uuid simply misses at the query level.
- Falling through to the existing create-new path on a miss turned out to be unsafe by itself: `UuidColumnHandler` reuses `resource.id` verbatim as `_uuid` whenever it's already a valid uuid, and the create path upserts by `_uuid` — so a cross-tenant uuid that missed the scoped query would silently land the write on the resource that already owns that uuid (verified live: versionId incremented on the other tenant's document) instead of creating a distinct one. Added a not-found guard for that case.
- Scoped the guard to callers whose query was actually narrowed by a specific `access/<tenant>` scope (not `*`, not patient-scoped) — for callers with unrestricted or patient-scoped access, no tenant filter was ever applied to the query, so "not found" already unambiguously means the uuid doesn't exist anywhere, and the existing, tested create-with-explicit-uuid flows (ActivityDefinition, proxy-patient fixtures) all rely on exactly that path.
- Updated `put_without_access.test.js`, which had encoded the old 403-confirms-existence behavior as the expected result.

## Test plan
- [x] New regression tests in `src/tests/update/put_cross_tenant_uuid/` covering: cross-tenant uuid PUT (404, target untouched), same-tenant uuid PUT (still updates), and a nonexistent uuid (same 404, no distinguishing signal)
- [x] Updated `put_without_access.test.js` expectation
- [x] Full `src/tests/update/` suite passes locally