### PR TITLE
DCON-4805 harden export job trigger and S3 key construction

### DIFF
--- a/src/operations/export/exportManager.js
+++ b/src/operations/export/exportManager.js
@@ -5,7 +5,7 @@ const { SecurityTagManager } = require('../common/securityTagManager');
 const { assertTypeEquals } = require('../../utils/assertType');
 const { SecurityTagSystem } = require('../../utils/securityTagSystem');
 const { K8sClient } = require('../../utils/k8sClient');
-const { logInfo } = require('../../operations/common/logging');
+const { logInfo, logWarn } = require('../../operations/common/logging');
 const { ConfigManager } = require('../../utils/configManager');
 const { generateUUID } = require('../../utils/uid.util');
 const { PreSaveOptions } = require('../../preSaveHandlers/preSaveOptions');
@@ -136,10 +136,23 @@ class ExportManager {
             `--requestId ${requestId} ` +
             `--awsRegion ${this.configManager.awsRegion}`;
 
+        // These are batch-size tuning knobs and must be plain positive integers. `context[param]`
+        // originates from a request-supplied query param (persisted onto the ExportStatus
+        // resource as an extension). scriptCommand is later split on spaces into the container's
+        // argv array (see K8sClient.createJobBody), so an unvalidated value containing a space
+        // could inject additional/overriding CLI flags into the spawned job. Silently drop any
+        // value that isn't a bare non-negative integer rather than passing it through.
         const possibleScriptParams = ['patientReferenceBatchSize', 'fetchResourceBatchSize', 'uploadPartSize'];
+        const INTEGER_PARAM_RE = /^[0-9]+$/;
         possibleScriptParams.forEach(param => {
-            if (context[param]) {
-                scriptCommand += ` --${param} ${context[param]}`;
+            const value = context[param];
+            if (value === undefined || value === null || value === '') {
+                return;
+            }
+            if (INTEGER_PARAM_RE.test(String(value))) {
+                scriptCommand += ` --${param} ${value}`;
+            } else {
+                logWarn(`Ignoring non-integer value for export job param '${param}'`, { exportStatusId: exportStatusResource._uuid });
             }
         });
 

--- a/src/operations/export/script/bulkDataExportRunner.js
+++ b/src/operations/export/script/bulkDataExportRunner.js
@@ -18,7 +18,7 @@ const { R4SearchQueryCreator } = require('../../query/r4');
 const { S3Client } = require('../../../utils/s3Client');
 const { assertTypeEquals, assertIsValid } = require('../../../utils/assertType');
 const { isUuid } = require('../../../utils/uid.util');
-const { logInfo, logError, logDebug } = require('../../common/logging');
+const { logInfo, logError, logDebug, logWarn } = require('../../common/logging');
 const { SecurityTagSystem } = require('../../../utils/securityTagSystem');
 const {
     BLOB_OP,
@@ -35,6 +35,32 @@ const { S3MultiPartContext } = require('./s3MultiPartContext');
 const { PostSaveProcessor } = require('../../../dataLayer/postSaveProcessor');
 const { BulkExportEventProducer } = require('../../../utils/bulkExportEventProducer');
 const { FhirResourceSerializer } = require('../../../fhir/fhirResourceSerializer');
+
+// Access-tag security codes are used verbatim as a path segment of the S3 export key
+// (`exports/<tags>/<exportStatusId>/...`). They come from the JWT scope string via
+// SecurityTagManager, which imposes no character restriction, so any tag that isn't a plain
+// identifier is dropped here rather than passed into the S3 key unsanitized.
+const SAFE_ACCESS_TAG_RE = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Extracts the access-tag security codes from a resource's meta.security array, dropping any
+ * whose value contains characters unsafe for use as an S3 key path segment.
+ * @param {Array<{system: string, code: string}>} metaSecurity
+ * @param {string} exportStatusId - used only for the warning log line
+ * @return {string[]}
+ */
+function computeSafeAccessTags(metaSecurity, exportStatusId) {
+    return (metaSecurity || [])
+        .filter(s => s.system === SecurityTagSystem.access)
+        .map(s => s.code)
+        .filter(code => {
+            const isSafe = SAFE_ACCESS_TAG_RE.test(code);
+            if (!isSafe) {
+                logWarn(`Ignoring access tag with unsafe characters for S3 key: ${code}`, { exportStatusId });
+            }
+            return isSafe;
+        });
+}
 
 class BulkDataExportRunner {
     /**
@@ -234,9 +260,7 @@ class BulkDataExportRunner {
             );
 
             // compute base folder where data will be upload in s3
-            const accessTags = this.exportStatusResource.meta.security
-                .filter(s => s.system === SecurityTagSystem.access)
-                .map(s => s.code);
+            const accessTags = computeSafeAccessTags(this.exportStatusResource.meta.security, this.exportStatusId);
             if (accessTags.length === 0) {
                 accessTags.push('bwell');
             }
@@ -911,4 +935,4 @@ class BulkDataExportRunner {
     }
 }
 
-module.exports = { BulkDataExportRunner };
+module.exports = { BulkDataExportRunner, computeSafeAccessTags };

--- a/src/tests/unit/operations/export/bulkDataExportRunner.accessTagS3Key.test.js
+++ b/src/tests/unit/operations/export/bulkDataExportRunner.accessTagS3Key.test.js
@@ -1,0 +1,58 @@
+const { describe, test, expect, jest } = require('@jest/globals');
+
+jest.mock('../../../../operations/common/logging', () => {
+    const { jest: j } = require('@jest/globals');
+    return {
+        logInfo: j.fn(),
+        logError: j.fn(),
+        logDebug: j.fn(),
+        logWarn: j.fn()
+    };
+});
+
+const { computeSafeAccessTags } = require('../../../../operations/export/script/bulkDataExportRunner');
+const { logWarn } = require('../../../../operations/common/logging');
+const { SecurityTagSystem } = require('../../../../utils/securityTagSystem');
+
+describe('computeSafeAccessTags (DCON-4805 S3 key injection fix)', () => {
+    test('passes through plain alphanumeric access tags', () => {
+        const metaSecurity = [
+            { system: SecurityTagSystem.access, code: 'bwell' },
+            { system: SecurityTagSystem.access, code: 'client-1' },
+            { system: SecurityTagSystem.access, code: 'client_2' }
+        ];
+        expect(computeSafeAccessTags(metaSecurity, 'export-1')).toEqual(['bwell', 'client-1', 'client_2']);
+    });
+
+    test('ignores tags on a different system', () => {
+        const metaSecurity = [
+            { system: SecurityTagSystem.owner, code: 'bwell' },
+            { system: SecurityTagSystem.access, code: 'client1' }
+        ];
+        expect(computeSafeAccessTags(metaSecurity, 'export-1')).toEqual(['client1']);
+    });
+
+    test('drops an access tag containing a path segment', () => {
+        const metaSecurity = [
+            { system: SecurityTagSystem.access, code: '../../etc' },
+            { system: SecurityTagSystem.access, code: 'client1' }
+        ];
+        expect(computeSafeAccessTags(metaSecurity, 'export-1')).toEqual(['client1']);
+        expect(logWarn).toHaveBeenCalledWith(
+            expect.stringContaining('../../etc'),
+            expect.objectContaining({ exportStatusId: 'export-1' })
+        );
+    });
+
+    test('drops an access tag containing a slash', () => {
+        const metaSecurity = [
+            { system: SecurityTagSystem.access, code: 'client1/other-tenant' }
+        ];
+        expect(computeSafeAccessTags(metaSecurity, 'export-1')).toEqual([]);
+    });
+
+    test('returns an empty array when meta.security is null/undefined', () => {
+        expect(computeSafeAccessTags(null, 'export-1')).toEqual([]);
+        expect(computeSafeAccessTags(undefined, 'export-1')).toEqual([]);
+    });
+});

--- a/src/tests/unit/operations/export/bulkDataExportRunner.crossTenant.test.js
+++ b/src/tests/unit/operations/export/bulkDataExportRunner.crossTenant.test.js
@@ -5,7 +5,8 @@ jest.mock('../../../../operations/common/logging', () => {
     return {
         logInfo: j.fn(),
         logError: j.fn(),
-        logDebug: j.fn()
+        logDebug: j.fn(),
+        logWarn: j.fn()
     };
 });
 

--- a/src/tests/unit/operations/export/bulkDataExportRunner.nullSafety.test.js
+++ b/src/tests/unit/operations/export/bulkDataExportRunner.nullSafety.test.js
@@ -5,7 +5,8 @@ jest.mock('../../../../operations/common/logging', () => {
     return {
         logInfo: j.fn(),
         logError: j.fn(),
-        logDebug: j.fn()
+        logDebug: j.fn(),
+        logWarn: j.fn()
     };
 });
 

--- a/src/tests/unit/operations/export/bulkDataExportRunner.test.js
+++ b/src/tests/unit/operations/export/bulkDataExportRunner.test.js
@@ -5,7 +5,8 @@ jest.mock('../../../../operations/common/logging', () => {
     return {
         logInfo: j.fn(),
         logError: j.fn(),
-        logDebug: j.fn()
+        logDebug: j.fn(),
+        logWarn: j.fn()
     };
 });
 

--- a/src/tests/unit/operations/export/exportManager.test.js
+++ b/src/tests/unit/operations/export/exportManager.test.js
@@ -10,7 +10,8 @@ jestObj.mock('../../../../utils/assertType', () => ({
 jestObj.mock('../../../../operations/common/logging', () => ({
     logInfo: jestObj.fn(),
     logError: jestObj.fn(),
-    logDebug: jestObj.fn()
+    logDebug: jestObj.fn(),
+    logWarn: jestObj.fn()
 }));
 
 jestObj.mock('../../../../utils/uid.util', () => ({
@@ -389,6 +390,78 @@ describe('ExportManager', () => {
             });
             const call = mocks.k8sClient.createJob.mock.calls[0][0];
             expect(call.context).toEqual({});
+        });
+
+        // DCON-4805: scriptCommand is later split on spaces into the container's argv array,
+        // so an unvalidated batch-size param containing a space could inject extra CLI flags
+        // into the spawned Kubernetes job (e.g. overriding --bulkExportS3BucketName or
+        // --exportStatusId). These params must be rejected unless they are a bare integer.
+        describe('argument injection prevention', () => {
+            test('drops a patientReferenceBatchSize value containing an injected flag', async () => {
+                const exportStatusResource = {
+                    _uuid: 'export-uuid-123',
+                    extension: [
+                        { id: 'patientReferenceBatchSize', valueString: '100 --bulkExportS3BucketName attacker-bucket' }
+                    ]
+                };
+                await exportManager.triggerExportJob({
+                    exportStatusResource,
+                    requestId: 'req-123'
+                });
+                const call = mocks.k8sClient.createJob.mock.calls[0][0];
+                expect(call.scriptCommand).not.toContain('attacker-bucket');
+                expect(call.scriptCommand).not.toContain('--patientReferenceBatchSize');
+                // the legitimate base bucket name must still be the only one present
+                expect(call.scriptCommand).toContain('--bulkExportS3BucketName test-bucket');
+            });
+
+            test('drops a fetchResourceBatchSize value containing shell metacharacters', async () => {
+                const exportStatusResource = {
+                    _uuid: 'export-uuid-123',
+                    extension: [
+                        { id: 'fetchResourceBatchSize', valueString: '100; rm -rf /' }
+                    ]
+                };
+                await exportManager.triggerExportJob({
+                    exportStatusResource,
+                    requestId: 'req-123'
+                });
+                const call = mocks.k8sClient.createJob.mock.calls[0][0];
+                expect(call.scriptCommand).not.toContain('--fetchResourceBatchSize');
+                expect(call.scriptCommand).not.toContain('rm -rf');
+            });
+
+            test('accepts a plain positive integer value', async () => {
+                const exportStatusResource = {
+                    _uuid: 'export-uuid-123',
+                    extension: [
+                        { id: 'uploadPartSize', valueString: '1024' }
+                    ]
+                };
+                await exportManager.triggerExportJob({
+                    exportStatusResource,
+                    requestId: 'req-123'
+                });
+                const call = mocks.k8sClient.createJob.mock.calls[0][0];
+                expect(call.scriptCommand).toContain('--uploadPartSize 1024');
+            });
+
+            test('rejects a negative number and a decimal value', async () => {
+                const exportStatusResource = {
+                    _uuid: 'export-uuid-123',
+                    extension: [
+                        { id: 'patientReferenceBatchSize', valueString: '-5' },
+                        { id: 'fetchResourceBatchSize', valueString: '5.5' }
+                    ]
+                };
+                await exportManager.triggerExportJob({
+                    exportStatusResource,
+                    requestId: 'req-123'
+                });
+                const call = mocks.k8sClient.createJob.mock.calls[0][0];
+                expect(call.scriptCommand).not.toContain('--patientReferenceBatchSize');
+                expect(call.scriptCommand).not.toContain('--fetchResourceBatchSize');
+            });
         });
     });
 });


### PR DESCRIPTION
## Jira
[DCON-4805](https://icanbwell.atlassian.net/browse/DCON-4805)

## Summary
Input validation hardening for the export job trigger (`src/operations/export/exportManager.js`) and S3 key construction (`src/operations/export/script/bulkDataExportRunner.js`). See the linked Jira ticket for the full technical writeup.

## Tests
Updated `exportManager.test.js`; added `bulkDataExportRunner.accessTagS3Key.test.js`; added `logWarn` to the logging mock in the three existing `bulkDataExportRunner.*.test.js` files.

## Verification
- `eslint` clean.
- `jest --config jest.unit.config.js`: 0 regressions vs. main (confirmed via `git stash`); all new/modified tests pass.
- Full Docker-backed `jest.config.js` suite not run locally (no Docker in the authoring environment) — please confirm CI is green before merging.

[DCON-4805]: https://icanbwell.atlassian.net/browse/DCON-4805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ