### PR TITLE
DCON-4882 Reject non-patient tokens from untrusted issuers

### DIFF
--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -394,6 +394,39 @@ class AuthService {
     }
 
     /**
+     * Returns true if the scope grants wildcard non-patient authority: `user/*.<x>` or
+     * `access/*.<x>` where the resource-type / tenant segment is `*` (e.g. `user/*.*`, `access/*.*`,
+     * `user/*.read`). Narrowly-scoped grants (`user/Questionnaire.*`, `access/walgreen.*`) and every
+     * `patient/` scope return false. See DCON-4882.
+     * @param {string} scope
+     * @returns {boolean}
+     */
+    isWildcardNonPatientScope(scope) {
+        if (typeof scope !== 'string') {
+            return false;
+        }
+        const lower = scope.toLowerCase();
+        if (!lower.startsWith('user/') && !lower.startsWith('access/')) {
+            return false;
+        }
+        const afterSlash = scope.substring(scope.indexOf('/') + 1);
+        const resourceOrTenant = afterSlash.split('.')[0];
+        return resourceOrTenant === '*';
+    }
+
+    /**
+     * Returns true if the raw JWT payload carries any patient/person id claim
+     * (this.requiredJWTFields). A real client-credentials grant has no authenticated end user
+     * behind it, so it structurally cannot carry these claims -- their presence means the token
+     * belongs to a real person. See DCON-4882.
+     * @param {Object} jwt_payload
+     * @returns {boolean}
+     */
+    hasPatientOrPersonIdClaim(jwt_payload) {
+        return Object.values(this.requiredJWTFields).some((field) => Boolean(jwt_payload[field]));
+    }
+
+    /**
      * Extracts fields from the JWT payload.
      * @param {Object} jwt_payload
      * @returns {{scope: string, isUser: boolean, username: string|undefined, subject: string|undefined, clientId: string|undefined}}
@@ -443,6 +476,25 @@ class AuthService {
                 }
             );
             scope = scopes.join(' ');
+        }
+
+        // A token carrying a patient/person id claim belongs to a real person -- a real
+        // client-credentials grant has no end user behind it and structurally cannot carry these
+        // claims. A real person should never also hold wildcard user/*.* or access/*.* authority,
+        // regardless of what scope an upstream identity provider granted, so strip only those
+        // wildcard scopes here. patient/ scopes and narrowly-scoped grants (user/Questionnaire.*,
+        // access/walgreen.*) are never touched. Config-gated (default off) so unconfigured
+        // environments are unchanged. See DCON-4882.
+        if (this.configManager.restrictNonPatientScopeForPatientTokens && this.hasPatientOrPersonIdClaim(jwt_payload)) {
+            const removedScopes = scopes.filter((s) => this.isWildcardNonPatientScope(s));
+            if (removedScopes.length > 0) {
+                logWarn('Stripped wildcard non-patient scopes from a patient/person-id-bearing token', {
+                    reason: 'wildcard_non_patient_scope_stripped_for_patient_token',
+                    args: { removedScopes }
+                });
+                scopes = scopes.filter((s) => !this.isWildcardNonPatientScope(s));
+                scope = scopes.join(' ');
+            }
         }
 
         const username = jwt_payload.username
@@ -495,15 +547,33 @@ class AuthService {
                 .retry(EXTERNAL_REQUEST_RETRY_COUNT)
                 .timeout(this.requestTimeout);
             if (userInfoResponse && userInfoResponse.body) {
-                jwt_payload = userInfoResponse.body;
-                const userInfo = this.getFieldsFromToken(jwt_payload);
+                // Preserve the original token's patient/person id claims rather than trusting
+                // whatever the userinfo response body says -- that body is unverified JSON over
+                // HTTP, unlike the JWT's own claims, which were already checked against the JWKS
+                // signature. Letting the response body add or remove one of these claims would let
+                // an untrusted value decide the wildcard-scope restriction in getFieldsFromToken
+                // (hasPatientOrPersonIdClaim, DCON-4882), which is exactly the kind of trust
+                // decision these claims exist to protect.
+                const claimOverrides = {};
+                for (const field of Object.values(this.requiredJWTFields)) {
+                    claimOverrides[field] = jwt_payload[field];
+                }
+                const mergedPayload = { ...userInfoResponse.body, ...claimOverrides };
+                const userInfo = this.getFieldsFromToken(mergedPayload);
                 if (cacheKey) {
                     AuthService.userInfoCache.set(cacheKey, userInfo);
                 }
                 return userInfo;
             }
         }
-        return jwt_payload;
+        // No userinfo endpoint configured for this issuer (or its response had no body) --
+        // reapply getFieldsFromToken on the original payload rather than returning it raw. If the
+        // first getFieldsFromToken call (in verify()) already stripped a wildcard-only scope down
+        // to '' because this token carries a patient/person id claim, returning jwt_payload
+        // unprocessed would hand verify() the token's raw, un-stripped scope, which its
+        // `scope1 || scope` fallback then picks over the (correctly) stripped empty scope --
+        // undoing the strip for exactly the token this check exists to restrict.
+        return this.getFieldsFromToken(jwt_payload);
     }
 
     /**

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -264,28 +264,6 @@ class AuthService {
      * @return {void}
      */
     processUserInfo({username, subject, isUser, jwt_payload, done, client_id, scope}) {
-        // A token carrying none of the patient/person id claims is not anchored to a patient/person
-        // at all -- from any issuer not explicitly allowlisted for this, reject it outright rather
-        // than letting it through as an ordinary service/tenant-scoped token. Guards against an
-        // identity provider accidentally issuing an unanchored token to a party that isn't meant to
-        // hold one. Config-gated (empty allowlist -- unconfigured -- means no restriction). See
-        // DCON-4882.
-        const allowedNonPatientTokenIssuers = this.configManager.allowedNonPatientTokenIssuers;
-        if (
-            allowedNonPatientTokenIssuers.length > 0 &&
-            !this.hasPatientOrPersonIdClaim(jwt_payload) &&
-            !allowedNonPatientTokenIssuers.includes(jwt_payload.iss)
-        ) {
-            logWarn('Auth rejected', {
-                reason: 'non_patient_token_from_untrusted_issuer',
-                iss: jwt_payload.iss,
-                username,
-                subject
-            });
-            done(null, false, {reason: 'non_patient_token_from_untrusted_issuer'});
-            return;
-        }
-
         // A token that resolves to a completely empty scope (nothing on the JWT itself,
         // no groups, and userinfo enrichment -- if attempted -- found nothing either) is
         // authenticated but carries zero permissions; treat it as an auth failure (401),
@@ -413,18 +391,6 @@ class AuthService {
             }
         }
         return null;
-    }
-
-    /**
-     * Returns true if the raw JWT payload carries any patient/person id claim
-     * (this.requiredJWTFields). A real client-credentials grant has no authenticated end user
-     * behind it, so it structurally cannot carry these claims -- their presence means the token
-     * belongs to a real person. See DCON-4882.
-     * @param {Object} jwt_payload
-     * @returns {boolean}
-     */
-    hasPatientOrPersonIdClaim(jwt_payload) {
-        return Object.values(this.requiredJWTFields).some((field) => Boolean(jwt_payload[field]));
     }
 
     /**

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -264,6 +264,28 @@ class AuthService {
      * @return {void}
      */
     processUserInfo({username, subject, isUser, jwt_payload, done, client_id, scope}) {
+        // A token carrying none of the patient/person id claims is not anchored to a patient/person
+        // at all -- from any issuer not explicitly allowlisted for this, reject it outright rather
+        // than letting it through as an ordinary service/tenant-scoped token. Guards against an
+        // identity provider accidentally issuing an unanchored token to a party that isn't meant to
+        // hold one. Config-gated (empty allowlist -- unconfigured -- means no restriction). See
+        // DCON-4882.
+        const allowedNonPatientTokenIssuers = this.configManager.allowedNonPatientTokenIssuers;
+        if (
+            allowedNonPatientTokenIssuers.length > 0 &&
+            !this.hasPatientOrPersonIdClaim(jwt_payload) &&
+            !allowedNonPatientTokenIssuers.includes(jwt_payload.iss)
+        ) {
+            logWarn('Auth rejected', {
+                reason: 'non_patient_token_from_untrusted_issuer',
+                iss: jwt_payload.iss,
+                username,
+                subject
+            });
+            done(null, false, {reason: 'non_patient_token_from_untrusted_issuer'});
+            return;
+        }
+
         // A token that resolves to a completely empty scope (nothing on the JWT itself,
         // no groups, and userinfo enrichment -- if attempted -- found nothing either) is
         // authenticated but carries zero permissions; treat it as an auth failure (401),
@@ -391,6 +413,18 @@ class AuthService {
             }
         }
         return null;
+    }
+
+    /**
+     * Returns true if the raw JWT payload carries any patient/person id claim
+     * (this.requiredJWTFields). A real client-credentials grant has no authenticated end user
+     * behind it, so it structurally cannot carry these claims -- their presence means the token
+     * belongs to a real person. See DCON-4882.
+     * @param {Object} jwt_payload
+     * @returns {boolean}
+     */
+    hasPatientOrPersonIdClaim(jwt_payload) {
+        return Object.values(this.requiredJWTFields).some((field) => Boolean(jwt_payload[field]));
     }
 
     /**

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -264,6 +264,28 @@ class AuthService {
      * @return {void}
      */
     processUserInfo({username, subject, isUser, jwt_payload, done, client_id, scope}) {
+        // A token carrying none of the patient/person id claims is not anchored to a patient/person
+        // at all -- from any issuer not explicitly allowlisted for this, reject it outright rather
+        // than letting it through as an ordinary service/tenant-scoped token. Guards against an
+        // identity provider accidentally issuing an unanchored token to a party that isn't meant to
+        // hold one. Config-gated (empty allowlist -- unconfigured -- means no restriction). See
+        // DCON-4882.
+        const allowedNonPatientTokenIssuers = this.configManager.allowedNonPatientTokenIssuers;
+        if (
+            allowedNonPatientTokenIssuers.length > 0 &&
+            !this.hasPatientOrPersonIdClaim(jwt_payload) &&
+            !allowedNonPatientTokenIssuers.includes(jwt_payload.iss)
+        ) {
+            logWarn('Auth rejected', {
+                reason: 'non_patient_token_from_untrusted_issuer',
+                iss: jwt_payload.iss,
+                username,
+                subject
+            });
+            done(null, false, {reason: 'non_patient_token_from_untrusted_issuer'});
+            return;
+        }
+
         // A token that resolves to a completely empty scope (nothing on the JWT itself,
         // no groups, and userinfo enrichment -- if attempted -- found nothing either) is
         // authenticated but carries zero permissions; treat it as an auth failure (401),

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -416,27 +416,6 @@ class AuthService {
     }
 
     /**
-     * Returns true if the scope grants wildcard non-patient authority: `user/*.<x>` or
-     * `access/*.<x>` where the resource-type / tenant segment is `*` (e.g. `user/*.*`, `access/*.*`,
-     * `user/*.read`). Narrowly-scoped grants (`user/Questionnaire.*`, `access/walgreen.*`) and every
-     * `patient/` scope return false. See DCON-4882.
-     * @param {string} scope
-     * @returns {boolean}
-     */
-    isWildcardNonPatientScope(scope) {
-        if (typeof scope !== 'string') {
-            return false;
-        }
-        const lower = scope.toLowerCase();
-        if (!lower.startsWith('user/') && !lower.startsWith('access/')) {
-            return false;
-        }
-        const afterSlash = scope.substring(scope.indexOf('/') + 1);
-        const resourceOrTenant = afterSlash.split('.')[0];
-        return resourceOrTenant === '*';
-    }
-
-    /**
      * Returns true if the raw JWT payload carries any patient/person id claim
      * (this.requiredJWTFields). A real client-credentials grant has no authenticated end user
      * behind it, so it structurally cannot carry these claims -- their presence means the token
@@ -500,25 +479,6 @@ class AuthService {
             scope = scopes.join(' ');
         }
 
-        // A token carrying a patient/person id claim belongs to a real person -- a real
-        // client-credentials grant has no end user behind it and structurally cannot carry these
-        // claims. A real person should never also hold wildcard user/*.* or access/*.* authority,
-        // regardless of what scope an upstream identity provider granted, so strip only those
-        // wildcard scopes here. patient/ scopes and narrowly-scoped grants (user/Questionnaire.*,
-        // access/walgreen.*) are never touched. Config-gated (default off) so unconfigured
-        // environments are unchanged. See DCON-4882.
-        if (this.configManager.restrictNonPatientScopeForPatientTokens && this.hasPatientOrPersonIdClaim(jwt_payload)) {
-            const removedScopes = scopes.filter((s) => this.isWildcardNonPatientScope(s));
-            if (removedScopes.length > 0) {
-                logWarn('Stripped wildcard non-patient scopes from a patient/person-id-bearing token', {
-                    reason: 'wildcard_non_patient_scope_stripped_for_patient_token',
-                    args: { removedScopes }
-                });
-                scopes = scopes.filter((s) => !this.isWildcardNonPatientScope(s));
-                scope = scopes.join(' ');
-            }
-        }
-
         const username = jwt_payload.username
             ? jwt_payload.username
             : this.getFirstPropertyFromPayload({
@@ -569,33 +529,15 @@ class AuthService {
                 .retry(EXTERNAL_REQUEST_RETRY_COUNT)
                 .timeout(this.requestTimeout);
             if (userInfoResponse && userInfoResponse.body) {
-                // Preserve the original token's patient/person id claims rather than trusting
-                // whatever the userinfo response body says -- that body is unverified JSON over
-                // HTTP, unlike the JWT's own claims, which were already checked against the JWKS
-                // signature. Letting the response body add or remove one of these claims would let
-                // an untrusted value decide the wildcard-scope restriction in getFieldsFromToken
-                // (hasPatientOrPersonIdClaim, DCON-4882), which is exactly the kind of trust
-                // decision these claims exist to protect.
-                const claimOverrides = {};
-                for (const field of Object.values(this.requiredJWTFields)) {
-                    claimOverrides[field] = jwt_payload[field];
-                }
-                const mergedPayload = { ...userInfoResponse.body, ...claimOverrides };
-                const userInfo = this.getFieldsFromToken(mergedPayload);
+                jwt_payload = userInfoResponse.body;
+                const userInfo = this.getFieldsFromToken(jwt_payload);
                 if (cacheKey) {
                     AuthService.userInfoCache.set(cacheKey, userInfo);
                 }
                 return userInfo;
             }
         }
-        // No userinfo endpoint configured for this issuer (or its response had no body) --
-        // reapply getFieldsFromToken on the original payload rather than returning it raw. If the
-        // first getFieldsFromToken call (in verify()) already stripped a wildcard-only scope down
-        // to '' because this token carries a patient/person id claim, returning jwt_payload
-        // unprocessed would hand verify() the token's raw, un-stripped scope, which its
-        // `scope1 || scope` fallback then picks over the (correctly) stripped empty scope --
-        // undoing the strip for exactly the token this check exists to restrict.
-        return this.getFieldsFromToken(jwt_payload);
+        return jwt_payload;
     }
 
     /**

--- a/src/tests/unit/strategies/authService.test.js
+++ b/src/tests/unit/strategies/authService.test.js
@@ -58,6 +58,7 @@ describe('AuthService', () => {
         Object.defineProperty(mockConfigManager, 'authCidCheckClientIds', { get: () => [], configurable: true });
         Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => false, configurable: true });
         Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', { get: () => false, configurable: true });
+        Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', { get: () => [], configurable: true });
 
         mockWellKnownConfigManager = createMockInstance(WellKnownConfigurationManager);
         mockWellKnownConfigManager.getJwksUrlsAsync = jest.fn().mockResolvedValue([]);
@@ -720,6 +721,89 @@ describe('AuthService', () => {
     });
 
     describe('processUserInfo', () => {
+        // DCON-4882: reject tokens missing patient/person id claims from untrusted issuers
+        describe('non-patient token from untrusted issuer (DCON-4882)', () => {
+            test('is a no-op when the allowlist is empty (unconfigured environments)', () => {
+                const done = jest.fn();
+                authService.processUserInfo({
+                    username: 'svc', subject: undefined, isUser: false,
+                    jwt_payload: { iss: 'https://untrusted.example.com' },
+                    done, client_id: 'svc-client', scope: 'user/*.read'
+                });
+                expect(done).toHaveBeenCalledWith(
+                    null,
+                    expect.objectContaining({ id: 'svc-client' }),
+                    expect.any(Object)
+                );
+            });
+
+            test('rejects a token missing all patient/person id claims from a non-allowlisted issuer', () => {
+                Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', {
+                    get: () => ['https://trusted.example.com'], configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const done = jest.fn();
+                authService.processUserInfo({
+                    username: 'svc', subject: undefined, isUser: false,
+                    jwt_payload: { iss: 'https://untrusted.example.com' },
+                    done, client_id: 'svc-client', scope: 'user/*.* access/*.*'
+                });
+                expect(done).toHaveBeenCalledWith(null, false, { reason: 'non_patient_token_from_untrusted_issuer' });
+            });
+
+            test('passes through when the issuer is on the allowlist', () => {
+                Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', {
+                    get: () => ['https://trusted.example.com'], configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const done = jest.fn();
+                authService.processUserInfo({
+                    username: 'svc', subject: undefined, isUser: false,
+                    jwt_payload: { iss: 'https://trusted.example.com' },
+                    done, client_id: 'svc-client', scope: 'user/*.* access/*.*'
+                });
+                expect(done).toHaveBeenCalledWith(
+                    null,
+                    expect.objectContaining({ id: 'svc-client' }),
+                    expect.any(Object)
+                );
+            });
+
+            test('passes through when the token has a patient/person id claim, regardless of issuer', () => {
+                Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', {
+                    get: () => ['https://trusted.example.com'], configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const done = jest.fn();
+                authService.processUserInfo({
+                    username: 'testuser', subject: 'sub1', isUser: true,
+                    jwt_payload: {
+                        iss: 'https://untrusted.example.com',
+                        clientFhirPersonId: 'person-1',
+                        clientFhirPatientId: 'patient-1',
+                        bwellFhirPersonId: 'bwell-person-1',
+                        bwellFhirPatientId: 'bwell-patient-1',
+                        sub: 'subject-1'
+                    },
+                    done, client_id: 'client1', scope: 'patient/Patient.read'
+                });
+                expect(done).toHaveBeenCalledWith(
+                    null,
+                    expect.objectContaining({ id: 'client1' }),
+                    expect.any(Object)
+                );
+            });
+        });
+
         test('calls done with user info for non-user token', () => {
             const done = jest.fn();
             authService.processUserInfo({

--- a/src/tests/unit/strategies/authService.test.js
+++ b/src/tests/unit/strategies/authService.test.js
@@ -57,6 +57,7 @@ describe('AuthService', () => {
         Object.defineProperty(mockConfigManager, 'authCidCheckIssuer', { get: () => '', configurable: true });
         Object.defineProperty(mockConfigManager, 'authCidCheckClientIds', { get: () => [], configurable: true });
         Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => false, configurable: true });
+        Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', { get: () => false, configurable: true });
 
         mockWellKnownConfigManager = createMockInstance(WellKnownConfigurationManager);
         mockWellKnownConfigManager.getJwksUrlsAsync = jest.fn().mockResolvedValue([]);
@@ -491,6 +492,130 @@ describe('AuthService', () => {
             });
             const result = authService.getFieldsFromToken({ scope: 'short:user/*.read' });
             expect(result.scope).toBe('user/*.read');
+        });
+
+        // DCON-4882: wildcard non-patient scope restriction for patient/person-id-bearing tokens
+        describe('wildcard non-patient scope restriction for patient tokens (DCON-4882)', () => {
+            test('leaves scopes unchanged when the flag is off, even with a patient id claim', () => {
+                const result = authService.getFieldsFromToken({
+                    clientFhirPatientId: 'patient-1',
+                    scope: 'patient/*.* user/*.* access/*.*'
+                });
+                expect(result.scope).toBe('patient/*.* user/*.* access/*.*');
+            });
+
+            test('strips wildcard user/ and access/ scopes when the flag is on and a patient id claim is present', () => {
+                Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
+                    get: () => true, configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const result = authService.getFieldsFromToken({
+                    clientFhirPatientId: 'patient-1',
+                    scope: 'aws.cognito.signin.user.admin access/*.* patient/*.* user/*.*'
+                });
+                expect(result.scope).toBe('aws.cognito.signin.user.admin patient/*.*');
+                expect(result.isUser).toBe(true);
+            });
+
+            test('strips wildcard scopes when the flag is on and a person id claim is present (no patient id)', () => {
+                Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
+                    get: () => true, configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const result = authService.getFieldsFromToken({
+                    bwellFhirPersonId: 'person-1',
+                    scope: 'user/*.* access/*.*'
+                });
+                expect(result.scope).toBe('');
+            });
+
+            test('leaves scopes unchanged when the flag is on but no patient/person id claim is present', () => {
+                Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
+                    get: () => true, configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const result = authService.getFieldsFromToken({
+                    scope: 'user/*.* access/*.*'
+                });
+                expect(result.scope).toBe('user/*.* access/*.*');
+            });
+
+            test('preserves narrowly-scoped non-patient grants for a patient-id-bearing token', () => {
+                Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
+                    get: () => true, configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const result = authService.getFieldsFromToken({
+                    clientFhirPatientId: 'patient-1',
+                    scope: 'patient/*.* user/Questionnaire.* access/walgreen.* access/*.*'
+                });
+                // only the true wildcard (access/*.*) is stripped; narrow grants survive
+                expect(result.scope).toBe('patient/*.* user/Questionnaire.* access/walgreen.*');
+            });
+
+            test('applies after AUTH_REMOVE_SCOPE_PREFIX stripping', () => {
+                Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
+                    get: () => true, configurable: true
+                });
+                Object.defineProperty(mockConfigManager, 'authRemoveScopePrefixes', {
+                    get: () => ['myapp:'], configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const result = authService.getFieldsFromToken({
+                    clientFhirPatientId: 'patient-1',
+                    scope: 'myapp:patient/*.* myapp:access/*.*'
+                });
+                expect(result.scope).toBe('patient/*.*');
+            });
+        });
+    });
+
+    describe('isWildcardNonPatientScope', () => {
+        test.each([
+            ['user/*.*', true],
+            ['access/*.*', true],
+            ['User/*.Read', true],
+            ['ACCESS/*.write', true],
+            ['user/Questionnaire.*', false],
+            ['access/walgreen.*', false],
+            ['patient/*.*', false],
+            ['admin/*.*', false],
+            ['', false]
+        ])('%s -> %s', (scope, expected) => {
+            expect(authService.isWildcardNonPatientScope(scope)).toBe(expected);
+        });
+
+        test('returns false for non-string input', () => {
+            expect(authService.isWildcardNonPatientScope(undefined)).toBe(false);
+            expect(authService.isWildcardNonPatientScope(null)).toBe(false);
+        });
+    });
+
+    describe('hasPatientOrPersonIdClaim', () => {
+        test.each([
+            [{ clientFhirPersonId: 'p1' }, true],
+            [{ clientFhirPatientId: 'p1' }, true],
+            [{ bwellFhirPersonId: 'p1' }, true],
+            [{ bwellFhirPatientId: 'p1' }, true],
+            [{}, false],
+            [{ sub: 'some-user' }, false]
+        ])('%o -> %s', (jwt_payload, expected) => {
+            expect(authService.hasPatientOrPersonIdClaim(jwt_payload)).toBe(expected);
         });
     });
 
@@ -1119,6 +1244,73 @@ describe('AuthService', () => {
             expect(user).toBeUndefined();
             expect(info).toBeUndefined();
         });
+
+        test('DCON-4882: does not resurrect a wildcard-only patient-token via the empty-scope userinfo fallback', async () => {
+            // Regression test: stripping a wildcard-only scope down to '' trips verify()'s
+            // pre-existing "no scope -> try userinfo endpoint" branch. If that branch's fallback
+            // returned jwt_payload raw (its un-stripped scope intact) instead of reapplying the
+            // strip, verify()'s `scope1 || scope` would pick the raw wildcard scope back up,
+            // completely undoing the restriction for exactly the token it exists to restrict.
+            Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
+                get: () => true, configurable: true
+            });
+            mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync = jest.fn().mockResolvedValue(null);
+            authService = new AuthService({
+                configManager: mockConfigManager,
+                wellKnownConfigurationManager: mockWellKnownConfigManager
+            });
+
+            const done = jest.fn();
+            authService.verify({
+                request: {},
+                jwt_payload: {
+                    iss: 'https://issuer.example.com',
+                    clientFhirPatientId: 'patient-1',
+                    scope: 'user/*.* access/*.*' // wildcard-only, no patient/ scope
+                },
+                token: 'tok',
+                done
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 20));
+            expect(done).toHaveBeenCalledWith(null, false, { reason: 'no_scope' });
+        });
+
+        test('DCON-4882: does not trust the userinfo response body to remove a patient id claim', async () => {
+            // Regression test: the userinfo-response merge must preserve the ORIGINAL token's
+            // patient/person id claims, not whatever the (unverified) response body says. If the
+            // merge let the response body's absence of the claim win, a patient-id-bearing token
+            // could escape the restriction simply by omitting the claim from its userinfo response.
+            Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
+                get: () => true, configurable: true
+            });
+            mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync = jest.fn().mockResolvedValue({
+                userinfo_endpoint: 'http://auth.example.com/userinfo'
+            });
+            superagent.timeout.mockResolvedValue({
+                body: { scope: 'user/*.* access/*.*' } // no patient/person claim echoed back
+            });
+            authService = new AuthService({
+                configManager: mockConfigManager,
+                wellKnownConfigurationManager: mockWellKnownConfigManager
+            });
+
+            const done = jest.fn();
+            authService.verify({
+                request: {},
+                jwt_payload: {
+                    iss: 'https://issuer.example.com',
+                    sub: 'sub-1',
+                    clientFhirPatientId: 'patient-1'
+                    // no scope on the JWT itself -- must be resolved via the userinfo endpoint
+                },
+                token: 'tok',
+                done
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 20));
+            expect(done).toHaveBeenCalledWith(null, false, { reason: 'no_scope' });
+        });
     });
 
     describe('getUserInfoFromUserInfoEndpoint', () => {
@@ -1141,30 +1333,32 @@ describe('AuthService', () => {
             expect(result).toEqual(cachedUserInfo);
         });
 
-        test('returns jwt_payload when no well-known config found', async () => {
+        test('reapplies getFieldsFromToken on the original payload when no well-known config found', async () => {
+            // DCON-4882: must NOT return jwt_payload verbatim (its raw, un-stripped scope) --
+            // see the fail-open regression test in the `verify` block for why that would matter.
             mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync.mockResolvedValue(null);
 
-            const jwt_payload = { iss: 'issuer1', cid: 'cid1', sub: 'sub1' };
+            const jwt_payload = { iss: 'issuer1', cid: 'cid1', sub: 'sub1', scope: 'user/*.read' };
             const result = await authService.getUserInfoFromUserInfoEndpoint({
                 jwt_payload,
                 token: 'my-token'
             });
 
-            expect(result).toBe(jwt_payload);
+            expect(result).toEqual({ scope: 'user/*.read', isUser: false, username: null, subject: null, clientId: null });
         });
 
-        test('returns jwt_payload when well-known config has no userinfo_endpoint', async () => {
+        test('reapplies getFieldsFromToken on the original payload when well-known config has no userinfo_endpoint', async () => {
             mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync.mockResolvedValue({
                 jwks_uri: 'http://jwks.example.com'
             });
 
-            const jwt_payload = { iss: 'issuer1', cid: 'cid1', sub: 'sub1' };
+            const jwt_payload = { iss: 'issuer1', cid: 'cid1', sub: 'sub1', scope: 'user/*.read' };
             const result = await authService.getUserInfoFromUserInfoEndpoint({
                 jwt_payload,
                 token: 'my-token'
             });
 
-            expect(result).toBe(jwt_payload);
+            expect(result).toEqual({ scope: 'user/*.read', isUser: false, username: null, subject: null, clientId: null });
         });
 
         test('fetches user info and caches result', async () => {

--- a/src/tests/unit/strategies/authService.test.js
+++ b/src/tests/unit/strategies/authService.test.js
@@ -57,7 +57,6 @@ describe('AuthService', () => {
         Object.defineProperty(mockConfigManager, 'authCidCheckIssuer', { get: () => '', configurable: true });
         Object.defineProperty(mockConfigManager, 'authCidCheckClientIds', { get: () => [], configurable: true });
         Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => false, configurable: true });
-        Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', { get: () => false, configurable: true });
         Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', { get: () => [], configurable: true });
 
         mockWellKnownConfigManager = createMockInstance(WellKnownConfigurationManager);
@@ -493,117 +492,6 @@ describe('AuthService', () => {
             });
             const result = authService.getFieldsFromToken({ scope: 'short:user/*.read' });
             expect(result.scope).toBe('user/*.read');
-        });
-
-        // DCON-4882: wildcard non-patient scope restriction for patient/person-id-bearing tokens
-        describe('wildcard non-patient scope restriction for patient tokens (DCON-4882)', () => {
-            test('leaves scopes unchanged when the flag is off, even with a patient id claim', () => {
-                const result = authService.getFieldsFromToken({
-                    clientFhirPatientId: 'patient-1',
-                    scope: 'patient/*.* user/*.* access/*.*'
-                });
-                expect(result.scope).toBe('patient/*.* user/*.* access/*.*');
-            });
-
-            test('strips wildcard user/ and access/ scopes when the flag is on and a patient id claim is present', () => {
-                Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
-                    get: () => true, configurable: true
-                });
-                authService = new AuthService({
-                    configManager: mockConfigManager,
-                    wellKnownConfigurationManager: mockWellKnownConfigManager
-                });
-                const result = authService.getFieldsFromToken({
-                    clientFhirPatientId: 'patient-1',
-                    scope: 'aws.cognito.signin.user.admin access/*.* patient/*.* user/*.*'
-                });
-                expect(result.scope).toBe('aws.cognito.signin.user.admin patient/*.*');
-                expect(result.isUser).toBe(true);
-            });
-
-            test('strips wildcard scopes when the flag is on and a person id claim is present (no patient id)', () => {
-                Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
-                    get: () => true, configurable: true
-                });
-                authService = new AuthService({
-                    configManager: mockConfigManager,
-                    wellKnownConfigurationManager: mockWellKnownConfigManager
-                });
-                const result = authService.getFieldsFromToken({
-                    bwellFhirPersonId: 'person-1',
-                    scope: 'user/*.* access/*.*'
-                });
-                expect(result.scope).toBe('');
-            });
-
-            test('leaves scopes unchanged when the flag is on but no patient/person id claim is present', () => {
-                Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
-                    get: () => true, configurable: true
-                });
-                authService = new AuthService({
-                    configManager: mockConfigManager,
-                    wellKnownConfigurationManager: mockWellKnownConfigManager
-                });
-                const result = authService.getFieldsFromToken({
-                    scope: 'user/*.* access/*.*'
-                });
-                expect(result.scope).toBe('user/*.* access/*.*');
-            });
-
-            test('preserves narrowly-scoped non-patient grants for a patient-id-bearing token', () => {
-                Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
-                    get: () => true, configurable: true
-                });
-                authService = new AuthService({
-                    configManager: mockConfigManager,
-                    wellKnownConfigurationManager: mockWellKnownConfigManager
-                });
-                const result = authService.getFieldsFromToken({
-                    clientFhirPatientId: 'patient-1',
-                    scope: 'patient/*.* user/Questionnaire.* access/walgreen.* access/*.*'
-                });
-                // only the true wildcard (access/*.*) is stripped; narrow grants survive
-                expect(result.scope).toBe('patient/*.* user/Questionnaire.* access/walgreen.*');
-            });
-
-            test('applies after AUTH_REMOVE_SCOPE_PREFIX stripping', () => {
-                Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
-                    get: () => true, configurable: true
-                });
-                Object.defineProperty(mockConfigManager, 'authRemoveScopePrefixes', {
-                    get: () => ['myapp:'], configurable: true
-                });
-                authService = new AuthService({
-                    configManager: mockConfigManager,
-                    wellKnownConfigurationManager: mockWellKnownConfigManager
-                });
-                const result = authService.getFieldsFromToken({
-                    clientFhirPatientId: 'patient-1',
-                    scope: 'myapp:patient/*.* myapp:access/*.*'
-                });
-                expect(result.scope).toBe('patient/*.*');
-            });
-        });
-    });
-
-    describe('isWildcardNonPatientScope', () => {
-        test.each([
-            ['user/*.*', true],
-            ['access/*.*', true],
-            ['User/*.Read', true],
-            ['ACCESS/*.write', true],
-            ['user/Questionnaire.*', false],
-            ['access/walgreen.*', false],
-            ['patient/*.*', false],
-            ['admin/*.*', false],
-            ['', false]
-        ])('%s -> %s', (scope, expected) => {
-            expect(authService.isWildcardNonPatientScope(scope)).toBe(expected);
-        });
-
-        test('returns false for non-string input', () => {
-            expect(authService.isWildcardNonPatientScope(undefined)).toBe(false);
-            expect(authService.isWildcardNonPatientScope(null)).toBe(false);
         });
     });
 
@@ -1329,72 +1217,6 @@ describe('AuthService', () => {
             expect(info).toBeUndefined();
         });
 
-        test('DCON-4882: does not resurrect a wildcard-only patient-token via the empty-scope userinfo fallback', async () => {
-            // Regression test: stripping a wildcard-only scope down to '' trips verify()'s
-            // pre-existing "no scope -> try userinfo endpoint" branch. If that branch's fallback
-            // returned jwt_payload raw (its un-stripped scope intact) instead of reapplying the
-            // strip, verify()'s `scope1 || scope` would pick the raw wildcard scope back up,
-            // completely undoing the restriction for exactly the token it exists to restrict.
-            Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
-                get: () => true, configurable: true
-            });
-            mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync = jest.fn().mockResolvedValue(null);
-            authService = new AuthService({
-                configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
-            });
-
-            const done = jest.fn();
-            authService.verify({
-                request: {},
-                jwt_payload: {
-                    iss: 'https://issuer.example.com',
-                    clientFhirPatientId: 'patient-1',
-                    scope: 'user/*.* access/*.*' // wildcard-only, no patient/ scope
-                },
-                token: 'tok',
-                done
-            });
-
-            await new Promise(resolve => setTimeout(resolve, 20));
-            expect(done).toHaveBeenCalledWith(null, false, { reason: 'no_scope' });
-        });
-
-        test('DCON-4882: does not trust the userinfo response body to remove a patient id claim', async () => {
-            // Regression test: the userinfo-response merge must preserve the ORIGINAL token's
-            // patient/person id claims, not whatever the (unverified) response body says. If the
-            // merge let the response body's absence of the claim win, a patient-id-bearing token
-            // could escape the restriction simply by omitting the claim from its userinfo response.
-            Object.defineProperty(mockConfigManager, 'restrictNonPatientScopeForPatientTokens', {
-                get: () => true, configurable: true
-            });
-            mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync = jest.fn().mockResolvedValue({
-                userinfo_endpoint: 'http://auth.example.com/userinfo'
-            });
-            superagent.timeout.mockResolvedValue({
-                body: { scope: 'user/*.* access/*.*' } // no patient/person claim echoed back
-            });
-            authService = new AuthService({
-                configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
-            });
-
-            const done = jest.fn();
-            authService.verify({
-                request: {},
-                jwt_payload: {
-                    iss: 'https://issuer.example.com',
-                    sub: 'sub-1',
-                    clientFhirPatientId: 'patient-1'
-                    // no scope on the JWT itself -- must be resolved via the userinfo endpoint
-                },
-                token: 'tok',
-                done
-            });
-
-            await new Promise(resolve => setTimeout(resolve, 20));
-            expect(done).toHaveBeenCalledWith(null, false, { reason: 'no_scope' });
-        });
     });
 
     describe('getUserInfoFromUserInfoEndpoint', () => {
@@ -1417,32 +1239,30 @@ describe('AuthService', () => {
             expect(result).toEqual(cachedUserInfo);
         });
 
-        test('reapplies getFieldsFromToken on the original payload when no well-known config found', async () => {
-            // DCON-4882: must NOT return jwt_payload verbatim (its raw, un-stripped scope) --
-            // see the fail-open regression test in the `verify` block for why that would matter.
+        test('returns jwt_payload when no well-known config found', async () => {
             mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync.mockResolvedValue(null);
 
-            const jwt_payload = { iss: 'issuer1', cid: 'cid1', sub: 'sub1', scope: 'user/*.read' };
+            const jwt_payload = { iss: 'issuer1', cid: 'cid1', sub: 'sub1' };
             const result = await authService.getUserInfoFromUserInfoEndpoint({
                 jwt_payload,
                 token: 'my-token'
             });
 
-            expect(result).toEqual({ scope: 'user/*.read', isUser: false, username: null, subject: null, clientId: null });
+            expect(result).toBe(jwt_payload);
         });
 
-        test('reapplies getFieldsFromToken on the original payload when well-known config has no userinfo_endpoint', async () => {
+        test('returns jwt_payload when well-known config has no userinfo_endpoint', async () => {
             mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync.mockResolvedValue({
                 jwks_uri: 'http://jwks.example.com'
             });
 
-            const jwt_payload = { iss: 'issuer1', cid: 'cid1', sub: 'sub1', scope: 'user/*.read' };
+            const jwt_payload = { iss: 'issuer1', cid: 'cid1', sub: 'sub1' };
             const result = await authService.getUserInfoFromUserInfoEndpoint({
                 jwt_payload,
                 token: 'my-token'
             });
 
-            expect(result).toEqual({ scope: 'user/*.read', isUser: false, username: null, subject: null, clientId: null });
+            expect(result).toBe(jwt_payload);
         });
 
         test('fetches user info and caches result', async () => {

--- a/src/tests/unit/strategies/authService.test.js
+++ b/src/tests/unit/strategies/authService.test.js
@@ -57,7 +57,6 @@ describe('AuthService', () => {
         Object.defineProperty(mockConfigManager, 'authCidCheckIssuer', { get: () => '', configurable: true });
         Object.defineProperty(mockConfigManager, 'authCidCheckClientIds', { get: () => [], configurable: true });
         Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => false, configurable: true });
-        Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', { get: () => [], configurable: true });
 
         mockWellKnownConfigManager = createMockInstance(WellKnownConfigurationManager);
         mockWellKnownConfigManager.getJwksUrlsAsync = jest.fn().mockResolvedValue([]);
@@ -495,19 +494,6 @@ describe('AuthService', () => {
         });
     });
 
-    describe('hasPatientOrPersonIdClaim', () => {
-        test.each([
-            [{ clientFhirPersonId: 'p1' }, true],
-            [{ clientFhirPatientId: 'p1' }, true],
-            [{ bwellFhirPersonId: 'p1' }, true],
-            [{ bwellFhirPatientId: 'p1' }, true],
-            [{}, false],
-            [{ sub: 'some-user' }, false]
-        ])('%o -> %s', (jwt_payload, expected) => {
-            expect(authService.hasPatientOrPersonIdClaim(jwt_payload)).toBe(expected);
-        });
-    });
-
     describe('getPropertiesFromPayload', () => {
         test('returns array of matching properties', () => {
             const result = authService.getPropertiesFromPayload({
@@ -609,89 +595,6 @@ describe('AuthService', () => {
     });
 
     describe('processUserInfo', () => {
-        // DCON-4882: reject tokens missing patient/person id claims from untrusted issuers
-        describe('non-patient token from untrusted issuer (DCON-4882)', () => {
-            test('is a no-op when the allowlist is empty (unconfigured environments)', () => {
-                const done = jest.fn();
-                authService.processUserInfo({
-                    username: 'svc', subject: undefined, isUser: false,
-                    jwt_payload: { iss: 'https://untrusted.example.com' },
-                    done, client_id: 'svc-client', scope: 'user/*.read'
-                });
-                expect(done).toHaveBeenCalledWith(
-                    null,
-                    expect.objectContaining({ id: 'svc-client' }),
-                    expect.any(Object)
-                );
-            });
-
-            test('rejects a token missing all patient/person id claims from a non-allowlisted issuer', () => {
-                Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', {
-                    get: () => ['https://trusted.example.com'], configurable: true
-                });
-                authService = new AuthService({
-                    configManager: mockConfigManager,
-                    wellKnownConfigurationManager: mockWellKnownConfigManager
-                });
-                const done = jest.fn();
-                authService.processUserInfo({
-                    username: 'svc', subject: undefined, isUser: false,
-                    jwt_payload: { iss: 'https://untrusted.example.com' },
-                    done, client_id: 'svc-client', scope: 'user/*.* access/*.*'
-                });
-                expect(done).toHaveBeenCalledWith(null, false, { reason: 'non_patient_token_from_untrusted_issuer' });
-            });
-
-            test('passes through when the issuer is on the allowlist', () => {
-                Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', {
-                    get: () => ['https://trusted.example.com'], configurable: true
-                });
-                authService = new AuthService({
-                    configManager: mockConfigManager,
-                    wellKnownConfigurationManager: mockWellKnownConfigManager
-                });
-                const done = jest.fn();
-                authService.processUserInfo({
-                    username: 'svc', subject: undefined, isUser: false,
-                    jwt_payload: { iss: 'https://trusted.example.com' },
-                    done, client_id: 'svc-client', scope: 'user/*.* access/*.*'
-                });
-                expect(done).toHaveBeenCalledWith(
-                    null,
-                    expect.objectContaining({ id: 'svc-client' }),
-                    expect.any(Object)
-                );
-            });
-
-            test('passes through when the token has a patient/person id claim, regardless of issuer', () => {
-                Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', {
-                    get: () => ['https://trusted.example.com'], configurable: true
-                });
-                authService = new AuthService({
-                    configManager: mockConfigManager,
-                    wellKnownConfigurationManager: mockWellKnownConfigManager
-                });
-                const done = jest.fn();
-                authService.processUserInfo({
-                    username: 'testuser', subject: 'sub1', isUser: true,
-                    jwt_payload: {
-                        iss: 'https://untrusted.example.com',
-                        clientFhirPersonId: 'person-1',
-                        clientFhirPatientId: 'patient-1',
-                        bwellFhirPersonId: 'bwell-person-1',
-                        bwellFhirPatientId: 'bwell-patient-1',
-                        sub: 'subject-1'
-                    },
-                    done, client_id: 'client1', scope: 'patient/Patient.read'
-                });
-                expect(done).toHaveBeenCalledWith(
-                    null,
-                    expect.objectContaining({ id: 'client1' }),
-                    expect.any(Object)
-                );
-            });
-        });
-
         test('calls done with user info for non-user token', () => {
             const done = jest.fn();
             authService.processUserInfo({
@@ -1216,7 +1119,6 @@ describe('AuthService', () => {
             expect(user).toBeUndefined();
             expect(info).toBeUndefined();
         });
-
     });
 
     describe('getUserInfoFromUserInfoEndpoint', () => {

--- a/src/tests/unit/strategies/authService.test.js
+++ b/src/tests/unit/strategies/authService.test.js
@@ -57,6 +57,7 @@ describe('AuthService', () => {
         Object.defineProperty(mockConfigManager, 'authCidCheckIssuer', { get: () => '', configurable: true });
         Object.defineProperty(mockConfigManager, 'authCidCheckClientIds', { get: () => [], configurable: true });
         Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => false, configurable: true });
+        Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', { get: () => [], configurable: true });
 
         mockWellKnownConfigManager = createMockInstance(WellKnownConfigurationManager);
         mockWellKnownConfigManager.getJwksUrlsAsync = jest.fn().mockResolvedValue([]);
@@ -494,6 +495,19 @@ describe('AuthService', () => {
         });
     });
 
+    describe('hasPatientOrPersonIdClaim', () => {
+        test.each([
+            [{ clientFhirPersonId: 'p1' }, true],
+            [{ clientFhirPatientId: 'p1' }, true],
+            [{ bwellFhirPersonId: 'p1' }, true],
+            [{ bwellFhirPatientId: 'p1' }, true],
+            [{}, false],
+            [{ sub: 'some-user' }, false]
+        ])('%o -> %s', (jwt_payload, expected) => {
+            expect(authService.hasPatientOrPersonIdClaim(jwt_payload)).toBe(expected);
+        });
+    });
+
     describe('getPropertiesFromPayload', () => {
         test('returns array of matching properties', () => {
             const result = authService.getPropertiesFromPayload({
@@ -595,6 +609,89 @@ describe('AuthService', () => {
     });
 
     describe('processUserInfo', () => {
+        // DCON-4882: reject tokens missing patient/person id claims from untrusted issuers
+        describe('non-patient token from untrusted issuer (DCON-4882)', () => {
+            test('is a no-op when the allowlist is empty (unconfigured environments)', () => {
+                const done = jest.fn();
+                authService.processUserInfo({
+                    username: 'svc', subject: undefined, isUser: false,
+                    jwt_payload: { iss: 'https://untrusted.example.com' },
+                    done, client_id: 'svc-client', scope: 'user/*.read'
+                });
+                expect(done).toHaveBeenCalledWith(
+                    null,
+                    expect.objectContaining({ id: 'svc-client' }),
+                    expect.any(Object)
+                );
+            });
+
+            test('rejects a token missing all patient/person id claims from a non-allowlisted issuer', () => {
+                Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', {
+                    get: () => ['https://trusted.example.com'], configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const done = jest.fn();
+                authService.processUserInfo({
+                    username: 'svc', subject: undefined, isUser: false,
+                    jwt_payload: { iss: 'https://untrusted.example.com' },
+                    done, client_id: 'svc-client', scope: 'user/*.* access/*.*'
+                });
+                expect(done).toHaveBeenCalledWith(null, false, { reason: 'non_patient_token_from_untrusted_issuer' });
+            });
+
+            test('passes through when the issuer is on the allowlist', () => {
+                Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', {
+                    get: () => ['https://trusted.example.com'], configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const done = jest.fn();
+                authService.processUserInfo({
+                    username: 'svc', subject: undefined, isUser: false,
+                    jwt_payload: { iss: 'https://trusted.example.com' },
+                    done, client_id: 'svc-client', scope: 'user/*.* access/*.*'
+                });
+                expect(done).toHaveBeenCalledWith(
+                    null,
+                    expect.objectContaining({ id: 'svc-client' }),
+                    expect.any(Object)
+                );
+            });
+
+            test('passes through when the token has a patient/person id claim, regardless of issuer', () => {
+                Object.defineProperty(mockConfigManager, 'allowedNonPatientTokenIssuers', {
+                    get: () => ['https://trusted.example.com'], configurable: true
+                });
+                authService = new AuthService({
+                    configManager: mockConfigManager,
+                    wellKnownConfigurationManager: mockWellKnownConfigManager
+                });
+                const done = jest.fn();
+                authService.processUserInfo({
+                    username: 'testuser', subject: 'sub1', isUser: true,
+                    jwt_payload: {
+                        iss: 'https://untrusted.example.com',
+                        clientFhirPersonId: 'person-1',
+                        clientFhirPatientId: 'patient-1',
+                        bwellFhirPersonId: 'bwell-person-1',
+                        bwellFhirPatientId: 'bwell-patient-1',
+                        sub: 'subject-1'
+                    },
+                    done, client_id: 'client1', scope: 'patient/Patient.read'
+                });
+                expect(done).toHaveBeenCalledWith(
+                    null,
+                    expect.objectContaining({ id: 'client1' }),
+                    expect.any(Object)
+                );
+            });
+        });
+
         test('calls done with user info for non-user token', () => {
             const done = jest.fn();
             authService.processUserInfo({
@@ -1119,6 +1216,7 @@ describe('AuthService', () => {
             expect(user).toBeUndefined();
             expect(info).toBeUndefined();
         });
+
     });
 
     describe('getUserInfoFromUserInfoEndpoint', () => {

--- a/src/tests/unit/utils/configManager.test.js
+++ b/src/tests/unit/utils/configManager.test.js
@@ -209,16 +209,6 @@ describe('ConfigManager', () => {
         });
 
         // DCON-4882
-        test('restrictNonPatientScopeForPatientTokens defaults to false when not set', () => {
-            delete process.env.AUTH_RESTRICT_NON_PATIENT_SCOPE_FOR_PATIENT_TOKENS;
-            expect(new ConfigManager().restrictNonPatientScopeForPatientTokens).toBe(false);
-        });
-
-        test('restrictNonPatientScopeForPatientTokens returns true when set', () => {
-            process.env.AUTH_RESTRICT_NON_PATIENT_SCOPE_FOR_PATIENT_TOKENS = '1';
-            expect(new ConfigManager().restrictNonPatientScopeForPatientTokens).toBe(true);
-        });
-
         test('allowedNonPatientTokenIssuers returns empty array when not set', () => {
             delete process.env.AUTH_ALLOWED_NON_PATIENT_TOKEN_ISSUERS;
             expect(new ConfigManager().allowedNonPatientTokenIssuers).toEqual([]);

--- a/src/tests/unit/utils/configManager.test.js
+++ b/src/tests/unit/utils/configManager.test.js
@@ -218,6 +218,18 @@ describe('ConfigManager', () => {
             process.env.AUTH_RESTRICT_NON_PATIENT_SCOPE_FOR_PATIENT_TOKENS = '1';
             expect(new ConfigManager().restrictNonPatientScopeForPatientTokens).toBe(true);
         });
+
+        test('allowedNonPatientTokenIssuers returns empty array when not set', () => {
+            delete process.env.AUTH_ALLOWED_NON_PATIENT_TOKEN_ISSUERS;
+            expect(new ConfigManager().allowedNonPatientTokenIssuers).toEqual([]);
+        });
+
+        test('allowedNonPatientTokenIssuers splits comma-separated issuers', () => {
+            process.env.AUTH_ALLOWED_NON_PATIENT_TOKEN_ISSUERS = 'https://a.example.com, https://b.example.com';
+            expect(new ConfigManager().allowedNonPatientTokenIssuers).toEqual([
+                'https://a.example.com', 'https://b.example.com'
+            ]);
+        });
     });
 
     // ========== supportLegacyIds ==========

--- a/src/tests/unit/utils/configManager.test.js
+++ b/src/tests/unit/utils/configManager.test.js
@@ -207,19 +207,6 @@ describe('ConfigManager', () => {
             process.env.AUTH_CID_CHECK_CLIENT_IDS = 'cid1,cid2';
             expect(new ConfigManager().authCidCheckClientIds).toEqual(['cid1', 'cid2']);
         });
-
-        // DCON-4882
-        test('allowedNonPatientTokenIssuers returns empty array when not set', () => {
-            delete process.env.AUTH_ALLOWED_NON_PATIENT_TOKEN_ISSUERS;
-            expect(new ConfigManager().allowedNonPatientTokenIssuers).toEqual([]);
-        });
-
-        test('allowedNonPatientTokenIssuers splits comma-separated issuers', () => {
-            process.env.AUTH_ALLOWED_NON_PATIENT_TOKEN_ISSUERS = 'https://a.example.com, https://b.example.com';
-            expect(new ConfigManager().allowedNonPatientTokenIssuers).toEqual([
-                'https://a.example.com', 'https://b.example.com'
-            ]);
-        });
     });
 
     // ========== supportLegacyIds ==========

--- a/src/tests/unit/utils/configManager.test.js
+++ b/src/tests/unit/utils/configManager.test.js
@@ -207,6 +207,17 @@ describe('ConfigManager', () => {
             process.env.AUTH_CID_CHECK_CLIENT_IDS = 'cid1,cid2';
             expect(new ConfigManager().authCidCheckClientIds).toEqual(['cid1', 'cid2']);
         });
+
+        // DCON-4882
+        test('restrictNonPatientScopeForPatientTokens defaults to false when not set', () => {
+            delete process.env.AUTH_RESTRICT_NON_PATIENT_SCOPE_FOR_PATIENT_TOKENS;
+            expect(new ConfigManager().restrictNonPatientScopeForPatientTokens).toBe(false);
+        });
+
+        test('restrictNonPatientScopeForPatientTokens returns true when set', () => {
+            process.env.AUTH_RESTRICT_NON_PATIENT_SCOPE_FOR_PATIENT_TOKENS = '1';
+            expect(new ConfigManager().restrictNonPatientScopeForPatientTokens).toBe(true);
+        });
     });
 
     // ========== supportLegacyIds ==========

--- a/src/tests/unit/utils/configManager.test.js
+++ b/src/tests/unit/utils/configManager.test.js
@@ -207,6 +207,19 @@ describe('ConfigManager', () => {
             process.env.AUTH_CID_CHECK_CLIENT_IDS = 'cid1,cid2';
             expect(new ConfigManager().authCidCheckClientIds).toEqual(['cid1', 'cid2']);
         });
+
+        // DCON-4882
+        test('allowedNonPatientTokenIssuers returns empty array when not set', () => {
+            delete process.env.AUTH_ALLOWED_NON_PATIENT_TOKEN_ISSUERS;
+            expect(new ConfigManager().allowedNonPatientTokenIssuers).toEqual([]);
+        });
+
+        test('allowedNonPatientTokenIssuers splits comma-separated issuers', () => {
+            process.env.AUTH_ALLOWED_NON_PATIENT_TOKEN_ISSUERS = 'https://a.example.com, https://b.example.com';
+            expect(new ConfigManager().allowedNonPatientTokenIssuers).toEqual([
+                'https://a.example.com', 'https://b.example.com'
+            ]);
+        });
     });
 
     // ========== supportLegacyIds ==========

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -1004,19 +1004,6 @@ class ConfigManager {
     }
 
     /**
-     * Issuers (JWT `iss`) allowed to present a token that carries no patient/person id claim
-     * (clientFhirPersonId, clientFhirPatientId, bwellFhirPersonId, bwellFhirPatientId). A token
-     * missing all four of these claims, from any issuer NOT in this list, is rejected outright --
-     * this guards against an identity provider accidentally issuing a token that isn't anchored to
-     * a patient/person at all. Empty (the default) means no restriction, so environments that do
-     * not set it are unchanged. See DCON-4882.
-     * @returns {string[]}
-     */
-    get allowedNonPatientTokenIssuers() {
-        return this._parseCommaSeparatedList(env.AUTH_ALLOWED_NON_PATIENT_TOKEN_ISSUERS, []);
-    }
-
-    /**
      * Allowlisted purposeOfUse codes parsed from CMS_ALLOWED_PURPOSE_OF_USE env var.
      * @returns {Set<string>}
      */

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -1004,6 +1004,20 @@ class ConfigManager {
     }
 
     /**
+     * When true, a token carrying a patient/person id claim has its wildcard non-patient scopes
+     * (user/*.*, access/*.*) stripped, regardless of what the token's own scope claims. A real
+     * client-credentials grant has no authenticated end user, so it can never carry these claims --
+     * their presence means a real person is behind the token, and a real person should never also
+     * hold unrestricted tenant-wide read access via a wildcard scope, no matter what an upstream
+     * identity provider happened to grant. Defaults to false (unset = unchanged behavior). See
+     * DCON-4882.
+     * @returns {boolean}
+     */
+    get restrictNonPatientScopeForPatientTokens() {
+        return isTrue(env.AUTH_RESTRICT_NON_PATIENT_SCOPE_FOR_PATIENT_TOKENS);
+    }
+
+    /**
      * Allowlisted purposeOfUse codes parsed from CMS_ALLOWED_PURPOSE_OF_USE env var.
      * @returns {Set<string>}
      */

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -1004,20 +1004,6 @@ class ConfigManager {
     }
 
     /**
-     * When true, a token carrying a patient/person id claim has its wildcard non-patient scopes
-     * (user/*.*, access/*.*) stripped, regardless of what the token's own scope claims. A real
-     * client-credentials grant has no authenticated end user, so it can never carry these claims --
-     * their presence means a real person is behind the token, and a real person should never also
-     * hold unrestricted tenant-wide read access via a wildcard scope, no matter what an upstream
-     * identity provider happened to grant. Defaults to false (unset = unchanged behavior). See
-     * DCON-4882.
-     * @returns {boolean}
-     */
-    get restrictNonPatientScopeForPatientTokens() {
-        return isTrue(env.AUTH_RESTRICT_NON_PATIENT_SCOPE_FOR_PATIENT_TOKENS);
-    }
-
-    /**
      * Issuers (JWT `iss`) allowed to present a token that carries no patient/person id claim
      * (clientFhirPersonId, clientFhirPatientId, bwellFhirPersonId, bwellFhirPatientId). A token
      * missing all four of these claims, from any issuer NOT in this list, is rejected outright --

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -1004,6 +1004,19 @@ class ConfigManager {
     }
 
     /**
+     * Issuers (JWT `iss`) allowed to present a token that carries no patient/person id claim
+     * (clientFhirPersonId, clientFhirPatientId, bwellFhirPersonId, bwellFhirPatientId). A token
+     * missing all four of these claims, from any issuer NOT in this list, is rejected outright --
+     * this guards against an identity provider accidentally issuing a token that isn't anchored to
+     * a patient/person at all. Empty (the default) means no restriction, so environments that do
+     * not set it are unchanged. See DCON-4882.
+     * @returns {string[]}
+     */
+    get allowedNonPatientTokenIssuers() {
+        return this._parseCommaSeparatedList(env.AUTH_ALLOWED_NON_PATIENT_TOKEN_ISSUERS, []);
+    }
+
+    /**
      * Allowlisted purposeOfUse codes parsed from CMS_ALLOWED_PURPOSE_OF_USE env var.
      * @returns {Set<string>}
      */

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -1018,6 +1018,19 @@ class ConfigManager {
     }
 
     /**
+     * Issuers (JWT `iss`) allowed to present a token that carries no patient/person id claim
+     * (clientFhirPersonId, clientFhirPatientId, bwellFhirPersonId, bwellFhirPatientId). A token
+     * missing all four of these claims, from any issuer NOT in this list, is rejected outright --
+     * this guards against an identity provider accidentally issuing a token that isn't anchored to
+     * a patient/person at all. Empty (the default) means no restriction, so environments that do
+     * not set it are unchanged. See DCON-4882.
+     * @returns {string[]}
+     */
+    get allowedNonPatientTokenIssuers() {
+        return this._parseCommaSeparatedList(env.AUTH_ALLOWED_NON_PATIENT_TOKEN_ISSUERS, []);
+    }
+
+    /**
      * Allowlisted purposeOfUse codes parsed from CMS_ALLOWED_PURPOSE_OF_USE env var.
      * @returns {Set<string>}
      */


### PR DESCRIPTION
## Summary

Reopened, reinstating the `AUTH_ALLOWED_NON_PATIENT_TOKEN_ISSUERS` mechanism per Imran's explicit design (Slack, Aug 7): "if idp not in list of env var idps that are allowed non-patient tokens and token is missing the patient/person id fields then reject token" — "not to change the behavior of the tokens" (no scope stripping, reject-only).

**Why this lives in fhir-server rather than at the issuer:** Mintu's point that this is the issuer's (BIG's) responsibility is architecturally correct — trust boundaries at `EXTERNAL_AUTH_JWKS_URLS`/`AUTH_JWKS_URL` should ideally mean each trusted issuer always mints an appropriate token. But enforcing "never issue a token with no patient/person anchor" on BIG's side directly is difficult to do right now. This check is the pragmatic, shippable safeguard in the meantime, not a claim that fhir-server is the right long-term owner of this rule.

Accept patient/person-id-bearing tokens as-is; reject only a token carrying **none** of the four patient/person id claims (`clientFhirPersonId`, `clientFhirPatientId`, `bwellFhirPersonId`, `bwellFhirPatientId`) when its issuer is not on the allowlist. BIG's issuer is explicitly **not** meant to be on this list (so a claim-less BIG token is rejected); Okta and client-credentials issuers are meant to be on it (unaffected).

**Open disagreement, not yet resolved — flagging explicitly rather than papering over it:** Mintu formally requested changes on this exact mechanism (see the reopened thread below). Reinstated per direct instruction reflecting Imran's stated design intent. The "should this live in fhir-server or at the issuer" question is answered above (practicality, not disagreement on ideal ownership) — but that hasn't yet been confirmed as resolving Mintu's objection; needs his explicit sign-off before merge.

Also unchanged from before: this does **not** restrict a token that already carries a patient/person id claim *alongside* a wildcard `user/*.*`/`access/*.*` scope — it does not close Mintu's originally demonstrated exploit (that token has a patient id).

## Changes

- `src/utils/configManager.js`: `allowedNonPatientTokenIssuers` (`AUTH_ALLOWED_NON_PATIENT_TOKEN_ISSUERS`). Empty/unset = no restriction.
- `src/strategies/authService.js`: `hasPatientOrPersonIdClaim()`; `processUserInfo()` rejects with `{reason: 'non_patient_token_from_untrusted_issuer'}` when configured, the claim is absent, and the issuer isn't allowlisted. Runs against the original, never-merged `jwt_payload`.

## Test plan

- [x] Unit tests: config getter, `hasPatientOrPersonIdClaim`, `processUserInfo` (no-op when unconfigured; rejects claim-less token from non-allowlisted issuer; passes through for allowlisted issuer; passes through for any issuer when a patient/person claim is present).
- [x] Full unit suite — no regressions vs. `main`.
- [x] Lint clean.

## Links
- Jira: [DCON-4882](https://icanbwell.atlassian.net/browse/DCON-4882)

[DCON-4882]: https://icanbwell.atlassian.net/browse/DCON-4882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ