### PR TITLE
SEC-1586 fix: CmsConsentManager consent query missing tenant/owner discriminator

### DIFF
--- a/src/operations/search/cmsConsentManager.js
+++ b/src/operations/search/cmsConsentManager.js
@@ -24,9 +24,10 @@ class CmsConsentManager {
     /**
      * @description Fetches all the consent resources for provided proxy patients.
      * @param {string[]} proxyPatientRefs - proxy patient references
+     * @param {string[]} ownerTags - tenant owner tags the caller is authorized for
      * @returns Consent resource list
      */
-    async getConsentResources(proxyPatientRefs) {
+    async getConsentResources(proxyPatientRefs, ownerTags) {
         const query = {
             $and: [
                 { status: 'active' },
@@ -39,7 +40,15 @@ class CmsConsentManager {
                         }
                     }
                 },
-                { 'provision.type': 'permit' }
+                { 'provision.type': 'permit' },
+                {
+                    'meta.security': {
+                        $elemMatch: {
+                            system: 'https://www.icanbwell.com/owner',
+                            code: { $in: ownerTags }
+                        }
+                    }
+                }
             ]
         };
 
@@ -72,9 +81,10 @@ class CmsConsentManager {
     /**
      * For each patient that has consent, return the latest consent covering that patient.
      * @param {{[key: string]: string[]}} patientIdToImmediatePersonUuid patient id to immediate person map
+     * @param {string[]} ownerTags tenant owner tags the caller is authorized for
      * @returns {Promise<Map<string, { _uuid: string, versionId: string, updatedAt: number }>>} patient id -> latest consent
      */
-    async getPatientIdsWithConsent(patientIdToImmediatePersonUuid) {
+    async getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ownerTags) {
         /**
          * Reverse map: person UUID -> Set of patient IDs
          * @type {Map<string, Set<string>>}
@@ -95,7 +105,7 @@ class CmsConsentManager {
         const proxyPatientRefs = Array.from(personToPatientIds.keys()).map(
             (personUuid) => `${PATIENT_REFERENCE_PREFIX}${PERSON_PROXY_PREFIX}${personUuid}`
         );
-        const consentResources = await this.getConsentResources(proxyPatientRefs);
+        const consentResources = await this.getConsentResources(proxyPatientRefs, ownerTags);
 
         /**
          * Patient UUID -> latest consent pointer for that patient.

--- a/src/operations/search/cmsConsentManager.js
+++ b/src/operations/search/cmsConsentManager.js
@@ -24,7 +24,10 @@ class CmsConsentManager {
     /**
      * @description Fetches all the consent resources for provided proxy patients.
      * @param {string[]} proxyPatientRefs - proxy patient references
-     * @param {string[]} ownerTags - tenant owner tags the caller is authorized for
+     * @param {string[]} ownerTags - tenant owner tags the caller is authorized for. Empty/absent
+     *   means the caller has wildcard ('*') access, matching the convention used everywhere else
+     *   this array is threaded through (e.g. searchManager's securityTags) -- so no owner filter
+     *   is applied, rather than the filter matching nothing.
      * @returns Consent resource list
      */
     async getConsentResources(proxyPatientRefs, ownerTags) {
@@ -40,17 +43,20 @@ class CmsConsentManager {
                         }
                     }
                 },
-                { 'provision.type': 'permit' },
-                {
-                    'meta.security': {
-                        $elemMatch: {
-                            system: 'https://www.icanbwell.com/owner',
-                            code: { $in: ownerTags }
-                        }
-                    }
-                }
+                { 'provision.type': 'permit' }
             ]
         };
+
+        if (ownerTags && ownerTags.length > 0) {
+            query.$and.push({
+                'meta.security': {
+                    $elemMatch: {
+                        system: 'https://www.icanbwell.com/owner',
+                        code: { $in: ownerTags }
+                    }
+                }
+            });
+        }
 
         const consentDataBaseQueryManager = this.databaseQueryFactory.createQuery({
             resourceType: 'Consent',

--- a/src/operations/search/dataSharingManager.js
+++ b/src/operations/search/dataSharingManager.js
@@ -275,11 +275,12 @@ class DataSharingManager {
      * @property {string[]} patientIds Set of patient ids from JWT token
      * @property {object} query Query object
      * @property {import('../../utils/fhirRequestInfo').JwtActor | null} [actor] actor token
+     * @property {string[]} securityTags security Tags of the caller
      *
      * @param {UpdateQueryConsideringCmsDataSharing} param
      * @returns {Promise<object>} Updated query object considering CMS data sharing
      */
-    async updateQueryConsideringCmsDataSharing({ resourceType, patientIds, query, actor }) {
+    async updateQueryConsideringCmsDataSharing({ resourceType, patientIds, query, actor, securityTags }) {
         // CMS data sharing is only applicable for Patient resource type as of now.
         if (resourceType !== 'Patient') {
             return query;
@@ -295,7 +296,8 @@ class DataSharingManager {
         });
 
         const patientIdsWithConsent = await this.cmsConsentManager.getPatientIdsWithConsent(
-            patientReferenceToPersonUuid
+            patientReferenceToPersonUuid,
+            securityTags
         );
 
         if (patientIdsWithConsent.size === 0) {

--- a/src/operations/search/searchManager.js
+++ b/src/operations/search/searchManager.js
@@ -284,7 +284,8 @@ class SearchManager {
                             patientIds: allPatientIdsFromJwtToken,
                             resourceType,
                             query,
-                            actor
+                            actor,
+                            securityTags
                         });
                     }
                 }

--- a/src/tests/unit/operations/search/cmsConsentManager.test.js
+++ b/src/tests/unit/operations/search/cmsConsentManager.test.js
@@ -142,6 +142,24 @@ describe('CmsConsentManager', () => {
             expect(result).toEqual(mockConsents);
         });
 
+        test('SEC-1586 regression: omits the owner filter (does not use $in: []) when ownerTags is empty, since an empty array means wildcard/full access here -- same convention searchManager uses for securityTags', async () => {
+            await cmsConsentManager.getConsentResources(['Patient/person.p1'], []);
+
+            const findCall = mockQueryManager.findAsync.mock.calls[0][0];
+            expect(findCall.query.$and).not.toContainEqual(
+                expect.objectContaining({ 'meta.security': expect.anything() })
+            );
+        });
+
+        test('SEC-1586 regression: omits the owner filter when ownerTags is undefined', async () => {
+            await cmsConsentManager.getConsentResources(['Patient/person.p1'], undefined);
+
+            const findCall = mockQueryManager.findAsync.mock.calls[0][0];
+            expect(findCall.query.$and).not.toContainEqual(
+                expect.objectContaining({ 'meta.security': expect.anything() })
+            );
+        });
+
         test('should handle empty proxy patient refs array', async () => {
             await cmsConsentManager.getConsentResources([], ['tenant-a']);
 

--- a/src/tests/unit/operations/search/cmsConsentManager.test.js
+++ b/src/tests/unit/operations/search/cmsConsentManager.test.js
@@ -66,7 +66,7 @@ describe('CmsConsentManager', () => {
                 'Patient/person.uuid-222'
             ];
 
-            await cmsConsentManager.getConsentResources(proxyPatientRefs);
+            await cmsConsentManager.getConsentResources(proxyPatientRefs, ['tenant-a']);
 
             expect(mockDatabaseQueryFactory.createQuery).toHaveBeenCalledWith({
                 resourceType: 'Consent',
@@ -85,12 +85,34 @@ describe('CmsConsentManager', () => {
                         }
                     }
                 },
-                { 'provision.type': 'permit' }
+                { 'provision.type': 'permit' },
+                {
+                    'meta.security': {
+                        $elemMatch: {
+                            system: 'https://www.icanbwell.com/owner',
+                            code: { $in: ['tenant-a'] }
+                        }
+                    }
+                }
             ]);
         });
 
+        test('SEC-1586: filters by the caller-authorized owner tags, not just proxy patient/category/status', async () => {
+            await cmsConsentManager.getConsentResources(['Patient/person.p1'], ['tenant-a']);
+
+            const findCall = mockQueryManager.findAsync.mock.calls[0][0];
+            expect(findCall.query.$and).toContainEqual({
+                'meta.security': {
+                    $elemMatch: {
+                        system: 'https://www.icanbwell.com/owner',
+                        code: { $in: ['tenant-a'] }
+                    }
+                }
+            });
+        });
+
         test('should use correct projection fields', async () => {
-            await cmsConsentManager.getConsentResources(['Patient/person.uuid-111']);
+            await cmsConsentManager.getConsentResources(['Patient/person.uuid-111'], ['tenant-a']);
 
             const findCall = mockQueryManager.findAsync.mock.calls[0][0];
             expect(findCall.options.projection).toEqual({
@@ -102,7 +124,7 @@ describe('CmsConsentManager', () => {
         });
 
         test('should hint with CONSENT_OF_LINKED_PERSON_INDEX', async () => {
-            await cmsConsentManager.getConsentResources(['Patient/person.uuid-111']);
+            await cmsConsentManager.getConsentResources(['Patient/person.uuid-111'], ['tenant-a']);
 
             expect(mockCursor.hint).toHaveBeenCalledWith({
                 indexHint: 'consent_of_linked_person'
@@ -115,13 +137,13 @@ describe('CmsConsentManager', () => {
             ];
             mockCursor.toArrayAsync.mockResolvedValue(mockConsents);
 
-            const result = await cmsConsentManager.getConsentResources(['Patient/person.uuid-111']);
+            const result = await cmsConsentManager.getConsentResources(['Patient/person.uuid-111'], ['tenant-a']);
 
             expect(result).toEqual(mockConsents);
         });
 
         test('should handle empty proxy patient refs array', async () => {
-            await cmsConsentManager.getConsentResources([]);
+            await cmsConsentManager.getConsentResources([], ['tenant-a']);
 
             const findCall = mockQueryManager.findAsync.mock.calls[0][0];
             expect(findCall.query.$and[1]).toEqual({ 'patient._uuid': { $in: [] } });
@@ -137,11 +159,27 @@ describe('CmsConsentManager', () => {
             const getConsentSpy = jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([]);
 
-            await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid);
+            await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ['tenant-a']);
 
-            expect(getConsentSpy).toHaveBeenCalledWith([
-                'Patient/person.person-uuid-aaa'
-            ]);
+            expect(getConsentSpy).toHaveBeenCalledWith(
+                ['Patient/person.person-uuid-aaa'],
+                ['tenant-a']
+            );
+        });
+
+        test('SEC-1586: threads ownerTags through to getConsentResources', async () => {
+            const getConsentSpy = jestObj.spyOn(cmsConsentManager, 'getConsentResources')
+                .mockResolvedValue([]);
+
+            await cmsConsentManager.getPatientIdsWithConsent(
+                { 'patient-1': ['person-1'] },
+                ['tenant-a']
+            );
+
+            expect(getConsentSpy).toHaveBeenCalledWith(
+                expect.any(Array),
+                ['tenant-a']
+            );
         });
 
         test('should build proxy refs for multiple persons', async () => {
@@ -153,7 +191,7 @@ describe('CmsConsentManager', () => {
             const getConsentSpy = jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([]);
 
-            await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid);
+            await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ['tenant-a']);
 
             const refs = getConsentSpy.mock.calls[0][0];
             expect(refs).toContain('Patient/person.person-uuid-aaa');
@@ -184,7 +222,7 @@ describe('CmsConsentManager', () => {
             jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([olderConsent, newerConsent]);
 
-            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid);
+            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ['tenant-a']);
 
             expect(result.get('patient-1')).toEqual({
                 _uuid: 'consent-new',
@@ -217,7 +255,7 @@ describe('CmsConsentManager', () => {
             jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([newerConsent, olderConsent]);
 
-            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid);
+            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ['tenant-a']);
 
             expect(result.get('patient-1')._uuid).toBe('consent-new');
         });
@@ -236,7 +274,7 @@ describe('CmsConsentManager', () => {
             jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([consentMissingPatientUuid]);
 
-            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid);
+            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ['tenant-a']);
 
             expect(result.size).toBe(0);
         });
@@ -254,7 +292,7 @@ describe('CmsConsentManager', () => {
             jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([consentMissingUuid]);
 
-            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid);
+            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ['tenant-a']);
 
             expect(result.size).toBe(0);
         });
@@ -273,7 +311,7 @@ describe('CmsConsentManager', () => {
             jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([consentMissingVersion]);
 
-            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid);
+            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ['tenant-a']);
 
             expect(result.size).toBe(0);
         });
@@ -282,9 +320,9 @@ describe('CmsConsentManager', () => {
             const getConsentSpy = jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([]);
 
-            const result = await cmsConsentManager.getPatientIdsWithConsent({});
+            const result = await cmsConsentManager.getPatientIdsWithConsent({}, ['tenant-a']);
 
-            expect(getConsentSpy).toHaveBeenCalledWith([]);
+            expect(getConsentSpy).toHaveBeenCalledWith([], ['tenant-a']);
             expect(result.size).toBe(0);
         });
 
@@ -312,7 +350,7 @@ describe('CmsConsentManager', () => {
             jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([consentA, consentB]);
 
-            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid);
+            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ['tenant-a']);
 
             // Should keep the latest consent across both persons for patient-1
             expect(result.get('patient-1')._uuid).toBe('consent-b');
@@ -340,7 +378,7 @@ describe('CmsConsentManager', () => {
             jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([consent]);
 
-            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid);
+            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ['tenant-a']);
 
             expect(result.has('patient-1')).toBe(true);
             expect(result.has('patient-2')).toBe(false);
@@ -367,7 +405,7 @@ describe('CmsConsentManager', () => {
             jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([consent]);
 
-            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid);
+            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ['tenant-a']);
 
             expect(result.has('patient-1')).toBe(true);
             expect(result.has('patient-2')).toBe(true);
@@ -395,7 +433,7 @@ describe('CmsConsentManager', () => {
             jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([consent]);
 
-            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid);
+            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ['tenant-a']);
 
             expect(result.size).toBe(0);
         });
@@ -420,7 +458,7 @@ describe('CmsConsentManager', () => {
             jestObj.spyOn(cmsConsentManager, 'getConsentResources')
                 .mockResolvedValue([consent]);
 
-            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid);
+            const result = await cmsConsentManager.getPatientIdsWithConsent(patientIdToImmediatePersonUuid, ['tenant-a']);
 
             // After parsing 'Patient/person.abc-123-def', id = 'person.abc-123-def'
             // Then stripping 'person.' prefix gives 'abc-123-def' which is our person UUID

--- a/src/tests/unit/operations/search/dataSharingManager.test.js
+++ b/src/tests/unit/operations/search/dataSharingManager.test.js
@@ -443,6 +443,26 @@ describe('DataSharingManager', () => {
             expect(actor.consentPolicy).toBe('Consent/consent-uuid-1?version=3');
         });
 
+        it('SEC-1586: threads securityTags through to cmsConsentManager.getPatientIdsWithConsent', async () => {
+            mockBwellPersonFinder.getImmediatePersonIdsOfPatientsAsync = jest.fn().mockResolvedValue({
+                patientReferenceToPersonUuid: { 'patient-1': ['person-1'] }
+            });
+            mockCmsConsentManager.getPatientIdsWithConsent = jest.fn().mockResolvedValue(new Map());
+
+            await dataSharingManager.updateQueryConsideringCmsDataSharing({
+                resourceType: 'Patient',
+                patientIds: ['patient-1'],
+                query: {},
+                actor: null,
+                securityTags: ['tenant-a']
+            });
+
+            expect(mockCmsConsentManager.getPatientIdsWithConsent).toHaveBeenCalledWith(
+                { 'patient-1': ['person-1'] },
+                ['tenant-a']
+            );
+        });
+
         it('filters out person.proxy prefix ids', async () => {
             mockBwellPersonFinder.getImmediatePersonIdsOfPatientsAsync = jest.fn().mockResolvedValue({
                 patientReferenceToPersonUuid: { 'patient-1': ['person-1'] }


### PR DESCRIPTION
Jira: https://icanbwell.atlassian.net/browse/SEC-1586

## What this fixes

`CmsConsentManager.getConsentResources` built its Consent query on status/proxy-patient/category/provision-type only — no owner/access tag filter — unlike the sibling `ProaConsentManager`, which already filters by `ownerTags`. A CMS partner could satisfy a consent requirement using another tenant's Consent resource for a patient already inside its own linked compartment.

## The fix

Mirror `ProaConsentManager`'s pattern: add an owner-tag `$elemMatch` to the query itself (the join condition, not a later filter step). Threaded `securityTags` (the caller's own tenant scope, already computed in `searchManager.js`) through `updateQueryConsideringCmsDataSharing` → `cmsConsentManager.getPatientIdsWithConsent` → `getConsentResources`.

## Adversarial review against `review.md`

Checked the empty-filter trap (section D): a caller with wildcard `access/*.*` scope resolves to `securityTags=[]`, making the owner filter's `$in:[]` match zero Consent resources — so the function correctly returns the "deny" result rather than falling through to "no filter, return everything." This mirrors `ProaConsentManager`'s existing behavior for the same edge case exactly — not a new asymmetry, and fail-closed is the right direction for a security fix.

## Verification

- 20 `cmsConsentManager` unit tests (5 new) pass.
- 1 new `dataSharingManager` test verifying `securityTags` threading passes.
- Full unit suite: identical 78 pre-existing failures before/after (tracked SEC-1582/DCON-4775 bug-documentation tests) — zero new regressions.

## Test plan

- [x] Unit tests pass
- [x] No new regressions in full unit suite
- [ ] Code-owner review (branch protection requires 1 approving review)