### PR TITLE
DCON-4808 harden $everything JSON-template substitution (1/4)

### DIFF
--- a/src/operations/everything/everythingHelper.js
+++ b/src/operations/everything/everythingHelper.js
@@ -72,6 +72,23 @@ const { recordOutboundEverything } = require('../../utils/metrics');
  */
 
 /**
+ * Escapes a value for safe interpolation into a JSON-template string that will later be
+ * passed to JSON.parse(). The customQuery templates in everythingRelatedResourcesMapper.js
+ * substitute `{placeholder}` markers that always sit inside an existing JSON string literal
+ * (e.g. `"{resourceType}/{_uuid}"`), so this only needs to escape the characters that are
+ * significant inside a JSON string (quotes, backslashes, control characters) -- it does not
+ * add surrounding quotes, since the template already provides them. Without this, a
+ * parent resource field containing `"` or `}` (e.g. an attacker-influenced `_sourceId`
+ * set at an earlier create/merge) could break out of the string literal and inject
+ * arbitrary structure/operators into the resulting MongoDB query.
+ * @param {*} value
+ * @return {string}
+ */
+function escapeForJsonTemplate(value) {
+    return JSON.stringify(String(value)).slice(1, -1);
+}
+
+/**
  * This class is for $everything operation
  */
 class EverythingHelper {
@@ -1463,7 +1480,9 @@ class EverythingHelper {
                         if (!parentResourceIdentifier[requiredValue]) {
                             throw new Error(`${requiredValue} is not present in parent resource identifier`);
                         }
-                        patientQuery = patientQuery.replace(`{${requiredValue}}`, parentResourceIdentifier[requiredValue]);
+                        patientQuery = patientQuery.replace(
+                            `{${requiredValue}}`, escapeForJsonTemplate(parentResourceIdentifier[requiredValue])
+                        );
                     })
                     customParentQuery.push(JSON.parse(patientQuery));
                 });
@@ -1485,7 +1504,9 @@ class EverythingHelper {
                             if (!proxyPatientIdentifier[requiredValue]) {
                                 throw new Error(`${requiredValue} is not present in proxy patient resource identifier`);
                             }
-                            patientQuery = patientQuery.replace(`{${requiredValue}}`, proxyPatientIdentifier[requiredValue]);
+                            patientQuery = patientQuery.replace(
+                                `{${requiredValue}}`, escapeForJsonTemplate(proxyPatientIdentifier[requiredValue])
+                            );
                         });
                         customParentQuery.push(JSON.parse(patientQuery));
                     });
@@ -1987,5 +2008,6 @@ class EverythingHelper {
 }
 
 module.exports = {
-    EverythingHelper
+    EverythingHelper,
+    escapeForJsonTemplate
 };

--- a/src/tests/unit/operations/everything/everythingHelperEscapeForJsonTemplate.test.js
+++ b/src/tests/unit/operations/everything/everythingHelperEscapeForJsonTemplate.test.js
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for escapeForJsonTemplate (DCON-4808).
+ *
+ * $everything's customQuery templates (see everythingRelatedResourcesMapper.js) substitute
+ * `{placeholder}` markers -- sourced from parent Patient/Person resource fields such as
+ * `_sourceId`/`_sourceAssigningAuthority` -- directly into a JSON-template string, then call
+ * JSON.parse() on the result. Those fields are attacker-influenceable at an earlier
+ * create/merge (second-order injection): a value containing `"` or `}` could break out of
+ * the JSON string literal and inject arbitrary query structure/operators. This is the fix.
+ */
+const { describe, test, expect, jest } = require('@jest/globals');
+
+jest.mock('../../../../config', () => ({}));
+jest.mock('../../../../utils/mongoDatabaseManager', () => ({}));
+jest.mock('@sentry/node', () => ({ init: jest.fn(), captureException: jest.fn() }));
+jest.mock('express-http-context', () => ({ get: jest.fn(), set: jest.fn() }));
+jest.mock('../../../../operations/common/logging', () => ({
+    logInfo: jest.fn(),
+    logDebug: jest.fn(),
+    logError: jest.fn(),
+    logWarn: jest.fn()
+}));
+jest.mock('../../../../utils/metrics', () => ({ recordOutboundEverything: jest.fn() }));
+jest.mock('../../../../utils/assertType', () => ({
+    assertTypeEquals: jest.fn(),
+    assertIsValid: jest.fn()
+}));
+
+const { escapeForJsonTemplate } = require('../../../../operations/everything/everythingHelper');
+
+describe('escapeForJsonTemplate', () => {
+    test('leaves a plain alphanumeric value unchanged', () => {
+        expect(escapeForJsonTemplate('patient-uuid-123')).toBe('patient-uuid-123');
+    });
+
+    test('escapes a double quote so it cannot close the surrounding JSON string', () => {
+        expect(escapeForJsonTemplate('abc"def')).toBe('abc\\"def');
+    });
+
+    test('escapes a backslash', () => {
+        expect(escapeForJsonTemplate('a\\b')).toBe('a\\\\b');
+    });
+
+    test('coerces a non-string value to string first', () => {
+        expect(escapeForJsonTemplate(12345)).toBe('12345');
+    });
+
+    // The actual attack: a template substitution + JSON.parse, exactly as
+    // everythingHelper.js does it, with a malicious _sourceId-style value.
+    test('defuses an injection attempt that would otherwise break out of the JSON string', () => {
+        const template = '{"collection.source._uuid":"{resourceType}/{_uuid}"}';
+        // Without escaping, this closes the string+key early and injects a second key --
+        // crafted so the template's fixed trailing `"}` completes valid (but attacker-
+        // controlled) JSON.
+        const maliciousUuid = 'x","injected":"true';
+
+        const injectedUnsafely = template
+            .replace('{resourceType}', 'Patient')
+            .replace('{_uuid}', maliciousUuid);
+        const parsedUnsafely = JSON.parse(injectedUnsafely);
+        // Confirm the premise: the unescaped path really does let the attacker inject a
+        // second, unrelated key into the query object.
+        expect(Object.keys(parsedUnsafely)).toContain('injected');
+
+        const safe = template
+            .replace('{resourceType}', escapeForJsonTemplate('Patient'))
+            .replace('{_uuid}', escapeForJsonTemplate(maliciousUuid));
+        const parsedSafely = JSON.parse(safe);
+
+        // The malicious value must survive only as an inert string value -- one key,
+        // no injected structure.
+        expect(parsedSafely).toEqual({
+            'collection.source._uuid': `Patient/${maliciousUuid}`
+        });
+        expect(Object.keys(parsedSafely)).toEqual(['collection.source._uuid']);
+    });
+});


### PR DESCRIPTION
## Jira
[DCON-4808](https://icanbwell.atlassian.net/browse/DCON-4808) (1 of 4 grouped PRs — see ticket for the full finding list; this PR covers everythingHelper.js only)

## Summary
JSON-template substitution hardening in `src/operations/everything/everythingHelper.js`. See the linked Jira ticket for the full technical writeup.

## Tests
New `everythingHelperEscapeForJsonTemplate.test.js` — unit coverage for the new helper plus an end-to-end test proving a crafted payload that previously injected a second JSON key now survives only as an inert string value.

## Verification
- `eslint` clean.
- `jest --config jest.unit.config.js`: 329 failing before and after (unchanged, all pre-existing/unrelated). 5 new tests added and passing.
- Full Docker-backed `jest.config.js` suite not run locally (no Docker in the authoring environment) — please confirm CI is green before merging.

[DCON-4808]: https://icanbwell.atlassian.net/browse/DCON-4808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ