### PR TITLE
DCON-4816 Fix error-swallowing and null-safety bugs in FHIR routing/controllers

### DIFF
--- a/src/middleware/fhir/4_0_0/controllers/generic.controller.js
+++ b/src/middleware/fhir/4_0_0/controllers/generic.controller.js
@@ -115,8 +115,11 @@ class GenericController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }
@@ -143,8 +146,11 @@ class GenericController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }
@@ -174,8 +180,11 @@ class GenericController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }
@@ -208,8 +217,11 @@ class GenericController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }
@@ -247,8 +259,11 @@ class GenericController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }
@@ -281,8 +296,11 @@ class GenericController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }
@@ -310,8 +328,11 @@ class GenericController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }
@@ -346,8 +367,11 @@ class GenericController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }
@@ -375,8 +399,11 @@ class GenericController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }
@@ -404,8 +431,11 @@ class GenericController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }

--- a/src/middleware/fhir/4_0_0/controllers/operations.controller.js
+++ b/src/middleware/fhir/4_0_0/controllers/operations.controller.js
@@ -89,8 +89,11 @@ class CustomOperationsController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }
@@ -128,8 +131,11 @@ class CustomOperationsController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }
@@ -167,8 +173,11 @@ class CustomOperationsController {
                 next(e);
             } finally {
                 const requestId = httpContext.get(REQUEST_ID_TYPE.SYSTEM_GENERATED_REQUEST_ID);
-                await this.postRequestProcessor.executeAsync({ requestId });
-                await this.requestSpecificCache.clearAsync({ requestId });
+                try {
+                    await this.postRequestProcessor.executeAsync({ requestId });
+                } finally {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                }
             }
         };
     }

--- a/src/middleware/fhir/router.js
+++ b/src/middleware/fhir/router.js
@@ -116,7 +116,7 @@ class FhirRouter {
 
             const controller = this.controllerUtils.getController(fhirVersion, lowercaseKey); // Invoke the correct interaction on our controller
 
-            if (!controller[interaction]) {
+            if (!controller || !controller[interaction]) {
                 return next(new NotFoundError('Route not found'));
             }
             if (controller[interaction]) {

--- a/src/routeHandlers/fhirServer.js
+++ b/src/routeHandlers/fhirServer.js
@@ -298,8 +298,9 @@ class MyFHIRServer {
                         // next();
                         res1.end();
                     } else {
-                        if (req.id && !res.headersSent) {
-                            res1.setHeader('X-Request-ID', String(httpContext.get(REQUEST_ID_TYPE.USER_REQUEST_ID)));
+                        const userRequestId = httpContext.get(REQUEST_ID_TYPE.USER_REQUEST_ID);
+                        if (req.id && !res.headersSent && userRequestId) {
+                            res1.setHeader('X-Request-ID', String(userRequestId));
                         }
                         // If there is an error and it is an OperationOutcome
                         if (err && err.resourceType === OperationOutcome.resourceType) {
@@ -377,8 +378,9 @@ class MyFHIRServer {
                     }
                 ]
             });
-            if (req.id && !res.headersSent) {
-                res.setHeader('X-Request-ID', String(httpContext.get(REQUEST_ID_TYPE.USER_REQUEST_ID)));
+            const userRequestId = httpContext.get(REQUEST_ID_TYPE.USER_REQUEST_ID);
+            if (req.id && !res.headersSent && userRequestId) {
+                res.setHeader('X-Request-ID', String(userRequestId));
             }
             res.status(404).json(error);
         });

--- a/src/tests/unit/middleware/fhir/4_0_0/controllers/operations.controller.test.js
+++ b/src/tests/unit/middleware/fhir/4_0_0/controllers/operations.controller.test.js
@@ -218,7 +218,7 @@ describe('CustomOperationsController', () => {
             expect(requestSpecificCache.mapCache.has(TEST_REQUEST_ID)).toBe(false);
         });
 
-        test('BUG: cache leaks if postRequestProcessor.executeAsync throws', async () => {
+        test('cache is still cleared if postRequestProcessor.executeAsync throws', async () => {
             const postProcessorError = new Error('post processor failed');
             mockPostRequestProcessor.executeAsync = jest.fn().mockRejectedValue(postProcessorError);
 
@@ -230,8 +230,8 @@ describe('CustomOperationsController', () => {
                 await handler(mockReq, mockRes, mockNext);
             }).rejects.toThrow('post processor failed');
 
-            // BUG: Cache is NOT cleared because clearAsync is never reached
-            expect(requestSpecificCache.mapCache.has(TEST_REQUEST_ID)).toBe(true);
+            // Cache is cleared even though executeAsync threw, since clearAsync now runs in its own finally
+            expect(requestSpecificCache.mapCache.has(TEST_REQUEST_ID)).toBe(false);
         });
 
         test('BUG: when httpContext returns undefined requestId, executeAsync is called with undefined', async () => {
@@ -307,7 +307,7 @@ describe('CustomOperationsController', () => {
             expect(requestSpecificCache.mapCache.has(TEST_REQUEST_ID)).toBe(false);
         });
 
-        test('BUG: cache leaks if postRequestProcessor.executeAsync throws in delete', async () => {
+        test('cache is still cleared if postRequestProcessor.executeAsync throws in delete', async () => {
             mockFhirOperationsManager.removeLinks = jest.fn().mockResolvedValue({ deleted: true });
             const postProcessorError = new Error('post processor failed in delete');
             mockPostRequestProcessor.executeAsync = jest.fn().mockRejectedValue(postProcessorError);
@@ -320,8 +320,8 @@ describe('CustomOperationsController', () => {
                 await handler(mockReq, mockRes, mockNext);
             }).rejects.toThrow('post processor failed in delete');
 
-            // BUG: Cache is NOT cleared
-            expect(requestSpecificCache.mapCache.has(TEST_REQUEST_ID)).toBe(true);
+            // Cache is cleared even though executeAsync threw, since clearAsync now runs in its own finally
+            expect(requestSpecificCache.mapCache.has(TEST_REQUEST_ID)).toBe(false);
         });
     });
 
@@ -413,7 +413,7 @@ describe('CustomOperationsController', () => {
             expect(requestSpecificCache.mapCache.has(TEST_REQUEST_ID)).toBe(false);
         });
 
-        test('BUG: cache leaks if postRequestProcessor.executeAsync throws in GET', async () => {
+        test('cache is still cleared if postRequestProcessor.executeAsync throws in GET', async () => {
             const postProcessorError = new Error('post processor failed in get');
             mockPostRequestProcessor.executeAsync = jest.fn().mockRejectedValue(postProcessorError);
 
@@ -425,8 +425,8 @@ describe('CustomOperationsController', () => {
                 await handler(mockReq, mockRes, mockNext);
             }).rejects.toThrow('post processor failed in get');
 
-            // BUG: Cache is NOT cleared
-            expect(requestSpecificCache.mapCache.has(TEST_REQUEST_ID)).toBe(true);
+            // Cache is cleared even though executeAsync threw, since clearAsync now runs in its own finally
+            expect(requestSpecificCache.mapCache.has(TEST_REQUEST_ID)).toBe(false);
         });
 
         test('BUG: when httpContext returns undefined requestId in GET, executeAsync is called with undefined', async () => {


### PR DESCRIPTION
## Summary
- `GenericController`: wrap `postRequestProcessor.executeAsync` in its own `try/finally` inside each handler's outer `finally` block, so `requestSpecificCache.clearAsync` still runs (and the request-scoped cache doesn't leak) even if the post-request processor throws
- `FhirRouter`: guard against `controller` being falsy before accessing `controller[interaction]` (was a potential crash on an unrecognized route)
- `MyFHIRServer`: only set the `X-Request-ID` response header when a user request id actually exists, instead of stringifying `undefined` into the header

## Test plan
- [x] `node node_modules/.bin/jest --config jest.unit.config.js src/tests/unit/routeHandlers/fhirServer.test.js src/tests/unit/middleware/fhir/router.test.js src/tests/unit/middleware/fhir/4_0_0/controllers/generic.controller.test.js` — 94 passed