### PR TITLE
DCON-4807 harden profile-fetch SSRF validation against IPv6 bypass

### DIFF
--- a/src/tests/unit/utils/urlParser.test.js
+++ b/src/tests/unit/utils/urlParser.test.js
@@ -258,6 +258,35 @@ describe('urlParser', () => {
             expect(() => validateUrl('https://0177.0.0.1')).not.toThrow();
         });
     });
+
+    // DCON-4807: the IPv4-only private-range check had no IPv6 equivalent, so any IPv6
+    // literal (loopback, IPv4-mapped, link-local, unique-local) bypassed SSRF protection
+    // entirely. Fixed by rejecting all IPv6 literal addresses outright.
+    describe('validateUrl - IPv6 literals are blocked outright (DCON-4807)', () => {
+        test('blocks IPv6 loopback ::1', () => {
+            expect(() => validateUrl('https://[::1]/admin')).toThrow('IPv6 literal');
+        });
+
+        test('blocks IPv4-mapped IPv6 loopback ::ffff:127.0.0.1', () => {
+            expect(() => validateUrl('https://[::ffff:127.0.0.1]/admin')).toThrow('IPv6 literal');
+        });
+
+        test('blocks IPv6 link-local fe80::1', () => {
+            expect(() => validateUrl('https://[fe80::1]/admin')).toThrow('IPv6 literal');
+        });
+
+        test('blocks IPv6 unique-local fc00::1', () => {
+            expect(() => validateUrl('https://[fc00::1]/admin')).toThrow('IPv6 literal');
+        });
+
+        test('blocks a public-looking IPv6 literal too (no legitimate use case for it here)', () => {
+            expect(() => validateUrl('https://[2001:4860:4860::8888]/')).toThrow('IPv6 literal');
+        });
+
+        test('blocks IPv6 literal with a port', () => {
+            expect(() => validateUrl('https://[::1]:8080/admin')).toThrow('IPv6 literal');
+        });
+    });
 });
 
 describe('isPrivateOrLoopbackIP (tested indirectly via validateUrl)', () => {

--- a/src/utils/urlParser.js
+++ b/src/utils/urlParser.js
@@ -1,3 +1,4 @@
+const net = require('net');
 const { logWarn, logDebug } = require("../operations/common/logging");
 
 
@@ -42,19 +43,16 @@ function isPrivateOrLoopbackIP(ip) {
 }
 
 /**
- * Check if a string is a valid IPv4 address
+ * Check if a string is a valid IPv4 address. Delegates to Node's own `net.isIPv4`
+ * rather than hand-parsing, so this always agrees with what Node's networking stack
+ * would actually treat as a connectable IPv4 literal (e.g. octal/hex/integer forms
+ * like "0177.0.0.1" or "2130706433" are correctly rejected as non-IPv4 here, matching
+ * the fact that Node's `net`/`dns` layer doesn't resolve them as IPs either).
  * @param {string} str
  * @returns {boolean}
  */
 function isValidIPv4(str) {
-    const parts = str.split('.');
-    if (parts.length !== 4) {
-        return false;
-    }
-    return parts.every(part => {
-        const num = Number(part);
-        return !isNaN(num) && num >= 0 && num <= 255 && part === String(num);
-    });
+    return net.isIPv4(str);
 }
 
 /**
@@ -64,8 +62,17 @@ function isValidIPv4(str) {
  * - Scheme must be HTTPS (rejects http://, file://, gopher://, etc.)
  *   Exception: HTTP is allowed for localhost/127.0.0.1 (local development & tests)
  *   and internal Kubernetes services (*.svc.cluster.local)
- * - Hostname must not be a private or loopback IP (except internal hosts)
+ * - Hostname must not be a private or loopback IPv4 address (except internal hosts)
  * - Blocks the cloud metadata endpoint (169.254.169.254)
+ * - Blocks any IPv6 literal address outright (::1, ::ffff:127.0.0.1, fc00::/7,
+ *   fe80::/10, etc.) -- there's no legitimate use case for a profile URL to target an
+ *   IPv6 literal, and the IPv4 private-range check above has no IPv6 equivalent, so
+ *   rejecting all IPv6 literals closes that class of bypass without needing to
+ *   replicate every IPv6 private/special-use range here.
+ *
+ * Not addressed: DNS rebinding (a hostname that resolves to a private IP at request
+ * time, after this validation already passed) -- closing that would require
+ * controlling DNS resolution at connect time, not just validating the URL string.
  *
  * @param {string} url - The URL to validate
  * @param {Object} options - Options object
@@ -80,7 +87,10 @@ function validateUrl(url) {
         throw new Error(`Not a valid URL: ${url}`);
     }
 
-    const hostname = parsed.hostname || '';
+    // URL.hostname wraps IPv6 literals in brackets, e.g. "[::1]" or "[::ffff:7f00:1]"
+    const rawHostname = parsed.hostname || '';
+    const isBracketedIPv6 = rawHostname.startsWith('[') && rawHostname.endsWith(']');
+    const hostname = isBracketedIPv6 ? rawHostname.slice(1, -1) : rawHostname;
 
     // Allow HTTP for localhost / 127.0.0.1 (local dev & test containers)
     // and for internal Kubernetes service URLs (*.svc.cluster.local), but not the
@@ -91,6 +101,11 @@ function validateUrl(url) {
     if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
         const scheme = parsed.protocol.replace(':', '');
         throw new Error(`URL must use HTTP or HTTPS, got: ${scheme}`);
+    }
+
+    if (isBracketedIPv6 || net.isIPv6(hostname)) {
+        logWarn(`Blocked SSRF attempt: IPv6 literal URLs are not allowed: ${hostname}`);
+        throw new Error(`URL cannot use an IPv6 literal address: ${hostname}`);
     }
 
     // Block private/loopback IPs and cloud metadata endpoints


### PR DESCRIPTION
## Jira
[DCON-4807](https://icanbwell.atlassian.net/browse/DCON-4807)

## Summary
SSRF validation hardening in `src/utils/urlParser.js` (used by `remoteFhirValidator.js`'s profile fetch). See the linked Jira ticket for the full technical writeup.

**Scope note:** the host-header/trust-proxy portion of DCON-4807 (`fhirRequestInfoBuilder.js`, `fhirResponseWriter.js`) is NOT included here — split out to [DCON-4809](https://icanbwell.atlassian.net/browse/DCON-4809), since the correct fix depends on the actual reverse-proxy topology per deployment environment, which isn't derivable from the codebase, and picking the wrong approach risks breaking legitimate multi-tenant hostname handling.

## Tests
Added IPv6-literal coverage to `urlParser.test.js` (loopback, IPv4-mapped, link-local, unique-local, and a public-looking IPv6 address, all blocked).

## Verification
- `eslint` clean.
- `jest --config jest.unit.config.js`: 329 failing before and after (unchanged, all pre-existing/unrelated). 6 new tests added and passing.
- Full Docker-backed `jest.config.js` suite not run locally (no Docker in the authoring environment) — please confirm CI is green before merging.

[DCON-4807]: https://icanbwell.atlassian.net/browse/DCON-4807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DCON-4809]: https://icanbwell.atlassian.net/browse/DCON-4809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ