### PR TITLE
DCON-4835 Phase 0: restore disabled_consent_based_data_access kill-switch test

### DIFF
--- a/src/tests/consented_data/consented_data/disabled_consent_based_data_access.test.js
+++ b/src/tests/consented_data/consented_data/disabled_consent_based_data_access.test.js
@@ -35,7 +35,7 @@ class MockConfigManager extends ConfigManager {
 
 const headers = getHeaders('user/*.read access/client.*');
 
-describe.skip('Disabled Consent Based Data Access Test', () => {
+describe('Disabled Consent Based Data Access Test', () => {
     const cursorSpy = jest.spyOn(DatabaseCursor.prototype, 'hint');
 
     beforeEach(async () => {


### PR DESCRIPTION
## Summary
- Part of the Phase 0 restoration work in `docs/superpowers/plans/2026-08-04-security-review-test-coverage.md` (PR #2423).
- `src/tests/consented_data/consented_data/disabled_consent_based_data_access.test.js` was `describe.skip`'d.
- Unlike the other Phase 0 files (see #2424), this one didn't need a behavioral fix: it asserts that consent has no effect on plain search when the feature is force-disabled via a mock config — that's already the real default behavior since DCON-2773 (#2048) scoped PROA-consent expansion to `$everything` only. Un-skipping alone was sufficient.

## Test plan
- [x] `node node_modules/.bin/jest src/tests/consented_data/consented_data/disabled_consent_based_data_access.test.js --runInBand` — 1 passed, 0 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)