### PR TITLE
DCON-4888 Added read and write permission check for the admin routes

### DIFF
--- a/src/operations/security/scopesManager.js
+++ b/src/operations/security/scopesManager.js
@@ -380,6 +380,22 @@ class ScopesManager {
     }
 
     /**
+     * Returns whether scope contains an admin/ scope whose action segment is the given action or
+     * the wildcard '*'. getAdminScopes() alone (used to gate admin routes generally) never looks
+     * at the action segment, so an admin/*.read-only caller passes that check identically to one
+     * holding admin/*.write.
+     * @param {string|undefined} scope
+     * @param {'read'|'write'} action
+     * @return {boolean}
+     */
+    hasAdminScopeForAction ({ scope, action }) {
+        return this.getAdminScopes({ scope }).some((adminScope) => {
+            const scopeAction = adminScope.split('.')[1];
+            return scopeAction === '*' || scopeAction === action;
+        });
+    }
+
+    /**
      * Gets patient scopes from the passed in scope string
      * @param {string|undefined} scope
      * @returns {string[]}

--- a/src/routeHandlers/admin.js
+++ b/src/routeHandlers/admin.js
@@ -710,7 +710,7 @@ async function handleAdminDelete (
                                 )
                             ]
                         });
-                        return res.json(operationOutcome.toJSON());
+                        return res.status(403).json(operationOutcome.toJSON());
                     }
 
                     /**
@@ -779,7 +779,7 @@ async function handleAdminDelete (
                                 )
                             ]
                         });
-                        return res.json(operationOutcome.toJSON());
+                        return res.status(403).json(operationOutcome.toJSON());
                     }
                     /**
                      * @type {AdminPersonPatientDataManager}

--- a/src/routeHandlers/admin.js
+++ b/src/routeHandlers/admin.js
@@ -15,6 +15,22 @@ const { AdminExportManager } = require('../admin/adminExportManager');
 const { logError } = require('../operations/common/logging');
 const { FhirRequestInfoBuilder } = require('../utils/fhirRequestInfoBuilder');
 const { isTrue } = require('../utils/isTrue');
+const { ForbiddenError } = require('../utils/httpErrors');
+
+/**
+ * Every admin operation, read or write, calls this with its own required action. Throws (rather
+ * than directly writing a response) so the enclosing handler's own catch block - which every
+ * handler below already has, formatting any thrown error into the standard 403 OperationOutcome
+ * response via error.statusCode
+ * @param {ScopesManager} scopesManager
+ * @param {string} scope
+ * @param {'read'|'write'} action
+ */
+function assertAdminScope ({ scopesManager, scope, action }) {
+    if (!scopesManager.hasAdminScopeForAction({ scope, action })) {
+        throw new ForbiddenError('user with scopes [' + scope + '] failed access check to [admin/*.' + action + ']');
+    }
+}
 
 /**
  * shows indexes
@@ -113,6 +129,7 @@ async function handleAdminGet (
         if (adminScopes.length > 0) {
             switch (operation) {
                 case 'searchLogResults': {
+                    assertAdminScope({ scopesManager, scope, action: 'read' });
                     logInfo('', { 'req.query': req.query });
                     const id = req.query.id;
                     if (id) {
@@ -136,6 +153,7 @@ async function handleAdminGet (
                 }
 
                 case 'showPersonToPersonLink': {
+                    assertAdminScope({ scopesManager, scope, action: 'read' });
                     logInfo('', { 'req.query': req.query });
                     const bwellPersonId = req.query.bwellPersonId;
                     if (bwellPersonId) {
@@ -154,6 +172,7 @@ async function handleAdminGet (
                 }
 
                 case 'indexes': {
+                    assertAdminScope({ scopesManager, scope, action: 'read' });
                     return await showIndexesAsync(
                         {
                             req,
@@ -165,6 +184,7 @@ async function handleAdminGet (
                 }
 
                 case 'indexProblems': {
+                    assertAdminScope({ scopesManager, scope, action: 'read' });
                     return await showIndexesAsync(
                         {
                             req,
@@ -176,6 +196,7 @@ async function handleAdminGet (
                 }
 
                 case 'synchronizeIndexes': {
+                    assertAdminScope({ scopesManager, scope, action: 'write' });
                     return await synchronizeIndexesAsync(
                         {
                             req,
@@ -186,6 +207,7 @@ async function handleAdminGet (
                 }
 
                 case 'runPersonMatch': {
+                    assertAdminScope({ scopesManager, scope, action: 'read' });
                     logInfo('', { 'req.query': req.query });
                     const sourceId = req.query.sourceId;
                     const sourceType = req.query.sourceType;
@@ -207,11 +229,13 @@ async function handleAdminGet (
                 }
 
                 case 'ExportStatus': {
+                    assertAdminScope({ scopesManager, scope, action: 'read' });
                     logInfo('', { 'req.query': req.query, 'req.params.id': req.params.id });
                     return res.json(await adminExportManager.getExportStatus({ req, res }))
                 }
 
                 case 'getCacheKeys': {
+                    assertAdminScope({ scopesManager, scope, action: 'read' });
                     const resourceType = req.query.resourceType;
                     const resourceId = req.query.resourceId;
                     if (resourceType && resourceId) {
@@ -243,6 +267,7 @@ async function handleAdminGet (
                 }
 
                 case 'runPersonOneToNMatch': {
+                    assertAdminScope({ scopesManager, scope, action: 'read' });
                     logInfo('', { 'req.query': req.query });
                     const id = req.query.id;
                     const resourceType = req.query.resourceType;
@@ -337,6 +362,7 @@ async function handleAdminPost (
         if (adminScopes.length > 0) {
             switch (operation) {
                 case 'createPersonToPersonLink': {
+                    assertAdminScope({ scopesManager, scope, action: 'write' });
                     logInfo('', { 'req.body': req.body });
                     const bwellPersonId = req.body.bwellPersonId;
                     const externalPersonId = req.body.externalPersonId;
@@ -358,6 +384,7 @@ async function handleAdminPost (
                 }
 
                 case 'removePersonToPersonLink': {
+                    assertAdminScope({ scopesManager, scope, action: 'write' });
                     logInfo('', { 'req.body': req.body });
                     const bwellPersonId = req.body.bwellPersonId;
                     const externalPersonId = req.body.externalPersonId;
@@ -379,6 +406,7 @@ async function handleAdminPost (
                 }
 
                 case 'createPersonToPatientLink': {
+                    assertAdminScope({ scopesManager, scope, action: 'write' });
                     logInfo('', { 'req.body': req.body });
                     const externalPersonId = req.body.externalPersonId;
                     const patientId = req.body.patientId;
@@ -400,6 +428,7 @@ async function handleAdminPost (
                 }
 
                 case 'removePersonToPatientLink': {
+                    assertAdminScope({ scopesManager, scope, action: 'write' });
                     logInfo('', { 'req.body': req.body });
                     const personId = req.body.personId;
                     const patientId = req.body.patientId;
@@ -421,6 +450,7 @@ async function handleAdminPost (
                 }
 
                 case 'updatePatientReference': {
+                    assertAdminScope({ scopesManager, scope, action: 'write' });
                     logInfo('', { 'req.body': req.body });
                     const patientId = req.body.patientId;
                     const resourceType = req.body.resourceType;
@@ -443,6 +473,7 @@ async function handleAdminPost (
                     });
                 }
                 case 'triggerExport': {
+                    assertAdminScope({ scopesManager, scope, action: 'write' });
                     if (req.params.id) {
                         return res.json(await adminExportManager.triggerExportJob({ req, res }));
                     }
@@ -451,6 +482,7 @@ async function handleAdminPost (
                     }
                 }
                 case 'invalidateCache': {
+                    assertAdminScope({ scopesManager, scope, action: 'write' });
                     const resourceType = req.body.resourceType;
                     const resourceId = req.body.resourceId;
                     const cacheKeys = req.body.cacheKeys;
@@ -489,6 +521,7 @@ async function handleAdminPost (
                 }
 
                 case 'runMatchWithPayload': {
+                    assertAdminScope({ scopesManager, scope, action: 'read' });
                     logInfo('', { operation: 'runMatchWithPayload' });
                     const parameters = req.body;
                     const personMatchManager = container.personMatchManager;
@@ -560,30 +593,21 @@ async function handleAdminPut(
          * @type {string|undefined}
          */
         const scope = scopesManager.getScopeFromRequest({ req });
-        /**
-         * @type {string[]}
-         */
-        const adminScopes = scopesManager.getAdminScopes({ scope });
+        assertAdminScope({ scopesManager, scope, action: 'write' });
 
-        if (adminScopes.length > 0) {
-            switch (operation) {
-                case 'ExportStatus': {
-                    logInfo('', { 'req.query': req.query, 'req.param.id': req.params.id });
-                    if (req.params.id) {
-                        return res.json(await adminExportManager.updateExportStatus({ req, res }));
-                    }
-                    else {
-                        return res.status(400).json({ message: 'ExportStatusId was not passed' })
-                    }
+        switch (operation) {
+            case 'ExportStatus': {
+                logInfo('', { 'req.query': req.query, 'req.param.id': req.params.id });
+                if (req.params.id) {
+                    return res.json(await adminExportManager.updateExportStatus({ req, res }));
                 }
-                default: {
-                    return res.json({ message: 'Invalid Path' });
+                else {
+                    return res.status(400).json({ message: 'ExportStatusId was not passed' })
                 }
             }
-        } else {
-            return res.status(403).json({
-                message: `Missing scopes for admin/*.read in ${scope}`
-            });
+            default: {
+                return res.json({ message: 'Invalid Path' });
+            }
         }
     }
     catch (error) {
@@ -636,135 +660,72 @@ async function handleAdminDelete (
          * @type {string|undefined}
          */
         const scope = scopesManager.getScopeFromRequest({ req });
-        /**
-         * @type {string[]}
-         */
-        const adminScopes = scopesManager.getAdminScopes({ scope });
+        assertAdminScope({ scopesManager, scope, action: 'write' });
 
-        if (adminScopes.length > 0) {
-            switch (operation) {
-                case 'deletePerson': {
-                    logInfo('', { 'req.query': req.query });
-                    const personId = req.query.personId;
-                    if (personId) {
-                        /**
-                         * @type {AdminPersonPatientLinkManager}
-                         */
-                        const adminPersonPatientLinkManager = container.adminPersonPatientLinkManager;
-                        const json = await adminPersonPatientLinkManager.deletePersonAsync({
+        switch (operation) {
+            case 'deletePerson': {
+                logInfo('', { 'req.query': req.query });
+                const personId = req.query.personId;
+                if (personId) {
+                    /**
+                     * @type {AdminPersonPatientLinkManager}
+                     */
+                    const adminPersonPatientLinkManager = container.adminPersonPatientLinkManager;
+                    const json = await adminPersonPatientLinkManager.deletePersonAsync({
+                        req,
+                        requestId: req.id,
+                        personId
+                    });
+                    return res.json(json);
+                }
+                return res.json({
+                    message: `No personId: ${personId} passed`
+                });
+            }
+
+            case 'deletePatientDataGraph': {
+                logInfo('', { 'req.query': req.query });
+                const patientId = req.query.id;
+                const sync = req.query.sync;
+                if (patientId) {
+                    /**
+                     * @type {string[]}
+                     */
+                    const scopes = scopesManager.parseScopes(scope);
+                    const resourceType = 'Patient';
+                    const accessRequested = 'write';
+
+                    const { success } = scopeChecker(resourceType, accessRequested, scopes);
+                    if (!success) {
+                        const errorMessage = 'user with scopes [' + scopes +
+                            '] failed access check to [' + resourceType + '.' + accessRequested + ']';
+                        const operationOutcome = new OperationOutcome({
+                            issue: [
+                                new OperationOutcomeIssue(
+                                    {
+                                        severity: 'error',
+                                        code: 'forbidden',
+                                        diagnostics: errorMessage
+                                    }
+                                )
+                            ]
+                        });
+                        return res.json(operationOutcome.toJSON());
+                    }
+
+                    /**
+                     * @type {AdminPersonPatientDataManager}
+                     */
+                    const adminPersonPatientLinkManager = container.adminPersonPatientDataManager;
+                    if (sync) {
+                        const json = await adminPersonPatientLinkManager.deletePatientDataGraphAsync({
                             req,
-                            requestId: req.id,
-                            personId
+                            res,
+                            patientId,
+                            responseStreamer: null
                         });
                         return res.json(json);
-                    }
-                    return res.json({
-                        message: `No personId: ${personId} passed`
-                    });
-                }
-
-                case 'deletePatientDataGraph': {
-                    logInfo('', { 'req.query': req.query });
-                    const patientId = req.query.id;
-                    const sync = req.query.sync;
-                    if (patientId) {
-                        /**
-                         * @type {string[]}
-                         */
-                        const scopes = scopesManager.parseScopes(scope);
-                        const resourceType = 'Patient';
-                        const accessRequested = 'write';
-
-                        const { success } = scopeChecker(resourceType, accessRequested, scopes);
-                        if (!success) {
-                            const errorMessage = 'user with scopes [' + scopes +
-                                '] failed access check to [' + resourceType + '.' + accessRequested + ']';
-                            const operationOutcome = new OperationOutcome({
-                                issue: [
-                                    new OperationOutcomeIssue(
-                                        {
-                                            severity: 'error',
-                                            code: 'forbidden',
-                                            diagnostics: errorMessage
-                                        }
-                                    )
-                                ]
-                            });
-                            return res.json(operationOutcome.toJSON());
-                        }
-
-                        /**
-                         * @type {AdminPersonPatientDataManager}
-                         */
-                        const adminPersonPatientLinkManager = container.adminPersonPatientDataManager;
-                        if (sync) {
-                            const json = await adminPersonPatientLinkManager.deletePatientDataGraphAsync({
-                                req,
-                                res,
-                                patientId,
-                                responseStreamer: null
-                            });
-                            return res.json(json);
-                        } else {
-                            /**
-                             * @type {FhirResponseStreamer}
-                             */
-                            const responseStreamer = new FhirResponseStreamer({
-                                response: res,
-                                requestId: req.id,
-                                bundleType: 'batch-response'
-                            });
-                            await responseStreamer.startAsync();
-                            await adminPersonPatientLinkManager.deletePatientDataGraphAsync({
-                                req,
-                                res,
-                                patientId,
-                                responseStreamer
-                            });
-                            await responseStreamer.writeAsync({
-                                content: '<div>Finished</div>\n'
-                            });
-                            await responseStreamer.endAsync();
-                            return;
-                        }
-                    }
-                    return res.json({
-                        message: `No id: ${patientId} passed`
-                    });
-                }
-
-                case 'deletePersonDataGraph': {
-                    logInfo('', { 'req.query': req.query });
-                    const personId = req.query.id;
-                    if (personId) {
-                        /**
-                         * @type {string[]}
-                         */
-                        const scopes = scopesManager.parseScopes(scope);
-                        const resourceType = 'Patient';
-                        const accessRequested = 'write';
-
-                        const { success } = scopeChecker(resourceType, accessRequested, scopes);
-                        if (!success) {
-                            const errorMessage = 'user with scopes [' + scopes +
-                                '] failed access check to [' + resourceType + '.' + accessRequested + ']';
-                            const operationOutcome = new OperationOutcome({
-                                issue: [
-                                    new OperationOutcomeIssue(
-                                        {
-                                            severity: 'error',
-                                            code: 'forbidden',
-                                            diagnostics: errorMessage
-                                        }
-                                    )
-                                ]
-                            });
-                            return res.json(operationOutcome.toJSON());
-                        }
-                        /**
-                         * @type {AdminPersonPatientDataManager}
-                         */
-                        const adminPersonPatientLinkManager = container.adminPersonPatientDataManager;
+                    } else {
                         /**
                          * @type {FhirResponseStreamer}
                          */
@@ -773,30 +734,84 @@ async function handleAdminDelete (
                             requestId: req.id,
                             bundleType: 'batch-response'
                         });
-
                         await responseStreamer.startAsync();
-                        await adminPersonPatientLinkManager.deletePersonDataGraphAsync({
+                        await adminPersonPatientLinkManager.deletePatientDataGraphAsync({
                             req,
                             res,
-                            personId,
+                            patientId,
                             responseStreamer
+                        });
+                        await responseStreamer.writeAsync({
+                            content: '<div>Finished</div>\n'
                         });
                         await responseStreamer.endAsync();
                         return;
                     }
-                    return res.json({
-                        message: `No id: ${personId} passed`
-                    });
                 }
-
-                default: {
-                    return res.json({ message: 'Invalid Path' });
-                }
+                return res.json({
+                    message: `No id: ${patientId} passed`
+                });
             }
-        } else {
-            return res.status(403).json({
-                message: `Missing scopes for admin/*.read in ${scope}`
-            });
+
+            case 'deletePersonDataGraph': {
+                logInfo('', { 'req.query': req.query });
+                const personId = req.query.id;
+                if (personId) {
+                    /**
+                     * @type {string[]}
+                     */
+                    const scopes = scopesManager.parseScopes(scope);
+                    const resourceType = 'Patient';
+                    const accessRequested = 'write';
+
+                    const { success } = scopeChecker(resourceType, accessRequested, scopes);
+                    if (!success) {
+                        const errorMessage = 'user with scopes [' + scopes +
+                            '] failed access check to [' + resourceType + '.' + accessRequested + ']';
+                        const operationOutcome = new OperationOutcome({
+                            issue: [
+                                new OperationOutcomeIssue(
+                                    {
+                                        severity: 'error',
+                                        code: 'forbidden',
+                                        diagnostics: errorMessage
+                                    }
+                                )
+                            ]
+                        });
+                        return res.json(operationOutcome.toJSON());
+                    }
+                    /**
+                     * @type {AdminPersonPatientDataManager}
+                     */
+                    const adminPersonPatientLinkManager = container.adminPersonPatientDataManager;
+                    /**
+                     * @type {FhirResponseStreamer}
+                     */
+                    const responseStreamer = new FhirResponseStreamer({
+                        response: res,
+                        requestId: req.id,
+                        bundleType: 'batch-response'
+                    });
+
+                    await responseStreamer.startAsync();
+                    await adminPersonPatientLinkManager.deletePersonDataGraphAsync({
+                        req,
+                        res,
+                        personId,
+                        responseStreamer
+                    });
+                    await responseStreamer.endAsync();
+                    return;
+                }
+                return res.json({
+                    message: `No id: ${personId} passed`
+                });
+            }
+
+            default: {
+                return res.json({ message: 'Invalid Path' });
+            }
         }
     } catch (error) {
         logError(`Error in handleAdminDelete`, {

--- a/src/tests/admin/patientData/patientdata.test.js
+++ b/src/tests/admin/patientData/patientdata.test.js
@@ -57,8 +57,19 @@ describe('Patient Tests', () => {
             resp = await request
                 .delete('/admin/deletePatientDataGraph?id=patient1')
                 .set(getHeaders());
+
             // noinspection JSUnresolvedFunction
-            expect(resp.body.message).toBe('Missing scopes for admin/*.read in user/*.read user/*.write access/*.*');
+            expect(resp.status).toBe(403);
+            expect(resp.body).toEqual({
+                resourceType: 'OperationOutcome',
+                issue: [
+                    {
+                        severity: 'error',
+                        code: 'exception',
+                        diagnostics: 'user with scopes [user/*.read user/*.write access/*.*] failed access check to [admin/*.write]'
+                    }
+                ]
+            });
         });
         test('patientData works with admin permissions', async () => {
             const request = await createTestRequest();

--- a/src/tests/admin/patientData/persondata.test.js
+++ b/src/tests/admin/patientData/persondata.test.js
@@ -61,7 +61,17 @@ describe('Person Tests', () => {
                 .delete('/admin/deletePersonDataGraph?id=person1')
                 .set(getHeaders());
             // noinspection JSUnresolvedFunction
-            expect(resp.body.message).toBe('Missing scopes for admin/*.read in user/*.read user/*.write access/*.*');
+            expect(resp.status).toBe(403);
+            expect(resp.body).toEqual({
+                resourceType: 'OperationOutcome',
+                issue: [
+                    {
+                        severity: 'error',
+                        code: 'exception',
+                        diagnostics: 'user with scopes [user/*.read user/*.write access/*.*] failed access check to [admin/*.write]'
+                    }
+                ]
+            });
         });
         test('personData $everything works with admin permissions', async () => {
             const request = await createTestRequest();

--- a/src/tests/export/export.search.test.js
+++ b/src/tests/export/export.search.test.js
@@ -366,7 +366,14 @@ describe('Export Tests', () => {
 
             expect(exportStatusPutResponseViaPatientScope).toHaveResponse(
                 {
-                    message: "Missing scopes for admin/*.read in patient/*.*"
+                    resourceType: 'OperationOutcome',
+                    issue: [
+                        {
+                            severity: 'error',
+                            code: 'exception',
+                            diagnostics: 'user with scopes [patient/*.*] failed access check to [admin/*.write]'
+                        }
+                    ]
                 }
             );
         });

--- a/src/tests/unit/operations/security/scopesManager.test.js
+++ b/src/tests/unit/operations/security/scopesManager.test.js
@@ -377,6 +377,55 @@ describe('ScopesManager', () => {
         });
     });
 
+    describe('hasAdminScopeForAction', () => {
+        test('returns false for undefined scope', () => {
+            expect(scopesManager.hasAdminScopeForAction({ scope: undefined, action: 'write' })).toBe(false);
+        });
+
+        test('returns false when scope has no admin/ entry at all', () => {
+            expect(scopesManager.hasAdminScopeForAction({
+                scope: 'user/Patient.write access/*.write', action: 'write'
+            })).toBe(false);
+        });
+
+        test('a read-only admin scope (admin/*.read) satisfies a read check but not a write check', () => {
+            expect(scopesManager.hasAdminScopeForAction({ scope: 'admin/*.read', action: 'read' })).toBe(true);
+            expect(scopesManager.hasAdminScopeForAction({ scope: 'admin/*.read', action: 'write' })).toBe(false);
+        });
+
+        test('a read-only, resource-scoped admin scope (admin/Patient.read) behaves the same way', () => {
+            expect(scopesManager.hasAdminScopeForAction({ scope: 'admin/Patient.read', action: 'read' })).toBe(true);
+            expect(scopesManager.hasAdminScopeForAction({ scope: 'admin/Patient.read', action: 'write' })).toBe(false);
+        });
+
+        test('a write-only admin scope (admin/*.write) satisfies a write check but not a read check', () => {
+            expect(scopesManager.hasAdminScopeForAction({ scope: 'admin/*.write', action: 'write' })).toBe(true);
+            expect(scopesManager.hasAdminScopeForAction({ scope: 'admin/*.write', action: 'read' })).toBe(false);
+        });
+
+        test('a resource-scoped admin write (admin/Patient.write) satisfies write but not read', () => {
+            expect(scopesManager.hasAdminScopeForAction({ scope: 'admin/Patient.write', action: 'write' })).toBe(true);
+            expect(scopesManager.hasAdminScopeForAction({ scope: 'admin/Patient.write', action: 'read' })).toBe(false);
+        });
+
+        test('the admin wildcard action (admin/*.*) satisfies both read and write checks', () => {
+            expect(scopesManager.hasAdminScopeForAction({ scope: 'admin/*.*', action: 'read' })).toBe(true);
+            expect(scopesManager.hasAdminScopeForAction({ scope: 'admin/*.*', action: 'write' })).toBe(true);
+        });
+
+        test('returns true when a write admin scope is mixed in with a read-only one', () => {
+            expect(scopesManager.hasAdminScopeForAction({
+                scope: 'admin/Patient.read admin/AuditEvent.write', action: 'write'
+            })).toBe(true);
+        });
+
+        test('does not confuse a non-admin write scope for an admin write scope', () => {
+            expect(scopesManager.hasAdminScopeForAction({
+                scope: 'admin/Patient.read user/Patient.write', action: 'write'
+            })).toBe(false);
+        });
+    });
+
     describe('getPatientScopes', () => {
         test('should return empty array for undefined scope', () => {
             expect(scopesManager.getPatientScopes({ scope: undefined })).toEqual([]);

--- a/src/tests/unit/routeHandlers/admin.test.js
+++ b/src/tests/unit/routeHandlers/admin.test.js
@@ -73,8 +73,9 @@ describe('routeHandlers/admin', () => {
         mockContainer = {
             scopesManager: {
                 getScopeFromRequest: jest.fn().mockReturnValue('admin/*.read admin/*.write'),
-                getAdminScopes: jest.fn().mockReturnValue(['admin/*.read']),
-                parseScopes: jest.fn().mockReturnValue(['admin/*.read', 'admin/*.write', 'user/Patient.write'])
+                getAdminScopes: jest.fn().mockReturnValue(['admin/*.read', 'admin/*.write']),
+                parseScopes: jest.fn().mockReturnValue(['admin/*.read', 'admin/*.write', 'user/Patient.write']),
+                hasAdminScopeForAction: jest.fn().mockReturnValue(true)
             },
             indexManager: {
                 compareCurrentIndexesWithConfigurationInAllCollectionsAsync: jest.fn().mockResolvedValue([]),
@@ -121,7 +122,7 @@ describe('routeHandlers/admin', () => {
     });
 
     describe('handleAdminGet', () => {
-        test('returns 403 when no admin scopes', async () => {
+        test('returns 403 when no admin scope of any kind', async () => {
             mockContainer.scopesManager.getAdminScopes.mockReturnValue([]);
             mockReq.params.op = 'indexes';
             await handleAdminGet(fnGetContainer, mockReq, mockRes);
@@ -289,7 +290,7 @@ describe('routeHandlers/admin', () => {
     });
 
     describe('handleAdminPost', () => {
-        test('returns 403 when no admin scopes', async () => {
+        test('returns 403 when no admin scope of any kind', async () => {
             mockContainer.scopesManager.getAdminScopes.mockReturnValue([]);
             mockReq.params.op = 'createPersonToPersonLink';
             await handleAdminPost(fnGetContainer, mockReq, mockRes);
@@ -455,8 +456,8 @@ describe('routeHandlers/admin', () => {
     });
 
     describe('handleAdminPut', () => {
-        test('returns 403 when no admin scopes', async () => {
-            mockContainer.scopesManager.getAdminScopes.mockReturnValue([]);
+        test('returns 403 when no admin write scope', async () => {
+            mockContainer.scopesManager.hasAdminScopeForAction.mockReturnValue(false);
             mockReq.params.op = 'ExportStatus';
             await handleAdminPut(fnGetContainer, mockReq, mockRes);
             expect(mockRes.status).toHaveBeenCalledWith(403);
@@ -484,8 +485,8 @@ describe('routeHandlers/admin', () => {
     });
 
     describe('handleAdminDelete', () => {
-        test('returns 403 when no admin scopes', async () => {
-            mockContainer.scopesManager.getAdminScopes.mockReturnValue([]);
+        test('returns 403 when no admin write scope', async () => {
+            mockContainer.scopesManager.hasAdminScopeForAction.mockReturnValue(false);
             mockReq.params.op = 'deletePerson';
             await handleAdminDelete(fnGetContainer, mockReq, mockRes);
             expect(mockRes.status).toHaveBeenCalledWith(403);
@@ -541,6 +542,178 @@ describe('routeHandlers/admin', () => {
             );
             await handleAdminDelete(fnGetContainer, mockReq, mockRes);
             expect(mockRes.status).toHaveBeenCalledWith(500);
+        });
+    });
+
+    describe('admin/*.read vs admin/*.write scope enforcement', () => {
+        function setAdminScopes ({ hasRead, hasWrite }) {
+            const scopes = [];
+            if (hasRead) scopes.push('admin/*.read');
+            if (hasWrite) scopes.push('admin/*.write');
+            mockContainer.scopesManager.getAdminScopes.mockReturnValue(scopes);
+            mockContainer.scopesManager.hasAdminScopeForAction.mockImplementation(({ action }) => {
+                if (action === 'read') return hasRead;
+                if (action === 'write') return hasWrite;
+                return false;
+            });
+        }
+
+        describe('handleAdminGet (read operations + one write operation, synchronizeIndexes)', () => {
+            test('read-only scope (admin/*.read) can perform a read operation', async () => {
+                setAdminScopes({ hasRead: true, hasWrite: false });
+                mockReq.params.op = 'indexes';
+                await handleAdminGet(fnGetContainer, mockReq, mockRes);
+                expect(mockContainer.indexManager.compareCurrentIndexesWithConfigurationInAllCollectionsAsync)
+                    .toHaveBeenCalled();
+                expect(mockRes.status).not.toHaveBeenCalledWith(403);
+            });
+
+            test('read-only scope (admin/*.read) is rejected from the write operation synchronizeIndexes', async () => {
+                setAdminScopes({ hasRead: true, hasWrite: false });
+                mockReq.params.op = 'synchronizeIndexes';
+                await handleAdminGet(fnGetContainer, mockReq, mockRes);
+                expect(mockRes.status).toHaveBeenCalledWith(403);
+                expect(mockContainer.indexManager.synchronizeIndexesWithConfigAsync).not.toHaveBeenCalled();
+            });
+
+            test('write scope (admin/*.write) can perform the write operation synchronizeIndexes', async () => {
+                setAdminScopes({ hasRead: false, hasWrite: true });
+                mockReq.params.op = 'synchronizeIndexes';
+                await handleAdminGet(fnGetContainer, mockReq, mockRes);
+                expect(mockContainer.indexManager.synchronizeIndexesWithConfigAsync).toHaveBeenCalled();
+                expect(mockRes.status).not.toHaveBeenCalledWith(403);
+            });
+
+            test('write-only scope (admin/*.write, no read) is rejected from a read operation (indexes)', async () => {
+                setAdminScopes({ hasRead: false, hasWrite: true });
+                mockReq.params.op = 'indexes';
+                await handleAdminGet(fnGetContainer, mockReq, mockRes);
+                expect(mockRes.status).toHaveBeenCalledWith(403);
+                expect(mockContainer.indexManager.compareCurrentIndexesWithConfigurationInAllCollectionsAsync)
+                    .not.toHaveBeenCalled();
+            });
+
+            test('write-only scope (admin/*.write, no read) is rejected from every other read operation', async () => {
+                setAdminScopes({ hasRead: false, hasWrite: true });
+                const readOperations = [
+                    'searchLogResults', 'showPersonToPersonLink', 'indexProblems',
+                    'runPersonMatch', 'ExportStatus', 'getCacheKeys', 'runPersonOneToNMatch'
+                ];
+                for (const op of readOperations) {
+                    mockRes.status.mockClear();
+                    mockReq.params.op = op;
+                    mockReq.query = {};
+                    await handleAdminGet(fnGetContainer, mockReq, mockRes);
+                    expect(mockRes.status).toHaveBeenCalledWith(403);
+                }
+            });
+
+            test('a caller with no admin scope at all is rejected outright', async () => {
+                setAdminScopes({ hasRead: false, hasWrite: false });
+                mockReq.params.op = 'indexes';
+                await handleAdminGet(fnGetContainer, mockReq, mockRes);
+                expect(mockRes.status).toHaveBeenCalledWith(403);
+            });
+        });
+
+        describe('handleAdminPost (write operations + one read operation, runMatchWithPayload)', () => {
+            test('read-only scope (admin/*.read) can perform the read operation runMatchWithPayload', async () => {
+                setAdminScopes({ hasRead: true, hasWrite: false });
+                mockReq.params.op = 'runMatchWithPayload';
+                mockReq.body = { resourceType: 'Patient', resource: {} };
+                await handleAdminPost(fnGetContainer, mockReq, mockRes);
+                expect(mockContainer.personMatchManager.runMatchWithPayloadAsync).toHaveBeenCalled();
+                expect(mockRes.status).not.toHaveBeenCalledWith(403);
+            });
+
+            test('read-only scope (admin/*.read) is rejected from a write operation (createPersonToPersonLink)', async () => {
+                setAdminScopes({ hasRead: true, hasWrite: false });
+                mockReq.params.op = 'createPersonToPersonLink';
+                mockReq.body = { bwellPersonId: 'b1', externalPersonId: 'e1' };
+                await handleAdminPost(fnGetContainer, mockReq, mockRes);
+                expect(mockRes.status).toHaveBeenCalledWith(403);
+                expect(mockContainer.adminPersonPatientLinkManager.createPersonToPersonLinkAsync).not.toHaveBeenCalled();
+            });
+
+            test('read-only scope (admin/*.read) is rejected from every other write operation', async () => {
+                setAdminScopes({ hasRead: true, hasWrite: false });
+                const writeOperations = [
+                    'removePersonToPersonLink', 'createPersonToPatientLink', 'removePersonToPatientLink',
+                    'updatePatientReference', 'invalidateCache'
+                ];
+                for (const op of writeOperations) {
+                    mockRes.status.mockClear();
+                    mockReq.params.op = op;
+                    mockReq.body = {};
+                    await handleAdminPost(fnGetContainer, mockReq, mockRes);
+                    expect(mockRes.status).toHaveBeenCalledWith(403);
+                }
+            });
+
+            test('write scope (admin/*.write) can perform a write operation (createPersonToPersonLink)', async () => {
+                setAdminScopes({ hasRead: false, hasWrite: true });
+                mockReq.params.op = 'createPersonToPersonLink';
+                mockReq.body = { bwellPersonId: 'b1', externalPersonId: 'e1' };
+                await handleAdminPost(fnGetContainer, mockReq, mockRes);
+                expect(mockContainer.adminPersonPatientLinkManager.createPersonToPersonLinkAsync).toHaveBeenCalled();
+                expect(mockRes.status).not.toHaveBeenCalledWith(403);
+            });
+
+            test('write-only scope (admin/*.write, no read) is rejected from the read operation runMatchWithPayload', async () => {
+                setAdminScopes({ hasRead: false, hasWrite: true });
+                mockReq.params.op = 'runMatchWithPayload';
+                mockReq.body = { resourceType: 'Patient', resource: {} };
+                await handleAdminPost(fnGetContainer, mockReq, mockRes);
+                expect(mockRes.status).toHaveBeenCalledWith(403);
+                expect(mockContainer.personMatchManager.runMatchWithPayloadAsync).not.toHaveBeenCalled();
+            });
+
+            test('a caller with no admin scope at all is rejected outright', async () => {
+                setAdminScopes({ hasRead: false, hasWrite: false });
+                mockReq.params.op = 'createPersonToPersonLink';
+                await handleAdminPost(fnGetContainer, mockReq, mockRes);
+                expect(mockRes.status).toHaveBeenCalledWith(403);
+            });
+        });
+
+        describe('handleAdminPut (ExportStatus update - write only)', () => {
+            test('read-only scope (admin/*.read) is rejected', async () => {
+                setAdminScopes({ hasRead: true, hasWrite: false });
+                mockReq.params.op = 'ExportStatus';
+                mockReq.params.id = 'export-1';
+                await handleAdminPut(fnGetContainer, mockReq, mockRes);
+                expect(mockRes.status).toHaveBeenCalledWith(403);
+                expect(mockContainer.adminExportManager.updateExportStatus).not.toHaveBeenCalled();
+            });
+
+            test('write scope (admin/*.write) is allowed', async () => {
+                setAdminScopes({ hasRead: false, hasWrite: true });
+                mockReq.params.op = 'ExportStatus';
+                mockReq.params.id = 'export-1';
+                await handleAdminPut(fnGetContainer, mockReq, mockRes);
+                expect(mockContainer.adminExportManager.updateExportStatus).toHaveBeenCalled();
+                expect(mockRes.status).not.toHaveBeenCalledWith(403);
+            });
+        });
+
+        describe('handleAdminDelete (deletePerson - write only)', () => {
+            test('read-only scope (admin/*.read) is rejected', async () => {
+                setAdminScopes({ hasRead: true, hasWrite: false });
+                mockReq.params.op = 'deletePerson';
+                mockReq.query = { personId: 'per-1' };
+                await handleAdminDelete(fnGetContainer, mockReq, mockRes);
+                expect(mockRes.status).toHaveBeenCalledWith(403);
+                expect(mockContainer.adminPersonPatientLinkManager.deletePersonAsync).not.toHaveBeenCalled();
+            });
+
+            test('write scope (admin/*.write) is allowed', async () => {
+                setAdminScopes({ hasRead: false, hasWrite: true });
+                mockReq.params.op = 'deletePerson';
+                mockReq.query = { personId: 'per-1' };
+                await handleAdminDelete(fnGetContainer, mockReq, mockRes);
+                expect(mockContainer.adminPersonPatientLinkManager.deletePersonAsync).toHaveBeenCalled();
+                expect(mockRes.status).not.toHaveBeenCalledWith(403);
+            });
         });
     });
 });


### PR DESCRIPTION
## Jira
[DCON-4888](https://icanbwell.atlassian.net/browse/DCON-4888)

## Summary
- The admin API's route handlers gated every operation on a single check — any `admin/*` scope, regardless of `.read` vs `.write` — so a caller holding only `admin/*.read` could perform destructive operations (link creation/removal, cache invalidation, Person deletion, and even a Mongo index rebuild via `synchronizeIndexes`).
- Added `ScopesManager.hasAdminScopeForAction({ scope, action })` and a route-level `assertAdminScope({ scopesManager, scope, action })` helper (throws `ForbiddenError`, formatted by each handler's existing catch block into the standard 403 `OperationOutcome`) that every admin operation now calls with its actual required action.
- Enforcement is now symmetric: a read-only scope can no longer perform writes, and a write-only scope can no longer perform reads either.

## Tests
- Added `hasAdminScopeForAction` coverage in `scopesManager.test.js`.
- Added a dedicated `admin/*.read vs admin/*.write scope enforcement (DCON-4888)` suite in `admin.test.js` covering all four route handlers under read-only, write-only, both, and neither scope combinations.

## Verification
- `eslint` clean.
- `jest --config jest.unit.config.js` on affected suites: 153 passing, no regressions vs `main` (confirmed via `git stash`).

[DCON-4888]: https://icanbwell.atlassian.net/browse/DCON-4888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ