### PR TITLE
DCON-4882 Restrict wildcard non-patient scopes to trusted (issuer, client_id) pairs

### DIFF
--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -547,7 +547,7 @@ class AuthService {
                 // echo it back -- getFieldsFromToken's wildcard-non-patient-scope issuer check (see
                 // isWildcardNonPatientScope, DCON-4882) needs the real issuer to avoid incorrectly
                 // treating a legitimate, allowlisted issuer's token as untrusted.
-                jwt_payload = { iss: jwt_payload.iss, ...userInfoResponse.body };
+                jwt_payload = { ...userInfoResponse.body, iss: jwt_payload.iss };
                 const userInfo = this.getFieldsFromToken(jwt_payload);
                 if (cacheKey) {
                     AuthService.userInfoCache.set(cacheKey, userInfo);

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -543,12 +543,14 @@ class AuthService {
                 .retry(EXTERNAL_REQUEST_RETRY_COUNT)
                 .timeout(this.requestTimeout);
             if (userInfoResponse && userInfoResponse.body) {
-                // Preserve the original token's iss if the userinfo endpoint's response body doesn't
-                // echo it back -- getFieldsFromToken's wildcard-non-patient-scope issuer check (see
-                // isWildcardNonPatientScope, DCON-4882) needs the real issuer to avoid incorrectly
-                // treating a legitimate, allowlisted issuer's token as untrusted.
-                jwt_payload = { ...userInfoResponse.body, iss: jwt_payload.iss };
-                const userInfo = this.getFieldsFromToken(jwt_payload);
+                // Always keep the original token's iss, even if the userinfo response body includes
+                // its own iss field -- that field is unverified JSON over HTTP, unlike the JWT's iss
+                // claim, which was already checked against the JWKS signature. Letting a response
+                // body value override a signature-verified claim would let an untrusted value decide
+                // getFieldsFromToken's wildcard-non-patient-scope issuer check (isWildcardNonPatientScope,
+                // DCON-4882), which is exactly the kind of trust decision that claim exists to protect.
+                const mergedPayload = { ...userInfoResponse.body, iss: jwt_payload.iss };
+                const userInfo = this.getFieldsFromToken(mergedPayload);
                 if (cacheKey) {
                     AuthService.userInfoCache.set(cacheKey, userInfo);
                 }

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -394,6 +394,28 @@ class AuthService {
     }
 
     /**
+     * Returns true if the scope grants wildcard non-patient authority: `user/*.<x>` or
+     * `access/*.<x>` where the resource-type / tenant segment is `*` (e.g. `user/*.*`, `access/*.*`,
+     * `user/*.read`). These bypass tenant/access-tag filtering for non-patient resources, so they are
+     * gated by trusted issuer in getFieldsFromToken. Narrowly-scoped grants (`user/Questionnaire.*`,
+     * `access/walgreen.*`) and every `patient/` scope return false. See DCON-4882.
+     * @param {string} scope
+     * @returns {boolean}
+     */
+    isWildcardNonPatientScope(scope) {
+        if (typeof scope !== 'string') {
+            return false;
+        }
+        const lower = scope.toLowerCase();
+        if (!lower.startsWith('user/') && !lower.startsWith('access/')) {
+            return false;
+        }
+        const afterSlash = scope.substring(scope.indexOf('/') + 1);
+        const resourceOrTenant = afterSlash.split('.')[0];
+        return resourceOrTenant === '*';
+    }
+
+    /**
      * Extracts fields from the JWT payload.
      * @param {Object} jwt_payload
      * @returns {{scope: string, isUser: boolean, username: string|undefined, subject: string|undefined, clientId: string|undefined}}
@@ -466,6 +488,32 @@ class AuthService {
                 propertyNames: this.configManager.authCustomClientId
             });
 
+        // Restrict wildcard non-patient authority to trusted (issuer, client_id) pairs. `access/*.*`
+        // collapses to the '*' access code in scopesManager, which bypasses tenant/access-tag
+        // filtering for every non-patient resource; `user/*.*` is its resource-type counterpart. A
+        // single Cognito pool (issuer) can serve both a trusted internal service and an external
+        // consumer app under different client_ids, so the allowlist is keyed on the pair, not the
+        // issuer alone. For any token whose (iss, client_id) pair is not on the allowlist, drop only
+        // these wildcard non-patient scopes so the token is confined to its patient compartment plus
+        // any explicit narrow grants (e.g. user/Questionnaire.*, access/walgreen.*). No-op when the
+        // allowlist is unset (unconfigured environments unchanged); patient/ scopes are never
+        // touched. See DCON-4882.
+        const allowedNonPatientScopeClients = this.configManager.allowedNonPatientScopeClients;
+        if (
+            allowedNonPatientScopeClients.size > 0 &&
+            !allowedNonPatientScopeClients.has(`${jwt_payload.iss}|${clientId}`)
+        ) {
+            const removedScopes = scopes.filter((s) => this.isWildcardNonPatientScope(s));
+            if (removedScopes.length > 0) {
+                logWarn('Stripped wildcard non-patient scopes from untrusted (issuer, client_id)', {
+                    reason: 'wildcard_non_patient_scope_stripped',
+                    args: { iss: jwt_payload.iss, clientId, removedScopes }
+                });
+                scopes = scopes.filter((s) => !this.isWildcardNonPatientScope(s));
+                scope = scopes.join(' ');
+            }
+        }
+
         const isUser = scopes.some((s) => s.toLowerCase().startsWith('patient/'));
 
         return {scope, isUser, username, subject, clientId};
@@ -495,7 +543,11 @@ class AuthService {
                 .retry(EXTERNAL_REQUEST_RETRY_COUNT)
                 .timeout(this.requestTimeout);
             if (userInfoResponse && userInfoResponse.body) {
-                jwt_payload = userInfoResponse.body;
+                // Preserve the original token's iss if the userinfo endpoint's response body doesn't
+                // echo it back -- getFieldsFromToken's wildcard-non-patient-scope issuer check (see
+                // isWildcardNonPatientScope, DCON-4882) needs the real issuer to avoid incorrectly
+                // treating a legitimate, allowlisted issuer's token as untrusted.
+                jwt_payload = { iss: jwt_payload.iss, ...userInfoResponse.body };
                 const userInfo = this.getFieldsFromToken(jwt_payload);
                 if (cacheKey) {
                     AuthService.userInfoCache.set(cacheKey, userInfo);

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -543,13 +543,16 @@ class AuthService {
                 .retry(EXTERNAL_REQUEST_RETRY_COUNT)
                 .timeout(this.requestTimeout);
             if (userInfoResponse && userInfoResponse.body) {
-                // Always keep the original token's iss, even if the userinfo response body includes
-                // its own iss field -- that field is unverified JSON over HTTP, unlike the JWT's iss
-                // claim, which was already checked against the JWKS signature. Letting a response
-                // body value override a signature-verified claim would let an untrusted value decide
-                // getFieldsFromToken's wildcard-non-patient-scope issuer check (isWildcardNonPatientScope,
-                // DCON-4882), which is exactly the kind of trust decision that claim exists to protect.
-                const mergedPayload = { ...userInfoResponse.body, iss: jwt_payload.iss };
+                // Always keep the original token's iss AND client_id, even if the userinfo response
+                // body includes its own values for either -- both are unverified JSON over HTTP,
+                // unlike the JWT's claims, which were already checked against the JWKS signature.
+                // Letting a response body value override a signature-verified claim would let an
+                // untrusted value decide getFieldsFromToken's wildcard-non-patient-scope (iss,
+                // client_id) allowlist check (isWildcardNonPatientScope, DCON-4882): dropping
+                // client_id here would compute `${iss}|undefined`, which can never match a real
+                // allowlist entry, silently stripping wildcard scope from a legitimately allowlisted
+                // service (standard OIDC/Cognito userinfo responses don't echo back client_id).
+                const mergedPayload = { ...userInfoResponse.body, iss: jwt_payload.iss, client_id: jwt_payload.client_id };
                 const userInfo = this.getFieldsFromToken(mergedPayload);
                 if (cacheKey) {
                     AuthService.userInfoCache.set(cacheKey, userInfo);
@@ -557,7 +560,15 @@ class AuthService {
                 return userInfo;
             }
         }
-        return jwt_payload;
+        // No userinfo endpoint configured for this issuer (or its response had no body) -- reapply
+        // getFieldsFromToken on the original payload rather than returning it raw. verify() only
+        // reaches this function when its first getFieldsFromToken call already returned an empty
+        // scope, which DCON-4882's wildcard-non-patient-scope strip can now legitimately produce for
+        // an untrusted (iss, client_id) pair whose token carries only wildcard scopes. Returning
+        // jwt_payload unprocessed would hand verify() the token's raw, un-stripped scope, which its
+        // `scope1 || scope` fallback then picks over the (correctly) stripped empty scope --
+        // completely undoing the strip for exactly the untrusted-client case it exists to stop.
+        return this.getFieldsFromToken(jwt_payload);
     }
 
     /**

--- a/src/tests/unit/strategies/authService.test.js
+++ b/src/tests/unit/strategies/authService.test.js
@@ -1262,6 +1262,80 @@ describe('AuthService', () => {
             expect(user).toBeUndefined();
             expect(info).toBeUndefined();
         });
+
+        test('DCON-4882: does not resurrect a wildcard-only untrusted token via the empty-scope userinfo fallback', async () => {
+            // Regression test for a real bug: stripping a wildcard-only scope down to '' trips
+            // verify()'s pre-existing "no scope -> try userinfo endpoint" branch. If that branch's
+            // fallback returned jwt_payload raw (its un-stripped scope intact), verify()'s
+            // `scope1 || scope` would pick the raw wildcard scope back up, completely undoing the
+            // strip for exactly the untrusted-client case it exists to stop.
+            Object.defineProperty(mockConfigManager, 'allowedNonPatientScopeClients', {
+                get: () => new Set(['https://trusted.example.com|trusted-client']), // a different pair; not this caller
+                configurable: true
+            });
+            // No well-known config for this issuer -- common for JWKS-only/client-credentials issuers
+            mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync = jest.fn().mockResolvedValue(null);
+            authService = new AuthService({
+                configManager: mockConfigManager,
+                wellKnownConfigurationManager: mockWellKnownConfigManager
+            });
+
+            const done = jest.fn();
+            authService.verify({
+                request: {},
+                jwt_payload: {
+                    iss: 'https://untrusted.example.com',
+                    client_id: 'untrusted-client',
+                    scope: 'user/*.* access/*.*' // wildcard-only, no patient/ scope
+                },
+                token: 'tok',
+                done
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 20));
+            expect(done).toHaveBeenCalledWith(null, false, { reason: 'no_scope' });
+        });
+
+        test('DCON-4882: preserves an allowlisted client_id through the userinfo-endpoint enrichment path', async () => {
+            // Regression test for a real bug: the userinfo-fallback merge preserved iss but dropped
+            // client_id, so a legitimately allowlisted service whose JWT carries no embedded scope
+            // (common for Cognito access tokens, which require a userinfo call) would compute
+            // `${iss}|undefined` at the allowlist check -- never matching -- and silently lose its
+            // wildcard non-patient scope despite being correctly configured.
+            Object.defineProperty(mockConfigManager, 'allowedNonPatientScopeClients', {
+                get: () => new Set(['https://trusted.example.com|trusted-service-client']),
+                configurable: true
+            });
+            mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync = jest.fn().mockResolvedValue({
+                userinfo_endpoint: 'http://auth.example.com/userinfo'
+            });
+            superagent.timeout.mockResolvedValue({
+                body: { scope: 'user/*.* access/*.*' } // standard userinfo response; no client_id field
+            });
+            authService = new AuthService({
+                configManager: mockConfigManager,
+                wellKnownConfigurationManager: mockWellKnownConfigManager
+            });
+
+            const done = jest.fn();
+            authService.verify({
+                request: {},
+                jwt_payload: {
+                    iss: 'https://trusted.example.com',
+                    client_id: 'trusted-service-client'
+                    // no scope on the JWT itself -- must be resolved via the userinfo endpoint
+                },
+                token: 'tok',
+                done
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 20));
+            expect(done).toHaveBeenCalledWith(
+                null,
+                expect.any(Object),
+                expect.objectContaining({ scope: 'user/*.* access/*.*' })
+            );
+        });
     });
 
     describe('getUserInfoFromUserInfoEndpoint', () => {
@@ -1284,30 +1358,32 @@ describe('AuthService', () => {
             expect(result).toEqual(cachedUserInfo);
         });
 
-        test('returns jwt_payload when no well-known config found', async () => {
+        test('reapplies getFieldsFromToken on the original payload when no well-known config found', async () => {
+            // DCON-4882: this must NOT return jwt_payload verbatim (its raw, un-stripped scope) --
+            // see the fail-open regression test below for why that would matter.
             mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync.mockResolvedValue(null);
 
-            const jwt_payload = { iss: 'issuer1', cid: 'cid1', sub: 'sub1' };
+            const jwt_payload = { iss: 'issuer1', cid: 'cid1', sub: 'sub1', scope: 'user/*.read' };
             const result = await authService.getUserInfoFromUserInfoEndpoint({
                 jwt_payload,
                 token: 'my-token'
             });
 
-            expect(result).toBe(jwt_payload);
+            expect(result).toEqual({ scope: 'user/*.read', isUser: false, username: null, subject: null, clientId: null });
         });
 
-        test('returns jwt_payload when well-known config has no userinfo_endpoint', async () => {
+        test('reapplies getFieldsFromToken on the original payload when well-known config has no userinfo_endpoint', async () => {
             mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync.mockResolvedValue({
                 jwks_uri: 'http://jwks.example.com'
             });
 
-            const jwt_payload = { iss: 'issuer1', cid: 'cid1', sub: 'sub1' };
+            const jwt_payload = { iss: 'issuer1', cid: 'cid1', sub: 'sub1', scope: 'user/*.read' };
             const result = await authService.getUserInfoFromUserInfoEndpoint({
                 jwt_payload,
                 token: 'my-token'
             });
 
-            expect(result).toBe(jwt_payload);
+            expect(result).toEqual({ scope: 'user/*.read', isUser: false, username: null, subject: null, clientId: null });
         });
 
         test('fetches user info and caches result', async () => {

--- a/src/tests/unit/strategies/authService.test.js
+++ b/src/tests/unit/strategies/authService.test.js
@@ -57,6 +57,7 @@ describe('AuthService', () => {
         Object.defineProperty(mockConfigManager, 'authCidCheckIssuer', { get: () => '', configurable: true });
         Object.defineProperty(mockConfigManager, 'authCidCheckClientIds', { get: () => [], configurable: true });
         Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => false, configurable: true });
+        Object.defineProperty(mockConfigManager, 'allowedNonPatientScopeClients', { get: () => new Set(), configurable: true });
 
         mockWellKnownConfigManager = createMockInstance(WellKnownConfigurationManager);
         mockWellKnownConfigManager.getJwksUrlsAsync = jest.fn().mockResolvedValue([]);
@@ -491,6 +492,148 @@ describe('AuthService', () => {
             });
             const result = authService.getFieldsFromToken({ scope: 'short:user/*.read' });
             expect(result.scope).toBe('user/*.read');
+        });
+
+        // DCON-4882: wildcard non-patient scope restriction by (issuer, client_id) pair
+        describe('wildcard non-patient scope restriction (DCON-4882)', () => {
+            test('leaves scopes unchanged when allowlist is empty (unconfigured environments)', () => {
+                const result = authService.getFieldsFromToken({
+                    iss: 'https://untrusted.example.com',
+                    client_id: 'any-client',
+                    scope: 'patient/*.* user/*.* access/*.*'
+                });
+                expect(result.scope).toBe('patient/*.* user/*.* access/*.*');
+            });
+
+            test('strips wildcard user/ and access/ scopes for a client not on the allowlist', () => {
+                // Same Cognito pool (iss) that a trusted internal service uses, but a different
+                // client_id -- e.g. bwellapp end-user login vs. mcp-fhir-agent's service client
+                // sharing one pool. Only the pair is trusted, not the issuer alone.
+                Object.defineProperty(mockConfigManager, 'allowedNonPatientScopeClients', {
+                    get: () => new Set(['https://cognito-idp.us-east-1.amazonaws.com/us-east-1_nj7c9EeTG|trusted-service-client']),
+                    configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const result = authService.getFieldsFromToken({
+                    iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_nj7c9EeTG',
+                    client_id: '5h2u1p2tvrq9q5sar7hvia08sr', // bwellapp's consumer client, not the trusted one
+                    scope: 'aws.cognito.signin.user.admin access/*.* patient/*.* user/*.*'
+                });
+                expect(result.scope).toBe('aws.cognito.signin.user.admin patient/*.*');
+                // patient/ scope is untouched, so a patient-scoped token is still isUser
+                expect(result.isUser).toBe(true);
+            });
+
+            test('passes wildcard scopes through unchanged for an allowlisted (iss, client_id) pair', () => {
+                Object.defineProperty(mockConfigManager, 'allowedNonPatientScopeClients', {
+                    get: () => new Set(['https://cognito-idp.us-east-1.amazonaws.com/us-east-1_nj7c9EeTG|trusted-service-client']),
+                    configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const result = authService.getFieldsFromToken({
+                    iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_nj7c9EeTG',
+                    client_id: 'trusted-service-client', // same pool, the trusted internal service's client
+                    scope: 'patient/*.* user/*.* access/*.*'
+                });
+                expect(result.scope).toBe('patient/*.* user/*.* access/*.*');
+            });
+
+            test('preserves narrowly-scoped non-patient grants for a non-allowlisted client', () => {
+                Object.defineProperty(mockConfigManager, 'allowedNonPatientScopeClients', {
+                    get: () => new Set(['https://trusted.example.com|trusted-client']),
+                    configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const result = authService.getFieldsFromToken({
+                    iss: 'https://untrusted.example.com',
+                    client_id: 'some-client',
+                    scope: 'patient/*.* user/Questionnaire.* access/walgreen.* access/*.*'
+                });
+                // only the true wildcard (access/*.*) is stripped; narrow grants survive
+                expect(result.scope).toBe('patient/*.* user/Questionnaire.* access/walgreen.*');
+            });
+
+            test('strips wildcard scopes when token has no iss/client_id and allowlist is non-empty', () => {
+                Object.defineProperty(mockConfigManager, 'allowedNonPatientScopeClients', {
+                    get: () => new Set(['https://trusted.example.com|trusted-client']),
+                    configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const result = authService.getFieldsFromToken({
+                    scope: 'patient/*.* access/*.*'
+                });
+                expect(result.scope).toBe('patient/*.*');
+            });
+
+            test('is a no-op when the token has no wildcard non-patient scopes to strip', () => {
+                Object.defineProperty(mockConfigManager, 'allowedNonPatientScopeClients', {
+                    get: () => new Set(['https://trusted.example.com|trusted-client']),
+                    configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const result = authService.getFieldsFromToken({
+                    iss: 'https://untrusted.example.com',
+                    client_id: 'some-client',
+                    scope: 'patient/Patient.read'
+                });
+                expect(result.scope).toBe('patient/Patient.read');
+            });
+
+            test('applies after AUTH_REMOVE_SCOPE_PREFIX stripping', () => {
+                Object.defineProperty(mockConfigManager, 'allowedNonPatientScopeClients', {
+                    get: () => new Set(['https://trusted.example.com|trusted-client']),
+                    configurable: true
+                });
+                Object.defineProperty(mockConfigManager, 'authRemoveScopePrefixes', {
+                    get: () => ['myapp:'], configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const result = authService.getFieldsFromToken({
+                    iss: 'https://untrusted.example.com',
+                    client_id: 'some-client',
+                    scope: 'myapp:patient/*.* myapp:access/*.*'
+                });
+                expect(result.scope).toBe('patient/*.*');
+            });
+        });
+    });
+
+    describe('isWildcardNonPatientScope', () => {
+        test.each([
+            ['user/*.*', true],
+            ['access/*.*', true],
+            ['User/*.Read', true],
+            ['ACCESS/*.write', true],
+            ['user/Questionnaire.*', false],
+            ['access/walgreen.*', false],
+            ['patient/*.*', false],
+            ['admin/*.*', false],
+            ['', false]
+        ])('%s -> %s', (scope, expected) => {
+            expect(authService.isWildcardNonPatientScope(scope)).toBe(expected);
+        });
+
+        test('returns false for non-string input', () => {
+            expect(authService.isWildcardNonPatientScope(undefined)).toBe(false);
+            expect(authService.isWildcardNonPatientScope(null)).toBe(false);
         });
     });
 

--- a/src/tests/unit/strategies/authService.test.js
+++ b/src/tests/unit/strategies/authService.test.js
@@ -1329,6 +1329,40 @@ describe('AuthService', () => {
             expect(AuthService.userInfoCache.has('issuer2-cid2-sub2')).toBe(true);
         });
 
+        test('DCON-4882: does not trust an iss value injected via the userinfo response body', async () => {
+            // Regression test for a real IDOR-via-issuer-spoofing bug: the original fix merged
+            // the userinfo body with `{ iss: jwt_payload.iss, ...userInfoResponse.body }`, which let
+            // a same-named `iss` field in the (unverified, HTTP-fetched) response body silently win
+            // over the original JWT's signature-verified `iss` claim. Here the allowlist trusts the
+            // spoofed issuer but NOT the real one -- if the bug were present, the wildcard access/*.*
+            // scope would survive; with the fix, the real iss governs and it must be stripped.
+            mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync.mockResolvedValue({
+                userinfo_endpoint: 'http://auth.example.com/userinfo'
+            });
+            superagent.timeout.mockResolvedValue({
+                body: {
+                    iss: 'https://spoofed-issuer.example.com',
+                    client_id: 'trusted-client',
+                    scope: 'patient/*.* access/*.*'
+                }
+            });
+            Object.defineProperty(mockConfigManager, 'allowedNonPatientScopeClients', {
+                get: () => new Set(['https://spoofed-issuer.example.com|trusted-client']),
+                configurable: true
+            });
+            authService = new AuthService({
+                configManager: mockConfigManager,
+                wellKnownConfigurationManager: mockWellKnownConfigManager
+            });
+
+            const result = await authService.getUserInfoFromUserInfoEndpoint({
+                jwt_payload: { iss: 'https://real-verified-issuer.example.com', cid: 'cid-x', sub: 'sub-x' },
+                token: 'my-token'
+            });
+
+            expect(result.scope).toBe('patient/*.*');
+        });
+
         test('does not cache when iss, cid, or sub is missing', async () => {
             mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync.mockResolvedValue({
                 userinfo_endpoint: 'http://auth.example.com/userinfo'

--- a/src/tests/unit/utils/configManager.test.js
+++ b/src/tests/unit/utils/configManager.test.js
@@ -207,6 +207,29 @@ describe('ConfigManager', () => {
             process.env.AUTH_CID_CHECK_CLIENT_IDS = 'cid1,cid2';
             expect(new ConfigManager().authCidCheckClientIds).toEqual(['cid1', 'cid2']);
         });
+
+        // DCON-4882
+        test('allowedNonPatientScopeClients returns empty set when not set', () => {
+            delete process.env.EXTERNAL_AUTH_ALLOWED_NON_PATIENT_SCOPE_CLIENTS;
+            expect(new ConfigManager().allowedNonPatientScopeClients).toEqual(new Set());
+        });
+
+        test('allowedNonPatientScopeClients parses comma-separated "iss|client_id" pairs', () => {
+            process.env.EXTERNAL_AUTH_ALLOWED_NON_PATIENT_SCOPE_CLIENTS =
+                'https://a.example.com|client-a, https://b.example.com|client-b';
+            expect(new ConfigManager().allowedNonPatientScopeClients).toEqual(new Set([
+                'https://a.example.com|client-a',
+                'https://b.example.com|client-b'
+            ]));
+        });
+
+        test('allowedNonPatientScopeClients ignores malformed entries missing a pipe or client_id', () => {
+            process.env.EXTERNAL_AUTH_ALLOWED_NON_PATIENT_SCOPE_CLIENTS =
+                'https://a.example.com|client-a, https://no-pipe.example.com, https://c.example.com|';
+            expect(new ConfigManager().allowedNonPatientScopeClients).toEqual(new Set([
+                'https://a.example.com|client-a'
+            ]));
+        });
     });
 
     // ========== supportLegacyIds ==========

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -1004,6 +1004,31 @@ class ConfigManager {
     }
 
     /**
+     * (issuer, client_id) pairs allowed to present wildcard non-patient scopes (user/*.* and
+     * access/*.*), parsed from EXTERNAL_AUTH_ALLOWED_NON_PATIENT_SCOPE_CLIENTS as a comma-separated
+     * list of "iss|client_id" entries (same "key|value" convention as
+     * EXTERNAL_SERVICES_WITH_REQ_LIMIT). Keyed on the (issuer, client_id) PAIR, not issuer alone,
+     * because a single Cognito pool can be the issuer for both a trusted internal service (via its
+     * own client_id) and an external consumer app (via a different client_id) -- issuer alone cannot
+     * distinguish them. For any token whose (iss, client_id) pair is NOT in this set, wildcard
+     * non-patient scopes are stripped so the token is confined to its patient compartment plus any
+     * explicit narrow grants. Empty (the default) means no restriction, so environments that do not
+     * set it are unchanged. See DCON-4882.
+     * @returns {Set<string>}
+     */
+    get allowedNonPatientScopeClients() {
+        const pairs = this._parseCommaSeparatedList(env.EXTERNAL_AUTH_ALLOWED_NON_PATIENT_SCOPE_CLIENTS, []);
+        return new Set(
+            pairs
+                .map((pair) => {
+                    const [issuer, clientId] = pair.split('|').map((part) => part && part.trim());
+                    return issuer && clientId ? `${issuer}|${clientId}` : null;
+                })
+                .filter((pair) => pair !== null)
+        );
+    }
+
+    /**
      * Allowlisted purposeOfUse codes parsed from CMS_ALLOWED_PURPOSE_OF_USE env var.
      * @returns {Set<string>}
      */


### PR DESCRIPTION
Closed — not proceeding with this implementation approach (code-level scope restriction gated by a new config flag) per review feedback. Redirecting to an infrastructure-level approach instead. Details and follow-up: [DCON-4882](https://icanbwell.atlassian.net/browse/DCON-4882).

[DCON-4882]: https://icanbwell.atlassian.net/browse/DCON-4882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ