### PR TITLE
SEC-1584 fix: $access-history skips authorization for service-account/tenant-scoped callers

### DIFF
--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -1000,7 +1000,8 @@ const createContainer = function () {
         patientFilterManager: c.patientFilterManager,
         accessHistoryClickHouseRepository: c.accessHistoryClickHouseRepository,
         configManager: c.configManager,
-        scopesValidator: c.scopesValidator
+        scopesValidator: c.scopesValidator,
+        scopesManager: c.scopesManager
     }));
 
     container.register('databaseAttachmentManager', (c) => new DatabaseAttachmentManager(

--- a/src/operations/accessHistory/accessHistory.js
+++ b/src/operations/accessHistory/accessHistory.js
@@ -4,6 +4,7 @@ const { PersonToPatientIdsExpander } = require('../../utils/personToPatientIdsEx
 const { PatientFilterManager } = require('../../fhir/patientFilterManager');
 const { ConfigManager } = require('../../utils/configManager');
 const { ScopesValidator } = require('../security/scopesValidator');
+const { ScopesManager } = require('../security/scopesManager');
 const { NotFoundError, BadRequestError, ForbiddenError } = require('../../utils/httpErrors');
 const { PERSON_PROXY_PREFIX } = require('../../constants');
 const { sliceIntoChunks } = require('../../utils/list.util');
@@ -19,6 +20,7 @@ class AccessHistoryOperation {
      * @param {AccessHistoryClickHouseRepository} params.accessHistoryClickHouseRepository
      * @param {ConfigManager} params.configManager
      * @param {ScopesValidator} params.scopesValidator
+     * @param {ScopesManager} params.scopesManager
      */
     constructor({
         databaseQueryFactory,
@@ -26,7 +28,8 @@ class AccessHistoryOperation {
         patientFilterManager,
         accessHistoryClickHouseRepository,
         configManager,
-        scopesValidator
+        scopesValidator,
+        scopesManager
     }) {
         this.databaseQueryFactory = databaseQueryFactory;
         assertTypeEquals(databaseQueryFactory, DatabaseQueryFactory);
@@ -44,6 +47,9 @@ class AccessHistoryOperation {
 
         this.scopesValidator = scopesValidator;
         assertTypeEquals(scopesValidator, ScopesValidator);
+
+        this.scopesManager = scopesManager;
+        assertTypeEquals(scopesManager, ScopesManager);
     }
 
     /**
@@ -98,12 +104,34 @@ class AccessHistoryOperation {
             throw new NotFoundError(`Person with id ${id} not found`);
         }
 
-        if (requestInfo.isUser &&
-            resolvedPersonUuid !== requestInfo.personIdFromJwtToken &&
-            resolvedPersonUuid !== requestInfo.masterPersonIdFromJwtToken) {
-            throw new ForbiddenError(
-                'Access denied: you can only view access history for your own Person resource'
-            );
+        if (requestInfo.isUser) {
+            if (resolvedPersonUuid !== requestInfo.personIdFromJwtToken &&
+                resolvedPersonUuid !== requestInfo.masterPersonIdFromJwtToken) {
+                throw new ForbiddenError(
+                    'Access denied: you can only view access history for your own Person resource'
+                );
+            }
+        } else {
+            // Service-account/tenant-scoped callers aren't anchored to a specific Person by JWT
+            // claim, so the identity check above doesn't apply to them -- verify their scope
+            // authorizes this specific Person's owner/access tags instead, the same way any other
+            // fetch-by-id read path does.
+            const [person] = await this._findResourcesByUuids({
+                resourceType: 'Person',
+                uuids: [resolvedPersonUuid],
+                base_version,
+                projection: { _uuid: 1, meta: 1 }
+            });
+            // Denied and genuinely-nonexistent are reported identically (NotFoundError) so a
+            // caller can't enumerate valid Person ids across tenants by distinguishing 403 from
+            // 404 -- same discipline exportById.js uses for ExportStatus lookups.
+            if (!person || !this.scopesManager.isAccessToResourceAllowedBySecurityTags({
+                resource: person,
+                user: requestInfo.user,
+                scope: requestInfo.scope
+            })) {
+                throw new NotFoundError(`Person with id ${id} not found`);
+            }
         }
 
         // 2. Collect entity_refs from MongoDB

--- a/src/tests/unit/operations/accessHistory/accessHistory.test.js
+++ b/src/tests/unit/operations/accessHistory/accessHistory.test.js
@@ -15,6 +15,7 @@ const { PersonToPatientIdsExpander } = require('../../../../utils/personToPatien
 const { PatientFilterManager } = require('../../../../fhir/patientFilterManager');
 const { ConfigManager } = require('../../../../utils/configManager');
 const { ScopesValidator } = require('../../../../operations/security/scopesValidator');
+const { ScopesManager } = require('../../../../operations/security/scopesManager');
 
 describe('AccessHistoryOperation', () => {
     let operation;
@@ -24,6 +25,7 @@ describe('AccessHistoryOperation', () => {
     let mockAccessHistoryClickHouseRepository;
     let mockConfigManager;
     let mockScopesValidator;
+    let mockScopesManager;
     let mockCursor;
 
     beforeEach(() => {
@@ -61,13 +63,28 @@ describe('AccessHistoryOperation', () => {
         mockScopesValidator = Object.create(ScopesValidator.prototype);
         mockScopesValidator.verifyHasValidScopesAsync = jest.fn().mockResolvedValue(true);
 
+        mockScopesManager = Object.create(ScopesManager.prototype);
+        mockScopesManager.isAccessToResourceAllowedBySecurityTags = jest.fn().mockReturnValue(true);
+
         operation = new AccessHistoryOperation({
             databaseQueryFactory: mockDatabaseQueryFactory,
             personToPatientIdsExpander: mockPersonToPatientIdsExpander,
             patientFilterManager: mockPatientFilterManager,
             accessHistoryClickHouseRepository: mockAccessHistoryClickHouseRepository,
             configManager: mockConfigManager,
-            scopesValidator: mockScopesValidator
+            scopesValidator: mockScopesValidator,
+            scopesManager: mockScopesManager
+        });
+
+        // Default: the Person auth check (for non-patient-scoped callers) resolves the target
+        // Person; other resource-type lookups (Practitioner, etc. for accessor display names)
+        // default to empty unless a test overrides this. Kept resourceType-aware so tests that
+        // override this for accessor-detail resolution don't also break the Person auth check.
+        operation._findResourcesByUuids = jest.fn().mockImplementation(({ resourceType }) => {
+            if (resourceType === 'Person') {
+                return Promise.resolve([{ _uuid: 'uuid-person-1', meta: { security: [] } }]);
+            }
+            return Promise.resolve([]);
         });
     });
 
@@ -76,6 +93,8 @@ describe('AccessHistoryOperation', () => {
             isUser: false,
             personIdFromJwtToken: null,
             masterPersonIdFromJwtToken: null,
+            user: 'tenant-a-service-account',
+            scope: 'access/tenant-a.read user/Person.read',
             path: '/Patient/p1/$access-history'
         };
 
@@ -131,6 +150,41 @@ describe('AccessHistoryOperation', () => {
                 resourceType: 'Patient'
             });
             expect(result.resourceType).toBe('Parameters');
+        });
+
+        test('SEC-1584: throws NotFoundError (not ForbiddenError, to avoid leaking existence) when service-account/tenant-scoped caller lacks access to the target Person', async () => {
+            mockScopesManager.isAccessToResourceAllowedBySecurityTags.mockReturnValue(false);
+            await expect(operation.accessHistoryAsync({
+                requestInfo: baseRequestInfo,
+                parsedArgs: baseParsedArgs,
+                resourceType: 'Patient'
+            })).rejects.toThrow('Person with id p1 not found');
+            expect(mockScopesManager.isAccessToResourceAllowedBySecurityTags).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    resource: expect.objectContaining({ _uuid: 'uuid-person-1' }),
+                    user: baseRequestInfo.user,
+                    scope: baseRequestInfo.scope
+                })
+            );
+        });
+
+        test('SEC-1584: allows service-account/tenant-scoped caller whose scope covers the target Person', async () => {
+            mockScopesManager.isAccessToResourceAllowedBySecurityTags.mockReturnValue(true);
+            const result = await operation.accessHistoryAsync({
+                requestInfo: baseRequestInfo,
+                parsedArgs: baseParsedArgs,
+                resourceType: 'Patient'
+            });
+            expect(result.resourceType).toBe('Parameters');
+        });
+
+        test('SEC-1584: throws NotFoundError when the target Person cannot be found for a tenant-scoped caller', async () => {
+            operation._findResourcesByUuids = jest.fn().mockResolvedValue([]);
+            await expect(operation.accessHistoryAsync({
+                requestInfo: baseRequestInfo,
+                parsedArgs: baseParsedArgs,
+                resourceType: 'Patient'
+            })).rejects.toThrow('Person with id p1 not found');
         });
 
         test('returns empty parameters when no ClickHouse rows found', async () => {


### PR DESCRIPTION
Jira: https://icanbwell.atlassian.net/browse/SEC-1584

## What this fixes

`AccessHistoryOperation`'s only instance-level authorization check only fired for patient-scoped tokens (`requestInfo.isUser`). A service-account/tenant-scoped caller skipped it entirely and could call `GET /Person/<any-uuid>/$access-history` for **any tenant's** Person and receive its full audit trail — who accessed their records, when, and why.

## The fix

For non-patient-scoped callers, fetch the target Person and verify the caller's scope authorizes its owner/access security tags via `ScopesManager.isAccessToResourceAllowedBySecurityTags` — the same per-resource check `expand.js` already uses for its fetch-by-id path. Added `scopesManager` as a constructor dependency, wired through the existing container registration.

## Adversarial review against `review.md`

Touch point: search/read, fetch-by-id. One real finding from the review pass itself: the denial path returns `NotFoundError`, not `ForbiddenError` — a distinguishable 403 vs 404 would let a caller enumerate valid Person ids across tenants by probing for the status-code difference. Fixed to match the same discipline `exportById.js` already uses for `ExportStatus` lookups.

Checked, no issue found: the existing patient-scoped identity check is unchanged and still gets an equivalent check on its own path (this fix closes the gap on the branch that previously had none). `_resolveAccessorDetails`'s cross-tenant accessor-name resolution is intentional — the feature's purpose is disclosing who accessed a record (accounting-of-disclosures), gated by the caller's own authorization for the target Person, which this fix is what verifies.

## Verification

- 28 unit tests (25 existing + 3 new) pass.
- Full unit suite: no new failures beyond the pre-existing tracked SEC-1582/DCON-4775 bug-documentation tests (78 failed suites, same before and after this change).
- Could not run the ClickHouse-backed integration test locally (no Docker). Traced its default `getHeaders()` token to scope `access/*.*`, which `scopesManager`'s existing wildcard handling already passes unconditionally — should be unaffected. Real CI will give final confirmation.

## Test plan

- [x] Unit tests pass (28/28)
- [x] Full unit suite shows no new regressions
- [ ] CI (ClickHouse-backed integration test) — final confirmation
- [ ] Code-owner review (branch protection requires 1 approving review)