### PR TITLE
DCON-4808 scope admin cache invalidation to the FHIR cache namespace (3/4)

### DIFF
--- a/src/tests/unit/utils/fhirCacheKeyManager.test.js
+++ b/src/tests/unit/utils/fhirCacheKeyManager.test.js
@@ -14,6 +14,10 @@ jestObj.mock('../../../utils/redisClient', () => ({
     RedisClient: class RedisClient {}
 }));
 
+jestObj.mock('../../../operations/common/logging', () => ({
+    logWarn: jestObj.fn()
+}));
+
 const { FhirCacheKeyManager } = require('../../../utils/fhirCacheKeyManager');
 
 describe('FhirCacheKeyManager', () => {
@@ -33,8 +37,12 @@ describe('FhirCacheKeyManager', () => {
     });
 
     describe('invalidateCacheKeys', () => {
-        test('connects to redis and deletes the specified keys', async () => {
-            const cacheKeys = ['key1', 'key2', 'key3'];
+        test('connects to redis and deletes keys within the FHIR cache namespace', async () => {
+            const cacheKeys = [
+                'Patient:123:everything:Scopes:abc',
+                'ClientPerson:456:search:Scopes:def',
+                'Patient:123:read:Generation'
+            ];
 
             await manager.invalidateCacheKeys({ cacheKeys });
 
@@ -47,6 +55,38 @@ describe('FhirCacheKeyManager', () => {
 
             expect(mockRedisClient.connectAsync).toHaveBeenCalled();
             expect(mockRedisClient.bulkDeleteKeys).toHaveBeenCalledWith([]);
+        });
+
+        // DCON-4808: cacheKeys arrives from an admin API endpoint's request body with no
+        // prior validation -- without a namespace check, any admin-scoped caller could
+        // delete arbitrary Redis keys (session data, rate-limit counters, etc.), not just
+        // FHIR cache entries.
+        describe('arbitrary Redis key deletion (DCON-4808)', () => {
+            test('drops keys outside the FHIR cache namespace', async () => {
+                const cacheKeys = ['session:abc123', 'ratelimit:ip:1.2.3.4', 'some-other-app-key'];
+
+                await manager.invalidateCacheKeys({ cacheKeys });
+
+                expect(mockRedisClient.bulkDeleteKeys).toHaveBeenCalledWith([]);
+            });
+
+            test('keeps only the namespaced keys from a mixed list', async () => {
+                const cacheKeys = ['Patient:123:everything:Scopes:abc', 'session:abc123'];
+
+                await manager.invalidateCacheKeys({ cacheKeys });
+
+                expect(mockRedisClient.bulkDeleteKeys).toHaveBeenCalledWith([
+                    'Patient:123:everything:Scopes:abc'
+                ]);
+            });
+
+            test('drops non-string entries', () => {
+                return expect(
+                    manager.invalidateCacheKeys({ cacheKeys: [null, 123, { key: 'Patient:1:x' }] })
+                ).resolves.toBeUndefined().then(() => {
+                    expect(mockRedisClient.bulkDeleteKeys).toHaveBeenCalledWith([]);
+                });
+            });
         });
     });
 

--- a/src/utils/fhirCacheKeyManager.js
+++ b/src/utils/fhirCacheKeyManager.js
@@ -1,5 +1,16 @@
 const { BaseCacheKeyGenerator } = require('../operations/common/baseCacheKeyGenerator');
 const { RedisClient } = require('./redisClient');
+const { logWarn } = require('../operations/common/logging');
+
+// Cache keys this manager may delete must live under the FHIR cache namespace this class
+// (and its subclasses, e.g. PatientEverythingCacheKeyGenerator / SummaryCacheKeyGenerator)
+// actually generates via generateIdComponent(): `(Patient|ClientPerson):<id>:...` (operation,
+// :Scopes:<hash>, and :Generation suffixes all vary by generator, so only the namespace
+// prefix -- the one thing every generator shares -- is validated here). invalidateCacheKeys()
+// is reachable from an admin API endpoint with a caller-supplied key array; without this
+// check, any admin-scoped caller could delete arbitrary Redis keys, not just entries in the
+// FHIR response cache.
+const FHIR_CACHE_KEY_NAMESPACE_RE = /^(Patient|ClientPerson):/;
 
 class FhirCacheKeyManager {
     constructor({ redisClient }) {
@@ -16,8 +27,15 @@ class FhirCacheKeyManager {
      * @return {Promise<void>}
      */
     async invalidateCacheKeys({ cacheKeys }) {
+        const safeCacheKeys = (cacheKeys || []).filter((key) => {
+            const isSafe = typeof key === 'string' && FHIR_CACHE_KEY_NAMESPACE_RE.test(key);
+            if (!isSafe) {
+                logWarn(`Ignoring cacheKey outside the FHIR cache namespace: ${key}`);
+            }
+            return isSafe;
+        });
         await this.redisClient.connectAsync();
-        await this.redisClient.bulkDeleteKeys(cacheKeys);
+        await this.redisClient.bulkDeleteKeys(safeCacheKeys);
     }
 
     /**


### PR DESCRIPTION
## Jira
[DCON-4808](https://icanbwell.atlassian.net/browse/DCON-4808) (3 of 4 grouped PRs — see ticket for the full finding list; this PR covers fhirCacheKeyManager.js only)

## Summary
Namespace-prefix validation for `invalidateCacheKeys` in `src/utils/fhirCacheKeyManager.js`. See the linked Jira ticket for the full technical writeup.

## Tests
Updated `fhirCacheKeyManager.test.js` — legitimate FHIR-namespaced keys still delete correctly; keys outside the namespace (session/rate-limit/other-app keys) are dropped; non-string entries are dropped.

## Verification
- `eslint` clean.
- `jest --config jest.unit.config.js`: 329 failing before and after (unchanged, all pre-existing/unrelated). 3 new tests added and passing.
- Full Docker-backed `jest.config.js` suite not run locally (no Docker in the authoring environment) — please confirm CI is green before merging.

[DCON-4808]: https://icanbwell.atlassian.net/browse/DCON-4808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ