### PR TITLE
DCON-4861 Invalidate Patient/$everything Redis cache on Consent writes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -79,7 +79,6 @@ module.exports = {
         '<rootDir>/src/tests/unit/graphql/resolvers/graphqlResolver.crossTenant.test.js',
         '<rootDir>/src/tests/unit/graphqlv2/crossTenantPhiLeakage.test.js',
         '<rootDir>/src/tests/unit/middleware/errorInformationDisclosure.test.js',
-        '<rootDir>/src/tests/unit/operations/everything/patientEverything.consent.test.js',
         '<rootDir>/src/tests/unit/operations/export/bulkDataExportRunner.crossTenant.test.js',
         '<rootDir>/src/tests/unit/operations/history/historyCrossTenant.test.js',
         '<rootDir>/src/tests/unit/operations/merge/merge.crossTenant.test.js',

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -104,6 +104,7 @@ const {MergeResourceValidator} = require('./operations/merge/validators/mergeRes
 const {RemoteFhirValidator} = require('./utils/remoteFhirValidator');
 const {PostSaveProcessor} = require('./dataLayer/postSaveProcessor');
 const {PostSaveHandlerFactory} = require('./dataLayer/postSaveHandlers/postSaveHandlerFactory');
+const {ConsentCacheInvalidationHandler} = require('./dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler');
 const {ProfileUrlMapper} = require('./utils/profileMapper');
 const {ReferenceQueryRewriter} = require('./queryRewriters/rewriters/referenceQueryRewriter');
 const {PatientScopeManager} = require('./operations/security/patientScopeManager');
@@ -740,7 +741,8 @@ const createContainer = function () {
         patientDataViewControlManager: c.patientDataViewControlManager,
         auditLogger: c.auditLogger,
         postRequestProcessor: c.postRequestProcessor,
-        redisStreamManager: c.redisStreamManager
+        redisStreamManager: c.redisStreamManager,
+        redisManager: c.redisManager
     }));
 
     container.register('everythingRelatedResourceMapper', (c) => new EverythingRelatedResourcesMapper());
@@ -1167,7 +1169,11 @@ const createContainer = function () {
     container.register('postSaveProcessor', (c) => {
         const handlers = [
             c.changeEventProducer,
-            c.patientPersonDataChangeEventProducer
+            c.patientPersonDataChangeEventProducer,
+            new ConsentCacheInvalidationHandler({
+                redisManager: c.redisManager,
+                bwellPersonFinder: c.bwellPersonFinder
+            })
         ];
 
         // Add ClickHouse handler for Group resources if enabled

--- a/src/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.js
+++ b/src/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.js
@@ -1,0 +1,173 @@
+const { BasePostSaveHandler } = require('../../../utils/basePostSaveHandler');
+const { assertTypeEquals } = require('../../../utils/assertType');
+const { RedisManager } = require('../../../utils/redisManager');
+const { BwellPersonFinder } = require('../../../utils/bwellPersonFinder');
+const { ReferenceParser } = require('../../../utils/referenceParser');
+const { isUuid } = require('../../../utils/uid.util');
+const { PERSON_PROXY_PREFIX } = require('../../../constants');
+const { logDebug, logError } = require('../../../operations/common/logging');
+
+/**
+ * Post-save handler that invalidates the Patient/$everything Redis cache whenever a
+ * Consent resource is created, updated, or removed.
+ *
+ * The $everything cache (see PatientEverythingCacheKeyGenerator) is keyed in part on a
+ * "generation" counter stored in Redis (Patient:<uuid>:Everything:Generation or
+ * ClientPerson:<uuid>:Everything:Generation). Bumping that counter changes the cache key
+ * on the next read, which makes any previously-cached entry unreachable - it is never
+ * read again and simply expires later via its normal TTL. No explicit cache delete is
+ * required.
+ *
+ * Without this handler there was NO invalidation trigger at all for the Everything cache
+ * on Consent writes, so stale PHI could be served for up to the cache TTL (~600s) after a
+ * Consent was revoked or otherwise changed.
+ *
+ * Known gap: if the Consent's `patient` reference is a direct Patient reference, this
+ * handler also does a best-effort lookup (via BwellPersonFinder, an existing traversal
+ * utility) for Person(s) immediately linked to that patient and bumps their
+ * ClientPerson:<uuid>:Everything:Generation key too, so the proxy-Person $everything path
+ * is covered for the common case. This is a single-hop, best-effort lookup - it does not
+ * walk the full Person/Patient link graph - so an $everything cache primed under a
+ * ClientPerson key that is more than one hop away from this patient will not be
+ * invalidated by this handler.
+ */
+class ConsentCacheInvalidationHandler extends BasePostSaveHandler {
+    /**
+     * @param {Object} params
+     * @param {RedisManager} params.redisManager
+     * @param {BwellPersonFinder} params.bwellPersonFinder
+     */
+    constructor({ redisManager, bwellPersonFinder }) {
+        super();
+
+        /**
+         * @type {RedisManager}
+         */
+        this.redisManager = redisManager;
+        assertTypeEquals(redisManager, RedisManager);
+
+        /**
+         * @type {BwellPersonFinder}
+         */
+        this.bwellPersonFinder = bwellPersonFinder;
+        assertTypeEquals(bwellPersonFinder, BwellPersonFinder);
+    }
+
+    /**
+     * Fires whenever a resource is changed. No-ops for anything but Consent.
+     * @param {string} requestId
+     * @param {string} eventType. Can be C = create, U = update, D = delete
+     * @param {string} resourceType
+     * @param {Resource} doc
+     * @return {Promise<void>}
+     */
+    async afterSaveAsync({ requestId, eventType, resourceType, doc }) {
+        if (resourceType !== 'Consent' || !doc) {
+            return;
+        }
+
+        try {
+            const patientReference = doc.patient;
+            const referenceValue = patientReference && patientReference.reference;
+            if (!referenceValue) {
+                logDebug('ConsentCacheInvalidationHandler: Consent has no patient reference, skipping cache invalidation', {
+                    requestId, consentId: doc.id, eventType
+                });
+                return;
+            }
+
+            const { id: rawId } = ReferenceParser.parseReference(referenceValue);
+            if (!rawId) {
+                return;
+            }
+
+            // Proxy-patient reference (Patient/person.<personUuid>) -> this Consent is about
+            // a Person directly, so bump that Person's Everything-cache generation.
+            if (rawId.startsWith(PERSON_PROXY_PREFIX)) {
+                const personUuid = rawId.replace(PERSON_PROXY_PREFIX, '');
+                if (isUuid(personUuid)) {
+                    await this.incrementGenerationAsync(`ClientPerson:${personUuid}:Everything:Generation`, {
+                        requestId, consentId: doc.id
+                    });
+                } else {
+                    logDebug('ConsentCacheInvalidationHandler: proxy-patient reference did not contain a valid person uuid, skipping', {
+                        requestId, consentId: doc.id, referenceValue
+                    });
+                }
+                return;
+            }
+
+            // Direct Patient reference. Prefer the pre-save-enriched canonical uuid
+            // (doc.patient._uuid, format "Patient/<uuid>") when it is a valid uuid,
+            // falling back to the raw reference id otherwise.
+            let patientUuid = rawId;
+            const enrichedUuidRef = patientReference._uuid;
+            if (enrichedUuidRef) {
+                const { id: enrichedId } = ReferenceParser.parseReference(enrichedUuidRef);
+                if (enrichedId && isUuid(enrichedId)) {
+                    patientUuid = enrichedId;
+                }
+            }
+
+            if (!isUuid(patientUuid)) {
+                logDebug('ConsentCacheInvalidationHandler: could not resolve a patient uuid from Consent.patient, skipping cache invalidation', {
+                    requestId, consentId: doc.id, referenceValue
+                });
+                return;
+            }
+
+            await this.incrementGenerationAsync(`Patient:${patientUuid}:Everything:Generation`, {
+                requestId, consentId: doc.id
+            });
+
+            // Best-effort: also bump the ClientPerson-keyed cache for any Person(s)
+            // immediately linked to this patient (the proxy-Person $everything path).
+            // Uses the existing BwellPersonFinder traversal utility - a single hop only.
+            try {
+                const { patientReferenceToPersonUuid } = await this.bwellPersonFinder.getImmediatePersonIdsOfPatientsAsync({
+                    patientReferences: [{ id: patientUuid, resourceType: 'Patient' }]
+                });
+                const linkedPersonUuids = (patientReferenceToPersonUuid && patientReferenceToPersonUuid[patientUuid]) || [];
+                for (const personUuid of linkedPersonUuids) {
+                    await this.incrementGenerationAsync(`ClientPerson:${personUuid}:Everything:Generation`, {
+                        requestId, consentId: doc.id, patientUuid
+                    });
+                }
+            } catch (error) {
+                // Best-effort only: failing to find linked Person(s) should not fail the
+                // Consent write, which has already been committed by this point.
+                logError('ConsentCacheInvalidationHandler: failed to look up linked Person(s) for cache invalidation', {
+                    error, requestId, consentId: doc.id, patientUuid
+                });
+            }
+        } catch (error) {
+            // Cache invalidation is best-effort: the Consent resource is already
+            // committed to MongoDB by the time this handler runs, so a failure here
+            // should not fail the write. Worst case, the cache serves stale data until
+            // its TTL expires - the same behavior as before this handler existed.
+            logError('ConsentCacheInvalidationHandler: failed to invalidate Everything cache for Consent change', {
+                error, requestId, consentId: doc && doc.id, resourceType, eventType
+            });
+        }
+    }
+
+    /**
+     * Increments the generation counter for the given key, logging (not throwing) on error.
+     * @param {string} generationKey
+     * @param {Object} logContext
+     * @return {Promise<void>}
+     */
+    async incrementGenerationAsync(generationKey, logContext) {
+        try {
+            await this.redisManager.incrementGenerationAsync(generationKey);
+        } catch (error) {
+            logError('ConsentCacheInvalidationHandler: failed to increment Everything cache generation', {
+                error, generationKey, ...logContext
+            });
+        }
+    }
+}
+
+module.exports = {
+    ConsentCacheInvalidationHandler
+};

--- a/src/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.js
+++ b/src/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.js
@@ -22,14 +22,19 @@ const { logDebug, logError } = require('../../../operations/common/logging');
  * on Consent writes, so stale PHI could be served for up to the cache TTL (~600s) after a
  * Consent was revoked or otherwise changed.
  *
- * Known gap: if the Consent's `patient` reference is a direct Patient reference, this
- * handler also does a best-effort lookup (via BwellPersonFinder, an existing traversal
- * utility) for Person(s) immediately linked to that patient and bumps their
- * ClientPerson:<uuid>:Everything:Generation key too, so the proxy-Person $everything path
- * is covered for the common case. This is a single-hop, best-effort lookup - it does not
- * walk the full Person/Patient link graph - so an $everything cache primed under a
- * ClientPerson key that is more than one hop away from this patient will not be
- * invalidated by this handler.
+ * Proxy-Person coverage: if the Consent's `patient` reference is a direct Patient reference,
+ * this handler also (best-effort, via the existing BwellPersonFinder traversals) bumps the
+ * ClientPerson:<uuid>:Everything:Generation key for both (a) the Person(s) immediately linked
+ * to the patient and (b) the bwell master Person at the top of the link graph. In bwell's
+ * master -> client -> Patient topology those are the two Persons a proxy $everything cache is
+ * realistically keyed under (the JWT person is usually the master Person or a direct client
+ * Person), so revoking consent now invalidates the master-Person-keyed cache too, not just the
+ * immediate client Person's.
+ *
+ * Residual gap: it still does not enumerate every intermediate Person in link graphs deeper
+ * than master -> client -> Patient; an $everything cache primed under such an intermediate
+ * Person key would not be invalidated. The traversal also adds a bounded per-Consent-write DB
+ * cost (the up-graph walk), which is acceptable on this low-frequency write path.
  */
 class ConsentCacheInvalidationHandler extends BasePostSaveHandler {
     /**
@@ -120,15 +125,39 @@ class ConsentCacheInvalidationHandler extends BasePostSaveHandler {
                 requestId, consentId: doc.id
             });
 
-            // Best-effort: also bump the ClientPerson-keyed cache for any Person(s)
-            // immediately linked to this patient (the proxy-Person $everything path).
-            // Uses the existing BwellPersonFinder traversal utility - a single hop only.
+            // Best-effort: also bump the ClientPerson-keyed cache for any Person(s) the proxy
+            // $everything path could be primed under. That cache is keyed on the Person the caller
+            // authenticated as (ClientPerson:<jwtPersonUuid>), which in bwell's
+            // master -> client -> Patient topology is usually either an immediate client Person
+            // (one hop from the patient) OR the bwell master Person (top of the link graph). We bump
+            // both, so a master-Person token's cache is invalidated too - not just the immediate
+            // client Person's, which was the residual gap in the first cut of this handler.
+            // Uses existing BwellPersonFinder traversals; the union is deduped so a Person that is
+            // both immediate and master is bumped once.
             try {
+                /**
+                 * @type {Set<string>}
+                 */
+                const personUuidsToBump = new Set();
+
                 const { patientReferenceToPersonUuid } = await this.bwellPersonFinder.getImmediatePersonIdsOfPatientsAsync({
                     patientReferences: [{ id: patientUuid, resourceType: 'Patient' }]
                 });
                 const linkedPersonUuids = (patientReferenceToPersonUuid && patientReferenceToPersonUuid[patientUuid]) || [];
                 for (const personUuid of linkedPersonUuids) {
+                    if (personUuid) {
+                        personUuidsToBump.add(personUuid);
+                    }
+                }
+
+                // Walk up the link graph to the bwell master Person, the common JWT-person for the
+                // proxy $everything path and the one the single-hop lookup missed.
+                const bwellPersonUuid = await this.bwellPersonFinder.getBwellPersonIdAsync({ patientId: patientUuid });
+                if (bwellPersonUuid) {
+                    personUuidsToBump.add(bwellPersonUuid);
+                }
+
+                for (const personUuid of personUuidsToBump) {
                     await this.incrementGenerationAsync(`ClientPerson:${personUuid}:Everything:Generation`, {
                         requestId, consentId: doc.id, patientUuid
                     });

--- a/src/operations/everything/everythingHelper.js
+++ b/src/operations/everything/everythingHelper.js
@@ -58,6 +58,7 @@ const { CustomTracer } = require('../../utils/customTracer');
 const { PatientDataViewControlManager } = require('../../utils/patientDataViewController');
 const { ResourceMapper, UuidOnlyMapper } = require('./resourceMapper');
 const { RedisStreamManager } = require('../../utils/redisStreamManager');
+const { RedisManager } = require('../../utils/redisManager');
 const { CachedFhirResponseStreamer } = require('../../utils/cachedFhirResponseStreamer');
 const httpContext = require('express-http-context');
 const { recordOutboundEverything } = require('../../utils/metrics');
@@ -111,6 +112,7 @@ class EverythingHelper {
      *
      * @param {EverythingHelperParams}
      * @param {RedisStreamManager} redisStreamManager
+     * @param {RedisManager} redisManager
      */
     constructor({
         databaseQueryFactory,
@@ -128,7 +130,8 @@ class EverythingHelper {
         patientDataViewControlManager,
         auditLogger,
         postRequestProcessor,
-        redisStreamManager
+        redisStreamManager,
+        redisManager
     }) {
         /**
          * @type {DatabaseQueryFactory}
@@ -247,6 +250,12 @@ class EverythingHelper {
          * @type {RedisStreamManager}
          */
         this.redisStreamManager = redisStreamManager;
+
+        /**
+         * @type {RedisManager}
+         */
+        this.redisManager = redisManager;
+        assertTypeEquals(redisManager, RedisManager);
     }
 
     /**
@@ -318,7 +327,7 @@ class EverythingHelper {
         if (!requestInfo.personIdFromJwtToken || requestInfo.userType) {
             return undefined;
         }
-        const keyGenerator = new PatientEverythingCacheKeyGenerator();
+        const keyGenerator = new PatientEverythingCacheKeyGenerator({ redisManager: this.redisManager });
         if (!keyGenerator.isResponseTypeCacheable(requestInfo.accept, parsedArgs)) {
             return undefined;
         }

--- a/src/operations/everything/patientEverythingCachekeyGenerator.js
+++ b/src/operations/everything/patientEverythingCachekeyGenerator.js
@@ -1,8 +1,10 @@
 const { BaseCacheKeyGenerator } = require('../common/baseCacheKeyGenerator');
 const { fhirContentTypes } = require('../../utils/contentTypes');
+const { assertTypeEquals } = require('../../utils/assertType');
+const { RedisManager } = require('../../utils/redisManager');
 
 class PatientEverythingCacheKeyGenerator extends BaseCacheKeyGenerator {
-    constructor() {
+    constructor({ redisManager }) {
         super();
         this.operation = 'Everything';
         this.invalidParamsForCache = [
@@ -27,6 +29,44 @@ class PatientEverythingCacheKeyGenerator extends BaseCacheKeyGenerator {
             fhirContentTypes.ndJson2,
             fhirContentTypes.ndJson3
         ];
+        // params to be included in cache key so that e.g. ?_type=Observation and
+        // ?_type=Condition don't share a cache entry
+        this.keyParamsforCache = ['_type'];
+
+        /**
+         * @type {RedisManager}
+         */
+        this.redisManager = redisManager;
+        assertTypeEquals(redisManager, RedisManager);
+    }
+
+    /**
+     * Get generation number for the given ID.
+     * Unlike SummaryCacheKeyGenerator, Everything's cache legitimately keys on both
+     * Patient:<id> (direct-patient path) and ClientPerson:<id> (proxy-Person path) - see
+     * EverythingHelper.getCacheKey() - so generation tracking is supported for both,
+     * not restricted to person IDs only.
+     * @typedef {Object} options
+     * @property {string} id
+     * @property {boolean} isPersonId
+     *
+     * @param {options} options
+     * @returns {Promise<number|undefined>}
+     */
+    async getGenerationForId({ id, isPersonId }) {
+        const keyPrefix = this.generateIdComponent({ id, isPersonId });
+        const generationKey = `${keyPrefix}:${this.operation}:Generation`;
+        const existingGeneration = await this.redisManager.getCacheAsync(generationKey);
+        if (existingGeneration) {
+            const parsedGeneration = Number.parseInt(existingGeneration, 10);
+            if (!Number.isNaN(parsedGeneration)) {
+                return parsedGeneration;
+            } else {
+                // throw error if generation value is not a valid number
+                throw new Error(`Invalid generation value for key ${generationKey}: ${existingGeneration}`);
+            }
+        }
+        return await this.redisManager.incrementGenerationAsync(generationKey);
     }
 }
 

--- a/src/tests/everything/person_or_patient/person_or_patient.test.js
+++ b/src/tests/everything/person_or_patient/person_or_patient.test.js
@@ -888,7 +888,7 @@ describe('Person and Patient $everything Tests', () => {
                 .set(patientHeader);
 
             expect(resp).toHaveResourceCount(8);
-            let cacheKey = 'Patient:24a5930e-11b4-5525-b482-669174917044:Everything:Scopes:41b78b54-0a8e-5477-af30-d99864d04833';
+            let cacheKey = 'Patient:24a5930e-11b4-5525-b482-669174917044:Everything:Generation:1:Scopes:41b78b54-0a8e-5477-af30-d99864d04833';
             expect(streams.keys()).toContain(cacheKey);
             expect(streams.get(cacheKey)).toHaveLength(8);
 

--- a/src/tests/everything/proxy_patient/proxy_patient.test.js
+++ b/src/tests/everything/proxy_patient/proxy_patient.test.js
@@ -336,7 +336,7 @@ describe('Proxy Patient $everything Tests', () => {
             .set(patientHeader);
 
         expect(resp).toHaveResourceCount(5);
-        let cacheKey = 'ClientPerson:7b99904f-2f85-51a3-9398-e2eed6854639:Everything:Scopes:41b78b54-0a8e-5477-af30-d99864d04833';
+        let cacheKey = 'ClientPerson:7b99904f-2f85-51a3-9398-e2eed6854639:Everything:Generation:1:Scopes:41b78b54-0a8e-5477-af30-d99864d04833';
         expect(streams.keys()).toContain(cacheKey);
         expect(streams.get(cacheKey)).toHaveLength(5);
 

--- a/src/tests/unit/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.test.js
+++ b/src/tests/unit/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.test.js
@@ -1,0 +1,115 @@
+'use strict';
+
+/**
+ * Unit tests for ConsentCacheInvalidationHandler (DCON-4861).
+ *
+ * Focus: the proxy-Person ($everything) cache invalidation on a direct-Patient Consent write
+ * bumps BOTH the immediate client Person key and the bwell master Person key, deduped, and is
+ * best-effort (a traversal failure never throws out of the handler).
+ */
+
+const { describe, beforeEach, afterEach, it, expect, jest } = require('@jest/globals');
+
+const { ConsentCacheInvalidationHandler } = require('../../../../../dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler');
+const { RedisManager } = require('../../../../../utils/redisManager');
+const { BwellPersonFinder } = require('../../../../../utils/bwellPersonFinder');
+
+jest.mock('../../../../../operations/common/logging', () => ({
+    logError: jest.fn(),
+    logInfo: jest.fn(),
+    logDebug: jest.fn()
+}));
+
+const PATIENT_UUID = '11111111-1111-1111-1111-111111111111';
+const CLIENT_PERSON_UUID = '22222222-2222-2222-2222-222222222222';
+const MASTER_PERSON_UUID = '33333333-3333-3333-3333-333333333333';
+const PROXY_PERSON_UUID = '44444444-4444-4444-4444-444444444444';
+
+describe('ConsentCacheInvalidationHandler', () => {
+    let handler;
+    let mockRedisManager;
+    let mockBwellPersonFinder;
+    let bumpedKeys;
+
+    beforeEach(() => {
+        bumpedKeys = [];
+        mockRedisManager = Object.create(RedisManager.prototype);
+        mockRedisManager.incrementGenerationAsync = jest.fn().mockImplementation(async (key) => {
+            bumpedKeys.push(key);
+        });
+
+        mockBwellPersonFinder = Object.create(BwellPersonFinder.prototype);
+        mockBwellPersonFinder.getImmediatePersonIdsOfPatientsAsync = jest.fn().mockResolvedValue({
+            patientReferenceToPersonUuid: { [PATIENT_UUID]: [CLIENT_PERSON_UUID] }
+        });
+        mockBwellPersonFinder.getBwellPersonIdAsync = jest.fn().mockResolvedValue(MASTER_PERSON_UUID);
+
+        handler = new ConsentCacheInvalidationHandler({
+            redisManager: mockRedisManager,
+            bwellPersonFinder: mockBwellPersonFinder
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    function directPatientConsent() {
+        return {
+            id: 'consent-1',
+            patient: { reference: `Patient/${PATIENT_UUID}`, _uuid: `Patient/${PATIENT_UUID}` }
+        };
+    }
+
+    it('is a no-op for non-Consent resources', async () => {
+        await handler.afterSaveAsync({ requestId: 'r1', eventType: 'U', resourceType: 'Observation', doc: { id: 'o1' } });
+        expect(mockRedisManager.incrementGenerationAsync).not.toHaveBeenCalled();
+    });
+
+    it('on a direct-Patient Consent bumps the Patient key, the immediate client Person, AND the bwell master Person', async () => {
+        await handler.afterSaveAsync({ requestId: 'r1', eventType: 'U', resourceType: 'Consent', doc: directPatientConsent() });
+
+        expect(bumpedKeys).toContain(`Patient:${PATIENT_UUID}:Everything:Generation`);
+        expect(bumpedKeys).toContain(`ClientPerson:${CLIENT_PERSON_UUID}:Everything:Generation`);
+        // the master-Person key is the gap this change closes
+        expect(bumpedKeys).toContain(`ClientPerson:${MASTER_PERSON_UUID}:Everything:Generation`);
+        expect(mockBwellPersonFinder.getBwellPersonIdAsync).toHaveBeenCalledWith({ patientId: PATIENT_UUID });
+    });
+
+    it('dedupes when the immediate client Person is also the bwell master Person (bumped once)', async () => {
+        mockBwellPersonFinder.getImmediatePersonIdsOfPatientsAsync.mockResolvedValue({
+            patientReferenceToPersonUuid: { [PATIENT_UUID]: [MASTER_PERSON_UUID] }
+        });
+        mockBwellPersonFinder.getBwellPersonIdAsync.mockResolvedValue(MASTER_PERSON_UUID);
+
+        await handler.afterSaveAsync({ requestId: 'r1', eventType: 'U', resourceType: 'Consent', doc: directPatientConsent() });
+
+        const masterKey = `ClientPerson:${MASTER_PERSON_UUID}:Everything:Generation`;
+        expect(bumpedKeys.filter(k => k === masterKey)).toHaveLength(1);
+    });
+
+    it('proxy-patient Consent bumps only that Person key and does not run the direct-Patient traversal', async () => {
+        const doc = { id: 'consent-2', patient: { reference: `Patient/person.${PROXY_PERSON_UUID}` } };
+        await handler.afterSaveAsync({ requestId: 'r1', eventType: 'U', resourceType: 'Consent', doc });
+
+        expect(bumpedKeys).toEqual([`ClientPerson:${PROXY_PERSON_UUID}:Everything:Generation`]);
+        expect(mockBwellPersonFinder.getImmediatePersonIdsOfPatientsAsync).not.toHaveBeenCalled();
+        expect(mockBwellPersonFinder.getBwellPersonIdAsync).not.toHaveBeenCalled();
+    });
+
+    it('still bumps the Patient key when the Person traversal fails (best-effort, never throws)', async () => {
+        mockBwellPersonFinder.getImmediatePersonIdsOfPatientsAsync.mockRejectedValue(new Error('mongo down'));
+
+        await expect(
+            handler.afterSaveAsync({ requestId: 'r1', eventType: 'U', resourceType: 'Consent', doc: directPatientConsent() })
+        ).resolves.toBeUndefined();
+
+        expect(bumpedKeys).toContain(`Patient:${PATIENT_UUID}:Everything:Generation`);
+    });
+
+    it('handles a delete (eventType D) the same way as a write', async () => {
+        await handler.afterSaveAsync({ requestId: 'r1', eventType: 'D', resourceType: 'Consent', doc: directPatientConsent() });
+        expect(bumpedKeys).toContain(`Patient:${PATIENT_UUID}:Everything:Generation`);
+        expect(bumpedKeys).toContain(`ClientPerson:${MASTER_PERSON_UUID}:Everything:Generation`);
+    });
+});

--- a/src/tests/unit/operations/everything/patientEverything.consent.test.js
+++ b/src/tests/unit/operations/everything/patientEverything.consent.test.js
@@ -1,18 +1,24 @@
 'use strict';
 
 /**
- * Security tests for PatientEverythingCacheKeyGenerator — PROA consent cache invalidation.
+ * Regression tests for PatientEverythingCacheKeyGenerator — PROA consent cache invalidation
+ * (DCON: fix Everything-cache Consent invalidation).
  *
- * These tests MUST FAIL against the current implementation to prove the following
- * HIPAA-violating vulnerabilities exist:
+ * These tests originally asserted the fixed behavior against a not-yet-implemented
+ * generation-tracking mechanism (see git history for the original "MUST FAIL" comments).
+ * Now that PatientEverythingCacheKeyGenerator implements getGenerationForId() (mirroring
+ * SummaryCacheKeyGenerator, but supporting both Patient:<id> and ClientPerson:<id> forms)
+ * and a ConsentCacheInvalidationHandler post-save handler bumps the generation counter on
+ * every Consent write, these tests verify that mechanism directly:
  *
- * 1. getGenerationForId() is not implemented — stale PROA PHI served from Redis for
- *    up to 600s after consent revocation.
- * 2. No mechanism to trigger cache invalidation on consent state change.
- * 3. PROA-specific access codes are not factored into the cache key, meaning requests
- *    with different consent scopes may share a cache entry.
- * 4. _type parameter is not included in keyParamsforCache or invalidParamsForCache,
- *    allowing resource-type cross-contamination in cached responses.
+ * 1. getGenerationForId() returns a real generation number (not undefined), so the
+ *    `:Generation:X` segment is appended to the cache key.
+ * 2. The generator accepts a redisManager, which is what the post-save handler's
+ *    generation bump (incrementGenerationAsync) ultimately affects.
+ * 3. The Generation segment is present in generated cache keys, which is what allows a
+ *    Consent-triggered generation bump to change the key on the next read.
+ * 4. _type is included in keyParamsforCache, so requests differing only by _type no
+ *    longer share a cache entry.
  */
 const { describe, test, expect, beforeEach, jest: jestGlobal } = require('@jest/globals');
 
@@ -23,33 +29,46 @@ jestGlobal.mock('../../../../operations/common/logging', () => ({
 }));
 
 const { PatientEverythingCacheKeyGenerator } = require('../../../../operations/everything/patientEverythingCachekeyGenerator');
+const { RedisManager } = require('../../../../utils/redisManager');
+
+/**
+ * Builds a real RedisManager backed by an in-memory fake redisClient, so
+ * getGenerationForId()/generateCacheKey() exercise the real generation-tracking logic
+ * without needing an actual Redis server.
+ * @returns {RedisManager}
+ */
+function createFakeRedisManager() {
+    const store = new Map();
+    const redisClient = {
+        connectAsync: jestGlobal.fn().mockResolvedValue(undefined),
+        get: jestGlobal.fn(async (key) => (store.has(key) ? String(store.get(key)) : null)),
+        incr: jestGlobal.fn(async (key) => {
+            const next = (store.get(key) || 0) + 1;
+            store.set(key, next);
+            return next;
+        })
+    };
+    return new RedisManager({ redisClient });
+}
 
 describe('PatientEverythingCacheKeyGenerator — PROA Consent Security', () => {
     let generator;
 
     beforeEach(() => {
-        generator = new PatientEverythingCacheKeyGenerator();
+        generator = new PatientEverythingCacheKeyGenerator({ redisManager: createFakeRedisManager() });
     });
 
     describe('INC-331: getGenerationForId must return a number for cache invalidation', () => {
         test('getGenerationForId returns a generation number (not undefined) to enable consent-aware invalidation', async () => {
-            // The SummaryCacheKeyGenerator properly implements getGenerationForId() to
-            // return a numeric generation counter from Redis. When consent is revoked,
-            // the generation is incremented, which changes the cache key and forces a
-            // fresh query instead of serving stale PHI.
-            //
-            // PatientEverythingCacheKeyGenerator inherits the base class stub that
-            // always returns undefined. This means the `:Generation:X` segment is
-            // NEVER appended to the cache key, so consent revocation has NO effect
-            // on cache validity. Stale PROA-consented PHI continues to be served
-            // for the full Redis TTL (600 seconds).
+            // SummaryCacheKeyGenerator returns a numeric generation counter from Redis, and
+            // when the counter is incremented (e.g. by ConsentCacheInvalidationHandler), the
+            // cache key changes and forces a fresh query instead of serving stale PHI.
+            // PatientEverythingCacheKeyGenerator now implements the same contract.
             const generation = await generator.getGenerationForId({
                 id: 'patient-abc-123',
                 isPersonId: true
             });
 
-            // ASSERTION: generation tracking must be active (returns a number).
-            // EXPECTED TO FAIL: current implementation returns undefined.
             expect(generation).not.toBeUndefined();
             expect(typeof generation).toBe('number');
         });
@@ -57,38 +76,26 @@ describe('PatientEverythingCacheKeyGenerator — PROA Consent Security', () => {
 
     describe('INC-331: Consent revocation must trigger cache key change', () => {
         test('generator must accept a redisManager to track generation changes on consent revocation', () => {
-            // SummaryCacheKeyGenerator accepts a redisManager in its constructor
-            // and uses it to read/increment the generation counter. This allows the
-            // consent-revocation event handler to increment the generation, which
-            // immediately invalidates all cached $everything responses for that patient.
-            //
-            // PatientEverythingCacheKeyGenerator has NO constructor parameter for
-            // redisManager and NO mechanism to detect consent state changes.
-            // This means there is literally no code path that can invalidate the
-            // cache when a PROA consent is revoked — a direct HIPAA violation.
+            // SummaryCacheKeyGenerator accepts a redisManager in its constructor and uses it
+            // to read/increment the generation counter. PatientEverythingCacheKeyGenerator
+            // now does the same, which is what allows ConsentCacheInvalidationHandler (a
+            // post-save handler that fires on every Consent write) to bump the generation
+            // and invalidate cached $everything responses for the affected patient/person.
             const hasRedisManager = generator.redisManager !== undefined;
 
-            // ASSERTION: generator must have a redisManager for generation tracking.
-            // EXPECTED TO FAIL: current constructor sets no redisManager property.
             expect(hasRedisManager).toBe(true);
         });
     });
 
     describe('INC-331: PROA access codes must differentiate cache keys', () => {
-        test('cache key differs when PROA-specific access scopes change', async () => {
+        test('cache key includes a Generation segment that changes when the generation counter is bumped', async () => {
             // When a patient has PROA consent, the $everything response includes PHI
             // from the PROA data source (e.g., health plan claims). The scope string
             // passed to generateCacheKey includes access codes like "patient/*.read access/proa".
             //
-            // If a consent is later revoked, the scope for subsequent requests should
-            // NOT match the old cache key. However, since getGenerationForId returns
-            // undefined for BOTH requests, the Generation segment is omitted from both
-            // keys. The only differentiator is the scope hash — but if the scope string
-            // is identical (same client, same patient), the same cache entry is served
-            // regardless of consent status.
-            //
-            // The generator SHOULD include a consent-state indicator (generation) in
-            // the key so that even with identical scopes, revoked consent forces a miss.
+            // The Generation segment (not the scope hash) is what forces a cache miss when
+            // a Consent write bumps the generation counter for this id, even if the scope
+            // string is otherwise identical across requests.
             const mockParsedArgs = {
                 getRawArgs: () => ({}),
                 _format: undefined
@@ -101,12 +108,21 @@ describe('PatientEverythingCacheKeyGenerator — PROA Consent Security', () => {
                 scope: 'patient/*.read access/proa'
             });
 
-            // Simulate consent revocation: generation should change, causing a new key.
-            // Since getGenerationForId always returns undefined, we cannot actually
-            // trigger a generation increment. We verify the key includes a Generation
-            // segment that would vary on consent state change.
             expect(keyBeforeRevocation).toBeDefined();
             expect(keyBeforeRevocation).toMatch(/Generation:\d+/);
+
+            // Simulate what ConsentCacheInvalidationHandler does on a Consent write: bump
+            // the generation counter for this id. The next generated key must differ.
+            await generator.redisManager.incrementGenerationAsync('ClientPerson:person-xyz:Everything:Generation');
+
+            const keyAfterRevocation = await generator.generateCacheKey({
+                id: 'person-xyz',
+                isPersonId: true,
+                parsedArgs: mockParsedArgs,
+                scope: 'patient/*.read access/proa'
+            });
+
+            expect(keyAfterRevocation).not.toEqual(keyBeforeRevocation);
         });
     });
 
@@ -118,9 +134,7 @@ describe('PatientEverythingCacheKeyGenerator — PROA Consent Security', () => {
             //   GET /Patient/123/$everything?_type=Condition
             //
             // These MUST produce different cache keys because they return different data.
-            // Currently, _type is in NEITHER invalidParamsForCache NOR keyParamsforCache,
-            // so both requests get the SAME cache key and the second request may receive
-            // cached Observations when it asked for Conditions.
+            // _type is now in keyParamsforCache, so both requests get different cache keys.
             const mockParsedArgsWithObservation = {
                 getRawArgs: () => ({ _type: 'Observation' }),
                 _format: undefined
@@ -145,8 +159,6 @@ describe('PatientEverythingCacheKeyGenerator — PROA Consent Security', () => {
                 scope: 'patient/*.read'
             });
 
-            // ASSERTION: different _type values must produce different cache keys.
-            // EXPECTED TO FAIL: both will be identical because _type is ignored.
             expect(keyForObservation).not.toEqual(keyForCondition);
         });
     });

--- a/src/tests/unit/operations/everything/patientEverythingCacheKeyGenerator.test.js
+++ b/src/tests/unit/operations/everything/patientEverythingCacheKeyGenerator.test.js
@@ -25,12 +25,29 @@ jestObj.mock('../../../../utils/contentTypes', () => ({
 }));
 
 const { PatientEverythingCacheKeyGenerator } = require('../../../../operations/everything/patientEverythingCachekeyGenerator');
+const { RedisManager } = require('../../../../utils/redisManager');
+
+/**
+ * Builds a real RedisManager backed by an in-memory fake redisClient, so the
+ * generator's `instanceof RedisManager` assertion is satisfied without needing a real
+ * Redis server.
+ * @returns {RedisManager}
+ */
+function createFakeRedisManager() {
+    return new RedisManager({
+        redisClient: {
+            connectAsync: jestObj.fn().mockResolvedValue(undefined),
+            get: jestObj.fn().mockResolvedValue(null),
+            incr: jestObj.fn().mockResolvedValue(1)
+        }
+    });
+}
 
 describe('PatientEverythingCacheKeyGenerator', () => {
     let generator;
 
     beforeEach(() => {
-        generator = new PatientEverythingCacheKeyGenerator();
+        generator = new PatientEverythingCacheKeyGenerator({ redisManager: createFakeRedisManager() });
     });
 
     test('sets operation to Everything', () => {
@@ -73,5 +90,13 @@ describe('PatientEverythingCacheKeyGenerator', () => {
 
     test('cacheableResponseTypes has 6 items total', () => {
         expect(generator.cacheableResponseTypes).toHaveLength(6);
+    });
+
+    test('keyParamsforCache includes _type so requests with different resource-type filters do not share a cache entry', () => {
+        expect(generator.keyParamsforCache).toEqual(['_type']);
+    });
+
+    test('constructor stores the provided redisManager', () => {
+        expect(generator.redisManager).toBeDefined();
     });
 });

--- a/src/tests/unit/operations/search/proaConsentVulnerabilities.test.js
+++ b/src/tests/unit/operations/search/proaConsentVulnerabilities.test.js
@@ -34,6 +34,10 @@ jest.mock('../../../../operations/common/systemEventLogging', () => ({
     logSystemEventAsync: jest.fn()
 }));
 
+// --- Vulnerability 5: auto-mock BwellPersonFinder so ConsentCacheInvalidationHandler's
+// best-effort Person lookup can be exercised without a real DatabaseQueryFactory/DB.
+jest.mock('../../../../utils/bwellPersonFinder');
+
 describe('VULNERABILITY 1: ProaConsentManager does not enforce consent period expiry', () => {
     /**
      * FILE: src/operations/search/proaConsentManager.js
@@ -332,57 +336,68 @@ describe('VULNERABILITY 3: DataSharingManager caches allowedPatientIds ignoring 
 
 describe('VULNERABILITY 4: $everything cache key has no generation tracking for consent changes', () => {
     /**
-     * FILE: src/operations/everything/patientEverythingCachekeyGenerator.js (lines 1-35)
-     *       src/operations/common/baseCacheKeyGenerator.js (line 130)
+     * FILE: src/operations/everything/patientEverythingCachekeyGenerator.js
      *
-     * VULNERABILITY: PatientEverythingCacheKeyGenerator inherits getGenerationForId
-     * from BaseCacheKeyGenerator which always returns undefined. This means:
-     * - Cache key is: Patient:<id>:Everything:Scopes:<scopeHash>
-     * - No generation counter is included
-     * - When a Consent is revoked (status changed to 'rejected'), the cache key
-     *   remains identical, so stale cached PHI continues to be served
+     * FIXED (DCON: fix Everything-cache Consent invalidation): PatientEverythingCacheKeyGenerator
+     * now implements getGenerationForId, mirroring SummaryCacheKeyGenerator but supporting both
+     * Patient:<id> and ClientPerson:<id> forms (Everything's cache legitimately keys on either,
+     * depending on whether the request went through the direct-patient or proxy-Person path).
+     * The Generation segment it returns is what allows ConsentCacheInvalidationHandler
+     * (see VULNERABILITY 5 below) to bust the cache on a Consent write.
      *
-     * EXPLOITATION: Patient revokes PROA consent. For the next 5 minutes (TTL=300s),
-     * the $everything endpoint continues to serve the pre-revocation data including
-     * all PROA-sourced resources that should now be excluded.
-     *
-     * SEVERITY: CRITICAL - PHI served after consent revocation for up to TTL duration
-     *
-     * CORRECT BEHAVIOR: getGenerationForId MUST return a generation number that
-     * changes when any consent affecting this patient is modified.
+     * These tests now verify that fixed behavior directly, using a real RedisManager backed by
+     * an in-memory fake redisClient (no real Redis server needed).
      */
 
     const { PatientEverythingCacheKeyGenerator } = require('../../../../operations/everything/patientEverythingCachekeyGenerator');
+    const { RedisManager } = require('../../../../utils/redisManager');
+
+    /**
+     * Builds a real RedisManager backed by an in-memory fake redisClient.
+     * @returns {RedisManager}
+     */
+    function createFakeRedisManager() {
+        const store = new Map();
+        return new RedisManager({
+            redisClient: {
+                connectAsync: jest.fn().mockResolvedValue(undefined),
+                get: jest.fn(async (key) => (store.has(key) ? String(store.get(key)) : null)),
+                incr: jest.fn(async (key) => {
+                    const next = (store.get(key) || 0) + 1;
+                    store.set(key, next);
+                    return next;
+                })
+            }
+        });
+    }
 
     it('getGenerationForId MUST return a non-undefined generation for person IDs', async () => {
-        const generator = new PatientEverythingCacheKeyGenerator();
+        const generator = new PatientEverythingCacheKeyGenerator({ redisManager: createFakeRedisManager() });
 
         const generation = await generator.getGenerationForId({
             id: 'person-uuid-abc',
             isPersonId: true
         });
 
-        // CORRECT: Must return a number so cache key changes when consent changes
-        // Currently returns undefined, meaning consent changes don't bust the cache
         expect(generation).not.toBeUndefined();
         expect(typeof generation).toBe('number');
     });
 
     it('getGenerationForId MUST return a non-undefined generation for patient IDs', async () => {
-        const generator = new PatientEverythingCacheKeyGenerator();
+        const generator = new PatientEverythingCacheKeyGenerator({ redisManager: createFakeRedisManager() });
 
         const generation = await generator.getGenerationForId({
             id: 'patient-uuid-xyz',
             isPersonId: false
         });
 
-        // CORRECT: Must return a number so cache key changes when consent changes
         expect(generation).not.toBeUndefined();
         expect(typeof generation).toBe('number');
     });
 
     it('cache key MUST differ before and after consent revocation', async () => {
-        const generator = new PatientEverythingCacheKeyGenerator();
+        const redisManager = createFakeRedisManager();
+        const generator = new PatientEverythingCacheKeyGenerator({ redisManager });
 
         // Simulate a ParsedArgs-like object for cache key generation
         const mockParsedArgs = {
@@ -397,86 +412,163 @@ describe('VULNERABILITY 4: $everything cache key has no generation tracking for 
             scope: 'patient/*.read'
         });
 
-        // After consent revocation, generation should change.
-        // Since getGenerationForId returns undefined, key1 === key2 always.
-        // This test would pass only if generation tracking is implemented.
-        // For now, we verify the key includes a Generation segment at all.
         expect(key1).toBeDefined();
         expect(key1).toMatch(/Generation:\d+/);
+
+        // Simulate what ConsentCacheInvalidationHandler does on consent revocation: bump
+        // the generation counter for this patient. The next generated key must differ.
+        await redisManager.incrementGenerationAsync('Patient:patient-uuid-1:Everything:Generation');
+
+        const key2 = await generator.generateCacheKey({
+            id: 'patient-uuid-1',
+            isPersonId: false,
+            parsedArgs: mockParsedArgs,
+            scope: 'patient/*.read'
+        });
+
+        expect(key2).not.toEqual(key1);
     });
 });
 
 
 describe('VULNERABILITY 5: No automatic cache invalidation when Consent status changes', () => {
     /**
-     * FILE: src/utils/fhirCacheKeyManager.js (entire file)
-     *       src/routeHandlers/admin.js (lines 453-467)
+     * FILE (original vulnerability write-up): src/utils/fhirCacheKeyManager.js,
+     *       src/routeHandlers/admin.js (admin-only /admin/invalidateCache endpoint)
      *
-     * VULNERABILITY: Cache invalidation for $everything responses only happens
-     * via the admin endpoint (/admin/invalidateCache). There is NO automatic
-     * hook in the FHIR write pipeline that invalidates $everything caches
-     * when a Consent resource is created, updated, or deleted.
+     * VULNERABILITY: Cache invalidation for $everything responses only happened via the
+     * admin endpoint (/admin/invalidateCache). There was NO automatic hook in the FHIR
+     * write pipeline that invalidated $everything caches when a Consent resource was
+     * created, updated, or deleted.
      *
-     * EXPLOITATION: A patient revokes consent (PUT Consent with status='rejected').
-     * The write succeeds in MongoDB. But NO code triggers cache invalidation for
-     * the associated patient's $everything cache. Until the Redis TTL expires
-     * (300s default), all $everything requests serve stale pre-revocation data.
+     * FIXED (DCON: fix Everything-cache Consent invalidation): a new post-save handler,
+     * ConsentCacheInvalidationHandler (src/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.js),
+     * is registered in the postSaveProcessor handler list (src/createContainer.js), which
+     * runs on every create/update/merge/patch/remove for every resource type. On a Consent
+     * write it resolves the patient uuid from Consent.patient and calls
+     * redisManager.incrementGenerationAsync('Patient:<uuid>:Everything:Generation'). Because
+     * PatientEverythingCacheKeyGenerator.getGenerationForId (VULNERABILITY 4 above) folds
+     * that counter into the cache key, the bump causes the next $everything cache-key
+     * computation for that patient to differ from any key computed before the Consent
+     * write - i.e. the old cached entry becomes unreachable and a fresh query runs.
      *
-     * SEVERITY: CRITICAL - Systematic PHI leak window after every consent revocation
-     *
-     * CORRECT BEHAVIOR: When a Consent resource is written/updated, the system
-     * MUST invalidate $everything caches for all patients linked to that consent.
-     * This should happen synchronously before the write response is returned.
+     * NOTE ON TEST DESIGN: the original version of this test asserted a
+     * `FhirCacheKeyManager.invalidateCacheForConsentChange` method. That was aspirational
+     * wording written before the fix's design was settled - it does not match the actual
+     * implementation, which deliberately reuses the existing-but-previously-unwired
+     * generation-counter pattern (shared with SummaryCacheKeyGenerator) via a post-save
+     * handler, rather than adding a new method to FhirCacheKeyManager. These tests assert
+     * the real behavior ("a Consent write causes future $everything cache lookups for that
+     * patient to miss/regenerate") against the actual implementation instead of forcing a
+     * same-named method that was never built onto FhirCacheKeyManager.
      */
 
-    const { FhirCacheKeyManager } = require('../../../../utils/fhirCacheKeyManager');
+    const { ConsentCacheInvalidationHandler } = require('../../../../dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler');
+    const { PatientEverythingCacheKeyGenerator } = require('../../../../operations/everything/patientEverythingCachekeyGenerator');
+    const { RedisManager } = require('../../../../utils/redisManager');
+    const { BwellPersonFinder } = require('../../../../utils/bwellPersonFinder');
 
-    it('FhirCacheKeyManager MUST have a method to invalidate caches for consent-linked patients', () => {
-        const mockRedisClient = {
-            connectAsync: jest.fn(),
-            bulkDeleteKeys: jest.fn(),
-            invalidateByPrefixAsync: jest.fn(),
-            getAllKeysByPrefix: jest.fn()
-        };
+    /**
+     * Builds a real RedisManager backed by an in-memory fake redisClient.
+     * @returns {RedisManager}
+     */
+    function createFakeRedisManager() {
+        const store = new Map();
+        return new RedisManager({
+            redisClient: {
+                connectAsync: jest.fn().mockResolvedValue(undefined),
+                get: jest.fn(async (key) => (store.has(key) ? String(store.get(key)) : null)),
+                incr: jest.fn(async (key) => {
+                    const next = (store.get(key) || 0) + 1;
+                    store.set(key, next);
+                    return next;
+                })
+            }
+        });
+    }
 
-        const manager = new FhirCacheKeyManager({ redisClient: mockRedisClient });
+    /**
+     * BwellPersonFinder is auto-mocked (jest.mock at top of file) so this can be
+     * instantiated without a real DatabaseQueryFactory/DB. Its lookup of Person(s)
+     * immediately linked to a patient is stubbed to return no links by default.
+     * @returns {BwellPersonFinder}
+     */
+    function createFakeBwellPersonFinder() {
+        const finder = new BwellPersonFinder();
+        finder.getImmediatePersonIdsOfPatientsAsync = jest.fn().mockResolvedValue({
+            patientReferenceToPersonUuid: {}
+        });
+        return finder;
+    }
 
-        // CORRECT BEHAVIOR: Should have a consent-aware invalidation method
-        // that takes a Consent resource and invalidates all linked patient caches
-        expect(typeof manager.invalidateCacheForConsentChange).toBe('function');
-    });
+    it('ConsentCacheInvalidationHandler MUST bump the Everything-cache generation for the consent patient on a Consent write', async () => {
+        const redisManager = createFakeRedisManager();
+        const handler = new ConsentCacheInvalidationHandler({
+            redisManager,
+            bwellPersonFinder: createFakeBwellPersonFinder()
+        });
 
-    it('invalidateCacheForConsentChange MUST invalidate patient $everything cache when consent is revoked', async () => {
-        const mockRedisClient = {
-            connectAsync: jest.fn().mockResolvedValue(undefined),
-            bulkDeleteKeys: jest.fn().mockResolvedValue(undefined),
-            invalidateByPrefixAsync: jest.fn().mockResolvedValue(undefined),
-            getAllKeysByPrefix: jest.fn().mockResolvedValue([])
-        };
-
-        const manager = new FhirCacheKeyManager({ redisClient: mockRedisClient });
-
-        // A revoked consent resource
+        // A revoked consent resource, as it would appear post-save (patient reference
+        // enriched with _uuid, mirroring referenceGlobalIdHandler's output shape)
         const revokedConsent = {
             resourceType: 'Consent',
-            _uuid: 'consent-uuid-1',
+            id: 'consent-uuid-1',
             status: 'rejected',
             patient: {
-                _uuid: 'Patient/patient-uuid-linked'
+                reference: 'Patient/3fa85f64-5717-4562-b3fc-2c963f66afa6',
+                _uuid: 'Patient/3fa85f64-5717-4562-b3fc-2c963f66afa6'
             }
         };
 
-        // CORRECT: This method should exist and invalidate the patient's cache
-        if (typeof manager.invalidateCacheForConsentChange === 'function') {
-            await manager.invalidateCacheForConsentChange({ consent: revokedConsent });
+        await handler.afterSaveAsync({
+            requestId: 'req-1',
+            eventType: 'U',
+            resourceType: 'Consent',
+            doc: revokedConsent
+        });
 
-            // Should have invalidated cache for the linked patient
-            expect(mockRedisClient.invalidateByPrefixAsync).toHaveBeenCalledWith(
-                expect.stringContaining('Patient:patient-uuid-linked')
-            );
-        } else {
-            // Method doesn't exist - this assertion will fail, proving the vulnerability
-            expect(typeof manager.invalidateCacheForConsentChange).toBe('function');
-        }
+        const generationValue = await redisManager.getCacheAsync('Patient:3fa85f64-5717-4562-b3fc-2c963f66afa6:Everything:Generation');
+        expect(Number(generationValue)).toBe(1);
+    });
+
+    it('a Consent write MUST cause the next $everything cache-key lookup for that patient to differ (cache miss/regenerate)', async () => {
+        const redisManager = createFakeRedisManager();
+        const handler = new ConsentCacheInvalidationHandler({
+            redisManager,
+            bwellPersonFinder: createFakeBwellPersonFinder()
+        });
+        const keyGenerator = new PatientEverythingCacheKeyGenerator({ redisManager });
+        const mockParsedArgs = { getRawArgs: () => ({}), _format: undefined };
+
+        const keyBeforeConsentWrite = await keyGenerator.generateCacheKey({
+            id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            isPersonId: false,
+            parsedArgs: mockParsedArgs,
+            scope: 'patient/*.read'
+        });
+
+        await handler.afterSaveAsync({
+            requestId: 'req-2',
+            eventType: 'U',
+            resourceType: 'Consent',
+            doc: {
+                resourceType: 'Consent',
+                id: 'consent-uuid-2',
+                status: 'rejected',
+                patient: {
+                    reference: 'Patient/3fa85f64-5717-4562-b3fc-2c963f66afa6',
+                    _uuid: 'Patient/3fa85f64-5717-4562-b3fc-2c963f66afa6'
+                }
+            }
+        });
+
+        const keyAfterConsentWrite = await keyGenerator.generateCacheKey({
+            id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            isPersonId: false,
+            parsedArgs: mockParsedArgs,
+            scope: 'patient/*.read'
+        });
+
+        expect(keyAfterConsentWrite).not.toEqual(keyBeforeConsentWrite);
     });
 });


### PR DESCRIPTION
## Summary
- Consent revocation had no cache-invalidation trigger at all for the Patient/`$everything` Redis cache, so stale PHI could be served for up to the cache TTL (~600s) after a Consent was revoked or otherwise changed. Confirmed even `SummaryCacheKeyGenerator`'s existing generation-counter mechanism had never been wired to any real trigger anywhere in the codebase — this PR builds that missing "bump" side, scoped to Everything/Consent.
- **Parity fix**: `PatientEverythingCacheKeyGenerator` now implements `getGenerationForId` (mirroring `SummaryCacheKeyGenerator`'s pattern, but supporting both `Patient:<id>` and `ClientPerson:<id>` keys since Everything legitimately uses both), takes a `redisManager` constructor dependency, and adds `_type` to `keyParamsforCache` so `?_type=Observation` and `?_type=Condition` no longer share a cache entry. Wired `redisManager` through `EverythingHelper` and `createContainer.js`.
- **Invalidation trigger**: new `ConsentCacheInvalidationHandler` (`src/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.js`), a `BasePostSaveHandler` registered in `postSaveProcessor`'s handler list (fires universally on every write path — create/update/merge/patch/remove — via `databaseBulkInserter`/`fastDatabaseBulkInserter`, filtered internally to `resourceType === 'Consent'`). On a Consent write it bumps `Patient:<uuid>:Everything:Generation` for the referenced patient, plus (best-effort, single-hop, via the existing `BwellPersonFinder` utility) `ClientPerson:<uuid>:Everything:Generation` for any immediately-linked Person(s), or directly for a proxy-patient reference. All failures are caught and logged, never rethrown — cache invalidation must not fail an already-committed write.
- **Known, documented residual gap**: the Person-lookup is single-hop, not a full link-graph traversal — an `$everything` cache primed under a `ClientPerson` key more than one hop away from the Consent's patient won't be invalidated by this handler. Noted in the handler's doc comment.
- Un-quarantines `patientEverything.consent.test.js`. Fixes the pre-existing, non-quarantined `patientEverythingCacheKeyGenerator.test.js` for the new required constructor arg. Updates `proaConsentVulnerabilities.test.js` Vulnerabilities 4 & 5 to assert against the real implementation instead of a `FhirCacheKeyManager.invalidateCacheForConsentChange` method that was never part of the chosen design — Vulnerabilities 1-3 are handled in separate PRs (#2450) and the file's `jest.config.js` entry is intentionally left in place since a whole-file entry can't be partially resolved.

## Test plan
- [x] `patientEverything.consent.test.js` — 4/4 passing
- [x] `proaConsentVulnerabilities.test.js` filtered to `VULNERABILITY 4|VULNERABILITY 5` — 5/5 passing (5 skipped, correctly out of scope)
- [x] `src/tests/unit/operations/everything/` + `src/tests/unit/dataLayer/postSaveHandlers/` — 11 suites / 204 tests passing, no regressions
- [x] Full `src/tests/unit` — 7536/7536 passing, no regressions anywhere in the repo
- [x] Container-wiring smoke check — `postSaveProcessor.handlers` resolves to `[ChangeEventProducer, PatientPersonDataChangeEventProducer, ConsentCacheInvalidationHandler]`, `everythingHelper.redisManager` is set, both construct cleanly with no DI errors
- [x] Lint clean on all changed/new files
- [ ] Integration tests requiring MongoDB Memory Server (`src/tests/everything/proxy_patient/`, `src/tests/everything/person_or_patient/`, broader `src/tests/everything/`, `src/tests/data_sharing/everything/`, `src/tests/graphqlv2/patientEverythingWithGraphqlV2/`) — **could not be run in this environment** (MongoDB Memory Server cannot spawn a `mongod` subprocess in this sandbox). Should run in CI before merge.
- [ ] Security review against `review.md` by someone else familiar with this surface, per this repo's `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)