### PR TITLE
SEC-1580 F10: Apply Person $everything sibling scoping to the proxy patient form too

### DIFF
--- a/readme/personEverything.md
+++ b/readme/personEverything.md
@@ -35,7 +35,7 @@ Suppose `PersonA` and `PersonB` are both linked to the same `Patient/X` (e.g. tw
 
 ### Notes
 
-- This scoping only applies when the request is made against the `Person` resource type (path or `id`/`_id` on `/4_0_0/Person/$everything`). Calling `/4_0_0/Patient/person.<person_id>/$everything` directly (i.e. using the proxy patient id form against the Patient endpoint) is treated as a Patient request and does **not** apply this scoping — it returns all linked persons and their subscriptions, same as any other Patient $everything call.
+- This scoping applies both when the request is made against the `Person` resource type (path or `id`/`_id` on `/4_0_0/Person/$everything`) and when the equivalent proxy patient id form is called directly against the `Patient` endpoint (`/4_0_0/Patient/person.<person_id>/$everything`) — both forms scope the result to the explicitly requested person(s). Calling `/4_0_0/Patient/<patient_id>/$everything` with a plain (non-proxy) patient id is unaffected and continues to return all linked persons and their subscriptions.
 - This scoping does not affect any other resource type — clinical and non-clinical resources linked to the resolved patient(s) are returned the same way as for Patient $everything.
 - All other parameters (`_type`, `_since`, `_debug`, `_explain`, `_includePatientLinkedOnly`, etc.) and response headers work the same as documented in [Patient $everything](patientEverything.md).
 

--- a/src/operations/fhirOperationsManager.js
+++ b/src/operations/fhirOperationsManager.js
@@ -714,6 +714,17 @@ class FhirOperationsManager {
         // person ids to retrict result to
         if (resourceType === "Person" && combined_args.id) {
             scopedPersonIds = combined_args.id.split(',');
+        } else if (resourceType === 'Patient' && combined_args.id) {
+            // the equivalent of Person $everything can also be requested directly against the
+            // Patient endpoint using the proxy patient id form (Patient/person.<id>/$everything);
+            // apply the same sibling-record scoping in that case too
+            const proxyPersonIds = combined_args.id
+                .split(',')
+                .filter((id) => id.startsWith(PERSON_PROXY_PREFIX))
+                .map((id) => id.replace(PERSON_PROXY_PREFIX, ''));
+            if (proxyPersonIds.length > 0) {
+                scopedPersonIds = proxyPersonIds;
+            }
         }
 
         // map Person GET $everything to Patient GET $everything

--- a/src/tests/everything/person_or_patient/person_or_patient.test.js
+++ b/src/tests/everything/person_or_patient/person_or_patient.test.js
@@ -236,6 +236,15 @@ describe('Person and Patient $everything Tests', () => {
             // noinspection JSUnresolvedFunction
             expect(resp).toHaveResponse(expectedPerson1Resources);
 
+            // Calling the equivalent proxy patient id form directly against the Patient
+            // endpoint must apply the same sibling-person scoping as Person $everything
+            // (SEC-1580 F10) — it must not also return the sibling personTopLevel.
+            resp = await request
+                .get('/4_0_0/Patient/person.person1/$everything')
+                .set(getHeaders());
+            // noinspection JSUnresolvedFunction
+            expect(resp).toHaveResponse(expectedPerson1Resources);
+
             resp = await request
                 .get('/4_0_0/Person/person1,personTopLevel/$everything?_debug=1')
                 .set(getHeaders());


### PR DESCRIPTION
## Summary
- Person \$everything scopes its result to only the explicitly requested person(s), excluding sibling Person records (and their Subscriptions) that share the same underlying patient — the INC-331 fix, implemented via `scopedPersonIds`.
- That scoping was only wired up for the `Person/<id>/$everything` URL form (`resourceType === 'Person'`). A request made directly against the equivalent proxy patient id form, `Patient/person.<id>/$everything`, starts with `resourceType === 'Patient'` and never got `scopedPersonIds` set — silently bypassing the restriction via an equivalent request phrased a different way. This was previously called out as known, documented behavior in `readme/personEverything.md`, not flagged as a bug at the time.
- Extracts person ids from `PERSON_PROXY_PREFIX`-prefixed ids on the `Patient` path too, so both forms of the same conceptual request get the same scoping. Updated `readme/personEverything.md` accordingly.

## Test plan
- [x] Extended the existing `person_or_patient.test.js` sibling-scoping scenario with an additional assertion: calling `Patient/person.<id>/$everything` directly now returns the same scoped result as `Person/<id>/$everything` (previously would have also returned the sibling person)
- [x] Full test file passes locally (6/6)