### PR TITLE
SEC-1580 INC-322: non-access tokens (id, missing token_use, refresh) are accepted

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -53,6 +53,11 @@ module.exports = {
         '<rootDir>/src/tests/unit/middleware/fhir/router.test.js',
         '<rootDir>/src/tests/unit/operations/common/patientQueryCreator.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everything.bugs.test.js',
+        // SEC-1580 fail-by-design security test: asserts the SECURE behavior for INC-322 and
+        // stays RED until non-access tokens (id, missing token_use, refresh) are refused.
+        // Excluded from the default run so a known, documented gap doesn't break CI. Run
+        // directly: npx jest src/tests/everything/inc322_id_token_accepted.bugs
+        '<rootDir>/src/tests/everything/inc322_id_token_accepted.bugs/inc322_id_token_accepted.bugs.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everythingRelatedResourcesMapper.test.js',
         '<rootDir>/src/tests/unit/operations/graph/graph.test.js',
         '<rootDir>/src/tests/unit/operations/history/history.test.js',

--- a/src/tests/everything/inc322_id_token_accepted.bugs/inc322_id_token_accepted.bugs.test.js
+++ b/src/tests/everything/inc322_id_token_accepted.bugs/inc322_id_token_accepted.bugs.test.js
@@ -1,0 +1,68 @@
+// ============================================================================
+// FAIL-BY-DESIGN security test — SEC-1580 INC-322 (mongo-only; no ClickHouse).
+// Gap: a token whose `token_use` claim is `id` rather than `access` is
+// accepted and returns data. The same applies to a token with no `token_use`
+// claim at all, and to a `refresh` token. Id and refresh tokens are issued
+// for other purposes and often have different lifetimes than access tokens,
+// so accepting them widens the set of credentials the server treats as valid.
+//
+// Setup: a single tenant-A-owned Patient. A normal access token can read it
+// (control). An id token, a token with no token_use claim, and a refresh
+// token -- all otherwise carrying the same scope -- must each be refused.
+//
+// Asserts the SECURE outcome; if any of the three non-access tokens are
+// honored, this FAILS. *.bugs, excluded from default CI.
+// ============================================================================
+const { commonBeforeEach, commonAfterEach, getHeaders, getHeadersWithCustomPayload, createTestRequest } = require('../../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+
+const ownA = {
+    resourceType: 'Patient', id: 'inc322OwnA',
+    meta: {
+        source: 'tenanta',
+        security: [
+            { system: 'https://www.icanbwell.com/owner', code: 'tenanta' },
+            { system: 'https://www.icanbwell.com/access', code: 'tenanta' }
+        ]
+    },
+    gender: 'female', birthDate: '1985-06-15'
+};
+
+async function seed () {
+    const request = await createTestRequest();
+    await request.post('/4_0_0/Person/1/$merge').send([ownA]).set(getHeaders());
+    return request;
+}
+
+describe('D-INC322 (fail-by-design) — an id/refresh token is accepted as an access token', () => {
+    beforeEach(async () => { await commonBeforeEach(); });
+    afterEach(async () => { await commonAfterEach(); });
+
+    test('control: a token with token_use=access works', async () => {
+        const request = await seed();
+        const resp = await request.get('/4_0_0/Patient/inc322OwnA')
+            .set(getHeadersWithCustomPayload({ scope: 'user/*.read access/tenanta.*', token_use: 'access' }));
+        expect(resp.status).toBe(200);
+    });
+
+    test('SECURE (fails until INC-322 enforced): a token with token_use=id is refused', async () => {
+        const request = await seed();
+        const resp = await request.get('/4_0_0/Patient/inc322OwnA')
+            .set(getHeadersWithCustomPayload({ scope: 'user/*.read access/tenanta.*', token_use: 'id' }));
+        expect([401, 403]).toContain(resp.status);
+    });
+
+    test('SECURE (fails until INC-322 enforced): a token with no token_use claim at all is refused', async () => {
+        const request = await seed();
+        const resp = await request.get('/4_0_0/Patient/inc322OwnA')
+            .set(getHeadersWithCustomPayload({ scope: 'user/*.read access/tenanta.*' }));
+        expect([401, 403]).toContain(resp.status);
+    });
+
+    test('SECURE (fails until INC-322 enforced): a refresh token is refused', async () => {
+        const request = await seed();
+        const resp = await request.get('/4_0_0/Patient/inc322OwnA')
+            .set(getHeadersWithCustomPayload({ scope: 'user/*.read access/tenanta.*', token_use: 'refresh' }));
+        expect([401, 403]).toContain(resp.status);
+    });
+});


### PR DESCRIPTION
## Summary
- Extracted from #2467 (the QUAL-73 security-integration-tests PR), which bundles many unrelated fail-by-design findings together. This PR isolates just the INC-322 token-validation gap so it can be triaged and fixed on its own.
- A token whose `token_use` claim is `id` rather than `access` is accepted and serves data. The same applies to a token with no `token_use` claim at all, and to a `refresh` token. These token types are issued for other purposes and often carry different lifetimes than access tokens, so accepting them widens the set of credentials the server treats as valid.
- Adds a fail-by-design test asserting the target SECURE behavior. Quarantined in `jest.config.js` (same convention as other `*.bugs.test.js` files) so it documents the gap without breaking CI.

## Test plan
- [x] `npx jest src/tests/everything/inc322_id_token_accepted.bugs` — control (real access token) passes; all three SECURE assertions (id token, missing token_use, refresh token) fail, documenting current behavior
- [x] `eslint` clean on the new file and `jest.config.js`
- [ ] Reviewer: confirm the fix should reject at the auth-middleware layer (401) rather than deeper in the request pipeline