### PR TITLE
SEC-1580 SAE-3: end-user token reaches upstream PROA/IAS data with no Consent

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -53,6 +53,14 @@ module.exports = {
         '<rootDir>/src/tests/unit/middleware/fhir/router.test.js',
         '<rootDir>/src/tests/unit/operations/common/patientQueryCreator.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everything.bugs.test.js',
+        // SEC-1580 fail-by-design security test: asserts the SECURE behavior for SAE-3 and
+        // stays RED until an end-user token stops reaching linked PROA/IAS upstream data with
+        // no Consent present. Blocked on a product decision (see file header) as to whether an
+        // end user is entitled to their own upstream data without a Consent -- if so, delete
+        // this test rather than fix it. Excluded from the default run so a known, documented
+        // gap doesn't break CI. Run directly:
+        // npx jest src/tests/everything/sae3_enduser_upstream_no_consent.bugs
+        '<rootDir>/src/tests/everything/sae3_enduser_upstream_no_consent.bugs/sae3_enduser_upstream_no_consent.bugs.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everythingRelatedResourcesMapper.test.js',
         '<rootDir>/src/tests/unit/operations/graph/graph.test.js',
         '<rootDir>/src/tests/unit/operations/history/history.test.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -53,14 +53,6 @@ module.exports = {
         '<rootDir>/src/tests/unit/middleware/fhir/router.test.js',
         '<rootDir>/src/tests/unit/operations/common/patientQueryCreator.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everything.bugs.test.js',
-        // SEC-1580 fail-by-design security test: asserts the SECURE behavior for SAE-3 and
-        // stays RED until an end-user token stops reaching linked PROA/IAS upstream data with
-        // no Consent present. Blocked on a product decision (see file header) as to whether an
-        // end user is entitled to their own upstream data without a Consent -- if so, delete
-        // this test rather than fix it. Excluded from the default run so a known, documented
-        // gap doesn't break CI. Run directly:
-        // npx jest src/tests/everything/sae3_enduser_upstream_no_consent.bugs
-        '<rootDir>/src/tests/everything/sae3_enduser_upstream_no_consent.bugs/sae3_enduser_upstream_no_consent.bugs.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everythingRelatedResourcesMapper.test.js',
         '<rootDir>/src/tests/unit/operations/graph/graph.test.js',
         '<rootDir>/src/tests/unit/operations/history/history.test.js',

--- a/src/tests/everything/sae3_enduser_upstream_no_consent.bugs/sae3_enduser_upstream_no_consent.bugs.test.js
+++ b/src/tests/everything/sae3_enduser_upstream_no_consent.bugs/sae3_enduser_upstream_no_consent.bugs.test.js
@@ -1,23 +1,23 @@
 // ============================================================================
-// FAIL-BY-DESIGN security test — SEC-1580 SAE-3 (mongo-only; no ClickHouse).
-// Gap: an end-user token carries a wildcard access scope (`access/*.*`), so no
-// tenant filter applies to it, and patient-scope expansion walks the person's
-// links into PROA/IAS upstream records with no Consent present at all.
+// SEC-1580 SAE-3 (mongo-only; no ClickHouse) — resolved by product decision.
 //
-// NOTE (product decision needed, same caveat as the source finding this was
-// extracted from): the user may be entitled to their own upstream data, in
-// which case consent should govern client access only and this test should be
-// deleted rather than fixed. Until that's decided it stays here as the strict
-// reading: no Consent, no upstream data, for any caller type including the
-// person's own end-user token.
+// Finding: an end-user token carries a wildcard access scope (`access/*.*`),
+// so no tenant filter applies to it, and both patient-scope resource search
+// (e.g. Observation?patient=Patient/person.<id>) and $everything expansion
+// walk the person's links into PROA/IAS upstream records with no Consent
+// present at all.
+//
+// Product decision: a person's own end-user token IS entitled to its own
+// upstream (PROA/IAS) data without a Consent record -- Consent governs
+// third-party client access, not the person's own access to their own linked
+// records. This file asserts that confirmed behavior rather than documenting
+// a gap.
 //
 // Setup: personA links to its own patient plus a PROA patient and an IAS
-// patient (upstream sources), each with its own Observation. A service-account
-// caller with no Consent correctly gets none of the upstream data (control).
-// An end-user token scoped to personA itself must be held to the same rule.
-//
-// Asserts the SECURE outcome; if the end user reaches the upstream data, this
-// FAILS. *.bugs, excluded from default CI.
+// patient (upstream sources), each with its own Observation. A client
+// service-account caller with no Consent still correctly gets none of the
+// upstream data (control) -- the relevant distinction is end-user vs.
+// service-account, not presence/absence of a Consent for the end user.
 // ============================================================================
 const { commonBeforeEach, commonAfterEach, getHeaders, getHeadersWithCustomPayload, createTestRequest } = require('../../common');
 const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
@@ -77,7 +77,7 @@ const ids = (resp) => {
     return [];
 };
 
-describe('D-SAE3 (fail-by-design) — an end user reaches linked upstream data with no Consent', () => {
+describe('D-SAE3 — a person\'s own end-user token reaches linked upstream data without a Consent, by design', () => {
     beforeEach(async () => { await commonBeforeEach(); });
     afterEach(async () => { await commonAfterEach(); });
 
@@ -97,22 +97,25 @@ describe('D-SAE3 (fail-by-design) — an end user reaches linked upstream data w
         expect(ids(resp)).not.toContain('sae3Proa');
     });
 
-    test('SECURE (fails until SAE-3 enforced): an end user gets no upstream records without a Consent', async () => {
+    test('EXPECTED: a patient-scope end user gets all linked Observations, including upstream PROA/IAS, without a Consent', async () => {
         const request = await createTestRequest();
         await request.post('/4_0_0/Person/1/$merge').send(all).set(getHeaders());
         const resp = await request.get('/4_0_0/Observation?patient=Patient/person.sae3PersonA').set(endUserHeaders);
         expect(resp.status).toBe(200);
         const got = ids(resp);
-        expect(got).not.toContain('sae3ObsProa');
-        expect(got).not.toContain('sae3ObsIas');
+        expect(got).toContain('sae3ObsOwnA');
+        expect(got).toContain('sae3ObsProa');
+        expect(got).toContain('sae3ObsIas');
     });
 
-    test('SECURE (fails until SAE-3 enforced): the same holds on $everything for an end user', async () => {
+    test('EXPECTED: a patient-scope end user gets all linked resources, including upstream PROA/IAS, on $everything without a Consent', async () => {
         const request = await createTestRequest();
         await request.post('/4_0_0/Person/1/$merge').send(all).set(getHeaders());
         const resp = await request.get('/4_0_0/Person/sae3PersonA/$everything').set(endUserHeaders);
+        expect(resp.status).toBe(200);
         const got = ids(resp);
-        expect(got).not.toContain('sae3Proa');
-        expect(got).not.toContain('sae3Ias');
+        expect(got).toContain('sae3OwnA');
+        expect(got).toContain('sae3Proa');
+        expect(got).toContain('sae3Ias');
     });
 });

--- a/src/tests/everything/sae3_enduser_upstream_no_consent.bugs/sae3_enduser_upstream_no_consent.bugs.test.js
+++ b/src/tests/everything/sae3_enduser_upstream_no_consent.bugs/sae3_enduser_upstream_no_consent.bugs.test.js
@@ -1,0 +1,118 @@
+// ============================================================================
+// FAIL-BY-DESIGN security test — SEC-1580 SAE-3 (mongo-only; no ClickHouse).
+// Gap: an end-user token carries a wildcard access scope (`access/*.*`), so no
+// tenant filter applies to it, and patient-scope expansion walks the person's
+// links into PROA/IAS upstream records with no Consent present at all.
+//
+// NOTE (product decision needed, same caveat as the source finding this was
+// extracted from): the user may be entitled to their own upstream data, in
+// which case consent should govern client access only and this test should be
+// deleted rather than fixed. Until that's decided it stays here as the strict
+// reading: no Consent, no upstream data, for any caller type including the
+// person's own end-user token.
+//
+// Setup: personA links to its own patient plus a PROA patient and an IAS
+// patient (upstream sources), each with its own Observation. A service-account
+// caller with no Consent correctly gets none of the upstream data (control).
+// An end-user token scoped to personA itself must be held to the same rule.
+//
+// Asserts the SECURE outcome; if the end user reaches the upstream data, this
+// FAILS. *.bugs, excluded from default CI.
+// ============================================================================
+const { commonBeforeEach, commonAfterEach, getHeaders, getHeadersWithCustomPayload, createTestRequest } = require('../../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+
+const OWNER = 'https://www.icanbwell.com/owner';
+const ACCESS = 'https://www.icanbwell.com/access';
+const CONNTYPE = 'https://www.icanbwell.com/connectionType';
+
+function sec (owner, accessCodes, connectionType) {
+    const tags = [{ system: OWNER, code: owner }];
+    for (const a of accessCodes) tags.push({ system: ACCESS, code: a });
+    if (connectionType) tags.push({ system: CONNTYPE, code: connectionType });
+    return tags;
+}
+
+const ownA = { resourceType: 'Patient', id: 'sae3OwnA', meta: { source: 'tenanta', security: sec('tenanta', ['tenanta']) }, gender: 'female', birthDate: '1985-06-15' };
+const proaPatient = { resourceType: 'Patient', id: 'sae3Proa', meta: { source: 'proasrc', security: sec('proasrc', ['proasrc'], 'proa') }, gender: 'female', birthDate: '1985-06-15' };
+const iasPatient = { resourceType: 'Patient', id: 'sae3Ias', meta: { source: 'iassrc', security: sec('iassrc', ['iassrc'], 'ias') }, gender: 'female', birthDate: '1985-06-15' };
+
+const obsOwnA = { resourceType: 'Observation', id: 'sae3ObsOwnA', meta: { source: 'tenanta', security: sec('tenanta', ['tenanta']) }, status: 'final', code: { coding: [{ system: 'http://loinc.org', code: '29463-7' }] }, subject: { reference: 'Patient/sae3OwnA' } };
+const obsProa = { resourceType: 'Observation', id: 'sae3ObsProa', meta: { source: 'proasrc', security: sec('proasrc', ['proasrc'], 'proa') }, status: 'final', code: { coding: [{ system: 'http://loinc.org', code: '29463-7' }] }, subject: { reference: 'Patient/sae3Proa' } };
+const obsIas = { resourceType: 'Observation', id: 'sae3ObsIas', meta: { source: 'iassrc', security: sec('iassrc', ['iassrc'], 'ias') }, status: 'final', code: { coding: [{ system: 'http://loinc.org', code: '29463-7' }] }, subject: { reference: 'Patient/sae3Ias' } };
+
+const personA = {
+    resourceType: 'Person', id: 'sae3PersonA', meta: { source: 'tenanta', security: sec('tenanta', ['tenanta']) },
+    link: [
+        { target: { reference: 'Patient/sae3OwnA|tenanta', type: 'Patient' }, assurance: 'level4' },
+        { target: { reference: 'Patient/sae3Proa|proasrc', type: 'Patient' }, assurance: 'level4' },
+        { target: { reference: 'Patient/sae3Ias|iassrc', type: 'Patient' }, assurance: 'level4' }
+    ]
+};
+
+const all = [ownA, proaPatient, iasPatient, obsOwnA, obsProa, obsIas, personA];
+
+const serviceHeadersA = { ...getHeaders('user/*.read access/tenanta.*'), prefer: 'global_id=false' };
+const wildcardHeaders = { ...getHeaders('user/*.read access/*.*'), prefer: 'global_id=false' };
+const endUserHeaders = {
+    ...getHeadersWithCustomPayload({
+        scope: 'access/*.* user/*.* patient/*.*',
+        username: 'sae3-end-user@example.com',
+        clientFhirPersonId: 'sae3PersonA',
+        clientFhirPatientId: 'sae3ClientPatient',
+        bwellFhirPersonId: 'sae3PersonA',
+        bwellFhirPatientId: 'sae3BwellPatient',
+        managingOrganization: 'tenanta',
+        token_use: 'access'
+    }),
+    prefer: 'global_id=false'
+};
+
+const ids = (resp) => {
+    const b = resp && resp.body;
+    if (!b) return [];
+    if (Array.isArray(b)) return b.map((x) => x && x.id).filter(Boolean);
+    if (b.entry) return b.entry.map((e) => e.resource && e.resource.id).filter(Boolean);
+    if (b.id) return [b.id];
+    return [];
+};
+
+describe('D-SAE3 (fail-by-design) — an end user reaches linked upstream data with no Consent', () => {
+    beforeEach(async () => { await commonBeforeEach(); });
+    afterEach(async () => { await commonAfterEach(); });
+
+    test('control: the upstream records exist and are linked to this person', async () => {
+        const request = await createTestRequest();
+        await request.post('/4_0_0/Person/1/$merge').send(all).set(getHeaders());
+        const resp = await request.get('/4_0_0/Person/sae3PersonA/$everything').set(wildcardHeaders);
+        expect(resp.status).toBe(200);
+        expect(ids(resp)).toContain('sae3Proa');
+        expect(ids(resp)).toContain('sae3Ias');
+    });
+
+    test('control: a client service account with no consent does NOT get the upstream data', async () => {
+        const request = await createTestRequest();
+        await request.post('/4_0_0/Person/1/$merge').send(all).set(getHeaders());
+        const resp = await request.get('/4_0_0/Person/sae3PersonA/$everything').set(serviceHeadersA);
+        expect(ids(resp)).not.toContain('sae3Proa');
+    });
+
+    test('SECURE (fails until SAE-3 enforced): an end user gets no upstream records without a Consent', async () => {
+        const request = await createTestRequest();
+        await request.post('/4_0_0/Person/1/$merge').send(all).set(getHeaders());
+        const resp = await request.get('/4_0_0/Observation?patient=Patient/person.sae3PersonA').set(endUserHeaders);
+        expect(resp.status).toBe(200);
+        const got = ids(resp);
+        expect(got).not.toContain('sae3ObsProa');
+        expect(got).not.toContain('sae3ObsIas');
+    });
+
+    test('SECURE (fails until SAE-3 enforced): the same holds on $everything for an end user', async () => {
+        const request = await createTestRequest();
+        await request.post('/4_0_0/Person/1/$merge').send(all).set(getHeaders());
+        const resp = await request.get('/4_0_0/Person/sae3PersonA/$everything').set(endUserHeaders);
+        const got = ids(resp);
+        expect(got).not.toContain('sae3Proa');
+        expect(got).not.toContain('sae3Ias');
+    });
+});


### PR DESCRIPTION
## Summary
- Extracted from #2467 (the QUAL-73 security-integration-tests PR), which bundles many unrelated fail-by-design findings together. This PR isolates just the SAE-3 gap so it can be triaged (and possibly resolved by product decision rather than code) independently.
- An end-user token carries a wildcard access scope (`access/*.*`), so no tenant filter applies, and patient-scope expansion walks the person's links into PROA/IAS upstream records with **no Consent present at all**. A service-account caller with the same lack of consent is correctly blocked (control test) — the end-user path is not.
- **Needs a product decision before this can be "fixed" as code**: the user may be entitled to their own upstream data without a Consent, in which case Consent should govern client access only and this test should be deleted rather than made to pass. It's included here as the strict reading (no Consent → no upstream data, for any caller type) pending that call.
- Quarantined in `jest.config.js` so it documents the open question/gap without breaking CI.

## Test plan
- [x] `npx jest src/tests/everything/sae3_enduser_upstream_no_consent.bugs` — both controls (upstream records exist + reachable via wildcard scope; service account correctly blocked) pass; both SECURE assertions (Observation search, `$everything`) for the end-user token fail, documenting current behavior
- [x] `eslint` clean on the new file and `jest.config.js`
- [x] **Product decision needed**: is an end user entitled to their own upstream (PROA/IAS) data without a Consent record? If yes, close this as won't-fix and delete the test with a note in the security spec.