### PR TITLE
SEC-1580 F11: Tighten access scope-prefix matching to 'access/'

### DIFF
--- a/src/operations/security/scopesManager.js
+++ b/src/operations/security/scopesManager.js
@@ -61,7 +61,7 @@ class ScopesManager {
          * @type {string}
          */
         for (const scope1 of scopes) {
-            if (scope1.startsWith('access')) {
+            if (scope1.startsWith('access/')) {
                 // ex: access/client.*
                 /**
                  * @type {string}

--- a/src/tests/operations/security/scopesManager.test.js
+++ b/src/tests/operations/security/scopesManager.test.js
@@ -1,0 +1,47 @@
+const {
+    describe,
+    beforeEach,
+    afterEach,
+    test,
+    expect
+} = require('@jest/globals');
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getTestContainer,
+    createTestRequest
+} = require('../../common');
+
+describe('ScopesManager - getAccessCodesFromScopes Tests', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    test('only matches scopes with the access/ prefix, not any scope merely starting with "access" (SEC-1580 F11)', async () => {
+        await createTestRequest();
+        const container = getTestContainer();
+        const scopesManager = container.scopesManager;
+
+        // a scope that starts with the literal characters "access" but is not
+        // an access/<tenant>.<action> scope must not be treated as one
+        const accessCodes = scopesManager.getAccessCodesFromScopes(
+            'write', 'testUser', 'accessory/clientA.write user/*.write'
+        );
+        expect(accessCodes).toStrictEqual([]);
+    });
+
+    test('still matches a real access/ scope', async () => {
+        await createTestRequest();
+        const container = getTestContainer();
+        const scopesManager = container.scopesManager;
+
+        const accessCodes = scopesManager.getAccessCodesFromScopes(
+            'write', 'testUser', 'access/clientA.write user/*.write'
+        );
+        expect(accessCodes).toStrictEqual(['clientA']);
+    });
+});


### PR DESCRIPTION
## Summary
- `getAccessCodesFromScopes` checked `scope1.startsWith('access')` but then unconditionally did `inner_scope.replace('access/', '')` and split on `.`, pushing whatever fell out as an authorized security tag code.
- Any scope string that merely begins with the letters "access" (e.g. a typo'd or unrelated scope like `accessory/x.write`) would be misparsed: since it doesn't contain the substring `access/`, the `.replace()` is a no-op, and the entire `accessory/x` string gets pushed into the caller's authorized access codes instead of being ignored as a non-access scope.
- Tightened the check to require the literal `access/` prefix, matching what the code immediately after already assumes.

## Test plan
- [x] New unit test in `src/tests/operations/security/scopesManager.test.js` demonstrating a scope starting with "access" but not `access/` is correctly ignored (and would have produced a garbage access code before this fix), plus a sanity check that real `access/` scopes still match