### PR TITLE
SEC-1580 F7: Restrict $export/:id lookup to its own requester

### DIFF
--- a/src/operations/export/exportById.js
+++ b/src/operations/export/exportById.js
@@ -44,7 +44,9 @@ class ExportByIdOperation {
             /** @type {string} */
             requestId,
             /** @type {string} */
-            scope
+            scope,
+            /** @type {string} */
+            user
         } = requestInfo;
 
         const { id } = args;
@@ -60,7 +62,12 @@ class ExportByIdOperation {
                 exportStatusId: id
             });
 
-            if (!exportStatusResource) {
+            // ExportStatus carries no tenant/access security tag (every job is tagged owner=bwell
+            // regardless of requester) — the only record of who may check on it is the `user` who
+            // started it, so ownership is checked against that instead. A mismatch returns the
+            // same not-found response as a truly nonexistent id, rather than confirming that a
+            // guessed/enumerated export id belongs to someone else.
+            if (!exportStatusResource || exportStatusResource.user !== user) {
                 throw new NotFoundError(`ExportStatus resoure with id ${id} doesn't exists`);
             }
 

--- a/src/tests/export/export.byId.access.test.js
+++ b/src/tests/export/export.byId.access.test.js
@@ -1,0 +1,70 @@
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    getHeadersWithCustomPayload,
+    createTestRequest
+} = require('../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+const { MockK8sClient } = require('./mocks/k8sClient');
+
+describe('Export byId access tests', () => {
+    beforeEach(async () => {
+        process.env.ENABLE_BULK_EXPORT = '1';
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        process.env.ENABLE_BULK_EXPORT = '0';
+        await commonAfterEach();
+    });
+
+    test('a caller who did not start the export cannot poll its status (SEC-1580 F7)', async () => {
+        const request = await createTestRequest((c) => {
+            c.register('k8sClient', (c) => new MockK8sClient({
+                configManager: c.configManager
+            }));
+            return c;
+        });
+
+        const createResp = await request
+            .post('/4_0_0/$export?_type=Patient')
+            .set(getHeaders())
+            .expect(202);
+
+        expect(createResp.headers['content-location']).toBeDefined();
+        const exportStatusId = createResp.headers['content-location'].split('/').pop();
+
+        // the same user who started the export can poll it
+        await request
+            .get(`/4_0_0/$export/${exportStatusId}`)
+            .set(getHeaders())
+            .expect(202);
+
+        // a different authenticated user, with equally broad scopes, must not be able to
+        // poll (or thereby confirm the existence of) someone else's export job
+        const otherUserResp = await request
+            .get(`/4_0_0/$export/${exportStatusId}`)
+            .set(getHeadersWithCustomPayload({
+                username: 'attacker',
+                scope: 'user/*.read user/*.write access/*.*',
+                token_use: 'access'
+            }));
+
+        expect(otherUserResp.status).toStrictEqual(404);
+    });
+
+    test('polling a export id that does not exist at all returns the same 404', async () => {
+        const request = await createTestRequest();
+
+        const resp = await request
+            .get('/4_0_0/$export/11111111-2222-5333-8444-555555555555')
+            .set(getHeadersWithCustomPayload({
+                username: 'attacker',
+                scope: 'user/*.read user/*.write access/*.*',
+                token_use: 'access'
+            }));
+
+        expect(resp.status).toStrictEqual(404);
+    });
+});


### PR DESCRIPTION
## Summary
- `exportById.js` fetched the `ExportStatus` resource by id with no ownership check at all beyond a blanket patient-scope rejection — any caller with generic export-capable scopes who learned or guessed another user's export id could fetch that job's metadata (request params/scope, error details, S3 output paths).
- `ExportStatus` resources carry no tenant/access security tag — every job is tagged `owner=bwell` regardless of requester — so the normal security-tag query filtering doesn't apply to this resource type at all. The only record of who may check on a job is the `user` field stored on the resource when the export was created.
- Checks the caller's identity against that `user` field and returns the same not-found response for a mismatch as for a genuinely nonexistent id, so a guessed/enumerated id can't be distinguished from one that doesn't exist.

## Test plan
- [x] New `src/tests/export/export.byId.access.test.js`: the requesting user can poll their own export; a different authenticated user (equally broad scopes) gets 404 polling it; a nonexistent id gets the identical 404
- [x] Full `src/tests/export/` suite passes locally (8/8, 32/32)