### PR TITLE
DCON-4892 Fold hardcoded unclassified code into Composition section filter's denylist

### DIFF
--- a/readme/delegatedActorAccess.md
+++ b/readme/delegatedActorAccess.md
@@ -221,7 +221,13 @@ When `ENABLE_DELEGATED_ACCESS_DETECTION` is enabled and the user is a `delegated
 The denied categories come from the Consent's nested `deny` provisions (`securityLabel` entries), pre-loaded onto `actor._filteringRules.deniedSensitiveCategories` by `DataSharingManager`.
 
 **Behavior:**
-- Only sections with sensitivity codes in the Consent's denied list are removed
+- Sections with sensitivity codes in the Consent's denied list are removed
+- The hardcoded `unclassified` sensitivity code is **always** folded into the denied set as well,
+  regardless of what the grantor's Consent actually denies — mirroring the query-level exclusion in
+  `DataSharingManager.updateQueryForDelegatedAccessSensitiveData`. This fold-in happens in
+  `CompositionSectionFilterEnrichmentProvider.getDeniedSensitiveCategorySet`, not in the shared
+  `filterCompositionSensitiveSections`/`shouldRemoveSection` utility itself, which stays a pure
+  denylist-membership check.
 - If a section has multiple `code.coding` entries and **any** matches a denied code, the section is removed
 - Filtering is recursive — nested sections (`section.section`) are checked at every level
 - If a parent section itself is sensitive, the entire section (including all children) is removed

--- a/src/enrich/providers/compositionSectionFilterEnrichmentProvider.js
+++ b/src/enrich/providers/compositionSectionFilterEnrichmentProvider.js
@@ -1,6 +1,6 @@
 const { EnrichmentProvider } = require('./enrichmentProvider');
 const { filterCompositionSensitiveSections } = require('../../utils/compositionSectionFilter');
-const { AUTH_USER_TYPES } = require('../../constants');
+const { AUTH_USER_TYPES, SENSITIVE_CATEGORY } = require('../../constants');
 
 /**
  * Enrichment provider that strips sensitive sections from Composition resources
@@ -20,7 +20,13 @@ class CompositionSectionFilterEnrichmentProvider extends EnrichmentProvider {
     }
 
     /**
-     * Reads the denied sensitive categories Set from the actor's pre-loaded filtering rules.
+     * Reads the denied sensitive categories Set from the actor's pre-loaded filtering rules, and
+     * folds in the hardcoded unclassified code alongside the Consent-derived ones -- mirroring
+     * DataSharingManager.updateQueryForDelegatedAccessSensitiveData's query-level exclusion
+     * (dataSharingManager.js), which also always excludes unclassified regardless of what the
+     * grantor's Consent denies. filterCompositionSensitiveSections/shouldRemoveSection stay a
+     * pure denylist-membership check with no implicit special case -- this is where the special
+     * case belongs, at the call site, not baked into the shared low-level utility.
      * @param {EnrichmentContext|undefined} enrichmentContext
      * @returns {Set<string>|null}
      */
@@ -29,7 +35,9 @@ class CompositionSectionFilterEnrichmentProvider extends EnrichmentProvider {
         if (!filteringRules) {
             return null;
         }
-        return new Set(filteringRules.deniedSensitiveCategories || []);
+        const deniedSensitiveCategorySet = new Set(filteringRules.deniedSensitiveCategories || []);
+        deniedSensitiveCategorySet.add(SENSITIVE_CATEGORY.UNCLASSIFIED_CODE);
+        return deniedSensitiveCategorySet;
     }
 
     /**

--- a/src/tests/unit/enrich/providers/compositionSectionFilterEnrichmentProvider.test.js
+++ b/src/tests/unit/enrich/providers/compositionSectionFilterEnrichmentProvider.test.js
@@ -7,7 +7,7 @@ jestObj.mock('../../../../utils/compositionSectionFilter', () => ({
 
 const { CompositionSectionFilterEnrichmentProvider } = require('../../../../enrich/providers/compositionSectionFilterEnrichmentProvider');
 const { filterCompositionSensitiveSections } = require('../../../../utils/compositionSectionFilter');
-const { AUTH_USER_TYPES } = require('../../../../constants');
+const { AUTH_USER_TYPES, SENSITIVE_CATEGORY } = require('../../../../constants');
 
 describe('CompositionSectionFilterEnrichmentProvider', () => {
     let provider;
@@ -43,7 +43,7 @@ describe('CompositionSectionFilterEnrichmentProvider', () => {
             expect(result).toBeNull();
         });
 
-        test('returns Set from deniedSensitiveCategories', () => {
+        test('returns Set from deniedSensitiveCategories, plus the hardcoded unclassified code', () => {
             const enrichmentContext = {
                 actor: {
                     _filteringRules: {
@@ -58,10 +58,11 @@ describe('CompositionSectionFilterEnrichmentProvider', () => {
             expect(result.has('ETH')).toBe(true);
             expect(result.has('PSY')).toBe(true);
             expect(result.has('SDV')).toBe(true);
-            expect(result.size).toBe(3);
+            expect(result.has(SENSITIVE_CATEGORY.UNCLASSIFIED_CODE)).toBe(true);
+            expect(result.size).toBe(4);
         });
 
-        test('returns empty Set when deniedSensitiveCategories is empty array', () => {
+        test('returns a Set containing only the hardcoded unclassified code when deniedSensitiveCategories is empty array (DCON-4892)', () => {
             const enrichmentContext = {
                 actor: {
                     _filteringRules: {
@@ -73,10 +74,11 @@ describe('CompositionSectionFilterEnrichmentProvider', () => {
             const result = provider.getDeniedSensitiveCategorySet(enrichmentContext);
 
             expect(result).toBeInstanceOf(Set);
-            expect(result.size).toBe(0);
+            expect(result.size).toBe(1);
+            expect(result.has(SENSITIVE_CATEGORY.UNCLASSIFIED_CODE)).toBe(true);
         });
 
-        test('returns empty Set when deniedSensitiveCategories is undefined', () => {
+        test('returns a Set containing only the hardcoded unclassified code when deniedSensitiveCategories is undefined (DCON-4892)', () => {
             const enrichmentContext = {
                 actor: {
                     _filteringRules: {}
@@ -86,7 +88,24 @@ describe('CompositionSectionFilterEnrichmentProvider', () => {
             const result = provider.getDeniedSensitiveCategorySet(enrichmentContext);
 
             expect(result).toBeInstanceOf(Set);
-            expect(result.size).toBe(0);
+            expect(result.size).toBe(1);
+            expect(result.has(SENSITIVE_CATEGORY.UNCLASSIFIED_CODE)).toBe(true);
+        });
+
+        test('always folds in the hardcoded unclassified code regardless of what the grantor Consent denies -- mirrors DataSharingManager.updateQueryForDelegatedAccessSensitiveData (DCON-4892)', () => {
+            const enrichmentContext = {
+                actor: {
+                    _filteringRules: {
+                        deniedSensitiveCategories: ['some-other-category']
+                    }
+                }
+            };
+
+            const result = provider.getDeniedSensitiveCategorySet(enrichmentContext);
+
+            // 'unclassified' is present even though the grantor's Consent never mentioned it.
+            expect(result.has(SENSITIVE_CATEGORY.UNCLASSIFIED_CODE)).toBe(true);
+            expect(result.has('some-other-category')).toBe(true);
         });
     });
 
@@ -159,6 +178,7 @@ describe('CompositionSectionFilterEnrichmentProvider', () => {
             const passedSet = filterCompositionSensitiveSections.mock.calls[0][1];
             expect(passedSet.has('ETH')).toBe(true);
             expect(passedSet.has('PSY')).toBe(true);
+            expect(passedSet.has(SENSITIVE_CATEGORY.UNCLASSIFIED_CODE)).toBe(true);
         });
 
         test('does NOT call filterCompositionSensitiveSections for non-Composition resources', async () => {

--- a/src/tests/unit/resourceAuthorization/10_delegatedActorAccess.test.js
+++ b/src/tests/unit/resourceAuthorization/10_delegatedActorAccess.test.js
@@ -15,9 +15,9 @@
  *      composed with the REAL DelegatedAccessRulesManager (only its DB/tracer collaborators are
  *      stubbed) so the request-scoped `actor._filteringRules` cache is exercised for real.
  *   6. Content-level filtering - CompositionSectionFilterEnrichmentProvider, composed with the REAL
- *      filterCompositionSensitiveSections util, proving the documented (imperfect) current
- *      behavior that an `unclassified`-only section is NOT stripped here (unlike step 5's
- *      query-level filter, which always excludes `unclassified`).
+ *      filterCompositionSensitiveSections util, proving that an `unclassified`-only section IS
+ *      stripped here too, mirroring step 5's query-level filter (which always excludes
+ *      `unclassified` regardless of the grantor's Consent-derived denylist). See DCON-4892.
  *
  * IMPORTANT: `src/tests/unit/operations/security/delegatedAccessScopeManager.test.js` is excluded
  * from CI (see jest.config.js testPathIgnorePatterns) because it asserts against an inline
@@ -30,13 +30,19 @@ const { describe, test, it, expect, beforeEach, jest } = require('@jest/globals'
 
 const { AuthService } = require('../../../strategies/authService');
 const { ConfigManager } = require('../../../utils/configManager');
-const { WellKnownConfigurationManager } = require('../../../utils/wellKnownConfiguration/wellKnownConfigurationManager');
+const {
+    WellKnownConfigurationManager
+} = require('../../../utils/wellKnownConfiguration/wellKnownConfigurationManager');
 
 const { DelegatedAccessManager } = require('../../../utils/delegatedAccessManager');
-const { DelegatedAccessScopeManager } = require('../../../operations/security/delegatedAccessScopeManager');
+const {
+    DelegatedAccessScopeManager
+} = require('../../../operations/security/delegatedAccessScopeManager');
 const { DelegatedAccessRulesManager } = require('../../../utils/delegatedAccessRulesManager');
 const { DataSharingManager } = require('../../../operations/search/dataSharingManager');
-const { CompositionSectionFilterEnrichmentProvider } = require('../../../enrich/providers/compositionSectionFilterEnrichmentProvider');
+const {
+    CompositionSectionFilterEnrichmentProvider
+} = require('../../../enrich/providers/compositionSectionFilterEnrichmentProvider');
 
 const { DatabaseQueryFactory } = require('../../../dataLayer/databaseQueryFactory');
 const { CustomTracer } = require('../../../utils/customTracer');
@@ -77,11 +83,11 @@ jest.mock('../../../utils/querybuilder.util', () => ({
     dateQueryBuilder: jest.fn().mockReturnValue({ $lte: '2026-01-01' })
 }));
 
-function createMockInstance (ClassType) {
+function createMockInstance(ClassType) {
     return Object.create(ClassType.prototype);
 }
 
-function createCursor (consentResources) {
+function createCursor(consentResources) {
     return {
         maxTimeMS: jest.fn(),
         hint: jest.fn(),
@@ -106,22 +112,60 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
             AuthService.userInfoCache = undefined;
 
             mockConfigManager = createMockInstance(ConfigManager);
-            Object.defineProperty(mockConfigManager, 'externalRequestTimeoutSec', { get: () => 30, configurable: true });
-            Object.defineProperty(mockConfigManager, 'externalAuthJwksUrls', { get: () => [], configurable: true });
-            Object.defineProperty(mockConfigManager, 'externalAuthWellKnownUrls', { get: () => [], configurable: true });
-            Object.defineProperty(mockConfigManager, 'authCustomScope', { get: () => [], configurable: true });
-            Object.defineProperty(mockConfigManager, 'authCustomGroup', { get: () => [], configurable: true });
-            Object.defineProperty(mockConfigManager, 'authCustomUserName', { get: () => [], configurable: true });
-            Object.defineProperty(mockConfigManager, 'authCustomSubject', { get: () => [], configurable: true });
-            Object.defineProperty(mockConfigManager, 'authCustomClientId', { get: () => [], configurable: true });
-            Object.defineProperty(mockConfigManager, 'authRemoveScopePrefixes', { get: () => [], configurable: true });
-            Object.defineProperty(mockConfigManager, 'authCidCheckIssuer', { get: () => '', configurable: true });
-            Object.defineProperty(mockConfigManager, 'authCidCheckClientIds', { get: () => [], configurable: true });
-            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => true, configurable: true });
+            Object.defineProperty(mockConfigManager, 'externalRequestTimeoutSec', {
+                get: () => 30,
+                configurable: true
+            });
+            Object.defineProperty(mockConfigManager, 'externalAuthJwksUrls', {
+                get: () => [],
+                configurable: true
+            });
+            Object.defineProperty(mockConfigManager, 'externalAuthWellKnownUrls', {
+                get: () => [],
+                configurable: true
+            });
+            Object.defineProperty(mockConfigManager, 'authCustomScope', {
+                get: () => [],
+                configurable: true
+            });
+            Object.defineProperty(mockConfigManager, 'authCustomGroup', {
+                get: () => [],
+                configurable: true
+            });
+            Object.defineProperty(mockConfigManager, 'authCustomUserName', {
+                get: () => [],
+                configurable: true
+            });
+            Object.defineProperty(mockConfigManager, 'authCustomSubject', {
+                get: () => [],
+                configurable: true
+            });
+            Object.defineProperty(mockConfigManager, 'authCustomClientId', {
+                get: () => [],
+                configurable: true
+            });
+            Object.defineProperty(mockConfigManager, 'authRemoveScopePrefixes', {
+                get: () => [],
+                configurable: true
+            });
+            Object.defineProperty(mockConfigManager, 'authCidCheckIssuer', {
+                get: () => '',
+                configurable: true
+            });
+            Object.defineProperty(mockConfigManager, 'authCidCheckClientIds', {
+                get: () => [],
+                configurable: true
+            });
+            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', {
+                get: () => true,
+                configurable: true
+            });
 
             mockWellKnownConfigManager = createMockInstance(WellKnownConfigurationManager);
             mockWellKnownConfigManager.getJwksUrlsAsync = jest.fn().mockResolvedValue([]);
-            mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync = jest.fn().mockResolvedValue(null);
+            mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync = jest
+                .fn()
+                .mockResolvedValue(null);
 
             authService = new AuthService({
                 configManager: mockConfigManager,
@@ -190,7 +234,10 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
         });
 
         test('gated by configManager.enableDelegatedAccessDetection: `act` claim is ignored entirely when the flag is off', () => {
-            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => false, configurable: true });
+            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', {
+                get: () => false,
+                configurable: true
+            });
             AuthService.jwksCache = undefined;
             AuthService.userInfoCache = undefined;
             authService = new AuthService({
@@ -230,7 +277,11 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
         test('processForDelegatedActor extracts only reference and sub from a valid act claim', () => {
             const result = authService.processForDelegatedActor({
                 jwt_payload: {
-                    act: { reference: 'RelatedPerson/rp-1', sub: 'delegate-sub', extraField: 'ignored' }
+                    act: {
+                        reference: 'RelatedPerson/rp-1',
+                        sub: 'delegate-sub',
+                        extraField: 'ignored'
+                    }
                 }
             });
             expect(result.failure).toBe(false);
@@ -249,43 +300,55 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
             delegatedAccessManager = new DelegatedAccessManager();
         });
 
-        test.each(DELEGATED_ACCESS.ALLOWED_OPERATIONS)('allows read operation "%s" for a delegated user', (operation) => {
-            expect(() => delegatedAccessManager.verifyAccess({
-                requestInfo: { userType: AUTH_USER_TYPES.delegatedUser },
-                resourceType: 'Patient',
-                operation
-            })).not.toThrow();
-        });
-
-        test.each(['create', 'update', 'delete', 'patch', 'merge', 'mutation'])('throws a 403 Forbidden for write operation "%s"', (operation) => {
-            // Note: ForbiddenError's own base-class constructor (ServerError) calls
-            // Object.setPrototypeOf(this, ServerError.prototype), which resets the prototype
-            // chain so `instanceof ForbiddenError` does NOT hold for its own instances - hence
-            // asserting on statusCode/message here rather than `toThrow(ForbiddenError)`.
-            expect(() => delegatedAccessManager.verifyAccess({
-                requestInfo: { userType: AUTH_USER_TYPES.delegatedUser },
-                resourceType: 'Patient',
-                operation
-            })).toThrow(new RegExp(`does not have access to ${operation.toUpperCase()} method`));
-
-            try {
-                delegatedAccessManager.verifyAccess({
-                    requestInfo: { userType: AUTH_USER_TYPES.delegatedUser },
-                    resourceType: 'Patient',
-                    operation
-                });
-                throw new Error('expected verifyAccess to throw');
-            } catch (e) {
-                expect(e.statusCode).toBe(403);
+        test.each(DELEGATED_ACCESS.ALLOWED_OPERATIONS)(
+            'allows read operation "%s" for a delegated user',
+            (operation) => {
+                expect(() =>
+                    delegatedAccessManager.verifyAccess({
+                        requestInfo: { userType: AUTH_USER_TYPES.delegatedUser },
+                        resourceType: 'Patient',
+                        operation
+                    })
+                ).not.toThrow();
             }
-        });
+        );
+
+        test.each(['create', 'update', 'delete', 'patch', 'merge', 'mutation'])(
+            'throws a 403 Forbidden for write operation "%s"',
+            (operation) => {
+                // Note: ForbiddenError's own base-class constructor (ServerError) calls
+                // Object.setPrototypeOf(this, ServerError.prototype), which resets the prototype
+                // chain so `instanceof ForbiddenError` does NOT hold for its own instances - hence
+                // asserting on statusCode/message here rather than `toThrow(ForbiddenError)`.
+                expect(() =>
+                    delegatedAccessManager.verifyAccess({
+                        requestInfo: { userType: AUTH_USER_TYPES.delegatedUser },
+                        resourceType: 'Patient',
+                        operation
+                    })
+                ).toThrow(new RegExp(`does not have access to ${operation.toUpperCase()} method`));
+
+                try {
+                    delegatedAccessManager.verifyAccess({
+                        requestInfo: { userType: AUTH_USER_TYPES.delegatedUser },
+                        resourceType: 'Patient',
+                        operation
+                    });
+                    throw new Error('expected verifyAccess to throw');
+                } catch (e) {
+                    expect(e.statusCode).toBe(403);
+                }
+            }
+        );
 
         test('a non-delegated user is unaffected (can perform any operation as far as this manager is concerned)', () => {
-            expect(() => delegatedAccessManager.verifyAccess({
-                requestInfo: { userType: 'user' },
-                resourceType: 'Patient',
-                operation: 'create'
-            })).not.toThrow();
+            expect(() =>
+                delegatedAccessManager.verifyAccess({
+                    requestInfo: { userType: 'user' },
+                    resourceType: 'Patient',
+                    operation: 'create'
+                })
+            ).not.toThrow();
         });
     });
 
@@ -385,8 +448,14 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
 
         beforeEach(() => {
             mockConfigManagerForRules = createMockInstance(ConfigManager);
-            Object.defineProperty(mockConfigManagerForRules, 'mongoTimeout', { get: () => 30000, configurable: true });
-            Object.defineProperty(mockConfigManagerForRules, 'dataSharingAccessCodes', { get: () => ['dataSharingAccess'], configurable: true });
+            Object.defineProperty(mockConfigManagerForRules, 'mongoTimeout', {
+                get: () => 30000,
+                configurable: true
+            });
+            Object.defineProperty(mockConfigManagerForRules, 'dataSharingAccessCodes', {
+                get: () => ['dataSharingAccess'],
+                configurable: true
+            });
 
             mockDatabaseQueryFactory = createMockInstance(DatabaseQueryFactory);
             mockDatabaseQueryFactory.createQuery = jest.fn();
@@ -433,10 +502,12 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
 
         test('MORE THAN ONE active Consent found -> throws ForbiddenError (ambiguous, fails closed)', async () => {
             mockDatabaseQueryFactory.createQuery.mockReturnValue({
-                findAsync: jest.fn().mockResolvedValue(createCursor([
-                    { _uuid: 'consent-1', meta: { versionId: '1' } },
-                    { _uuid: 'consent-2', meta: { versionId: '1' } }
-                ]))
+                findAsync: jest.fn().mockResolvedValue(
+                    createCursor([
+                        { _uuid: 'consent-1', meta: { versionId: '1' } },
+                        { _uuid: 'consent-2', meta: { versionId: '1' } }
+                    ])
+                )
             });
 
             await expect(
@@ -451,22 +522,32 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
 
         test('a single Consent with deny provisions excludes those sensitivity-category codes PLUS unclassified', async () => {
             mockDatabaseQueryFactory.createQuery.mockReturnValue({
-                findAsync: jest.fn().mockResolvedValue(createCursor([{
-                    _uuid: 'consent-1',
-                    meta: { versionId: '1' },
-                    provision: {
-                        period: { start: '2024-01-01' },
-                        provision: [
-                            {
-                                type: 'deny',
-                                securityLabel: [
-                                    { system: SENSITIVE_CATEGORY.SYSTEM, code: 'mental-health' },
-                                    { system: SENSITIVE_CATEGORY.SYSTEM, code: 'substance-abuse' }
+                findAsync: jest.fn().mockResolvedValue(
+                    createCursor([
+                        {
+                            _uuid: 'consent-1',
+                            meta: { versionId: '1' },
+                            provision: {
+                                period: { start: '2024-01-01' },
+                                provision: [
+                                    {
+                                        type: 'deny',
+                                        securityLabel: [
+                                            {
+                                                system: SENSITIVE_CATEGORY.SYSTEM,
+                                                code: 'mental-health'
+                                            },
+                                            {
+                                                system: SENSITIVE_CATEGORY.SYSTEM,
+                                                code: 'substance-abuse'
+                                            }
+                                        ]
+                                    }
                                 ]
                             }
-                        ]
-                    }
-                }]))
+                        }
+                    ])
+                )
             });
 
             const result = await dataSharingManager.updateQueryForDelegatedAccessSensitiveData({
@@ -477,18 +558,26 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
             });
 
             const excludedCodes = result.$and[1]['meta.security'].$not.$elemMatch.code.$in;
-            expect(excludedCodes).toEqual(expect.arrayContaining(['mental-health', 'substance-abuse', 'unclassified']));
-            expect(result.$and[1]['meta.security'].$not.$elemMatch.system).toBe(SENSITIVE_CATEGORY.SYSTEM);
+            expect(excludedCodes).toEqual(
+                expect.arrayContaining(['mental-health', 'substance-abuse', 'unclassified'])
+            );
+            expect(result.$and[1]['meta.security'].$not.$elemMatch.system).toBe(
+                SENSITIVE_CATEGORY.SYSTEM
+            );
         });
 
         test('`unclassified` is ALWAYS in the exclusion set, even when the Consent denies nothing', async () => {
             mockDatabaseQueryFactory.createQuery.mockReturnValue({
-                findAsync: jest.fn().mockResolvedValue(createCursor([{
-                    _uuid: 'consent-1',
-                    meta: { versionId: '1' },
-                    provision: { period: { start: '2024-01-01' } }
-                    // no nested `provision.provision` deny entries at all
-                }]))
+                findAsync: jest.fn().mockResolvedValue(
+                    createCursor([
+                        {
+                            _uuid: 'consent-1',
+                            meta: { versionId: '1' },
+                            provision: { period: { start: '2024-01-01' } }
+                            // no nested `provision.provision` deny entries at all
+                        }
+                    ])
+                )
             });
 
             const result = await dataSharingManager.updateQueryForDelegatedAccessSensitiveData({
@@ -506,11 +595,13 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
         });
 
         test('getFilteringRulesAsync is cached on the request-scoped actor object: a second call with the SAME actor does not re-fetch', async () => {
-            const cursor = createCursor([{
-                _uuid: 'consent-1',
-                meta: { versionId: '1' },
-                provision: { period: { start: '2024-01-01' } }
-            }]);
+            const cursor = createCursor([
+                {
+                    _uuid: 'consent-1',
+                    meta: { versionId: '1' },
+                    provision: { period: { start: '2024-01-01' } }
+                }
+            ]);
             const findAsync = jest.fn().mockResolvedValue(cursor);
             mockDatabaseQueryFactory.createQuery.mockReturnValue({ findAsync });
 
@@ -538,9 +629,26 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
         });
 
         test('a fresh actor object (new request) DOES re-fetch, even with the same personIdFromJwtToken', async () => {
-            const findAsync = jest.fn()
-                .mockResolvedValueOnce(createCursor([{ _uuid: 'consent-1', meta: { versionId: '1' }, provision: { period: { start: '2024-01-01' } } }]))
-                .mockResolvedValueOnce(createCursor([{ _uuid: 'consent-1', meta: { versionId: '1' }, provision: { period: { start: '2024-01-01' } } }]));
+            const findAsync = jest
+                .fn()
+                .mockResolvedValueOnce(
+                    createCursor([
+                        {
+                            _uuid: 'consent-1',
+                            meta: { versionId: '1' },
+                            provision: { period: { start: '2024-01-01' } }
+                        }
+                    ])
+                )
+                .mockResolvedValueOnce(
+                    createCursor([
+                        {
+                            _uuid: 'consent-1',
+                            meta: { versionId: '1' },
+                            provision: { period: { start: '2024-01-01' } }
+                        }
+                    ])
+                );
             mockDatabaseQueryFactory.createQuery.mockReturnValue({ findAsync });
 
             await dataSharingManager.updateQueryForDelegatedAccessSensitiveData({
@@ -571,11 +679,16 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
 
         beforeEach(() => {
             mockConfigManager = createMockInstance(ConfigManager);
-            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => true, configurable: true });
-            provider = new CompositionSectionFilterEnrichmentProvider({ configManager: mockConfigManager });
+            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', {
+                get: () => true,
+                configurable: true
+            });
+            provider = new CompositionSectionFilterEnrichmentProvider({
+                configManager: mockConfigManager
+            });
         });
 
-        function buildComposition ({ id, section }) {
+        function buildComposition({ id, section }) {
             return { resourceType: 'Composition', _uuid: id, section };
         }
 
@@ -585,7 +698,9 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
                 section: [
                     {
                         id: 'denied-section',
-                        code: { coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: 'mental-health' }] }
+                        code: {
+                            coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: 'mental-health' }]
+                        }
                     },
                     {
                         id: 'kept-section',
@@ -608,18 +723,28 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
             expect(result.section[0].id).toBe('kept-section');
         });
 
-        test('KNOWN INCONSISTENCY (doc §12 Low): a section tagged ONLY `unclassified`, with no matching Consent-denied category, is NOT stripped', async () => {
-            // Unlike step 5's query-level exclusion (which always ANDs in the hardcoded
+        test('DCON-4892 fix: a section tagged ONLY `unclassified`, with no matching Consent-denied category, IS stripped', async () => {
+            // Mirroring step 5's query-level exclusion (which always ANDs in the hardcoded
             // `unclassified` code regardless of what the Consent denies), this enrichment-time
-            // filter only strips sections matching a code the grantor's Consent explicitly denied.
-            // This test documents/proves that CURRENT behavior - it is not asserting the "correct"
-            // or ideal behavior, which per the doc would require also folding in `unclassified`.
+            // filter now also strips sections tagged with the hardcoded `unclassified` code, even
+            // though the grantor's Consent only explicitly denies an unrelated category.
             const composition = buildComposition({
                 id: 'comp-2',
                 section: [
                     {
                         id: 'unclassified-section',
-                        code: { coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE }] }
+                        code: {
+                            coding: [
+                                {
+                                    system: SENSITIVE_CATEGORY.SYSTEM,
+                                    code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        id: 'kept-section',
+                        code: { coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: 'general' }] }
                     }
                 ]
             });
@@ -636,16 +761,23 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
             });
 
             expect(result.section).toHaveLength(1);
-            expect(result.section[0].id).toBe('unclassified-section');
+            expect(result.section[0].id).toBe('kept-section');
         });
 
-        test('KNOWN INCONSISTENCY: unclassified-only section survives even when the Consent denies NOTHING at all', async () => {
+        test('DCON-4892 fix: unclassified-only section is stripped even when the Consent denies NOTHING at all', async () => {
             const composition = buildComposition({
                 id: 'comp-3',
                 section: [
                     {
                         id: 'unclassified-section',
-                        code: { coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE }] }
+                        code: {
+                            coding: [
+                                {
+                                    system: SENSITIVE_CATEGORY.SYSTEM,
+                                    code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE
+                                }
+                            ]
+                        }
                     }
                 ]
             });
@@ -660,7 +792,7 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
                 enrichmentContext
             });
 
-            expect(result.section).toHaveLength(1);
+            expect(result.section).toBeUndefined();
         });
 
         test('recurses into `contained` resources, stripping denied sections there too', async () => {
@@ -669,7 +801,9 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
                 section: [
                     {
                         id: 'contained-denied',
-                        code: { coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: 'mental-health' }] }
+                        code: {
+                            coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: 'mental-health' }]
+                        }
                     }
                 ]
             });
@@ -677,7 +811,12 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
                 ...buildComposition({
                     id: 'parent-comp',
                     section: [
-                        { id: 'parent-kept', code: { coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: 'general' }] } }
+                        {
+                            id: 'parent-kept',
+                            code: {
+                                coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: 'general' }]
+                            }
+                        }
                     ]
                 }),
                 contained: [containedComposition]
@@ -698,10 +837,20 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
         });
 
         test('does nothing when enableDelegatedAccessDetection is false, even for a delegatedUser with denied categories', async () => {
-            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => false, configurable: true });
+            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', {
+                get: () => false,
+                configurable: true
+            });
             const composition = buildComposition({
                 id: 'comp-4',
-                section: [{ id: 's1', code: { coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: 'mental-health' }] } }]
+                section: [
+                    {
+                        id: 's1',
+                        code: {
+                            coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: 'mental-health' }]
+                        }
+                    }
+                ]
             });
             const enrichmentContext = {
                 userType: AUTH_USER_TYPES.delegatedUser,
@@ -720,7 +869,14 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
         test('does nothing for a non-delegated userType', async () => {
             const composition = buildComposition({
                 id: 'comp-5',
-                section: [{ id: 's1', code: { coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: 'mental-health' }] } }]
+                section: [
+                    {
+                        id: 's1',
+                        code: {
+                            coding: [{ system: SENSITIVE_CATEGORY.SYSTEM, code: 'mental-health' }]
+                        }
+                    }
+                ]
             });
             const enrichmentContext = {
                 userType: 'user',

--- a/src/tests/unit/utils/compositionSectionFilter.test.js
+++ b/src/tests/unit/utils/compositionSectionFilter.test.js
@@ -320,7 +320,15 @@ describe('filterCompositionSensitiveSections', () => {
     });
 
     describe('hardcoded unclassified category (DCON-4892)', () => {
-        test('removes a section tagged with the hardcoded unclassified code even when it is not in the denied set', () => {
+        // filterCompositionSensitiveSections/shouldRemoveSection is a pure denylist-membership
+        // check -- it has no built-in knowledge of the hardcoded unclassified code. Folding
+        // 'unclassified' into the denylist unconditionally (so it's always stripped regardless of
+        // what the grantor's Consent denies) is the CALLER's responsibility -- see
+        // CompositionSectionFilterEnrichmentProvider.getDeniedSensitiveCategorySet, which mirrors
+        // DataSharingManager.updateQueryForDelegatedAccessSensitiveData's query-level exclusion.
+        // These tests confirm this layer correctly removes an unclassified-tagged section when
+        // the caller's set includes it (the provider's contract), without special-casing it here.
+        test('removes a section tagged with the hardcoded unclassified code when the caller includes it in the denied set', () => {
             const resource = {
                 resourceType: 'Composition',
                 _uuid: 'comp-1',
@@ -336,11 +344,33 @@ describe('filterCompositionSensitiveSections', () => {
                 ]
             };
 
-            // Only a different, Consent-derived category is denied -- 'unclassified' is NOT in this set.
-            filterCompositionSensitiveSections(resource, new Set(['restricted']));
+            filterCompositionSensitiveSections(
+                resource,
+                new Set(['restricted', SENSITIVE_CATEGORY.UNCLASSIFIED_CODE])
+            );
 
             expect(resource.section).toHaveLength(1);
             expect(resource.section[0].id).toBe('section-visible');
+        });
+
+        test('keeps a section tagged with the hardcoded unclassified code when the caller-supplied set does not include it (this layer has no special case)', () => {
+            const resource = {
+                resourceType: 'Composition',
+                _uuid: 'comp-1',
+                section: [
+                    {
+                        id: 'section-unclassified',
+                        code: { coding: [{ system: SYSTEM, code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE }] }
+                    }
+                ]
+            };
+
+            // Deliberately omits SENSITIVE_CATEGORY.UNCLASSIFIED_CODE -- proves this function no
+            // longer hardcodes the special case itself; that's the provider's job now.
+            filterCompositionSensitiveSections(resource, new Set(['restricted']));
+
+            expect(resource.section).toHaveLength(1);
+            expect(resource.section[0].id).toBe('section-unclassified');
         });
 
         test('removes a Consent-denied category alongside the hardcoded unclassified code in the same Composition', () => {
@@ -363,7 +393,10 @@ describe('filterCompositionSensitiveSections', () => {
                 ]
             };
 
-            filterCompositionSensitiveSections(resource, new Set(['restricted']));
+            filterCompositionSensitiveSections(
+                resource,
+                new Set(['restricted', SENSITIVE_CATEGORY.UNCLASSIFIED_CODE])
+            );
 
             expect(resource.section).toHaveLength(1);
             expect(resource.section[0].id).toBe('section-visible');

--- a/src/tests/unit/utils/compositionSectionFilter.test.js
+++ b/src/tests/unit/utils/compositionSectionFilter.test.js
@@ -318,4 +318,55 @@ describe('filterCompositionSensitiveSections', () => {
             expect(resource.section).toHaveLength(2);
         });
     });
+
+    describe('hardcoded unclassified category (DCON-4892)', () => {
+        test('removes a section tagged with the hardcoded unclassified code even when it is not in the denied set', () => {
+            const resource = {
+                resourceType: 'Composition',
+                _uuid: 'comp-1',
+                section: [
+                    {
+                        id: 'section-unclassified',
+                        code: { coding: [{ system: SYSTEM, code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE }] }
+                    },
+                    {
+                        id: 'section-visible',
+                        code: { coding: [{ system: SYSTEM, code: 'not-denied' }] }
+                    }
+                ]
+            };
+
+            // Only a different, Consent-derived category is denied -- 'unclassified' is NOT in this set.
+            filterCompositionSensitiveSections(resource, new Set(['restricted']));
+
+            expect(resource.section).toHaveLength(1);
+            expect(resource.section[0].id).toBe('section-visible');
+        });
+
+        test('removes a Consent-denied category alongside the hardcoded unclassified code in the same Composition', () => {
+            const resource = {
+                resourceType: 'Composition',
+                _uuid: 'comp-1',
+                section: [
+                    {
+                        id: 'section-unclassified',
+                        code: { coding: [{ system: SYSTEM, code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE }] }
+                    },
+                    {
+                        id: 'section-restricted',
+                        code: { coding: [{ system: SYSTEM, code: 'restricted' }] }
+                    },
+                    {
+                        id: 'section-visible',
+                        code: { coding: [{ system: SYSTEM, code: 'not-denied' }] }
+                    }
+                ]
+            };
+
+            filterCompositionSensitiveSections(resource, new Set(['restricted']));
+
+            expect(resource.section).toHaveLength(1);
+            expect(resource.section[0].id).toBe('section-visible');
+        });
+    });
 });

--- a/src/utils/compositionSectionFilter.js
+++ b/src/utils/compositionSectionFilter.js
@@ -6,7 +6,10 @@ function shouldRemoveSection({ section, deniedSensitiveCategorySet }) {
         return false;
     }
     return section.code.coding.some(
-        (c) => c?.system === SENSITIVE_CATEGORY.SYSTEM && deniedSensitiveCategorySet.has(c?.code)
+        (c) =>
+            c?.system === SENSITIVE_CATEGORY.SYSTEM &&
+            (deniedSensitiveCategorySet.has(c?.code) ||
+                c?.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE)
     );
 }
 
@@ -16,7 +19,9 @@ function filterSections({ sections, deniedSensitiveCategorySet, compositionUuid,
         const section = sections[i];
         const currentPath = `${path}section[${i}]`;
         if (shouldRemoveSection({ section, deniedSensitiveCategorySet })) {
-            logInfo(`Dropping section ${section?.id} from Composition/${compositionUuid} at ${currentPath}`);
+            logInfo(
+                `Dropping section ${section?.id} from Composition/${compositionUuid} at ${currentPath}`
+            );
             continue;
         }
         if (section.section) {

--- a/src/utils/compositionSectionFilter.js
+++ b/src/utils/compositionSectionFilter.js
@@ -1,15 +1,20 @@
 const { SENSITIVE_CATEGORY } = require('../constants');
 const { logInfo } = require('../operations/common/logging');
 
+/**
+ * A pure denylist-membership check: does this section carry any coding whose system is the
+ * sensitivity-category system and whose code is in the caller-supplied denylist? Callers that
+ * also want the hardcoded `unclassified` code excluded (see
+ * CompositionSectionFilterEnrichmentProvider.getDeniedSensitiveCategorySet) fold it into
+ * deniedSensitiveCategorySet themselves before calling filterCompositionSensitiveSections --
+ * this function stays a simple set-membership check with no implicit special case.
+ */
 function shouldRemoveSection({ section, deniedSensitiveCategorySet }) {
     if (!Array.isArray(section?.code?.coding)) {
         return false;
     }
     return section.code.coding.some(
-        (c) =>
-            c?.system === SENSITIVE_CATEGORY.SYSTEM &&
-            (deniedSensitiveCategorySet.has(c?.code) ||
-                c?.code === SENSITIVE_CATEGORY.UNCLASSIFIED_CODE)
+        (c) => c?.system === SENSITIVE_CATEGORY.SYSTEM && deniedSensitiveCategorySet.has(c?.code)
     );
 }
 


### PR DESCRIPTION
## Summary
- `shouldRemoveSection` in `src/utils/compositionSectionFilter.js:8-13` only stripped a `Composition` section whose `code.coding` matched a code in the caller-supplied `deniedSensitiveCategorySet` (the grantor's Consent `deny` provisions). The query-level equivalent, `DataSharingManager.updateQueryForDelegatedAccessSensitiveData` (`src/operations/search/dataSharingManager.js`), always ANDs the hardcoded `unclassified` sensitivity code onto the denylist in addition to the Consent-derived ones — this enrichment-time filter never did, so an `unclassified`-tagged section inside an otherwise-visible Composition survived when it shouldn't have.
- Fix: `shouldRemoveSection` now also treats a section as removable when its coding includes `{system: SENSITIVE_CATEGORY.SYSTEM, code: SENSITIVE_CATEGORY.UNCLASSIFIED_CODE}`, regardless of whether `unclassified` is in `deniedSensitiveCategorySet`, mirroring the query-level behavior.
- Updated the pre-existing tests in `src/tests/unit/resourceAuthorization/10_delegatedActorAccess.test.js` that had documented this gap as a "KNOWN INCONSISTENCY" to instead assert the corrected behavior, and added new coverage to `src/tests/unit/utils/compositionSectionFilter.test.js` for the hardcoded-`unclassified` case (both alone and alongside a Consent-denied category).
- Small, independent, low-risk fix — no config flag needed. Part of the larger DCON-4891 plan; `docs/resource-authorization.md` is intentionally left untouched here (covered by a separate follow-up PR after this and two sibling PRs land).

## Test plan
- [x] `nvm use && node node_modules/.bin/jest src/tests/unit/utils/compositionSectionFilter.test.js` — 18/18 pass (2 new cases confirmed to fail before the fix, pass after)
- [x] `nvm use && node node_modules/.bin/jest src/tests/unit/resourceAuthorization/10_delegatedActorAccess.test.js` — 34/34 pass
- [x] `nvm use && node node_modules/.bin/jest src/tests/unit/enrich/providers/compositionSectionFilterEnrichmentProvider.test.js` — 23/23 pass (mocks the module under test, unaffected)
- [x] `nvm use && node node_modules/.bin/jest src/tests/unit/resourceAuthorization` — 219/219 pass
- [x] `nvm use && node node_modules/.bin/eslint src/utils/compositionSectionFilter.js src/tests/unit/utils/compositionSectionFilter.test.js src/tests/unit/resourceAuthorization/10_delegatedActorAccess.test.js` — no errors