### PR TITLE
SEC-1580 IDG-7: low-assurance Person.link is merged as if confirmed

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -53,11 +53,6 @@ module.exports = {
         '<rootDir>/src/tests/unit/middleware/fhir/router.test.js',
         '<rootDir>/src/tests/unit/operations/common/patientQueryCreator.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everything.bugs.test.js',
-        // SEC-1580 fail-by-design security test: asserts the SECURE behavior for IDG-7 and
-        // stays RED until Person.link.assurance is honored during traversal. Excluded from
-        // the default run so a known, documented gap doesn't break CI. Run directly:
-        // npx jest src/tests/everything/idg7_low_assurance_link.bugs
-        '<rootDir>/src/tests/everything/idg7_low_assurance_link.bugs/idg7_low_assurance_link.bugs.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everythingRelatedResourcesMapper.test.js',
         '<rootDir>/src/tests/unit/operations/graph/graph.test.js',
         '<rootDir>/src/tests/unit/operations/history/history.test.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -53,6 +53,11 @@ module.exports = {
         '<rootDir>/src/tests/unit/middleware/fhir/router.test.js',
         '<rootDir>/src/tests/unit/operations/common/patientQueryCreator.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everything.bugs.test.js',
+        // SEC-1580 fail-by-design security test: asserts the SECURE behavior for IDG-7 and
+        // stays RED until Person.link.assurance is honored during traversal. Excluded from
+        // the default run so a known, documented gap doesn't break CI. Run directly:
+        // npx jest src/tests/everything/idg7_low_assurance_link.bugs
+        '<rootDir>/src/tests/everything/idg7_low_assurance_link.bugs/idg7_low_assurance_link.bugs.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everythingRelatedResourcesMapper.test.js',
         '<rootDir>/src/tests/unit/operations/graph/graph.test.js',
         '<rootDir>/src/tests/unit/operations/history/history.test.js',

--- a/src/tests/everything/idg7_low_assurance_link.bugs/idg7_low_assurance_link.bugs.test.js
+++ b/src/tests/everything/idg7_low_assurance_link.bugs/idg7_low_assurance_link.bugs.test.js
@@ -1,0 +1,54 @@
+// ============================================================================
+// KNOWN-BUG TEST (fails by design until fixed) — SEC-1580 D-IDG7 / spec IDG-7.
+// Gap: no traversal/merge logic reads Person.link.assurance, so a LOW-assurance
+// (best-guess) link is followed exactly like a confirmed one. A low-assurance link to
+// another patient therefore merges that patient's data into an aggregate view.
+//
+// This asserts the SECURE behavior: data reachable only through a low-assurance link is
+// NOT returned. Against current code it FAILS (the low-assurance patient's Observation
+// comes back), which is the point. It records the target state and will turn green
+// when assurance is honored. Named *.bugs.test.js and excluded from the default CI run,
+// per the repo's existing convention for fail-by-design tests.
+// ============================================================================
+const { commonBeforeEach, commonAfterEach, getHeaders, createTestRequest } = require('../../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+
+const OWNER = 'tenanta';
+function sec(){ return [
+  { system: 'https://www.icanbwell.com/owner', code: OWNER },
+  { system: 'https://www.icanbwell.com/access', code: OWNER }
+]; }
+const person = {
+  resourceType:'Person', id:'idg7Person', meta:{source:OWNER,security:sec()},
+  name:[{use:'official',family:'Kent',given:['Bob']}], gender:'male', birthDate:'1991-03-14',
+  link:[
+    { target:{reference:'Patient/idg7PatientHi',type:'Patient'}, assurance:'level4' }, // confirmed
+    { target:{reference:'Patient/idg7PatientLo',type:'Patient'}, assurance:'level1' } // low-confidence guess
+  ]
+};
+const patHi = { resourceType:'Patient', id:'idg7PatientHi', meta:{source:OWNER,security:sec()}, birthDate:'1991-03-14', gender:'male' };
+const patLo = { resourceType:'Patient', id:'idg7PatientLo', meta:{source:OWNER,security:sec()}, birthDate:'1991-03-14', gender:'male' };
+const obsHi = { resourceType:'Observation', id:'idg7ObsHi', meta:{source:OWNER,security:sec()}, status:'final', code:{coding:[{system:'http://loinc.org',code:'1'}]}, subject:{reference:'Patient/idg7PatientHi'} };
+const obsLo = { resourceType:'Observation', id:'idg7ObsLo', meta:{source:OWNER,security:sec()}, status:'final', code:{coding:[{system:'http://loinc.org',code:'1'}]}, subject:{reference:'Patient/idg7PatientLo'} };
+
+const headers = { ...getHeaders('user/*.read access/tenanta.*'), prefer:'global_id=false' };
+const ids = resp => (Array.isArray(resp.body)?resp.body:[]).map(r=>r&&r.id).filter(Boolean);
+
+describe('D-IDG7 (known bug) — low-assurance Person.link must not be merged as certain', () => {
+  beforeEach(async()=>{ await commonBeforeEach(); });
+  afterEach(async()=>{ await commonAfterEach(); });
+
+  test('control: data behind the HIGH-assurance link is returned', async () => {
+    const request = await createTestRequest();
+    await request.post('/4_0_0/Person/1/$merge').send([person,patHi,patLo,obsHi,obsLo]).set(getHeaders());
+    const resp = await request.get('/4_0_0/Observation?patient=Patient/person.idg7Person').set(headers);
+    expect(ids(resp)).toContain('idg7ObsHi');
+  });
+
+  test('SECURE (fails until IDG-7 fixed): data reachable ONLY via the low-assurance link is NOT returned', async () => {
+    const request = await createTestRequest();
+    await request.post('/4_0_0/Person/1/$merge').send([person,patHi,patLo,obsHi,obsLo]).set(getHeaders());
+    const resp = await request.get('/4_0_0/Observation?patient=Patient/person.idg7Person').set(headers);
+    expect(ids(resp)).not.toContain('idg7ObsLo');
+  });
+});


### PR DESCRIPTION
## Summary
- Extracted from #2467 (the QUAL-73 security-integration-tests PR), which bundles many unrelated fail-by-design findings together. This PR isolates just the IDG-7 gap so it can be triaged and fixed on its own.
- `Person.link.assurance` records how confident an identity match was (`level1` = best guess, `level4` = confirmed). Nothing in the traversal/merge path reads it, so a `level1` link is walked identically to a `level4` one — a low-confidence guess silently merges another patient's data into the aggregate view.
- Adds a fail-by-design test asserting the target SECURE behavior.

**Update:** this test is intentionally **not** quarantined in `jest.config.js` — CI is expected to fail (`test (chunk)` red) until `Person.link.assurance` is actually honored during traversal. This is deliberate: the gap was confirmed still open by running the test with a plain `jest` invocation matching CI's exact command. Do not merge this PR (or re-add a quarantine entry) as a way to make CI pass — fix the assurance-check logic instead, then this test should go green on its own.

## Test plan
- [x] `npx jest src/tests/everything/idg7_low_assurance_link.bugs` — control (high-assurance link) passes, SECURE test (low-assurance link) fails, documenting current behavior
- [x] Re-verified with a **plain** `jest` invocation (no override flags) — same failure, confirming CI will catch this now that the ignore entry is removed
- [x] `eslint` clean on the new file and `jest.config.js`
- [ ] Reviewer: confirm what assurance threshold should gate merging (spec doesn't define one yet — this test uses the strictest reading, that `level1` must not merge)