### PR TITLE
DCON-4803 fix: correct unresolvable schema require() paths and unhandled hang in Bundle result assembly

### DIFF
--- a/src/middleware/fhir/base/base.service.js
+++ b/src/middleware/fhir/base/base.service.js
@@ -11,11 +11,11 @@ const request = require('superagent');
 const errors = require('../utils/error.utils');
 
 const makeResultBundle = (results, res, baseVersion, type) => {
-    const Bundle = require(`../resources/${baseVersion}/schemas/bundle`);
+    const Bundle = require(`../../../fhir/classes/${baseVersion}/resources/bundle`);
 
-    const BundleLink = require(`../resources/${baseVersion}/schemas/bundlelink`);
+    const BundleLink = require(`../../../fhir/classes/${baseVersion}/backbone_elements/bundleLink`);
 
-    const BundleEntry = require(`../resources/${baseVersion}/schemas/bundleentry`);
+    const BundleEntry = require(`../../../fhir/classes/${baseVersion}/backbone_elements/bundleEntry`);
 
     const selfLink = new BundleLink({
         url: `${res.req.protocol}://${path.join(res.req.get('host'), res.req.baseUrl)}`,
@@ -93,7 +93,7 @@ const processRequest = requestType => {
 
             const resultsBundle = makeResultBundle(results, res, baseVersion, requestType);
             resolve(resultsBundle);
-        });
+        }).catch(reject);
     });
 };
 

--- a/src/tests/unit/middleware/fhir/base/base.service.resultBundle.test.js
+++ b/src/tests/unit/middleware/fhir/base/base.service.resultBundle.test.js
@@ -1,0 +1,72 @@
+const { describe, test, expect, beforeEach, jest: jestGlobal } = require('@jest/globals');
+
+jestGlobal.mock('../../../../../winstonInit', () => ({
+    getLogger: () => ({ info: jestGlobal.fn(), error: jestGlobal.fn() })
+}));
+
+const chainable = () => ({
+    send: () => ({ set: () => Promise.resolve({ status: 200 }) })
+});
+
+const mockSuperagent = {
+    get: jestGlobal.fn(chainable),
+    post: jestGlobal.fn(chainable)
+};
+jestGlobal.mock('superagent', () => mockSuperagent);
+
+const svc = require('../../../../../middleware/fhir/base/base.service.js');
+
+/**
+ * Regression coverage for DCON-4803: makeResultBundle's dynamic requires (Bundle/BundleLink/
+ * BundleEntry) previously pointed at paths that don't exist in this codebase, and the throw
+ * that caused was silently swallowed by an unreferenced promise chain, leaving the batch/
+ * transaction handler's returned promise pending forever instead of resolving or rejecting.
+ */
+describe('base.service batch - result bundle assembly (DCON-4803)', () => {
+    beforeEach(() => {
+        Object.values(mockSuperagent).forEach((fn) => fn.mockClear());
+    });
+
+    const makeReq = () => ({
+        headers: { host: 'localhost:3000' },
+        protocol: 'http',
+        hostname: 'localhost',
+        baseUrl: '',
+        params: { base_version: '4_0_0' },
+        body: {
+            resourceType: 'Bundle',
+            type: 'batch',
+            entry: [{ request: { method: 'GET', url: 'Patient/123' }, resource: null }]
+        }
+    });
+
+    const makeRes = () => ({
+        req: { protocol: 'http', baseUrl: '', get: () => 'localhost:3000' }
+    });
+
+    test('a successful batch request resolves with a real Bundle response instead of hanging or throwing MODULE_NOT_FOUND', async () => {
+        const resultBundle = await svc.batch(makeReq(), makeRes());
+
+        expect(resultBundle.resourceType).toBe('Bundle');
+        expect(resultBundle.type).toBe('batch');
+        expect(resultBundle.entry).toHaveLength(1);
+        expect(resultBundle.link[0].url).toBe('http://localhost:3000');
+    });
+
+    test('an error during result assembly rejects the returned promise instead of leaving it pending forever', async () => {
+        // res.req.get('host') throwing simulates any error inside the Promise.all(...).then()
+        // callback - previously this became an unhandled rejection on an orphaned promise chain,
+        // and svc.batch()'s returned promise never settled.
+        const brokenRes = {
+            req: {
+                protocol: 'http',
+                baseUrl: '',
+                get: () => {
+                    throw new Error('boom');
+                }
+            }
+        };
+
+        await expect(svc.batch(makeReq(), brokenRes)).rejects.toThrow('boom');
+    });
+});


### PR DESCRIPTION
## DCON-4803: Bundle batch/transaction result assembly uses unresolvable require() paths and hangs forever on error

Found incidentally while adding test coverage for the SSRF fix in the same file (DCON-4801 / #2392) — unrelated to that vulnerability, kept out of that PR to keep it scoped.

### Bug 1 — unresolvable require() paths

`makeResultBundle` dynamically required FHIR classes from a path that doesn't exist anywhere in this codebase:

```js
const Bundle = require(`../resources/${baseVersion}/schemas/bundle`);
const BundleLink = require(`../resources/${baseVersion}/schemas/bundlelink`);
const BundleEntry = require(`../resources/${baseVersion}/schemas/bundleentry`);
```

There's no `middleware/fhir/resources/<version>/schemas/` directory. The real classes live at `fhir/classes/<version>/resources/bundle.js` and `fhir/classes/<version>/backbone_elements/bundle{Link,Entry}.js` — confirmed against every other caller in the codebase (e.g. `src/operations/common/bundleManager.js`). Any **fully successful** batch or transaction request hit this line and threw `MODULE_NOT_FOUND`.

### Bug 2 — the request then hung forever instead of failing

That throw happened inside `processRequest`'s `Promise.all(requestPromises).then(responses => {...})` callback, which had no `.catch()` and wasn't connected to the outer `new Promise((resolve, reject) => ...)`. The throw became an unhandled rejection on an orphaned promise chain — the promise returned to the caller never settled. In production, a successful batch/transaction request didn't error, it just hung indefinitely.

### Fix

1. Corrected the three require paths.
2. Added `.catch(reject)` to the `Promise.all(...).then(...)` chain, so any error during result assembly rejects properly instead of hanging.

### Verification

New regression tests (`src/tests/unit/middleware/fhir/base/base.service.resultBundle.test.js`): a successful batch request now resolves with a real `Bundle` response instead of throwing `MODULE_NOT_FOUND`; an error during result assembly now rejects instead of hanging. Confirmed no new test failures introduced (this repo has ~78 pre-existing unrelated failing suites from an unrelated `@kubernetes/client-node` module-resolution issue — identical count with and without this change). `eslint` clean; diff is minimal/scoped.

Jira: [DCON-4803](https://icanbwell.atlassian.net/browse/DCON-4803)
Related: DCON-4801 / #2392 (separate SSRF fix in the same file — different bug, don't conflate).


[DCON-4803]: https://icanbwell.atlassian.net/browse/DCON-4803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ