### PR TITLE
DCON-4806 harden graph DELETE scope check and validate delegated filtering (3/4)

### DIFF
--- a/src/operations/graph/graph.js
+++ b/src/operations/graph/graph.js
@@ -96,13 +96,19 @@ class GraphOperation {
             method
         } = requestInfo;
 
+        // DELETE dispatches to deleteGraphAsync below and must be scope-checked as a write,
+        // not a read -- otherwise a read-only-scoped caller could delete the resource graph.
+        // Guard defensively rather than calling method.toLowerCase() unconditionally: an
+        // undefined/malformed method should surface at the dispatch check below (inside the
+        // try block, where it's caught and logged), not crash this pre-flight scope check.
+        const accessRequested = (method && method.toLowerCase() === 'delete') ? 'write' : 'read';
         await this.scopesValidator.verifyHasValidScopesAsync({
             requestInfo,
             parsedArgs,
             resourceType,
             startTime,
             action: currentOperationName,
-            accessRequested: 'read'
+            accessRequested
         });
 
         try {

--- a/src/operations/validate/validate.js
+++ b/src/operations/validate/validate.js
@@ -99,7 +99,11 @@ class ValidateOperation {
             /** @type {string | null} */
             scope,
             /** @type {string} */
-            path
+            path,
+            /** @type {string | null} */
+            userType,
+            /** @type {import('../../utils/fhirRequestInfo').JwtActor|null} */
+            actor
         } = requestInfo;
         // Note: no auth check needed to call validate
 
@@ -134,11 +138,13 @@ class ValidateOperation {
                         user,
                         scope,
                         isUser,
+                        userType,
                         resourceType,
                         useAccessIndex,
                         personIdFromJwtToken,
                         parsedArgs,
-                        operation: READ
+                        operation: READ,
+                        actor
                     }
                 );
 

--- a/src/tests/unit/operations/graph/graph.test.js
+++ b/src/tests/unit/operations/graph/graph.test.js
@@ -152,6 +152,34 @@ describe('GraphOperation', () => {
             expect(mockGraphHelper.processGraphAsync).not.toHaveBeenCalled();
         });
 
+        // DCON-4806: verifyHasValidScopesAsync must be checked as a write for DELETE,
+        // otherwise a read-only-scoped caller could delete the resource graph.
+        test('should verify write scope (not read) when method is DELETE', async () => {
+            mockRequestInfo.method = 'DELETE';
+
+            await graphOperation.graph({
+                requestInfo: mockRequestInfo,
+                parsedArgs: mockParsedArgs,
+                resourceType: 'Patient'
+            });
+
+            expect(mockScopesValidator.verifyHasValidScopesAsync).toHaveBeenCalledWith(
+                expect.objectContaining({ accessRequested: 'write' })
+            );
+        });
+
+        test('should verify read scope for non-DELETE methods', async () => {
+            await graphOperation.graph({
+                requestInfo: mockRequestInfo,
+                parsedArgs: mockParsedArgs,
+                resourceType: 'Patient'
+            });
+
+            expect(mockScopesValidator.verifyHasValidScopesAsync).toHaveBeenCalledWith(
+                expect.objectContaining({ accessRequested: 'read' })
+            );
+        });
+
         test('should extract graph from Parameters resource', async () => {
             mockRequestInfo.body = {
                 resourceType: 'Parameters',

--- a/src/tests/unit/operations/validate/validate.test.js
+++ b/src/tests/unit/operations/validate/validate.test.js
@@ -297,4 +297,49 @@ describe('ValidateOperation - null safety bugs', () => {
             expect(result.resourceType).toBe('OperationOutcome');
         });
     });
+
+    // DCON-4806: constructQueryAsync must receive userType/actor so delegated-access
+    // sensitive-data filtering (gated on userType === AUTH_USER_TYPES.delegatedUser in
+    // searchManager.js) actually applies to id-based $validate lookups.
+    describe('validateAsync - passes userType/actor through to constructQueryAsync', () => {
+        test('forwards userType and actor from requestInfo', async () => {
+            const mockCursor = {
+                hasNext: jest.fn().mockResolvedValue(false),
+                nextObject: jest.fn()
+            };
+            const mockDatabaseQueryManager = {
+                findAsync: jest.fn().mockResolvedValue(mockCursor)
+            };
+            mocks.databaseQueryFactory.createQuery = jest.fn().mockReturnValue(mockDatabaseQueryManager);
+
+            const parsedArgs = createMockInstance(ParsedArgs);
+            parsedArgs.id = 'some-id';
+            parsedArgs.resource = undefined;
+            parsedArgs.base_version = '4_0_0';
+            parsedArgs._useAccessIndex = false;
+            parsedArgs.profile = undefined;
+            parsedArgs.getRawArgs = jest.fn().mockReturnValue({});
+
+            const actor = { sub: 'delegate-actor-1' };
+            const requestInfo = {
+                isUser: true,
+                personIdFromJwtToken: 'person-1',
+                user: 'delegate-user',
+                scope: 'user/*.*',
+                path: '/4_0_0/Patient/$validate',
+                userType: 'delegatedUser',
+                actor
+            };
+
+            await validateOp.validateAsync({
+                requestInfo,
+                parsedArgs,
+                resourceType: 'Patient'
+            });
+
+            expect(mocks.searchManager.constructQueryAsync).toHaveBeenCalledWith(
+                expect.objectContaining({ userType: 'delegatedUser', actor })
+            );
+        });
+    });
 });


### PR DESCRIPTION
## Jira
[DCON-4806](https://icanbwell.atlassian.net/browse/DCON-4806) (3 of 4 grouped PRs — see ticket for the full finding list; this PR covers graph.js and validate.js only)

## Summary
Scope-check and delegated-access-filtering fixes in `src/operations/graph/graph.js` and `src/operations/validate/validate.js`. See the linked Jira ticket for the full technical writeup.

## Tests
Added coverage in `graph.test.js` (DELETE vs. non-DELETE `accessRequested`) and `validate.test.js` (`userType`/`actor` forwarded to `constructQueryAsync`).

## Verification
- `eslint` clean.
- `jest --config jest.unit.config.js`: confirmed via `git stash` comparison — 2 pre-existing failures unchanged (unrelated: null-return and null-body edge cases already broken on main), 3 new tests added and passing. Full suite: 329 failing before and after, unchanged. Zero regressions.
- Full Docker-backed `jest.config.js` suite not run locally (no Docker in the authoring environment) — please confirm CI is green before merging.

[DCON-4806]: https://icanbwell.atlassian.net/browse/DCON-4806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ