### PR TITLE
DCON-4812 chore: cancel superseded CI runs on new commits

### DIFF
--- a/.github/workflows/aikido.yml
+++ b/.github/workflows/aikido.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   aikido-security:
     name: Aikido Security Scan

--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main, 'releases/*']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check-commit-message:
     name: Check Commit Message

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,10 @@ on:
     schedule:
         - cron: '21 9 * * 5'
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
     analyze:
         name: Analyze

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-architecture-review.yml
+++ b/.github/workflows/pr-architecture-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
## Summary
- No workflow in `.github/workflows/` had a `concurrency` group, so pushing a new commit to a branch/PR left the previous, now-superseded run going to completion instead of cancelling it.
- `node.js.yml` is the expensive one to leave running needlessly: lint + a 12-way sharded jest matrix (~10 min/shard). `check-commit-message.yml`, `codeql.yml`, `aikido.yml`, and `pr-architecture-review.yml` also re-trigger on every push/sync.
- Added `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: ... }` to all 5. For workflows that can run on pushes to `main` (`node.js.yml`, `check-commit-message.yml`, `codeql.yml`), `cancel-in-progress` is conditional on `github.ref != 'refs/heads/main'` — PR runs get cancelled when superseded, but every merge to `main` still gets its own completed run (used for deploy/release gating). The PR-only workflows (`aikido.yml`, `pr-architecture-review.yml`) always cancel-in-progress since there's no main-push case to protect.

## Test plan
- [x] All 5 YAML files validated with `yaml.safe_load`
- [ ] Push a second commit to this PR after opening it and confirm the first run gets cancelled rather than completing