### PR TITLE
SEC-1580 SAE-4: malformed _sort value crashes with a 500

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -53,11 +53,6 @@ module.exports = {
         '<rootDir>/src/tests/unit/middleware/fhir/router.test.js',
         '<rootDir>/src/tests/unit/operations/common/patientQueryCreator.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everything.bugs.test.js',
-        // SEC-1580 fail-by-design security test: asserts the SECURE behavior for SAE-4 and
-        // stays RED until a malformed _sort value returns a 4xx instead of a raw 500.
-        // Excluded from the default run so a known, documented gap doesn't break CI. Run
-        // directly: npx jest src/tests/everything/sae4_malformed_sort_crashes_500.bugs
-        '<rootDir>/src/tests/everything/sae4_malformed_sort_crashes_500.bugs/sae4_malformed_sort_crashes_500.bugs.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everythingRelatedResourcesMapper.test.js',
         '<rootDir>/src/tests/unit/operations/graph/graph.test.js',
         '<rootDir>/src/tests/unit/operations/history/history.test.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -53,6 +53,11 @@ module.exports = {
         '<rootDir>/src/tests/unit/middleware/fhir/router.test.js',
         '<rootDir>/src/tests/unit/operations/common/patientQueryCreator.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everything.bugs.test.js',
+        // SEC-1580 fail-by-design security test: asserts the SECURE behavior for SAE-4 and
+        // stays RED until a malformed _sort value returns a 4xx instead of a raw 500.
+        // Excluded from the default run so a known, documented gap doesn't break CI. Run
+        // directly: npx jest src/tests/everything/sae4_malformed_sort_crashes_500.bugs
+        '<rootDir>/src/tests/everything/sae4_malformed_sort_crashes_500.bugs/sae4_malformed_sort_crashes_500.bugs.test.js',
         '<rootDir>/src/tests/unit/operations/everything/everythingRelatedResourcesMapper.test.js',
         '<rootDir>/src/tests/unit/operations/graph/graph.test.js',
         '<rootDir>/src/tests/unit/operations/history/history.test.js',

--- a/src/tests/everything/sae4_malformed_sort_crashes_500.bugs/sae4_malformed_sort_crashes_500.bugs.test.js
+++ b/src/tests/everything/sae4_malformed_sort_crashes_500.bugs/sae4_malformed_sort_crashes_500.bugs.test.js
@@ -1,0 +1,65 @@
+// ============================================================================
+// FAIL-BY-DESIGN security test — SEC-1580 SAE-4 (mongo-only; no ClickHouse).
+// Gap: a `_sort` value of `$$$` returns a raw 500 instead of a 4xx. A crash is
+// a robustness concern on its own, and a 500 is the response most likely to
+// carry a stack trace, so it's the most likely place for internal detail to
+// leak (the response BODY is checked here too, and passes today -- no detail
+// currently appears in it, but the status code itself should not be a 500).
+//
+// The other malformed-parameter shapes below are included as controls: they
+// already return a proper 4xx today and must keep doing so. Only `_sort=$$$`
+// is the fail-by-design SECURE assertion.
+//
+// Asserts the SECURE outcome; if `_sort=$$$` still 500s, this FAILS. *.bugs,
+// excluded from default CI.
+// ============================================================================
+const { commonBeforeEach, commonAfterEach, getHeaders, createTestRequest } = require('../../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+
+const ownA = {
+    resourceType: 'Patient', id: 'sae4OwnA',
+    meta: {
+        source: 'tenanta',
+        security: [
+            { system: 'https://www.icanbwell.com/owner', code: 'tenanta' },
+            { system: 'https://www.icanbwell.com/access', code: 'tenanta' }
+        ]
+    },
+    gender: 'female', birthDate: '1985-06-15'
+};
+
+const headersA = { ...getHeaders('user/*.read access/tenanta.*'), prefer: 'global_id=false' };
+
+async function seed () {
+    const request = await createTestRequest();
+    await request.post('/4_0_0/Person/1/$merge').send([ownA]).set(getHeaders());
+    return request;
+}
+
+const CONTROL_QUERIES = [
+    '/4_0_0/Patient?birthdate=not-a-date',
+    '/4_0_0/Patient?_count=notanumber',
+    '/4_0_0/Patient?_security=missing-separator',
+    '/4_0_0/Observation?subject:Patient._id[$ne]=x',
+    '/4_0_0/Patient?_lastUpdated=garbage',
+    '/4_0_0/Patient?_total=nonsense'
+];
+
+describe('D-SAE4 (fail-by-design) — a malformed _sort value returns 500 instead of a 4xx', () => {
+    beforeEach(async () => { await commonBeforeEach(); });
+    afterEach(async () => { await commonAfterEach(); });
+
+    for (const q of CONTROL_QUERIES) {
+        test(`control: ${q} already returns a client error, not 500`, async () => {
+            const request = await seed();
+            const resp = await request.get(q).set(headersA);
+            expect(resp.status).toBeLessThan(500);
+        });
+    }
+
+    test('SECURE (fails until SAE-4 enforced): /4_0_0/Patient?_sort=$$$ returns a client error, not 500', async () => {
+        const request = await seed();
+        const resp = await request.get('/4_0_0/Patient?_sort=$$$').set(headersA);
+        expect(resp.status).toBeLessThan(500);
+    });
+});


### PR DESCRIPTION
## Summary
- Extracted from #2467 (the QUAL-73 security-integration-tests PR), which bundles many unrelated fail-by-design findings together. This PR isolates just the SAE-4 crash (of several malformed-parameter shapes tested, only this one still fails) so it can be triaged and fixed on its own.
- A `_sort` value of `$$$` returns a raw 500 instead of a 4xx. A crash is a robustness concern on its own, and a 500 is the response most likely to carry a stack trace — the response body is checked too and no internal detail currently leaks in it, but the status code itself shouldn't be a 500.
- Six other malformed-parameter shapes (`birthdate=not-a-date`, `_count=notanumber`, `_security=missing-separator`, an operator-injection attempt, `_lastUpdated=garbage`, `_total=nonsense`) are included as controls — they already return a proper 4xx and must keep doing so.
- Adds a fail-by-design test asserting the target SECURE behavior. Quarantined in `jest.config.js` (same convention as other `*.bugs.test.js` files) so it documents the gap without breaking CI.

## Test plan
- [x] `npx jest src/tests/everything/sae4_malformed_sort_crashes_500.bugs` — all 6 controls pass; the `_sort=$$$` SECURE assertion fails, documenting current behavior
- [x] `eslint` clean on the new file and `jest.config.js`
- [ ] Reviewer: confirm the fix should validate/reject the `_sort` value earlier in the pipeline rather than letting it reach whatever throws today