### PR TITLE
build(deps): bump brace-expansion to 1.1.18, 2.1.4, 5.0.9 to fix CVE-2026-14257 and CVE-2026-69152

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "brace-expansion@npm:^1.1.7": "1.1.16",
     "brace-expansion@npm:^2.0.1": "2.1.2",
     "brace-expansion@npm:^2.0.2": "2.1.2",
+    "brace-expansion@npm:^3.0.0": "5.0.7",
+    "brace-expansion@npm:^4.0.0": "5.0.7",
     "brace-expansion@npm:^5.0.5": "5.0.7"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,12 +64,12 @@
   "resolutions": {
     "uuid": "^14.0.0",
     "yargs": "^18.1.0",
-    "brace-expansion@npm:^1.1.7": "1.1.16",
-    "brace-expansion@npm:^2.0.1": "2.1.2",
-    "brace-expansion@npm:^2.0.2": "2.1.2",
-    "brace-expansion@npm:^3.0.0": "5.0.7",
-    "brace-expansion@npm:^4.0.0": "5.0.7",
-    "brace-expansion@npm:^5.0.5": "5.0.7"
+    "brace-expansion@npm:^1.1.7": "1.1.18",
+    "brace-expansion@npm:^2.0.1": "2.1.4",
+    "brace-expansion@npm:^2.0.2": "2.1.4",
+    "brace-expansion@npm:^3.0.0": "5.0.9",
+    "brace-expansion@npm:^4.0.0": "5.0.9",
+    "brace-expansion@npm:^5.0.5": "5.0.9"
   },
   "dependencies": {
     "@apollo/server": "5.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5508,31 +5508,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:1.1.16":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
+"brace-expansion@npm:1.1.18":
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:2.1.2":
-  version: 2.1.2
-  resolution: "brace-expansion@npm:2.1.2"
+"brace-expansion@npm:2.1.4":
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.7":
-  version: 5.0.7
-  resolution: "brace-expansion@npm:5.0.7"
+"brace-expansion@npm:5.0.9":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Follow-up to #2408, which fixed CVE-2026-13149 (brace-expansion exponential-time DoS, [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/ghsa-3jxr-9vmj-r5cp)) by scoping per-range resolutions to the `^1.1.7`, `^2.0.1`, `^2.0.2`, and `^5.0.5` requests actually present in the tree.
- **Coverage gap (original commit):** the advisory's vulnerable range is broader than `^5.0.5` alone — **all of `3.0.0` through `<5.0.7`** — with no patched release within the `3.x`/`4.x` line itself. Nothing in #2408 would catch a future transitive dependency landing on `brace-expansion@^3.x` or `@^4.x`. Added `^3.0.0`/`^4.0.0` → `5.0.7` (matching the existing pattern) as a dormant safety net; no current consumer requests those ranges.
- **New CVEs found during review:** while validating an Aikido-suggested fix for CVE-2026-14257 (unbounded expansion length → OOM DoS), found that:
  - Aikido's suggestion aliased `brace-expansion` to `npm:@rootio/brace-expansion@*-aikido.1` — a package that **does not exist on the public npm registry** (Root.io serves patched forks from a private, token-authenticated registry, `pkg.root.io`). Adopting it as proposed would require new registry scope-routing and vendor trust, with real dependency-confusion exposure if that routing were ever misconfigured.
  - There's already an official, publicly-published fix for CVE-2026-14257 **and** its later bypass (CVE-2026-69152, "unbounded intermediate arrays") from the real upstream maintainer: `1.1.18`, `2.1.4`, `3.0.6`, `5.0.9`. Our then-current pins (`1.1.16`, `2.1.2`, `5.0.7`) were vulnerable to both.
  - Bumped all resolutions to these versions instead of the third-party fork — same trust chain we already rely on, no new registry, and it closes both CVEs rather than just one.

No consumer currently requests brace-expansion in the 3.x/4.x range, so the `^3.0.0`/`^4.0.0` entries remain a no-op today — verified via `yarn install`.

## Test plan
- [x] `yarn install --mode=skip-build` resolves cleanly to `1.1.18` / `2.1.4` / `5.0.9`, lockfile updated accordingly
- [x] `make lint` passes
- [x] `yarn npm audit --severity moderate` shows no `brace-expansion` findings