### PR TITLE
SEC-1580 F4: Scope $graph's per-batch consent cache by chunk index

### DIFF
--- a/src/operations/graph/graphHelpers.js
+++ b/src/operations/graph/graphHelpers.js
@@ -275,7 +275,8 @@ class GraphHelper {
                                         explain,
                                         debug,
                                         supportLegacyId = true,
-                                        params = {}
+                                        params = {},
+                                        graphChunkIndex
                                     }) {
         try {
             if (!parentEntities || parentEntities.length === 0 || !isValidResource(resourceType)) {
@@ -359,7 +360,8 @@ class GraphHelper {
                 actor: requestInfo.actor,
                 requestId: requestInfo.requestId,
                 parsedArgs: childParseArgs,
-                operation: READ
+                operation: READ,
+                everythingChunkIndex: graphChunkIndex
             });
 
             if (filterProperty) {
@@ -545,7 +547,8 @@ class GraphHelper {
                                         supportLegacyId = true,
                                         proxyPatientIds = [],
                                         proxyPatientResources = [],
-                                        params = {}
+                                        params = {},
+                                        graphChunkIndex
                                     }) {
         try {
             if (!(reverse_filter)) {
@@ -645,7 +648,8 @@ class GraphHelper {
                     actor: requestInfo.actor,
                     requestId: requestInfo.requestId,
                     parsedArgs: relatedResourceParsedArgs,
-                    operation: READ
+                    operation: READ,
+                    everythingChunkIndex: graphChunkIndex
                 }
             );
 
@@ -950,7 +954,8 @@ class GraphHelper {
             parsedArgs,
             supportLegacyId = true,
             proxyPatientIds = [],
-            proxyPatientResources = []
+            proxyPatientResources = [],
+            graphChunkIndex
         }
     ) {
         try {
@@ -1016,7 +1021,8 @@ class GraphHelper {
                                 debug,
                                 supportLegacyId,
                                 parsedArgs,
-                                params: targetParams
+                                params: targetParams,
+                                graphChunkIndex
 
                             }
                         );
@@ -1087,7 +1093,8 @@ class GraphHelper {
                                 proxyPatientIds,
                                 proxyPatientResources,
                                 parsedArgs,
-                                params: targetParams
+                                params: targetParams,
+                                graphChunkIndex
                             }
                         );
                         if (queryItem) {
@@ -1132,7 +1139,8 @@ class GraphHelper {
                                 parsedArgs,
                                 supportLegacyId,
                                 proxyPatientIds,
-                                proxyPatientResources
+                                proxyPatientResources,
+                                graphChunkIndex
                             }
                         )
                     );
@@ -1210,7 +1218,8 @@ class GraphHelper {
             parsedArgs,
             supportLegacyId = true,
             proxyPatientIds = [],
-            proxyPatientResources = []
+            proxyPatientResources = [],
+            graphChunkIndex
         }
     ) {
         try {
@@ -1236,7 +1245,8 @@ class GraphHelper {
                         parsedArgs,
                         supportLegacyId,
                         proxyPatientIds,
-                        proxyPatientResources
+                        proxyPatientResources,
+                        graphChunkIndex
                     }
                 )
             );
@@ -1292,7 +1302,8 @@ class GraphHelper {
             parsedArgs,
             supportLegacyId = true,
             proxyPatientIds = [],
-            proxyPatientResources = []
+            proxyPatientResources = [],
+            graphChunkIndex
         }
     ) {
         try {
@@ -1324,7 +1335,8 @@ class GraphHelper {
                         parsedArgs,
                         supportLegacyId,
                         proxyPatientIds,
-                        proxyPatientResources
+                        proxyPatientResources,
+                        graphChunkIndex
                     }
                 )
             );
@@ -1406,7 +1418,8 @@ class GraphHelper {
             idsAlreadyProcessed,
             supportLegacyId = true,
             proxyPatientIds = [],
-            proxyPatientResources = []
+            proxyPatientResources = [],
+            graphChunkIndex
         }
     ) {
         assertTypeEquals(parsedArgs, ParsedArgs);
@@ -1434,7 +1447,8 @@ class GraphHelper {
                 requestId: requestInfo.requestId,
                 parsedArgs,
                 operation: READ,
-                accessRequested: (requestInfo.method.toLowerCase() === 'delete' ? 'write' : 'read')
+                accessRequested: (requestInfo.method.toLowerCase() === 'delete' ? 'write' : 'read'),
+                everythingChunkIndex: graphChunkIndex
             });
 
             /**
@@ -1539,7 +1553,8 @@ class GraphHelper {
                     parsedArgs,
                     supportLegacyId,
                     proxyPatientIds,
-                    proxyPatientResources
+                    proxyPatientResources,
+                    graphChunkIndex
                 }
             );
 
@@ -1755,6 +1770,7 @@ class GraphHelper {
              */
             let bundleEntryIdsProcessed = [];
 
+            let graphChunkIndex = 0;
             for (const /** @type {string[]} */ idChunk of idChunks) {
                 const parsedArgsForChunk = parsedArgs.clone();
                 parsedArgsForChunk.id = idChunk;
@@ -1798,7 +1814,8 @@ class GraphHelper {
                         idsAlreadyProcessed: bundleEntryIdsProcessed,
                         supportLegacyId,
                         proxyPatientIds,
-                        proxyPatientResources
+                        proxyPatientResources,
+                        graphChunkIndex: graphChunkIndex++
                     }
                 );
                 entries = entries.concat(entries1);


### PR DESCRIPTION
## Summary

Fixes **F4** from the SEC-1580 cross-tenant data access audit.

INC-331's root cause was `dataSharingManager`'s per-request consent cache being keyed only by `requestId`, while `$everything` internally processes multiple different id-batches under that one `requestId`. The fix (DCON-4598) threads an `everythingChunkIndex` through every `constructQueryAsync` call in `everythingHelper.js` so each batch gets an isolated cache bucket.

`$graph` batches its starting ids the same way (`graphBatchSize`, default 10) but never passed an equivalent chunk index into its own `constructQueryAsync` calls — reusing the exact bug class INC-331 fixed. This is currently latent (per discussion on the ticket, `$graph` doesn't accept the `allowConsentedProaDataAccess` param and HIE data-sharing is disabled by default across all envs), but nothing in the code prevents it from becoming live if either of those changes.

## Fix

Threads a `graphChunkIndex`, assigned per id-batch in `processGraphAsync`'s existing chunking loop, down through the full recursive graph traversal (`processGraphLinksAsync` → `processOneGraphLinkAsync` → `processLinkTargetAsync` → `getForwardReferencesAsync`/`getReverseReferencesAsync`) into all 3 `constructQueryAsync` call sites, passed as the existing `everythingChunkIndex` parameter `dataSharingManager`'s cache key already understands — no new cache-key mechanism needed, just closing the one call site that wasn't using it.

## Testing

- `src/tests/practitioner/graph_pss/practitioner.graph_pss_chunked.test.js` (forces `graphBatchSize` chunking to exercise the exact multi-batch code path this fix touches) and `src/tests/unit/operations/graph/graphHelpers.test.js`: 25/25 passing.
- `make lint`: clean.

## Notes for reviewers

- A related but narrower fix, PR #2377 (`DataSharingManager request cache not scoped by securityTags`), is already merged into `main` — that fixes the cache key not incorporating the caller's `securityTags`, a different gap in the same function. This PR is independent and additive to that one.
- Per a ticket comment, the team is also tracking DCON-4766 to remove `$graph`'s currently-dead consent/HIE-data-sharing code paths entirely rather than maintain them — if that lands, this fix becomes moot, but until then this closes the structural gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)