### PR TITLE
DCON-4768 map PATCH interaction to write scope in sof-scope middleware

### DIFF
--- a/src/middleware/fhir/sof-scope.middleware.js
+++ b/src/middleware/fhir/sof-scope.middleware.js
@@ -30,6 +30,7 @@ function deriveActionFromInteraction (interaction) {
         case INTERACTIONS.CREATE:
         case INTERACTIONS.UPDATE:
         case INTERACTIONS.DELETE:
+        case INTERACTIONS.PATCH:
         case INTERACTIONS.OPERATIONS_POST:
             return 'write';
 

--- a/src/tests/unit/middleware/fhir/sof-scope.middleware.test.js
+++ b/src/tests/unit/middleware/fhir/sof-scope.middleware.test.js
@@ -77,6 +77,19 @@ describe('sofScopeCheckMiddleware', () => {
             expect(scopeChecker).toHaveBeenCalledWith('Patient', 'write', ['patient/Patient.write']);
         });
 
+        test('correctly derives a write action for a patch interaction', () => {
+            scopeChecker.mockReturnValue({});
+            const middleware = sofScopeCheckMiddleware({
+                route: { interaction: 'patch' },
+                name: 'patient',
+                auth: { type: 'smart', strategy: {} }
+            });
+            const req = { user: { scope: 'patient/Patient.write' }, params: {} };
+            const next = jestObj.fn();
+            middleware(req, {}, next);
+            expect(scopeChecker).toHaveBeenCalledWith('Patient', 'write', ['patient/Patient.write']);
+        });
+
         test('rejects when scopeChecker reports an authorization error', () => {
             const errors = require('../../../../middleware/fhir/utils/error.utils');
             scopeChecker.mockReturnValue({ error: { message: 'insufficient scope' } });


### PR DESCRIPTION
## Summary
- `deriveActionFromInteraction` in `sof-scope.middleware.js` had no case for `INTERACTIONS.PATCH`, so PATCH requests fell through to the `'*'` default action, requiring a wildcard scope instead of the `write` scope granted to other write interactions (create/update/delete).
- Added `case INTERACTIONS.PATCH:` to the `write` branch and a unit test covering it.

## Test plan
- [x] `node node_modules/.bin/jest src/tests/unit/middleware/fhir/sof-scope.middleware.test.js` — 7/7 pass