### PR TITLE
DCON-4837 Phase 0: restore and fix scenario_1 PROA-consent tests

### DIFF
--- a/src/tests/data_sharing/scenario_1/data_sharing_scenario_1.test.js
+++ b/src/tests/data_sharing/scenario_1/data_sharing_scenario_1.test.js
@@ -94,7 +94,10 @@ describe('Data sharing test cases for different scenarios', () => {
             expect(respIds).toEqual(expect.arrayContaining([clientObservationResource.id, clientObservation1Resource.id]));
         });
 
-        test.skip('Ref of master person: Get Client patient & proa patient data, consent provided', async () => {
+        // Plain (non-$everything) search intentionally stopped including PROA-consented data as
+        // of DCON-2773 (#2048, Feb 2026) — allowConsentedProaDataAccess now defaults to false and
+        // is only passed true from everythingHelper.js. See PR #2424 for the full root-cause.
+        test('Ref of master person: Get Client patient & proa patient data, consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -114,9 +117,9 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(3);
+            expect(respIds.length).toEqual(2);
             expect(respIds).toEqual(expect.arrayContaining([
-                clientObservationResource.id, clientObservation1Resource.id, proaObservationResource.id
+                clientObservationResource.id, clientObservation1Resource.id
             ]));
         });
 
@@ -144,7 +147,10 @@ describe('Data sharing test cases for different scenarios', () => {
             expect(respIds).toEqual([clientObservation1Resource.id]);
         });
 
-        test.skip('Ref of master person: Get Client patient & proa patient data, consent provided, and later consent revoked.', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424): plain search no longer varies
+        // with consent state, so both the pre- and post-revoke reads return client-only data.
+        // Revocation itself is meaningfully testable only via $everything.
+        test('Ref of master person: Get Client patient & proa patient data, consent provided, and later consent revoked.', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -164,9 +170,9 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(3);
+            expect(respIds.length).toEqual(2);
             expect(respIds).toEqual(expect.arrayContaining([
-                clientObservationResource.id, clientObservation1Resource.id, proaObservationResource.id
+                clientObservationResource.id, clientObservation1Resource.id
             ]));
 
             resp = await request.post('/4_0_0/Person/1/$merge').send([
@@ -186,7 +192,8 @@ describe('Data sharing test cases for different scenarios', () => {
             ]));
         });
 
-        test.skip('Ref of master person: Get client & proa data, when consent provided, here proa patient has id and not uuid', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424).
+        test('Ref of master person: Get client & proa data, when consent provided, here proa patient has id and not uuid', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -206,10 +213,9 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(4);
-            // Here client observations, proa connection type observation & proa observation with ID are expected
+            expect(respIds.length).toEqual(2);
             expect(respIds).toEqual(expect.arrayContaining(
-                [clientObservationResource.id, clientObservation1Resource.id, proaObservationResource.id, proaObservation1Resource.id]
+                [clientObservationResource.id, clientObservation1Resource.id]
             ));
         });
 
@@ -317,7 +323,8 @@ describe('Data sharing test cases for different scenarios', () => {
             ));
         });
 
-        test.skip('Ref of client person: Get client & proa data both, when consent provided', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424).
+        test('Ref of client person: Get client & proa data both, when consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -337,13 +344,14 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(4);
+            expect(respIds.length).toEqual(2);
             expect(respIds).toEqual(expect.arrayContaining(
-                [clientObservationResource.id, clientObservation1Resource.id, proaObservationResource.id, proaObservation1Resource.id]
+                [clientObservationResource.id, clientObservation1Resource.id]
             ));
         });
 
-        test.skip('Ref of client person(uuid): Get client & proa data both, when consent provided', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424).
+        test('Ref of client person(uuid): Get client & proa data both, when consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -363,9 +371,9 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(4);
+            expect(respIds.length).toEqual(2);
             expect(respIds).toEqual(expect.arrayContaining(
-                [clientObservationResource.id, clientObservation1Resource.id, proaObservationResource.id, proaObservation1Resource.id]
+                [clientObservationResource.id, clientObservation1Resource.id]
             ));
         });
 
@@ -486,7 +494,9 @@ describe('Data sharing test cases for different scenarios', () => {
             expect(respIds.length).toEqual(0);
         });
 
-        test.skip('Ref of proa patient: Get proa data only, when consent provided', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424): the proa patient is no longer
+        // resolvable via plain search regardless of consent, matching the "no consent" case above.
+        test('Ref of proa patient: Get proa data only, when consent provided', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -506,11 +516,11 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(1);
-            expect(respIds).toEqual([proaObservationResource.id]);
+            expect(respIds.length).toEqual(0);
         });
 
-        test.skip('Ref of proa patient: Get proa observation with ID, when consent provided & proa patient searched with UUID', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424).
+        test('Ref of proa patient: Get proa observation with ID, when consent provided & proa patient searched with UUID', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -530,11 +540,11 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(1);
-            expect(respIds).toEqual([proaObservation1Resource.id]);
+            expect(respIds.length).toEqual(0);
         });
 
-        test.skip('Ref of proa patient: Get proa observation with ID, when consent provided & proa patient searched with id & source assigning authority', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424).
+        test('Ref of proa patient: Get proa observation with ID, when consent provided & proa patient searched with id & source assigning authority', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -554,11 +564,11 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(1);
-            expect(respIds).toEqual([proaObservation1Resource.id]);
+            expect(respIds.length).toEqual(0);
         });
 
-        test.skip('Ref of proa patient: Get proa observation with ID, when consent provided & proa patient searched with id only', async () => {
+        // Same DCON-2773 behavior change as above (see PR #2424).
+        test('Ref of proa patient: Get proa observation with ID, when consent provided & proa patient searched with id only', async () => {
             const request = await createTestRequest((c) => {
                 return c;
             });
@@ -578,8 +588,7 @@ describe('Data sharing test cases for different scenarios', () => {
                 .set(headers);
             const respIds = resp.body.map(item => item.id);
 
-            expect(respIds.length).toEqual(1);
-            expect(respIds).toEqual([proaObservation1Resource.id]);
+            expect(respIds.length).toEqual(0);
         });
 
         test('Search for ActivityDefinition resource which is not a patient related resource', async () => {


### PR DESCRIPTION
## Summary
- Final item of the Phase 0 punch list in `docs/superpowers/plans/2026-08-04-security-review-test-coverage.md` (PR #2423).
- The plan's Task 0.1 only explicitly called out one individual `test.skip` in `src/tests/data_sharing/scenario_1/data_sharing_scenario_1.test.js` (the "...and later consent revoked" case), but the file actually had 9 individually-skipped tests, all following the same pattern documented in #2424: commit `1d349a34a` (DCON-2773, #2048, Feb 2026) deliberately restricted the PROA-consent `$or` query branch to `$everything`/`$graph` only.
- Corrected `respIds` counts/arrays across all 9 tests to drop entries only reachable via that branch.

## Test plan
- [x] `node node_modules/.bin/jest src/tests/data_sharing/scenario_1/data_sharing_scenario_1.test.js --runInBand` — 23 passed, 0 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)