### PR TITLE
BAI-218 implement orchestrator byte-range splitting and event publishing

### DIFF
--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -36,8 +36,8 @@ const BULK_IMPORT_RANGE_COMPLETED_EXTENSION_URL = 'https://www.icanbwell.com/bul
  * src/operations/asyncJobs/worker.js (topic fhir_server.bulk_import.events) route into this
  * same handler; handleMessageAsync dispatches on the CloudEvent "type" rather than the topic,
  * since a single job's messages can arrive on more than one topic:
- * - TaskCreated: validates S3 inputs and will publish ImportRangeRequested events (byte-range
- *   splitting is a follow-up — see the TODO in handleTaskCreatedAsync).
+ * - TaskCreated: HEADs each S3 input to validate it and get its size, splits it into byte
+ *   ranges, and publishes an ImportRangeRequested event per range.
  * - ImportRangeRequested: reads a byte range's NDJSON, merges resources, writes result/error
  *   output to S3, and records completion on the Task.
  */
@@ -273,40 +273,33 @@ class BulkImportHandler {
             user
         });
 
-        // TODO: S3 HEAD validation and byte-range splitting will be added in a follow-up PR.
-        // The orchestrator will:
-        // 1. Load the Task resource
-        // 2. HEAD each S3 file to get sizes and validate
-        // 3. Split files into byte ranges
-        // 4. Publish ImportRangeRequested events for each range
-        //
-        // const task = await this.loadTaskAsync(taskId);
-        // if (!task) {
-        //     logError('Task not found for orchestrator message', { taskId });
-        //     return;
-        // }
-        //
-        // let inputsWithSizes;
-        // try {
-        //     inputsWithSizes = await this.headS3FilesAsync(inputs);
-        // } catch (e) {
-        //     logError('S3 validation failed for import task', { taskId, error: e.message });
-        //     await this.updateOrchestratorTaskStatusAsync(task, 'failed', e.message);
-        //     return;
-        // }
-        //
-        // const messageCount = await this.bulkImportEventProducer.publishImportEventsAsync({
-        //     taskId,
-        //     inputs: inputsWithSizes,
-        //     requestId,
-        //     scope,
-        //     user
-        // });
-        //
-        // logInfo('Orchestrator published byte-range messages', {
-        //     taskId,
-        //     messageCount
-        // });
+        const task = await this.loadTaskAsync(taskId);
+        if (!task) {
+            logError('Task not found for orchestrator message', { taskId });
+            return;
+        }
+
+        let inputsWithSizes;
+        try {
+            inputsWithSizes = await this.headS3FilesAsync(inputs);
+        } catch (e) {
+            logError('S3 validation failed for import task', { taskId, error: e.message });
+            await this.updateOrchestratorTaskStatusAsync(task, 'failed', e.message);
+            return;
+        }
+
+        const messageCount = await this.bulkImportEventProducer.publishImportEventsAsync({
+            taskId,
+            inputs: inputsWithSizes,
+            requestId,
+            scope,
+            user
+        });
+
+        logInfo('Orchestrator published byte-range messages', {
+            taskId,
+            messageCount
+        });
     }
 
     // ── ImportRangeRequested (worker side, topic fhir_server.bulk_import.events) ───────────

--- a/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
@@ -57,21 +57,52 @@ function createMockConfigManager(overrides = {}) {
 }
 
 /**
- * Creates a BulkImportHandler with mock dependencies.
+ * Creates a mock Task resource with a working clone() (needed by
+ * updateOrchestratorTaskStatusAsync).
+ * @param {Object} [overrides]
+ */
+function createMockTask(overrides = {}) {
+    const task = {
+        resourceType: 'Task',
+        id: 'task-abc-123',
+        status: 'requested',
+        meta: { lastUpdated: '2026-01-01T00:00:00.000Z' },
+        ...overrides
+    };
+    task.clone = jestGlobal.fn(() => ({ ...task }));
+    return task;
+}
+
+/**
+ * Creates a BulkImportHandler with mock dependencies. Defaults simulate the happy path
+ * (Task found, S3 HEAD succeeds via the outer beforeEach's mockSend, events published) so
+ * individual tests only need to override what's actually relevant to them.
  * @param {Object} [configOverrides] - ConfigManager overrides
+ * @param {Object} [depsOverrides] - Constructor dependency overrides (e.g. databaseQueryFactory)
  * @returns {BulkImportHandler}
  */
-function createHandler(configOverrides = {}) {
+function createHandler(configOverrides = {}, depsOverrides = {}) {
     return new BulkImportHandler({
         configManager: createMockConfigManager(configOverrides),
         kafkaClientV2: {},
-        bulkImportEventProducer: {},
-        databaseQueryFactory: { createQuery: jestGlobal.fn() },
-        databaseUpdateFactory: { createDatabaseUpdateManager: jestGlobal.fn() },
+        bulkImportEventProducer: {
+            publishImportEventsAsync: jestGlobal.fn().mockResolvedValue(1)
+        },
+        databaseQueryFactory: {
+            createQuery: jestGlobal.fn(() => ({
+                findOneAsync: jestGlobal.fn().mockResolvedValue(createMockTask())
+            }))
+        },
+        databaseUpdateFactory: {
+            createDatabaseUpdateManager: jestGlobal.fn(() => ({
+                updateOneAsync: jestGlobal.fn().mockResolvedValue(undefined)
+            }))
+        },
         fastDatabaseBulkInserter: {},
         s3NdjsonReader: {},
         postRequestProcessor: {},
-        requestSpecificCache: {}
+        requestSpecificCache: {},
+        ...depsOverrides
     });
 }
 
@@ -101,6 +132,9 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
     beforeEach(() => {
         jestGlobal.clearAllMocks();
         mockSend.mockReset();
+        // Default happy-path S3 HEAD response (10 MB) -- the headS3FilesAsync describe
+        // block below overrides this per-test via its own nested beforeEach/tests.
+        mockSend.mockResolvedValue({ ContentLength: 10 * 1024 * 1024 });
         handler = createHandler();
     });
 
@@ -486,6 +520,101 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
                 expect.objectContaining({
                     scope: 'system/*.*',
                     user: 'admin/superuser'
+                })
+            );
+        });
+    });
+
+    // =========================================================================
+    // handleTaskCreatedAsync: byte-range splitting and publishing
+    // =========================================================================
+    describe('handleTaskCreatedAsync range publishing', () => {
+        test('HEADs S3 inputs, publishes range messages, and logs the count', async () => {
+            const publishImportEventsAsync = jestGlobal.fn().mockResolvedValue(3);
+            handler = createHandler({}, {
+                bulkImportEventProducer: { publishImportEventsAsync }
+            });
+
+            const message = {
+                key: 'task-abc-123',
+                value: createTaskCreatedMessage({
+                    taskId: 'task-abc-123',
+                    inputs: [{ url: 's3://allowed-bucket/data/patients.ndjson' }],
+                    requestId: 'req-001',
+                    scope: 'system/*.read',
+                    user: 'practitioner/dr-smith'
+                }),
+                headers: []
+            };
+
+            await handler.handleMessageAsync(message);
+
+            expect(publishImportEventsAsync).toHaveBeenCalledWith({
+                taskId: 'task-abc-123',
+                inputs: [{ url: 's3://allowed-bucket/data/patients.ndjson', fileSize: 10 * 1024 * 1024 }],
+                requestId: 'req-001',
+                scope: 'system/*.read',
+                user: 'practitioner/dr-smith'
+            });
+            expect(logInfo).toHaveBeenCalledWith(
+                'Orchestrator published byte-range messages',
+                expect.objectContaining({ taskId: 'task-abc-123', messageCount: 3 })
+            );
+        });
+
+        test('logs and returns without publishing when the Task cannot be found', async () => {
+            const publishImportEventsAsync = jestGlobal.fn().mockResolvedValue(1);
+            handler = createHandler({}, {
+                bulkImportEventProducer: { publishImportEventsAsync },
+                databaseQueryFactory: {
+                    createQuery: jestGlobal.fn(() => ({
+                        findOneAsync: jestGlobal.fn().mockResolvedValue(null)
+                    }))
+                }
+            });
+
+            const message = {
+                key: 'task-missing',
+                value: createTaskCreatedMessage({ taskId: 'task-missing' }),
+                headers: []
+            };
+
+            await handler.handleMessageAsync(message);
+
+            expect(logError).toHaveBeenCalledWith(
+                'Task not found for orchestrator message',
+                { taskId: 'task-missing' }
+            );
+            expect(publishImportEventsAsync).not.toHaveBeenCalled();
+        });
+
+        test('marks the Task failed and does not publish when S3 validation fails', async () => {
+            mockSend.mockRejectedValue(Object.assign(new Error('NotFound'), { name: 'NotFound' }));
+            const publishImportEventsAsync = jestGlobal.fn().mockResolvedValue(1);
+            const updateOneAsync = jestGlobal.fn().mockResolvedValue(undefined);
+            handler = createHandler({}, {
+                bulkImportEventProducer: { publishImportEventsAsync },
+                databaseUpdateFactory: {
+                    createDatabaseUpdateManager: jestGlobal.fn(() => ({ updateOneAsync }))
+                }
+            });
+
+            const message = {
+                key: 'task-bad-s3',
+                value: createTaskCreatedMessage({ taskId: 'task-bad-s3' }),
+                headers: []
+            };
+
+            await handler.handleMessageAsync(message);
+
+            expect(logError).toHaveBeenCalledWith(
+                'S3 validation failed for import task',
+                expect.objectContaining({ taskId: 'task-bad-s3' })
+            );
+            expect(publishImportEventsAsync).not.toHaveBeenCalled();
+            expect(updateOneAsync).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    doc: expect.objectContaining({ status: 'failed' })
                 })
             );
         });


### PR DESCRIPTION
## Summary
- Wires up `handleTaskCreatedAsync`'s previously-stubbed logic (`src/operations/asyncJobs/bulkImport/handler.js`): load the Task, HEAD each S3 input via `headS3FilesAsync` to validate it and get its size, then publish one `ImportRangeRequested` event per byte range via `BulkImportEventProducer.publishImportEventsAsync`.
- Both of those pieces already existed and were fully implemented/unit-tested — this just calls them, replacing the commented-out TODO block that already sketched out the exact same plan.
- On S3 validation failure, the Task is marked `failed` with the error as `statusReason` (same as the original plan).
- No changes to the worker side (`handleImportRangeRequestedAsync`), which was already fully built and is what will now actually receive traffic once this merges.

This closes the last gap identified in the bulk-import pipeline: `POST /$import` → Task created → `TaskCreated` published → orchestrator consumes → **(this PR: HEAD + split + publish)** → worker consumes ranges → writes to Mongo → result/error output to S3 → Task completed. Verified via a live test `$import` call in dev that the pipeline correctly reaches the orchestrator; this PR is what lets it continue past that point.

## Test plan
- [x] New tests in `handlerOrchestrator.test.js`: happy path (HEADs inputs, publishes range messages, logs count with correct enriched `inputs`), Task-not-found (logs and returns without publishing), S3-validation-failure (logs, marks Task failed, does not publish)
- [x] All 32 pre-existing tests in the same file still pass unchanged with real dependency wiring (previously they used no-op/stub mocks since this code path never ran)
- [x] Full `asyncJobs`/`bulkImport` suite passes (156 tests)
- [x] Lint clean