### PR TITLE
DCON-4806 harden auth-gating middleware (1/4)

### DIFF
--- a/src/middleware/fhir/authentication.middleware.js
+++ b/src/middleware/fhir/authentication.middleware.js
@@ -90,7 +90,14 @@ module.exports = function authenticationMiddleware (config) {
         } = config.auth.strategy;
         return authenticateWithJsonFailure(name, {session: useSession});
     } else {
-        return noOpMiddleware;
+        // Fail closed: a missing auth strategy must never fall through to an
+        // unauthenticated pass-through (this previously returned noOpMiddleware, which
+        // let every request through with no credential check at all). If this branch is
+        // ever hit outside tests, auth configuration is broken or missing -- the safe
+        // behavior is to deny every request, not silently allow them.
+        return function missingAuthStrategyMiddleware (req, res) {
+            sendUnauthorizedJson(res);
+        };
     }
 };
 

--- a/src/middleware/fhir/sof-scope.middleware.js
+++ b/src/middleware/fhir/sof-scope.middleware.js
@@ -4,7 +4,7 @@ const noOpMiddleware = require('./noop.middleware.js');
 
 const {
     INTERACTIONS
-} = require('../../constants');
+} = require('./utils/constants');
 
 const errors = require('./utils/error.utils');
 

--- a/src/tests/unit/middleware/fhir/authentication.middleware.test.js
+++ b/src/tests/unit/middleware/fhir/authentication.middleware.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { describe, test, expect, beforeEach, jest: jestObj } = require('@jest/globals');
+const { describe, test, expect, beforeEach, afterEach, jest: jestObj } = require('@jest/globals');
 
 jestObj.mock('passport', () => ({
     authenticate: jestObj.fn(),
@@ -10,7 +10,8 @@ jestObj.mock('passport', () => ({
 jestObj.mock('../../noop.middleware.js', () => (req, res, next) => next(), { virtual: true });
 
 const passport = require('passport');
-const { authenticateWithJsonFailure, sendUnauthorizedJson } = require('../../../../middleware/fhir/authentication.middleware');
+const authenticationMiddleware = require('../../../../middleware/fhir/authentication.middleware');
+const { authenticateWithJsonFailure, sendUnauthorizedJson } = authenticationMiddleware;
 
 describe('authentication.middleware', () => {
     let req;
@@ -197,6 +198,64 @@ describe('authentication.middleware', () => {
             const middleware = authenticateWithJsonFailure('bearer');
             middleware(req, res, next);
             expect(next).toHaveBeenCalledWith(loginErr);
+        });
+    });
+
+    // DCON-4806: a missing/falsy auth strategy must fail closed (deny), not fail open
+    // (pass through unauthenticated) -- see authenticationMiddleware's default export.
+    describe('authenticationMiddleware (default export) fail-closed behavior', () => {
+        const savedNodeEnv = process.env.NODE_ENV;
+
+        beforeEach(() => {
+            process.env.NODE_ENV = 'production';
+        });
+
+        afterEach(() => {
+            process.env.NODE_ENV = savedNodeEnv;
+        });
+
+        test('denies with 401 when config.auth.strategy is missing entirely', () => {
+            const middleware = authenticationMiddleware({ auth: {} });
+            middleware(req, res, next);
+            expect(res.status).toHaveBeenCalledWith(401);
+            expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+                resourceType: 'OperationOutcome'
+            }));
+            expect(next).not.toHaveBeenCalled();
+        });
+
+        test('denies with 401 when config.auth is entirely missing', () => {
+            const middleware = authenticationMiddleware({});
+            middleware(req, res, next);
+            expect(res.status).toHaveBeenCalledWith(401);
+        });
+
+        test('does NOT fall through to next() when strategy is missing', () => {
+            const middleware = authenticationMiddleware({ auth: { strategy: null } });
+            middleware(req, res, next);
+            expect(next).not.toHaveBeenCalled();
+        });
+
+        test('uses the real passport-backed middleware when a strategy is configured', () => {
+            passport.authenticate.mockImplementation((strategy, options, callback) => {
+                return (innerReq, innerRes, innerNext) => {
+                    callback(null, { id: 'user-1' }, {});
+                };
+            });
+            passport.transformAuthInfo.mockImplementation((authInfo, innerReq, cb) => cb(null, authInfo));
+
+            const middleware = authenticationMiddleware({ auth: { strategy: { name: 'jwt' } } });
+            middleware(req, res, next);
+            expect(passport.authenticate).toHaveBeenCalledWith('jwt', expect.objectContaining({ session: false }), expect.any(Function));
+            expect(next).toHaveBeenCalledWith();
+        });
+
+        test('returns noOpMiddleware in test env even with no strategy configured', () => {
+            process.env.NODE_ENV = 'test';
+            const middleware = authenticationMiddleware({});
+            middleware(req, res, next);
+            expect(next).toHaveBeenCalledWith();
+            expect(res.status).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/tests/unit/middleware/fhir/sof-scope.middleware.test.js
+++ b/src/tests/unit/middleware/fhir/sof-scope.middleware.test.js
@@ -41,12 +41,16 @@ describe('sofScopeCheckMiddleware', () => {
         expect(next).toHaveBeenCalledWith();
     });
 
-    describe('with smart auth enabled (BUG: INTERACTIONS imported from wrong module)', () => {
+    // DCON-4806: INTERACTIONS was imported from '../../constants' (src/constants.js), which
+    // exports no INTERACTIONS key -- the destructure silently resolved to `undefined`, so
+    // every `case INTERACTIONS.SEARCH` etc. threw a TypeError at request time. Fixed by
+    // importing from './utils/constants', the module that actually defines INTERACTIONS.
+    describe('with smart auth enabled', () => {
         beforeEach(() => {
             process.env.NODE_ENV = 'production';
         });
 
-        test('BUG: deriveActionFromInteraction crashes because INTERACTIONS is undefined', () => {
+        test('does not throw and correctly derives a read action for a search interaction', () => {
             scopeChecker.mockReturnValue({});
             const middleware = sofScopeCheckMiddleware({
                 route: { interaction: 'search' },
@@ -55,7 +59,37 @@ describe('sofScopeCheckMiddleware', () => {
             });
             const req = { user: { scope: 'patient/Patient.read' }, params: {} };
             const next = jestObj.fn();
-            expect(() => middleware(req, {}, next)).toThrow(TypeError);
+            expect(() => middleware(req, {}, next)).not.toThrow();
+            expect(scopeChecker).toHaveBeenCalledWith('Patient', 'read', ['patient/Patient.read']);
+            expect(next).toHaveBeenCalledWith();
+        });
+
+        test('correctly derives a write action for a create interaction', () => {
+            scopeChecker.mockReturnValue({});
+            const middleware = sofScopeCheckMiddleware({
+                route: { interaction: 'create' },
+                name: 'patient',
+                auth: { type: 'smart', strategy: {} }
+            });
+            const req = { user: { scope: 'patient/Patient.write' }, params: {} };
+            const next = jestObj.fn();
+            middleware(req, {}, next);
+            expect(scopeChecker).toHaveBeenCalledWith('Patient', 'write', ['patient/Patient.write']);
+        });
+
+        test('rejects when scopeChecker reports an authorization error', () => {
+            const errors = require('../../../../middleware/fhir/utils/error.utils');
+            scopeChecker.mockReturnValue({ error: { message: 'insufficient scope' } });
+            const middleware = sofScopeCheckMiddleware({
+                route: { interaction: 'search' },
+                name: 'patient',
+                auth: { type: 'smart', strategy: {} }
+            });
+            const req = { user: { scope: '' }, params: {} };
+            const next = jestObj.fn();
+            middleware(req, {}, next);
+            expect(errors.unauthorized).toHaveBeenCalledWith('insufficient scope', undefined);
+            expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
         });
     });
 });


### PR DESCRIPTION
## Jira
[DCON-4806](https://icanbwell.atlassian.net/browse/DCON-4806) (1 of 4 grouped PRs — see ticket for the full finding list; this PR covers the auth-gating middleware layer only)

## Summary
Hardening for `src/middleware/fhir/authentication.middleware.js` and `src/middleware/fhir/sof-scope.middleware.js`. See the linked Jira ticket for the full technical writeup.

## Tests
Updated `authentication.middleware.test.js` and `sof-scope.middleware.test.js` with new coverage for the changed behavior.

## Verification
- `eslint` clean.
- `jest --config jest.unit.config.js`: 0 regressions vs. main; all new/modified tests pass.
- Full Docker-backed `jest.config.js` suite not run locally (no Docker in the authoring environment) — please confirm CI is green before merging.

[DCON-4806]: https://icanbwell.atlassian.net/browse/DCON-4806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ