### PR TITLE
DCON-4791 Fix missing-modifier and dateTime typo bugs in GraphQL search parameter conversion

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -61,7 +61,6 @@ module.exports = {
         '<rootDir>/src/tests/unit/operations/history/history.test.js',
         '<rootDir>/src/tests/unit/operations/merge/merge.nullSafety.test.js',
         '<rootDir>/src/tests/unit/operations/patch/strategies/groupMemberPatchStrategy.bugs.test.js',
-        '<rootDir>/src/tests/unit/operations/query/convertGraphQLParameters.test.js',
         '<rootDir>/src/tests/unit/operations/query/r4SearchQueryCreator.test.js',
         '<rootDir>/src/tests/unit/operations/remove/removeHelper.test.js',
         '<rootDir>/src/tests/unit/operations/search/dataSharingManager.test.js',

--- a/src/operations/query/convertGraphQLParameters.js
+++ b/src/operations/query/convertGraphQLParameters.js
@@ -12,6 +12,10 @@ function convertGraphQLParameters (queryParameterValue) {
         !Array.isArray(queryParameterValue) &&
         queryParameterValue.searchType
     ) {
+        // keep a reference to the original input object: some branches below (e.g. notEquals
+        // handling for string/reference/quantity) reassign the local `queryParameterValue`
+        // variable to `[]`, which would otherwise hide the caller-supplied `missing` property
+        const originalQueryParameterValue = queryParameterValue;
         let useNotEquals = false;
         switch (queryParameterValue.searchType) {
             case 'string':
@@ -219,9 +223,9 @@ function convertGraphQLParameters (queryParameterValue) {
                 orQueryParameterValue = queryParameterValue;
                 break;
         }
-        if (Object.hasOwn(queryParameterValue, 'missing') && orQueryParameterValue === null) {
+        if (Object.hasOwn(originalQueryParameterValue, 'missing') && orQueryParameterValue === null) {
             modifiers.push('missing');
-            orQueryParameterValue = queryParameterValue.missing;
+            orQueryParameterValue = originalQueryParameterValue.missing;
         }
     } else {
         orQueryParameterValue = queryParameterValue;

--- a/src/operations/query/r4.js
+++ b/src/operations/query/r4.js
@@ -226,7 +226,7 @@ class R4SearchQueryCreator {
                 case fhirFilterTypes.uri:
                     andSegments = new FilterByUri(filterParameters).filter();
                     break;
-                case fhirFilterTypes.dateTime:
+                case fhirFilterTypes.datetime:
                 case fhirFilterTypes.date:
                 case fhirFilterTypes.period:
                 case fhirFilterTypes.instant:

--- a/src/operations/query/r4ArgsParser.js
+++ b/src/operations/query/r4ArgsParser.js
@@ -186,6 +186,13 @@ class R4ArgsParser {
                 queryParameterValue
             ));
 
+            // Keep the pre-concat modifiers (from the colon-suffixed argName) separately: newModifiers
+            // (e.g. 'contains', 'exact', 'missing') describes orQueryParameterValue/andQueryParameterValue,
+            // not notQueryParameterValue, since convertGraphQLParameters returns them from the same call
+            // with no way to tell them apart. Applying newModifiers to the not-item below as well would
+            // route its value through the wrong filter (e.g. 'missing' forcing it through FilterByMissing).
+            const preConvertModifiers = modifiers;
+
             if (newModifiers && Array.isArray(newModifiers) && newModifiers.length) {
                 modifiers = modifiers.concat(newModifiers);
             }
@@ -240,8 +247,8 @@ class R4ArgsParser {
                     notQueryParameterValue.filter(v => v).length > 0
                 )
             ) {
-                const newModifiers = deepcopy(modifiers);
-                newModifiers.push('not');
+                const notModifiers = deepcopy(preConvertModifiers);
+                notModifiers.push('not');
                 parseArgItems.push(
                     new ParsedArgsItem({
                         queryParameter,
@@ -250,7 +257,7 @@ class R4ArgsParser {
                             operator: useOrFilterForArrays ? '$or' : '$and'
                         }),
                         propertyObj,
-                        modifiers: newModifiers
+                        modifiers: notModifiers
                     })
                 );
             }

--- a/src/tests/query/r4ArgsParser/r4argsparser.test.js
+++ b/src/tests/query/r4ArgsParser/r4argsparser.test.js
@@ -70,6 +70,47 @@ args: {
             expect(parsedArgs.parsedArgItems[1].queryParameterValue.value).toStrictEqual('true');
             expect(parsedArgs.parsedArgItems[1].modifiers).toStrictEqual(['missing']);
         });
+        test('r4ArgsParser does not leak the missing modifier onto a GraphQL notEquals item', async () => {
+            await createTestRequest();
+            /**
+             * @type {SimpleContainer}
+             */
+            const container = getTestContainer();
+            /**
+             * @type  {R4ArgsParser}
+             */
+            const r4ArgsParser = container.r4ArgsParser;
+            assertTypeEquals(r4ArgsParser, R4ArgsParser);
+
+            // GraphQL-shaped arg combining notEquals with missing on a reference search type.
+            // convertGraphQLParameters() returns both notQueryParameterValue (the notEquals value)
+            // and newModifiers (['missing']) from the same call; newModifiers must only apply to the
+            // missing-derived item below, not to the notEquals-derived ('not') item.
+            const parsedArgs = r4ArgsParser.parseArgs({
+                resourceType: 'Patient',
+                args: {
+                    base_version: VERSIONS['4_0_0'],
+                    'general-practitioner': {
+                        searchType: 'reference',
+                        notEquals: { target: 'Practitioner', value: '123' },
+                        missing: false
+                    }
+                }
+            });
+
+            const generalPractitionerItems = parsedArgs.parsedArgItems.filter(
+                (item) => item.queryParameter === 'general-practitioner'
+            );
+            expect(generalPractitionerItems.length).toStrictEqual(2);
+
+            const missingItem = generalPractitionerItems.find((item) => item.modifiers.includes('missing'));
+            expect(missingItem.queryParameterValue.value).toStrictEqual(false);
+            expect(missingItem.modifiers).toStrictEqual(['missing']);
+
+            const notItem = generalPractitionerItems.find((item) => item.modifiers.includes('not'));
+            expect(notItem.queryParameterValue.value).toStrictEqual('Practitioner/123');
+            expect(notItem.modifiers).toStrictEqual(['not']);
+        });
         test('r4ArgsParser works for gt', async () => {
             await createTestRequest();
             /**


### PR DESCRIPTION
## Summary
Two related GraphQL search-parameter bugs, each with its own ticket:

**DCON-4791** — `convertGraphQLParameters()` reassigned the local `queryParameterValue` variable to `[]` inside the `notEquals` branches for string/reference/quantity search types. The trailing `Object.hasOwn(queryParameterValue, 'missing')` check then inspected that reassigned `[]` instead of the caller-supplied object, so the `missing` modifier was silently dropped whenever a GraphQL search argument combined `notEquals` with `missing`. Fix: capture a reference to the original input object before the switch and use it for the trailing `missing` check.

**DCON-4792** — `getColumnsAndSegmentsForParameterType()` switched on `propertyObj.type` using `case fhirFilterTypes.dateTime:`, but `fhirFilterTypes` has no `dateTime` key (only lowercase `datetime`), so this evaluated to `case undefined:`. An undefined/malformed `propertyObj.type` would silently match this case and be treated as a date/time filter instead of falling through to `default:`, which throws `Unknown type=...`. Fix: correct the typo to `fhirFilterTypes.datetime`.

## Test plan
- [x] `node node_modules/.bin/jest --config jest.unit.config.js src/tests/unit/operations/query/` — 58 passed