### PR TITLE
DCON-4814 Fix null-safety and edge-case bugs in admin bulk-operation runners

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,6 @@ module.exports = {
         '<rootDir>/.claude/',
         '<rootDir>/src/tests/unit/admin/adminExportManager.test.js',
         '<rootDir>/src/tests/unit/admin/runners/changeSourceAssigningAuthorityRunner.test.js',
-        '<rootDir>/src/tests/unit/admin/runners/fixDuplicatePractitionerRunner.test.js',
         '<rootDir>/src/tests/unit/admin/runners/fixDuplicateUuidRunner.test.js',
         '<rootDir>/src/tests/unit/admin/runners/fixPersonLinksRunner.test.js',
         '<rootDir>/src/tests/unit/admin/runners/getMasterPatientUsageDataRunner.test.js',

--- a/src/admin/adminExportManager.js
+++ b/src/admin/adminExportManager.js
@@ -291,6 +291,10 @@ class AdminExportManager {
                 source: 'AdminExportManager triggerExportJob'
             });
             throw error;
+        } finally {
+            const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
+            await this.postRequestProcessor.executeAsync({ requestId });
+            await this.requestSpecificCache.clearAsync({ requestId });
         }
     }
 }

--- a/src/admin/runners/fixDuplicatePractitionerRunner.js
+++ b/src/admin/runners/fixDuplicatePractitionerRunner.js
@@ -321,7 +321,7 @@ class FixDuplicatePractitionerRunner extends BaseBulkOperationRunner {
                     for (let i = 0; i < f0.length; i++) {
                         const ref = f0[i];
                         if (ref && this.dupUuids.includes(ref._uuid)) {
-                            const newRef = this.substituteOneReference({ ref });
+                            const newRef = await this.substituteOneReference({ ref });
                             resource[fields[0]][i] = newRef;
                          }
                     }
@@ -342,7 +342,7 @@ class FixDuplicatePractitionerRunner extends BaseBulkOperationRunner {
 
                              const ref = subObj[fields[1]];
                              if (ref && this.dupUuids.includes(ref._uuid)) {
-                                 const newRef = this.substituteOneReference({ ref });
+                                 const newRef = await this.substituteOneReference({ ref });
                                  resource[fields[0]][i][fields[1]][j] = newRef;
                              }
                          }

--- a/src/admin/runners/fixDuplicatePractitionerRunner.js
+++ b/src/admin/runners/fixDuplicatePractitionerRunner.js
@@ -271,7 +271,7 @@ class FixDuplicatePractitionerRunner extends BaseBulkOperationRunner {
         if (subs) {
             // do simple fields
             ref._uuid = subs.goodUuid;
-            if (ref.reference.startsWith(subs.goodSourceId)) {
+            if (ref.reference && ref.reference.startsWith(subs.goodSourceId)) {
                 ref.reference = subs.goodReference;
             } else {
                 ref.reference = subs.goodUuid;
@@ -320,7 +320,7 @@ class FixDuplicatePractitionerRunner extends BaseBulkOperationRunner {
                     }
                     for (let i = 0; i < f0.length; i++) {
                         const ref = f0[i];
-                        if (this.dupUuids.includes(ref._uuid)) {
+                        if (ref && this.dupUuids.includes(ref._uuid)) {
                             const newRef = this.substituteOneReference({ ref });
                             resource[fields[0]][i] = newRef;
                          }
@@ -341,7 +341,7 @@ class FixDuplicatePractitionerRunner extends BaseBulkOperationRunner {
                              const subObj = subf[j];
 
                              const ref = subObj[fields[1]];
-                             if (this.dupUuids.includes(ref._uuid)) {
+                             if (ref && this.dupUuids.includes(ref._uuid)) {
                                  const newRef = this.substituteOneReference({ ref });
                                  resource[fields[0]][i][fields[1]][j] = newRef;
                              }

--- a/src/admin/runners/fixDuplicateUuidRunner.js
+++ b/src/admin/runners/fixDuplicateUuidRunner.js
@@ -234,7 +234,12 @@ class FixDuplicateUuidRunner extends BaseBulkOperationRunner {
              * @type {number}
              */
             const versionIdToKeep = resources.reduce(
-                (versionId, res) => Math.max(versionId, Number(res.meta.versionId)),
+                (versionId, res) => {
+                    const currentVersionId = Number(res.meta.versionId);
+                    // Ignore non-numeric versionIds so a single malformed resource
+                    // doesn't poison the max computation for the whole group with NaN.
+                    return Number.isNaN(currentVersionId) ? versionId : Math.max(versionId, currentVersionId);
+                },
                 0
             );
 
@@ -245,8 +250,21 @@ class FixDuplicateUuidRunner extends BaseBulkOperationRunner {
                 (res) => Number(res.meta.versionId) === versionIdToKeep
             );
 
+            if (resourcesWithMaxVersionId.length === 0) {
+                // safety check: happens if none of the resources have a numeric versionId
+                this.adminLogger.logInfo(`No resource with a valid numeric versionId found for uuid: ${uuid}`);
+                return [];
+            }
+
             if (resourcesWithMaxVersionId.length > 1) {
-                resourcesWithMaxVersionId.sort((res1, res2) => (new Date(res2.meta.lastUpdated)).getTime() - (new Date(res1.meta.lastUpdated)).getTime());
+                resourcesWithMaxVersionId.sort((res1, res2) => {
+                    const dateDiff = (new Date(res2.meta.lastUpdated)).getTime() - (new Date(res1.meta.lastUpdated)).getTime();
+                    // Fall back to a stable tiebreaker (_id) when lastUpdated is missing/invalid
+                    // on both sides so the result doesn't depend on arbitrary input ordering.
+                    return Number.isNaN(dateDiff) || dateDiff === 0
+                        ? String(res1._id).localeCompare(String(res2._id))
+                        : dateDiff;
+                });
             }
 
             const resourcesToDelete = resources.reduce((toDelete, res) => {

--- a/src/admin/runners/fixPersonLinksRunner.js
+++ b/src/admin/runners/fixPersonLinksRunner.js
@@ -112,7 +112,7 @@ class FixPersonLinksRunner extends BaseBulkOperationRunner {
         if (isSame === undefined && resource.name && resource.name.length && linkedResource.name && linkedResource.name.length) {
             const currentPersonName = resource.name[0];
             const linkedPersonName = linkedResource.name[0];
-            isSame = currentPersonName.family === linkedPersonName.family && currentPersonName.given.join(',') === linkedPersonName.given.join(',');
+            isSame = currentPersonName.family === linkedPersonName.family && (currentPersonName.given || []).join(',') === (linkedPersonName.given || []).join(',');
         }
         return !!isSame;
     }

--- a/src/admin/runners/fixReferenceIdRunner.js
+++ b/src/admin/runners/fixReferenceIdRunner.js
@@ -1095,7 +1095,7 @@ class FixReferenceIdRunner extends BaseBulkOperationRunner {
 
         if (this.startFromId) {
             const startId = isValidMongoObjectId(this.startFromId) ? new ObjectId(this.startFromId) : this.startFromId;
-            if (Object.keys(query) > 0) {
+            if (Object.keys(query).length > 0) {
                 // noinspection JSValidateTypes
                 query = {
                     $and: [

--- a/src/admin/runners/getMasterPatientUsageDataRunner.js
+++ b/src/admin/runners/getMasterPatientUsageDataRunner.js
@@ -230,7 +230,7 @@ class GetMasterPatientUsageDataRunner extends BaseBulkOperationRunner {
         writeStream.write('Resource| Count| Uuid with min lastUpdated| Min LastUpdated| Uuid with max lastUpdated| Max LastUpdated|\n');
         for (const [resourceType, { count, minUuid, minLastUpdated, maxUuid, maxlastUpdated }] of this.usageData) {
             writeStream.write(
-                `${resourceType}| ${count}| ${minUuid}| ${minLastUpdated.toISOString()}| ${maxUuid}| ${maxlastUpdated.toISOString()}|\n`
+                `${resourceType}| ${count}| ${minUuid}| ${minLastUpdated ? minLastUpdated.toISOString() : ''}| ${maxUuid}| ${maxlastUpdated ? maxlastUpdated.toISOString() : ''}|\n`
             );
         }
         writeStream.end();

--- a/src/admin/runners/migrateHistoryToCloudStorageRunner.js
+++ b/src/admin/runners/migrateHistoryToCloudStorageRunner.js
@@ -143,12 +143,20 @@ class MigrateHistoryToCloudStorageRunner extends BaseScriptRunner {
                 return await this.processRecordAsync(hisResource);
             })
         );
-        const bulkResult = await collection.bulkWrite(operations.filter(item => item !== null), {
-            session
-        });
+        operations = operations.filter(item => item !== null);
         this.lastProcessId = this.lastBatchDocId;
-        this.documentsUpdated += bulkResult.modifiedCount;
         this.historyBatch = [];
+
+        if (operations.length === 0) {
+            this.adminLogger.logInfo(
+                `Processed batch ${this.batchCount}, no operations to write, last id: ${this.lastProcessId}`
+            );
+            this.batchCount += 1;
+            return;
+        }
+
+        const bulkResult = await collection.bulkWrite(operations, { session });
+        this.documentsUpdated += bulkResult.modifiedCount;
 
         const message =
             `Processed batch ${this.batchCount}, ` +

--- a/src/admin/runners/partitionAuditEventRunner.js
+++ b/src/admin/runners/partitionAuditEventRunner.js
@@ -92,7 +92,7 @@ class PartitionAuditEventRunner extends BaseBulkOperationRunner {
      */
     async copyRecordAsync (doc) {
         const operations = [];
-        const accessCodes = doc.meta.security.filter(s => s.system === SecurityTagSystem.access).map(s => s.code);
+        const accessCodes = (doc.meta?.security || []).filter(s => s.system === SecurityTagSystem.access).map(s => s.code);
 
         if (accessCodes.length > 0 && !doc._access) {
             const _access = {};
@@ -123,7 +123,7 @@ class PartitionAuditEventRunner extends BaseBulkOperationRunner {
      */
     async setAccessIndexRecordAsync (doc) {
         const operations = [];
-        const accessCodes = doc.meta.security.filter(s => s.system === SecurityTagSystem.access).map(s => s.code);
+        const accessCodes = (doc.meta?.security || []).filter(s => s.system === SecurityTagSystem.access).map(s => s.code);
 
         if (accessCodes.length > 0 && !doc._access) {
             const _access = {};

--- a/src/admin/runners/removeDuplicatePersonLinkRunner.js
+++ b/src/admin/runners/removeDuplicatePersonLinkRunner.js
@@ -86,8 +86,11 @@ class RemoveDuplicatePersonLinkRunner extends BaseBulkOperationRunner {
      */
     async removeDuplicateLinks (resource) {
         const linkSet = new Set();
-        resource.link = resource.link.reduce((uniqueLinks, link) => {
-            const reference = link?.target?._uuid;
+        resource.link = (resource.link || []).reduce((uniqueLinks, link) => {
+            // Fall back to target.reference when target._uuid is missing so that links
+            // without a _uuid (e.g. not yet matched) aren't all treated as duplicates of
+            // each other just because they share the same undefined _uuid.
+            const reference = link?.target?._uuid || link?.target?.reference;
             if (!linkSet.has(reference)) {
                 linkSet.add(reference);
                 uniqueLinks.push(link);
@@ -126,7 +129,7 @@ class RemoveDuplicatePersonLinkRunner extends BaseBulkOperationRunner {
         // for speed, first check if the incoming resource is exactly the same
         const updatedResourceJsonInternal = updatedResource.toJSONInternal();
         const currentResourceJsonInternal = currentResource.toJSONInternal();
-        if (deepEqual(updatedResourceJsonInternal.link, currentResourceJsonInternal.link) === true) {
+        if (deepEqual(updatedResourceJsonInternal.link || [], currentResourceJsonInternal.link || []) === true) {
             return operations;
         }
 

--- a/src/admin/runners/updateCollectionsRunner.js
+++ b/src/admin/runners/updateCollectionsRunner.js
@@ -262,19 +262,16 @@ class UpdateCollectionsRunner {
                         let targetLastUpdated = targetDocument.meta.lastUpdated;
                         let sourceLastUpdated = sourceDocument.meta.lastUpdated;
 
-                        if (!(targetLastUpdated instanceof Date)) {
-                            targetLastUpdated =
-                                moment(targetLastUpdated).format('YYYY-MM-DDTHH:mm:ssZ');
-                        }
-                        if (!(sourceLastUpdated instanceof Date)) {
-                            sourceLastUpdated =
-                                moment(sourceLastUpdated).format('YYYY-MM-DDTHH:mm:ssZ');
-                        }
+                        // Normalize both values to moment instances so comparisons below are
+                        // always numeric (Date/string vs moment mixed comparisons can silently
+                        // evaluate to false due to JS coercing an unparsed string to NaN).
+                        targetLastUpdated = moment(targetLastUpdated);
+                        sourceLastUpdated = moment(sourceLastUpdated);
 
-                        if (targetLastUpdated > this.updatedBefore) {
+                        if (targetLastUpdated.isAfter(this.updatedBefore)) {
                             targetLastUpdatedGreaterThanUpdatedBefore += 1;
                             continue;
-                        } else if (targetLastUpdated > sourceLastUpdated) {
+                        } else if (targetLastUpdated.isAfter(sourceLastUpdated)) {
                             targetLastUpdatedGreaterThanSource += 1;
                             continue;
                         }
@@ -282,8 +279,8 @@ class UpdateCollectionsRunner {
                         try {
                             if (
                                 targetDocument &&
-                                targetLastUpdated < this.updatedBefore &&
-                                targetLastUpdated < sourceLastUpdated
+                                targetLastUpdated.isBefore(this.updatedBefore) &&
+                                targetLastUpdated.isBefore(sourceLastUpdated)
                             ) {
                                 // Updating the document in targetDatabase.
                                 result = await targetDatabaseCollection.updateOne(

--- a/src/admin/runners/updateCollectionsRunner.js
+++ b/src/admin/runners/updateCollectionsRunner.js
@@ -212,7 +212,7 @@ class UpdateCollectionsRunner {
                     let updatedCount = 0; // Keeps track of the total updated documents
                     let skippedCount = 0; // Keeps track of documents that are skipped as they don't match the requirements.
                     let lastProcessedId = null; // For each collect help in keeping track of the last id processed.
-                    const sourceMissingLastUpdated = 0; // Keeps tranch of source document that doesn't have lastUpdated.
+                    let sourceMissingLastUpdated = 0; // Keeps tranch of source document that doesn't have lastUpdated.
                     let targetMissingLastUpdated = 0; // Keeps track of target document that doesn't have last updated.
                     let totalProcessedDoc = 0; // Keep tracks of the total processed id.
                     let targetLastUpdatedGreaterThanUpdatedBefore = 0; // Keeps tracks of the documnet that is skipped and target last update is greater than updated before.
@@ -255,6 +255,13 @@ class UpdateCollectionsRunner {
                         // Skip target documents in which lastUpdated is not present.
                         if (targetDocument?.meta?.lastUpdated === undefined) {
                             targetMissingLastUpdated += 1;
+                            continue;
+                        }
+                        // Skip source documents in which lastUpdated is not present, since without it
+                        // we can't determine whether the source is actually fresher than the target
+                        // (moment(undefined) resolves to "now", which would make it look freshest).
+                        if (sourceDocument?.meta?.lastUpdated === undefined) {
+                            sourceMissingLastUpdated += 1;
                             continue;
                         }
 


### PR DESCRIPTION
## Summary
- Guard against `meta.security` being undefined in `partitionAuditEventRunner`
- Ignore non-numeric `versionId`s instead of poisoning the max computation with `NaN` in `fixDuplicateUuidRunner`, and handle the case where no resource has a valid version
- Fall back to `target.reference` when `target._uuid` is missing in `removeDuplicatePersonLinkRunner` so links aren't all collapsed as duplicates
- Guard missing `ref.reference` / `ref` in `fixDuplicatePractitionerRunner`
- Fix `Object.keys(query) > 0` (always false, missing `.length`) in `fixReferenceIdRunner`
- Guard missing `name.given` arrays in `fixPersonLinksRunner`
- Guard missing `minLastUpdated`/`maxlastUpdated` before calling `.toISOString()` in `getMasterPatientUsageDataRunner`
- Skip an empty `bulkWrite` call in `migrateHistoryToCloudStorageRunner` when a batch has no operations
- Normalize date comparisons to `moment` instances in `updateCollectionsRunner` (mixed Date/string comparisons could silently evaluate incorrectly)
- Ensure post-request cleanup (`postRequestProcessor`/`requestSpecificCache`) runs in `adminExportManager.triggerExportJob`'s `finally` block

## Test plan
- [ ] `make tests` / run affected admin runner unit tests