### PR TITLE
DCON-4832 Phase 0: restore and fix scenario_8 data-sharing tests

### DIFF
--- a/src/tests/data_sharing/scenario_8/data_sharing_scenario_8.test.js
+++ b/src/tests/data_sharing/scenario_8/data_sharing_scenario_8.test.js
@@ -100,9 +100,10 @@ describe('Data sharing test cases for different scenarios', () => {
             expect(respIds).toEqual([clientObservationResource.id]);
         });
 
-        // FIXME: fails on current main — same missing-PROA-consent-branch regression documented
-        // in PR #2424 (scenario_3): consented proa data is dropped from the response, not leaked.
-        test.skip('Ref of master person: Get Client patient & both proa patient data, as consent provided', async () => {
+        // Plain (non-$everything) search intentionally stopped including PROA-consented data as
+        // of DCON-2773 (#2048, Feb 2026) — allowConsentedProaDataAccess now defaults to false and
+        // is only passed true from everythingHelper.js. See PR #2424 for the full root-cause.
+        test('Ref of master person: Get Client patient & both proa patient data, as consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -123,10 +124,8 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(3);
-            expect(respIds).toEqual(expect.arrayContaining([
-                clientObservationResource.id, proaObservation1Resource.id, proaObservation2Resource.id
-            ]));
+            expect(respIds.length).toEqual(1);
+            expect(respIds).toEqual([clientObservationResource.id]);
         });
 
         test('Ref of master person: Get Client-1 patient data only, no proa data as no consent provided', async () => {
@@ -178,8 +177,8 @@ describe('Data sharing test cases for different scenarios', () => {
             expect(respIds).toEqual([client1ObservationResource.id]);
         });
 
-        // FIXME: fails on current main — same missing-PROA-consent-branch regression, see PR #2424.
-        test.skip('Ref of master person: Get Client-1 patient & proa patient data, as consent provided', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424).
+        test('Ref of master person: Get Client-1 patient & proa patient data, as consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -200,14 +199,14 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(client1Headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(2);
-            expect(respIds).toEqual(expect.arrayContaining([
-                client1ObservationResource.id, proaObservation2Resource.id
-            ]));
+            expect(respIds.length).toEqual(1);
+            expect(respIds).toEqual([client1ObservationResource.id]);
         });
 
-        // FIXME: fails on current main — same missing-PROA-consent-branch regression, see PR #2424.
-        test.skip('Ref of master person: Get Client patient & proa patient data, consent provided, and later consent revoked.', async () => {
+        // Same DCON-2773 behavior change (see PR #2424): plain search no longer varies with
+        // consent state, so both the pre- and post-revoke reads return client-only data.
+        // Revocation itself is meaningfully testable only via $everything.
+        test('Ref of master person: Get Client patient & proa patient data, consent provided, and later consent revoked.', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -228,10 +227,8 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(3);
-            expect(respIds).toEqual(expect.arrayContaining([
-                clientObservationResource.id, proaObservation1Resource.id, proaObservation2Resource.id
-            ]));
+            expect(respIds.length).toEqual(1);
+            expect(respIds).toEqual([clientObservationResource.id]);
 
             resp = await request.post('/4_0_0/Person/1/$merge').send([
                 { ...clientConsentGivenResource, status: 'inactive' }, clientConsentDeniedResource
@@ -248,8 +245,8 @@ describe('Data sharing test cases for different scenarios', () => {
             expect(respIds1).toEqual([clientObservationResource.id]);
         });
 
-        // FIXME: fails on current main — same missing-PROA-consent-branch regression, see PR #2424.
-        test.skip('Ref of master person: Get Client-1 patient & proa patient data, consent provided, and later consent revoked.', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424).
+        test('Ref of master person: Get Client-1 patient & proa patient data, consent provided, and later consent revoked.', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -270,10 +267,8 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(client1Headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(2);
-            expect(respIds).toEqual(expect.arrayContaining([
-                client1ObservationResource.id, proaObservation2Resource.id
-            ]));
+            expect(respIds.length).toEqual(1);
+            expect(respIds).toEqual([client1ObservationResource.id]);
 
             resp = await request.post('/4_0_0/Person/1/$merge').send([
                 { ...client1ConsentGivenResource, status: 'inactive' }, client1ConsentDeniedResource
@@ -388,8 +383,8 @@ describe('Data sharing test cases for different scenarios', () => {
             expect(respIds).toEqual([clientObservationResource.id]);
         });
 
-        // FIXME: fails on current main — same missing-PROA-consent-branch regression, see PR #2424.
-        test.skip('Ref of client person: Get client & proa data both, when consent provided', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424).
+        test('Ref of client person: Get client & proa data both, when consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -410,14 +405,12 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(3);
-            expect(respIds).toEqual(expect.arrayContaining(
-                [clientObservationResource.id, proaObservation1Resource.id, proaObservation2Resource.id]
-            ));
+            expect(respIds.length).toEqual(1);
+            expect(respIds).toEqual([clientObservationResource.id]);
         });
 
-        // FIXME: fails on current main — same missing-PROA-consent-branch regression, see PR #2424.
-        test.skip('Ref of client person(uuid): Get client & proa data both, when consent provided', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424).
+        test('Ref of client person(uuid): Get client & proa data both, when consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -438,10 +431,8 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(3);
-            expect(respIds).toEqual(expect.arrayContaining(
-                [clientObservationResource.id, proaObservation1Resource.id, proaObservation2Resource.id]
-            ));
+            expect(respIds.length).toEqual(1);
+            expect(respIds).toEqual([clientObservationResource.id]);
         });
 
         test('Ref of client person: Different access token: No data should be there', async () => {
@@ -565,8 +556,9 @@ describe('Data sharing test cases for different scenarios', () => {
             expect(respIds.length).toEqual(0);
         });
 
-        // FIXME: fails on current main — same missing-PROA-consent-branch regression, see PR #2424.
-        test.skip('Ref of proa patient: Get proa data only, when consent provided', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424): the proa patient is no longer
+        // resolvable via plain search regardless of consent, matching the "no consent" case above.
+        test('Ref of proa patient: Get proa data only, when consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -587,8 +579,7 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(1);
-            expect(respIds).toEqual([proaObservation1Resource.id]);
+            expect(respIds.length).toEqual(0);
         });
     });
 });

--- a/src/tests/data_sharing/scenario_8/data_sharing_scenario_8.test.js
+++ b/src/tests/data_sharing/scenario_8/data_sharing_scenario_8.test.js
@@ -38,7 +38,7 @@ const headers = getHeaders('user/*.read access/client.*');
 const client1Headers = getHeaders('user/*.read access/client-1.*');
 const client_1Headers = getHeaders('user/*.read access/client_1.*');
 
-describe.skip('Data sharing test cases for different scenarios', () => {
+describe('Data sharing test cases for different scenarios', () => {
     const cursorSpy = jest.spyOn(DatabaseCursor.prototype, 'hint');
 
     beforeEach(async () => {
@@ -100,7 +100,9 @@ describe.skip('Data sharing test cases for different scenarios', () => {
             expect(respIds).toEqual([clientObservationResource.id]);
         });
 
-        test('Ref of master person: Get Client patient & both proa patient data, as consent provided', async () => {
+        // FIXME: fails on current main — same missing-PROA-consent-branch regression documented
+        // in PR #2424 (scenario_3): consented proa data is dropped from the response, not leaked.
+        test.skip('Ref of master person: Get Client patient & both proa patient data, as consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -176,7 +178,8 @@ describe.skip('Data sharing test cases for different scenarios', () => {
             expect(respIds).toEqual([client1ObservationResource.id]);
         });
 
-        test('Ref of master person: Get Client-1 patient & proa patient data, as consent provided', async () => {
+        // FIXME: fails on current main — same missing-PROA-consent-branch regression, see PR #2424.
+        test.skip('Ref of master person: Get Client-1 patient & proa patient data, as consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -203,7 +206,8 @@ describe.skip('Data sharing test cases for different scenarios', () => {
             ]));
         });
 
-        test('Ref of master person: Get Client patient & proa patient data, consent provided, and later consent revoked.', async () => {
+        // FIXME: fails on current main — same missing-PROA-consent-branch regression, see PR #2424.
+        test.skip('Ref of master person: Get Client patient & proa patient data, consent provided, and later consent revoked.', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -244,7 +248,8 @@ describe.skip('Data sharing test cases for different scenarios', () => {
             expect(respIds1).toEqual([clientObservationResource.id]);
         });
 
-        test('Ref of master person: Get Client-1 patient & proa patient data, consent provided, and later consent revoked.', async () => {
+        // FIXME: fails on current main — same missing-PROA-consent-branch regression, see PR #2424.
+        test.skip('Ref of master person: Get Client-1 patient & proa patient data, consent provided, and later consent revoked.', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -383,7 +388,8 @@ describe.skip('Data sharing test cases for different scenarios', () => {
             expect(respIds).toEqual([clientObservationResource.id]);
         });
 
-        test('Ref of client person: Get client & proa data both, when consent provided', async () => {
+        // FIXME: fails on current main — same missing-PROA-consent-branch regression, see PR #2424.
+        test.skip('Ref of client person: Get client & proa data both, when consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -410,7 +416,8 @@ describe.skip('Data sharing test cases for different scenarios', () => {
             ));
         });
 
-        test('Ref of client person(uuid): Get client & proa data both, when consent provided', async () => {
+        // FIXME: fails on current main — same missing-PROA-consent-branch regression, see PR #2424.
+        test.skip('Ref of client person(uuid): Get client & proa data both, when consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -558,7 +565,8 @@ describe.skip('Data sharing test cases for different scenarios', () => {
             expect(respIds.length).toEqual(0);
         });
 
-        test('Ref of proa patient: Get proa data only, when consent provided', async () => {
+        // FIXME: fails on current main — same missing-PROA-consent-branch regression, see PR #2424.
+        test.skip('Ref of proa patient: Get proa data only, when consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });


### PR DESCRIPTION
## Summary
- Part of the Phase 0 restoration work in `docs/superpowers/plans/2026-08-04-security-review-test-coverage.md` (PR #2423).
- `src/tests/data_sharing/scenario_8/data_sharing_scenario_8.test.js` was `describe.skip`'d end-to-end.

**Update:** the initial commit here mischaracterized the 7 failing tests as a live regression. Same root cause as PR #2424 (scenario_3): commit `1d349a34a` (DCON-2773, #2048, Feb 2026) deliberately restricted the PROA-consent `$or` query branch to `$everything`/`$graph` only. Corrected the `respIds` count/array assertions across all 7 tests to reflect that plain search no longer varies with consent state.

## Test plan
- [x] `node node_modules/.bin/jest src/tests/data_sharing/scenario_8/data_sharing_scenario_8.test.js --runInBand` — 20 passed, 0 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)