### PR TITLE
SEC-1580 F2: Protect the access security tag on write to prevent cross-tenant re-tagging

### DIFF
--- a/src/operations/create/create.js
+++ b/src/operations/create/create.js
@@ -223,6 +223,9 @@ class CreateOperation {
             await this.scopesValidator.isAccessToResourceAllowedByAccessAndPatientScopes({
                 requestInfo, resource, base_version
             });
+            this.scopesValidator.isAccessTagChangeAllowedByAccessScopes({
+                requestInfo, currentResource: null, updatedResource: resource
+            });
             /**
              * @type {Resource}
              */

--- a/src/operations/merge/validators/writeAllowedByScopesValidator.js
+++ b/src/operations/merge/validators/writeAllowedByScopesValidator.js
@@ -55,9 +55,21 @@ class WriteAllowedByScopesValidator extends BaseValidator {
                     await this.scopesValidator.isAccessToResourceAllowedByAccessAndPatientScopes({
                         resource: foundResource, requestInfo, base_version
                     });
+                    // the check above ran against the resource as stored, so the access tags coming from the
+                    // incoming body still need to be validated. A smart merge only appends to arrays, so tags
+                    // missing from the incoming body aren't removals and must not be treated as such.
+                    this.scopesValidator.isAccessTagChangeAllowedByAccessScopes({
+                        requestInfo,
+                        currentResource: foundResource,
+                        updatedResource: resource,
+                        ignoreRemovals: effectiveSmartMerge
+                    });
                 } else {
                     await this.scopesValidator.isAccessToResourceAllowedByAccessAndPatientScopes({
                         resource, requestInfo, base_version
+                    });
+                    this.scopesValidator.isAccessTagChangeAllowedByAccessScopes({
+                        requestInfo, currentResource: null, updatedResource: resource
                     });
                 }
                 validIncomingResources.push(resource);

--- a/src/operations/patch/patch.js
+++ b/src/operations/patch/patch.js
@@ -394,6 +394,12 @@ class PatchOperation {
             const preSaveOptions = PreSaveOptions.fromRequestInfo(requestInfo);
             resource = await this.preSaveManager.preSaveAsync({ resource, options: preSaveOptions });
 
+            // the check above ran against the resource as stored, so any access tag the patch itself added or
+            // removed still needs to be validated
+            this.scopesValidator.isAccessTagChangeAllowedByAccessScopes({
+                requestInfo, currentResource: originalResource, updatedResource: resource
+            });
+
             /**
              * @type {OperationOutcome|null}
              */

--- a/src/operations/security/scopesManager.js
+++ b/src/operations/security/scopesManager.js
@@ -118,6 +118,75 @@ class ScopesManager {
     }
 
     /**
+     * Returns the codes of all access tags present on the resource
+     * @param {Resource|Object|null} resource
+     * @return {string[]}
+     */
+    getAccessTagCodes (resource) {
+        if (!resource || !resource.meta || !resource.meta.security) {
+            return [];
+        }
+        return resource.meta.security
+            .filter(s => s.system === SecurityTagSystem.access)
+            .map(s => s.code);
+    }
+
+    /**
+     * Returns whether the caller is allowed to change a resource's access tags from oldAccessCodes to
+     * newAccessCodes.
+     *
+     * A resource can legitimately carry access tags for several clients at once, and a client that has
+     * access to a resource is allowed to share it with, or stop sharing it with, other clients by adding
+     * or removing access tags. But the write check on the resource itself only requires that *one* of its
+     * access tags matches the caller's scopes, so without this check a caller could add an access tag for
+     * a client it has no access to (silently sharing the resource with that client) or remove one
+     * (silently hiding the resource from a client that was entitled to it). So unless the caller holds the
+     * '*' access code, every access code it adds or removes must be one it is itself authorized for.
+     *
+     * @typedef {Object} IsAccessTagChangeAllowedByScopesParams
+     * @property {string[]} oldAccessCodes access codes on the resource as currently stored
+     * @property {string[]} newAccessCodes access codes on the resource as it will be stored
+     * @property {string} resourceType
+     * @property {string} user
+     * @property {string} scope
+     * @property {boolean} ignoreRemovals when the write path can only add access tags, never remove them
+     *
+     * @param {IsAccessTagChangeAllowedByScopesParams}
+     * @return {boolean}
+     */
+    isAccessTagChangeAllowedByScopes ({
+        oldAccessCodes,
+        newAccessCodes,
+        resourceType,
+        user,
+        scope,
+        ignoreRemovals = false
+    }) {
+        // a patient scoped caller is authorized by the patient the resource belongs to rather than by access
+        // codes, and holds no access scopes to compare against, so leave it to the patient scope checks
+        if (this.isAccessAllowedByPatientScopes({ scope, resourceType })) {
+            return true;
+        }
+        /**
+         * @type {string[]}
+         */
+        const accessCodes = this.getAccessCodesFromScopes('write', user, scope);
+        if (accessCodes.includes('*')) {
+            return true;
+        }
+        const oldCodes = new Set(oldAccessCodes);
+        const newCodes = new Set(newAccessCodes);
+        /**
+         * @type {string[]}
+         */
+        const changedCodes = newAccessCodes.filter(c => !oldCodes.has(c));
+        if (!ignoreRemovals) {
+            changedCodes.push(...oldAccessCodes.filter(c => !newCodes.has(c)));
+        }
+        return changedCodes.every(c => accessCodes.includes(c));
+    }
+
+    /**
      * Returns true if resource can be accessed with scope
      * @param {Resource} resource
      * @param {string} user

--- a/src/operations/security/scopesValidator.js
+++ b/src/operations/security/scopesValidator.js
@@ -202,6 +202,35 @@ class ScopesValidator {
 
 
     /**
+     * Throws forbidden error when the caller is not allowed to make this change to the resource's access tags
+     * @typedef {Object} IsAccessTagChangeAllowedByAccessScopesParams
+     * @property {import('../../utils/fhirRequestInfo').FhirRequestInfo} requestInfo
+     * @property {Resource|null} currentResource resource as currently stored, null when it is being created
+     * @property {Resource} updatedResource resource as it will be stored
+     * @property {boolean} ignoreRemovals set when the write path can only add access tags, never remove them
+     *
+     * @param {IsAccessTagChangeAllowedByAccessScopesParams}
+     */
+    isAccessTagChangeAllowedByAccessScopes({requestInfo, currentResource, updatedResource, ignoreRemovals = false}) {
+        const {user, scope} = requestInfo;
+        if (
+            !this.scopesManager.isAccessTagChangeAllowedByScopes({
+                oldAccessCodes: this.scopesManager.getAccessTagCodes(currentResource),
+                newAccessCodes: this.scopesManager.getAccessTagCodes(updatedResource),
+                resourceType: updatedResource.resourceType,
+                user,
+                scope,
+                ignoreRemovals
+            })
+        ) {
+            throw new ForbiddenError(
+                `user ${user} with scopes [${scope}] can only add or remove access tags it has access to, ` +
+                `for resource ${updatedResource.resourceType} with id ${updatedResource.id}`
+            );
+        }
+    }
+
+    /**
      * Throws forbidden error when access through access scope is not allowed
      * @typedef {Object} IsAccessToResourceAllowedByAccessScopesParams
      * @property {import('../../utils/fhirRequestInfo').FhirRequestInfo} requestInfo

--- a/src/operations/update/update.js
+++ b/src/operations/update/update.js
@@ -410,6 +410,12 @@ class UpdateOperation {
                 doc = await this.base64DataManager.transformAsync(doc, BLOB_OP.INSERT, requestInfo, { alwaysCreateNew: true });
 
                 if (data && data.meta) {
+                    // the check above ran against the resource as stored, so the access tags the merge took
+                    // from the incoming body still need to be validated before the merged doc is persisted
+                    this.scopesValidator.isAccessTagChangeAllowedByAccessScopes({
+                        requestInfo, currentResource: foundResource, updatedResource: doc
+                    });
+
                     const contextData = buildContextDataForHybridStorage(resourceType, doc, requestInfo);
 
                     await this.databaseBulkInserter.replaceOneAsync(
@@ -429,6 +435,9 @@ class UpdateOperation {
                     doc.meta.lastUpdated = new Date(moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
                     await this.scopesValidator.isAccessToResourceAllowedByAccessAndPatientScopes({
                         resource: doc, requestInfo, base_version
+                    });
+                    this.scopesValidator.isAccessTagChangeAllowedByAccessScopes({
+                        requestInfo, currentResource: null, updatedResource: doc
                     });
 
                     const contextData = buildContextDataForHybridStorage(resourceType, doc, requestInfo);

--- a/src/tests/operations/security/scopesManager.test.js/scopesManager.test.js
+++ b/src/tests/operations/security/scopesManager.test.js/scopesManager.test.js
@@ -1,0 +1,126 @@
+const { describe, test, expect } = require('@jest/globals');
+const { ScopesManager } = require('../../../../operations/security/scopesManager');
+const { ConfigManager } = require('../../../../utils/configManager');
+const { PatientFilterManager } = require('../../../../fhir/patientFilterManager');
+const { SecurityTagSystem } = require('../../../../utils/securityTagSystem');
+
+describe('ScopesManager Tests', () => {
+    const scopesManager = new ScopesManager({
+        configManager: new ConfigManager(),
+        patientFilterManager: new PatientFilterManager()
+    });
+
+    /**
+     * @param {string[]} accessCodes
+     */
+    function resourceWithAccessCodes (accessCodes) {
+        return {
+            resourceType: 'Patient',
+            id: '1',
+            meta: {
+                security: [
+                    { system: SecurityTagSystem.owner, code: 'clientA' },
+                    ...accessCodes.map(code => ({ system: SecurityTagSystem.access, code }))
+                ]
+            }
+        };
+    }
+
+    describe('getAccessTagCodes', () => {
+        test('should return only the codes of access tags', () => {
+            expect(scopesManager.getAccessTagCodes(resourceWithAccessCodes(['clientA', 'clientB'])))
+                .toEqual(['clientA', 'clientB']);
+        });
+
+        test('should return an empty array when the resource has no access tags or no meta', () => {
+            expect(scopesManager.getAccessTagCodes(resourceWithAccessCodes([]))).toEqual([]);
+            expect(scopesManager.getAccessTagCodes({ resourceType: 'Patient', id: '1' })).toEqual([]);
+            expect(scopesManager.getAccessTagCodes(null)).toEqual([]);
+        });
+    });
+
+    describe('isAccessTagChangeAllowedByScopes', () => {
+        const user = 'test-user';
+
+        /**
+         * @param {string[]} oldAccessCodes
+         * @param {string[]} newAccessCodes
+         * @param {string} scope
+         * @param {boolean} ignoreRemovals
+         */
+        function isChangeAllowed (oldAccessCodes, newAccessCodes, scope, ignoreRemovals = false) {
+            return scopesManager.isAccessTagChangeAllowedByScopes({
+                oldAccessCodes, newAccessCodes, resourceType: 'Patient', user, scope, ignoreRemovals
+            });
+        }
+
+        test('should allow adding an access tag the caller has access to', () => {
+            expect(isChangeAllowed(['clientA'], ['clientA', 'clientB'], 'access/clientA.* access/clientB.*'))
+                .toBeTrue();
+        });
+
+        test('should not allow adding an access tag the caller has no access to', () => {
+            expect(isChangeAllowed(['clientA'], ['clientA', 'clientB'], 'access/clientA.*')).toBeFalse();
+        });
+
+        test('should allow removing an access tag the caller has access to', () => {
+            expect(isChangeAllowed(['clientA', 'clientB'], ['clientA'], 'access/clientA.* access/clientB.*'))
+                .toBeTrue();
+        });
+
+        test('should not allow removing an access tag the caller has no access to', () => {
+            expect(isChangeAllowed(['clientA', 'clientB'], ['clientA'], 'access/clientA.*')).toBeFalse();
+        });
+
+        test('should allow leaving an access tag the caller has no access to untouched', () => {
+            expect(isChangeAllowed(['clientA', 'clientB'], ['clientA', 'clientB'], 'access/clientA.*'))
+                .toBeTrue();
+        });
+
+        test('should allow any change when the caller has the * access code', () => {
+            expect(isChangeAllowed(['clientA'], ['clientB', 'clientC'], 'access/*.*')).toBeTrue();
+        });
+
+        test('should not allow a change when the caller has no write access scopes', () => {
+            expect(isChangeAllowed(['clientA'], ['clientA', 'clientB'], 'access/clientB.read')).toBeFalse();
+        });
+
+        test('should require write access, not read access, on the added code', () => {
+            expect(isChangeAllowed(['clientA'], ['clientA', 'clientB'], 'access/clientA.* access/clientB.read'))
+                .toBeFalse();
+        });
+
+        test('should ignore removals when the write path cannot remove access tags', () => {
+            expect(isChangeAllowed(['clientA', 'clientB'], ['clientA'], 'access/clientA.*', true)).toBeTrue();
+        });
+
+        test('should still check additions when removals are ignored', () => {
+            expect(isChangeAllowed(['clientA'], ['clientA', 'clientB'], 'access/clientA.*', true)).toBeFalse();
+        });
+
+        test('should allow a create whose access tags the caller has access to', () => {
+            expect(isChangeAllowed([], ['clientA'], 'access/clientA.*')).toBeTrue();
+        });
+
+        test('should not allow a create with an access tag the caller has no access to', () => {
+            expect(isChangeAllowed([], ['clientA', 'clientB'], 'access/clientA.*')).toBeFalse();
+        });
+
+        test('should leave a patient scoped caller to the patient scope checks', () => {
+            // a patient scoped caller holds no access scopes to compare against
+            expect(isChangeAllowed(['clientA'], ['clientA', 'clientB'], 'patient/Patient.write')).toBeTrue();
+        });
+
+        test('should still check a caller that has both patient and access scopes on a resource type not accessible by patient scope', () => {
+            expect(
+                scopesManager.isAccessTagChangeAllowedByScopes({
+                    oldAccessCodes: ['clientA'],
+                    newAccessCodes: ['clientA', 'clientB'],
+                    resourceType: 'Organization',
+                    user,
+                    scope: 'patient/Organization.write access/clientA.*'
+                })
+            ).toBeFalse();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Addresses **F2** from the SEC-1580 cross-tenant data access audit: update/merge/patch did not protect the `access` security tag, allowing cross-tenant self re-tagging.

The write-access check on update/patch/merge runs against the resource **as currently stored**, but `resourceMerger.overWriteNonWritableFields` force-preserves only the `owner` and `sourceAssigningAuthority` tag systems — never `access`. The merged document was then persisted with no re-validation. So a caller with legitimate write access to a resource could add an `access` tag for a tenant it has no authorization for (silently sharing the resource with that tenant) or remove one (silently hiding it from a tenant that was entitled to it).

## Approach

Rather than requiring *every* access tag on the resource to be authorized — which would break legitimate writes to resources already shared across tenants — this gates the **delta**. Unless the caller holds the `*` access code, every access code it adds or removes must be one it is itself authorized for. Tags for other tenants can be left untouched, just not modified.

- `ScopesManager.getAccessTagCodes` — extracts access-tag codes, tolerant of null/missing `meta`
- `ScopesManager.isAccessTagChangeAllowedByScopes` — symmetric difference of the old and new access-code sets, each changed code checked against the caller's write access codes
- `ScopesValidator.isAccessTagChangeAllowedByAccessScopes` — throwing wrapper (403)

Wired into `update.js` (both the merged-replace and insert-new branches), `patch.js`, `create.js`, and `writeAllowedByScopesValidator.js` for `$merge`. `remove.js` and graph-delete are untouched — deletion doesn't mutate tags.

## Notes for reviewers

Three judgment calls worth a look:

1. **`ignoreRemovals` for `$merge`.** A smart merge only *appends* to arrays, so a tag absent from the incoming body is not a removal. Checking symmetric difference there would produce false 403s on ordinary merges, so removals are ignored when `effectiveSmartMerge` is true (the default). Additions are still checked.

2. **Patient-scoped callers are carved out.** Tokens like `patient/Condition.write` carry no `access/` scopes at all and are authorized via the patient rather than via access codes, so the check defers to the patient-scope checks — mirroring the existing carve-out in `isAccessToResourceAllowedBySecurityTags`. Without this, 4 existing tests failed. Note this leaves patient-scoped callers able to set arbitrary access tags; that is a pre-existing gap (see the `TODO` in `isAccessToResourceAllowedBySecurityTags`) tracked separately under DCON-4755, deliberately not expanded into here.

3. **Creates are in scope** (old set is empty, so every tag counts as an addition). This also closes F3's original attack scenario — creating a resource with `[clientA, clientB]` while holding only `clientA`. Happy to narrow this to modifications only if preferred.

This supersedes F3's original "require every access code to be authorized on write" recommendation, which would have been too restrictive on legitimately shared resources.

## Testing

- New unit tests in `src/tests/operations/security/scopesManager.test.js` — 16 cases covering add/remove authorized and unauthorized, untouched foreign tags, `*` bypass, read-vs-write scope on the changed code, `ignoreRemovals`, create paths, and the patient-scope carve-out.
- Regression runs (all passing): `patientScope` write suites 23/23, `update` 40/40, `create` + `patch` 51/51 (incl. `patch_meta`), `merge` 66/68.
- The 2 `merge` failures are the known cross-file container-state leak in multi-file jest runs — that file passes 3/3 in isolation and the failure carries no 403/access-tag error.
