### PR TITLE
DCON-4856 Cap WiredTiger cache size for test MongoMemoryReplSet

### DIFF
--- a/src/tests/mongoTestRunner.js
+++ b/src/tests/mongoTestRunner.js
@@ -8,7 +8,13 @@ let mongoRepl;
 async function startTestMongoServerAsync () {
     mongoRepl = await MongoMemoryReplSet.create({
         replSet: { count: 1, storageEngine: 'wiredTiger' },
-        binary: { version: '8.0.20' }
+        binary: { version: '8.0.20' },
+        // Without this, each mongod independently sizes its cache off total system RAM
+        // (default ~50%), so running several agents/worktrees concurrently makes every
+        // instance overcommit memory it doesn't actually have, causing hangs/OOM kills.
+        instanceOpts: [
+            { args: ['--wiredTigerCacheSizeGB', process.env.MONGO_MEMORY_SERVER_WT_CACHE_GB || '0.5'] }
+        ]
     });
     await mongoRepl.waitUntilRunning();
     process.env.MONGO_MEMORY_SERVER_URL = mongoRepl.getUri();


### PR DESCRIPTION
## Summary
- Each test-suite `mongod` spawned via `MongoMemoryReplSet` sizes its WiredTiger cache off ~50% of total *system* RAM by default, unaware of sibling `mongod` instances doing the same.
- Running multiple agents/worktrees with tests concurrently causes every instance to overcommit memory it doesn't actually have, leading to replica-set election hangs or OOM kills of `mongod`/`node`.
- Caps the cache at 0.5GB per instance via `instanceOpts.args`, overridable with `MONGO_MEMORY_SERVER_WT_CACHE_GB` if a larger dataset ever needs more.

## Test plan
- [x] `node node_modules/.bin/jest src/tests/unit/utils --runInBand` — 119 suites / 2333 tests passed with the capped cache
- [x] CI full suite run — `test (chunk)` passed in 11m30s (https://github.com/icanbwell/fhir-server/actions/runs/31058599182/job/92481434888)

🤖 Generated with [Claude Code](https://claude.com/claude-code)