### PR TITLE
SEC-1580 sync _access on access-tag removal; stop prototype-named search params returning 500

### DIFF
--- a/src/preSaveHandlers/handlers/accessColumnHandler.js
+++ b/src/preSaveHandlers/handlers/accessColumnHandler.js
@@ -14,19 +14,29 @@ class AccessColumnHandler extends PreSaveHandler {
      * @returns {Promise<import('../../fhir/classes/4_0_0/resources/resource')>}
      */
     async preSaveAsync ({ resource }) {
-        if (resource.meta && resource.meta.security) {
+        // Only meta.security actually present as an array is authoritative about what the access
+        // tags are. When it is absent/null we have no statement about access at all, so _access is
+        // left alone rather than being wrongly emptied.
+        if (resource.meta && Array.isArray(resource.meta.security)) {
             /**
              * @type {string[]}
              */
             const accessCodes = resource.meta.security.filter(s => s.system === SecurityTagSystem.access).map(s => s.code);
-            if (accessCodes.length > 0) {
-                resource._access = resource._access || {};
-                // remove any tags that are don't have corresponding security tags
+            // Remove any _access entries that no longer have a corresponding access tag. This runs
+            // even when accessCodes is empty: previously it was nested inside `accessCodes.length > 0`,
+            // so removing the LAST access tag (or every access tag) left the old _access codes behind
+            // forever. _access is what the access-index query path filters on
+            // ({'_access.<code>': 1}), so a stale entry keeps the resource readable by a tenant whose
+            // access tag was revoked.
+            if (resource._access) {
                 for (const [tagName] of Object.entries(resource._access)) {
                     if (!accessCodes.includes(tagName)) {
                         delete resource._access[`${tagName}`];
                     }
                 }
+            }
+            if (accessCodes.length > 0) {
+                resource._access = resource._access || {};
                 // now add any new/updated tags
                 for (const /** @type {string} **/ accessCode of accessCodes) {
                     if (resource._access[`${accessCode}`] !== 1) {

--- a/src/searchParameters/searchParametersManager.js
+++ b/src/searchParameters/searchParametersManager.js
@@ -83,10 +83,19 @@ class SearchParametersManager {
          * @type {Record<string, SearchParameterDefinition>}
          */
         const searchParametersForResource = this.getSearchParametersForResource({ resourceType });
-        if (searchParametersForResource) {
+        // Use hasOwnProperty rather than bare bracket access: the search-parameter maps are plain
+        // objects, so a query parameter literally named `constructor`, `toString`, `valueOf`,
+        // `hasOwnProperty` etc. would otherwise resolve to the inherited Object.prototype member.
+        // That value is truthy, so callers skip their `!propertyObj` unknown-parameter branch and
+        // then dereference `propertyObj.fields`, throwing a TypeError -> HTTP 500 on what is really
+        // just an unrecognized search parameter.
+        if (searchParametersForResource &&
+            Object.prototype.hasOwnProperty.call(searchParametersForResource, queryParameter)) {
             propertyObj = searchParametersForResource[`${queryParameter}`];
         }
-        if (!propertyObj) {
+        if (!propertyObj &&
+            this.combinedSearchParameters.Resource &&
+            Object.prototype.hasOwnProperty.call(this.combinedSearchParameters.Resource, queryParameter)) {
             const searchParametersInheritedFromResource = this.combinedSearchParameters.Resource[`${queryParameter}`];
             propertyObj = searchParametersInheritedFromResource;
         }

--- a/src/tests/unit/preSaveHandlers/accessColumnHandler.staleAccess.test.js
+++ b/src/tests/unit/preSaveHandlers/accessColumnHandler.staleAccess.test.js
@@ -1,0 +1,166 @@
+'use strict';
+
+/**
+ * SEC-1580 BB.3 #11 - AccessColumnHandler never cleared the denormalized `_access` field when
+ * access tags were removed from meta.security.
+ *
+ * `_access` is not a cache - it is a query surface. `securityTagManager.getQueryWithSecurityTags()`
+ * filters on `{ '_access.<tagcode>': 1 }` whenever the access index is in use, so a stale
+ * `_access` entry keeps a resource readable by a tenant whose access tag has already been revoked.
+ * That makes it a permanent cross-tenant read, not a transient staleness window.
+ *
+ * The bug was that the stale-entry removal loop lived inside `if (accessCodes.length > 0)`, so it
+ * only ever ran when at least one access tag survived. Removing the last access tag - or replacing
+ * the access tags with tags of a different system - skipped removal entirely.
+ *
+ * Oracle: bwell-business-logic-master.md
+ *   §3  Security Tag System
+ *   §67 Fail-Open vs Fail-Closed Classification
+ *   §110 Pre-Save Handler Chain (All Resources)
+ */
+
+const { describe, test, expect, beforeEach } = require('@jest/globals');
+const { AccessColumnHandler } = require('../../../preSaveHandlers/handlers/accessColumnHandler');
+const { SecurityTagSystem } = require('../../../utils/securityTagSystem');
+
+describe('AccessColumnHandler - _access stays synchronized with meta.security (SEC-1580 BB.3 #11)', () => {
+    let handler;
+
+    beforeEach(() => {
+        handler = new AccessColumnHandler();
+    });
+
+    describe('revoking access tags revokes _access', () => {
+        test('removing the only access tag empties _access', async () => {
+            const resource = {
+                resourceType: 'Observation',
+                meta: {
+                    security: [
+                        { system: SecurityTagSystem.owner, code: 'clientA' }
+                    ]
+                },
+                // what was written on a previous save, when clientA still had an access tag
+                _access: { clientA: 1 }
+            };
+
+            const result = await handler.preSaveAsync({ resource });
+
+            // §3: "The internal `_access` field MUST be exactly synchronized with meta.security
+            // access tags. For each access code, `_access[code]` = 1. Stale codes MUST be deleted."
+            expect(result._access).toEqual({});
+            expect(result._access).not.toHaveProperty('clientA');
+        });
+
+        test('removing every access tag empties _access even when several were present', async () => {
+            const resource = {
+                resourceType: 'Observation',
+                meta: { security: [] },
+                _access: { clientA: 1, clientB: 1, clientC: 1 }
+            };
+
+            const result = await handler.preSaveAsync({ resource });
+
+            // §67: "FAIL CLOSED: ... Resources with no access tag visible to nobody." A surviving
+            // _access entry is exactly the "visible to somebody" outcome that must not happen.
+            expect(result._access).toEqual({});
+        });
+
+        test('revoking one of two access tags drops only the revoked code', async () => {
+            const resource = {
+                resourceType: 'Observation',
+                meta: {
+                    security: [
+                        { system: SecurityTagSystem.access, code: 'clientA' }
+                    ]
+                },
+                _access: { clientA: 1, clientB: 1 }
+            };
+
+            const result = await handler.preSaveAsync({ resource });
+
+            // §3: exact synchronization - clientA retained, clientB deleted.
+            expect(result._access).toEqual({ clientA: 1 });
+        });
+
+        test('replacing access tags with non-access tags of the same system family empties _access', async () => {
+            const resource = {
+                resourceType: 'Observation',
+                meta: {
+                    security: [
+                        { system: SecurityTagSystem.owner, code: 'clientA' },
+                        { system: SecurityTagSystem.sourceAssigningAuthority, code: 'clientA' },
+                        { system: SecurityTagSystem.vendor, code: 'vendorX' }
+                    ]
+                },
+                _access: { clientA: 1 }
+            };
+
+            const result = await handler.preSaveAsync({ resource });
+
+            // §3: only tags whose system is the access system produce _access entries. An owner or
+            // sourceAssigningAuthority tag with the same code does NOT keep read access alive.
+            expect(result._access).toEqual({});
+        });
+    });
+
+    describe('cross-tenant revocation scenario', () => {
+        test('un-sharing a resource from clientB removes clientB from the access-index surface', async () => {
+            // clientA owns the resource and had shared it with clientB.
+            const resource = {
+                resourceType: 'Condition',
+                meta: {
+                    security: [
+                        { system: SecurityTagSystem.owner, code: 'clientA' },
+                        { system: SecurityTagSystem.access, code: 'clientA' }
+                    ]
+                },
+                _access: { clientA: 1, clientB: 1 }
+            };
+
+            const result = await handler.preSaveAsync({ resource });
+
+            // §3 + §2: tenant isolation is enforced by security tags on EVERY query path. The
+            // access-index path filters on `_access.<code>`, so clientB must not remain there once
+            // its access tag is gone - otherwise the un-share never takes effect for that path.
+            expect(result._access).toEqual({ clientA: 1 });
+            expect(result._access).not.toHaveProperty('clientB');
+        });
+    });
+
+    describe('absent meta.security is not a statement about access', () => {
+        // meta.security absent entirely means the caller supplied no access information, which is
+        // different from supplying an empty list. Leaving _access untouched there is intentional:
+        // it avoids stripping access from a resource whose meta was simply not loaded.
+        test.each([
+            ['no meta at all', { resourceType: 'Patient', _access: { clientA: 1 } }],
+            ['meta without security', { resourceType: 'Patient', meta: { versionId: '1' }, _access: { clientA: 1 } }],
+            ['meta.security null', { resourceType: 'Patient', meta: { security: null }, _access: { clientA: 1 } }]
+        ])('leaves _access untouched when %s', async (_label, resource) => {
+            const result = await handler.preSaveAsync({ resource });
+
+            expect(result._access).toEqual({ clientA: 1 });
+        });
+    });
+
+    describe('idempotency', () => {
+        test('running twice after a revocation is stable', async () => {
+            const resource = {
+                resourceType: 'Observation',
+                meta: {
+                    security: [
+                        { system: SecurityTagSystem.access, code: 'clientA' }
+                    ]
+                },
+                _access: { clientA: 1, clientB: 1 }
+            };
+
+            await handler.preSaveAsync({ resource });
+            const afterFirst = { ...resource._access };
+            await handler.preSaveAsync({ resource });
+
+            // §110: the pre-save chain runs on every write; repeated runs must converge.
+            expect(resource._access).toEqual(afterFirst);
+            expect(resource._access).toEqual({ clientA: 1 });
+        });
+    });
+});

--- a/src/tests/unit/preSaveHandlers/accessColumnHandler.test.js
+++ b/src/tests/unit/preSaveHandlers/accessColumnHandler.test.js
@@ -267,7 +267,10 @@ describe('AccessColumnHandler', () => {
             expect(result._access).toEqual({ tenantA: 1 });
         });
 
-        test('does not clear _access when meta.security is empty array', async () => {
+        // These two previously asserted that _access survives when meta.security IS present but
+        // carries no access tags. That is the opposite of what the security model requires, so they
+        // now assert the required behavior instead.
+        test('clears _access when meta.security is an empty array', async () => {
             const resource = {
                 resourceType: 'Patient',
                 meta: { security: [] },
@@ -276,10 +279,12 @@ describe('AccessColumnHandler', () => {
 
             const result = await handler.preSaveAsync({ resource });
 
-            expect(result._access).toEqual({ tenantA: 1, tenantB: 1 });
+            // §3: _access MUST be exactly synchronized with meta.security access tags; stale codes
+            // MUST be deleted. §67: a resource with no access tag is visible to nobody (fail closed).
+            expect(result._access).toEqual({});
         });
 
-        test('does not clear _access when security has tags but none are access system', async () => {
+        test('clears _access when security has tags but none are access system', async () => {
             const resource = {
                 resourceType: 'Patient',
                 meta: {
@@ -292,7 +297,9 @@ describe('AccessColumnHandler', () => {
 
             const result = await handler.preSaveAsync({ resource });
 
-            expect(result._access).toEqual({ tenantA: 1 });
+            // §3: an owner tag is not an access tag - it grants no _access entry, and the stale
+            // tenantA entry must not survive.
+            expect(result._access).toEqual({});
         });
     });
 

--- a/src/tests/unit/searchParameters/searchParametersManager.prototypeParams.test.js
+++ b/src/tests/unit/searchParameters/searchParametersManager.prototypeParams.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+/**
+ * SEC-1580 - a query parameter whose name collides with an Object.prototype member resolves to the
+ * inherited prototype value instead of `undefined`.
+ *
+ * `SearchParametersManager.getPropertyObject()` looked its argument up with bare bracket access on
+ * a plain object. `?constructor=x` therefore returned `Object.prototype.constructor` - a truthy
+ * value - so `r4ArgsParser` skipped its `if (!propertyObj)` unknown-parameter branch and then
+ * dereferenced `propertyObj.fields.length`, throwing a TypeError. The request surfaced as HTTP 500.
+ *
+ * Reachable unauthenticated-shaped on a plain `GET /4_0_0/Patient?constructor=x`: Express 5's
+ * default `simple` query parser uses Node `querystring`, which keeps `constructor` as an own key,
+ * and `get_all_args.js` Object.assign's it onto a normal object. A POST `_search` Parameters body
+ * with `{"name":"constructor"}` reaches the same place.
+ *
+ * Oracle: bwell-business-logic-master.md
+ *   §22 Error Response Codes
+ */
+
+const { describe, test, expect, beforeEach } = require('@jest/globals');
+const { SearchParametersManager } = require('../../../searchParameters/searchParametersManager');
+
+describe('SearchParametersManager.getPropertyObject - prototype-named query parameters', () => {
+    let searchParametersManager;
+
+    beforeEach(() => {
+        searchParametersManager = new SearchParametersManager();
+    });
+
+    // Every own-property-shaped name that a plain object inherits from Object.prototype.
+    const prototypeMemberNames = [
+        'constructor',
+        'toString',
+        'valueOf',
+        'hasOwnProperty',
+        'isPrototypeOf',
+        'propertyIsEnumerable',
+        'toLocaleString'
+    ];
+
+    test.each(prototypeMemberNames)(
+        'returns undefined for a query parameter named "%s" on a resource type',
+        (queryParameter) => {
+            const propertyObj = searchParametersManager.getPropertyObject({
+                resourceType: 'Patient',
+                queryParameter
+            });
+
+            // §22: an unrecognized search parameter is an "Invalid/missing parameter" condition -
+            // it must be reported as 400, which requires the parser's unknown-parameter branch to
+            // be reached. That branch is gated on this returning a falsy value. Returning the
+            // inherited Object.prototype member instead sends the parser down the known-parameter
+            // path, where it dereferences `.fields` and throws -> 500 "Unhandled server error".
+            expect(propertyObj).toBeUndefined();
+        }
+    );
+
+    test.each(prototypeMemberNames)(
+        'returns undefined for a query parameter named "%s" on an unknown resource type',
+        (queryParameter) => {
+            // Exercises the second lookup, against combinedSearchParameters.Resource, by making the
+            // per-resource-type lookup miss first.
+            const propertyObj = searchParametersManager.getPropertyObject({
+                resourceType: 'NotARealResourceType',
+                queryParameter
+            });
+
+            // §22
+            expect(propertyObj).toBeUndefined();
+        }
+    );
+
+    test('whatever is returned for a prototype-named parameter is never dereferenced into a TypeError', () => {
+        // This is the actual crash shape in r4ArgsParser: `propertyObj.fields.length > 0`.
+        const propertyObj = searchParametersManager.getPropertyObject({
+            resourceType: 'Patient',
+            queryParameter: 'constructor'
+        });
+
+        // §22: the parser only reaches this expression when propertyObj is truthy, so either
+        // propertyObj is falsy (unknown-parameter branch, 400) or it is a real search parameter
+        // definition carrying `fields`. An inherited prototype member is neither.
+        expect(() => (propertyObj ? propertyObj.fields.length : 0)).not.toThrow();
+    });
+
+    // Guard against the fix over-tightening the lookup into always returning undefined.
+    test.each([
+        ['birthdate', 'birthDate'],
+        ['family', 'name.family'],
+        ['gender', 'gender']
+    ])('still resolves the genuine Patient search parameter "%s"', (queryParameter, expectedField) => {
+        const propertyObj = searchParametersManager.getPropertyObject({
+            resourceType: 'Patient',
+            queryParameter
+        });
+
+        expect(propertyObj).toBeDefined();
+        expect(propertyObj.fields).toEqual([expectedField]);
+    });
+
+    test('still resolves a search parameter inherited from Resource', () => {
+        const propertyObj = searchParametersManager.getPropertyObject({
+            resourceType: 'Patient',
+            queryParameter: '_lastUpdated'
+        });
+
+        expect(propertyObj).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Summary

Re-walked the SEC-1580 audit catalog against current `main` (`fae36448`) rather than against the audit
write-up, and only kept the items that are still reproducible and have no fix already in flight.

**Most of the catalog is already fixed.** That is the main result of this pass. Of the ~30 findings I
checked in the priority areas (tenant isolation on query paths, the authorization decision tree,
patient scope / identity-graph traversal, `$everything`, consent evaluation, cache-key granularity),
two were still live and un-owned. Both are fixed here with tests.

Neither fix changes an authorization decision or a query-planning path; they correct a denormalized
index field and a property lookup.

## Per-finding table

| Finding | Oracle § | Test file | Fix included | Expected failure |
|---|---|---|---|---|
| BB.3 #11 — `AccessColumnHandler` never clears stale `_access` when access tags are removed | §3, §67, §110 | `src/tests/unit/preSaveHandlers/accessColumnHandler.staleAccess.test.js` | yes | no |
| Prototype-named search parameter (`?constructor=x`) returns 500 instead of 400 | §22 | `src/tests/unit/searchParameters/searchParametersManager.prototypeParams.test.js` | yes | no |

### BB.3 #11 — stale `_access` after access-tag removal

`_access` is not a cache, it is a query surface: `securityTagManager.getQueryWithSecurityTags()`
filters on `{ '_access.<tagcode>': 1 }` whenever the access index is in use. The stale-entry removal
loop in `AccessColumnHandler` lived *inside* `if (accessCodes.length > 0)`, so it only ran when at
least one access tag survived. Removing the **last** access tag — or replacing the access tags with
tags of a different system — skipped removal entirely, and the old code stayed in `_access`
permanently. A tenant whose access tag was revoked keeps reading the resource on the access-index
path.

§3 requires `_access` to be *exactly* synchronized with the `meta.security` access tags and says
stale codes MUST be deleted. §67 classifies "resource with no access tag" as fail-closed — visible to
nobody. The fix moves the removal loop out of the `length > 0` guard.

Deliberately scoped: removal now runs whenever `meta.security` is **present as an array**. When
`meta`/`meta.security` is absent or null the handler still leaves `_access` alone, because an absent
`meta.security` is not a statement that there are no access tags — it usually means meta was not
loaded on that path. Emptying `_access` there would strip access from live resources. That
distinction is covered by a parameterized test.

### Prototype-named search parameters return 500

`SearchParametersManager.getPropertyObject()` looked its argument up with bare bracket access on a
plain object, so a query parameter literally named `constructor` (also `toString`, `valueOf`,
`hasOwnProperty`, …) resolved to the inherited `Object.prototype` member. That value is truthy, so
`r4ArgsParser` skipped its `if (!propertyObj)` unknown-parameter branch and then dereferenced
`propertyObj.fields.length`, throwing a `TypeError`.

§22 maps an unrecognized search parameter to 400 ("Invalid/missing parameter") and reserves 500 for
"Unhandled server error", so this is a spec deviation as well as a cheap way to force 500s. Reachable
on a plain `GET /4_0_0/Patient?constructor=x` — Express 5's default `simple` query parser keeps
`constructor` as an own key — and via a `POST .../_search` Parameters body. Note `__proto__`
specifically does *not* survive `Object.assign`, so there is no prototype pollution here; the impact
is a 500 per request, not object contamination.

Fixed with `Object.prototype.hasOwnProperty.call` guards on both lookups. Guard tests assert real
Patient-specific parameters (`birthdate`, `family`, `gender`) and a Resource-inherited one
(`_lastUpdated`) still resolve, so the fix cannot over-tighten into always returning `undefined`.

## One existing test file corrected

Two tests in `src/tests/unit/preSaveHandlers/accessColumnHandler.test.js` asserted that `_access`
**survives** when `meta.security` is present but carries no access tags — i.e. they had codified the
vulnerability as expected behavior:

- `does not clear _access when meta.security is empty array`
- `does not clear _access when security has tags but none are access system`

Both now assert the required behavior, with the § citation inline. Flagging this explicitly because
it is the one place this PR changes an existing assertion — it strengthens them to match §3/§67, it
does not weaken anything to get CI green. The four sibling tests covering genuinely *absent*
`meta.security` are unchanged and still pass.

## Skipped — a fix is already pending

Not duplicated here. Each was checked against current `main` before being set aside:

| Finding | Already covered by |
|---|---|
| IDG-2 same-owner duplicate-master traversal | [#2470](https://github.com/icanbwell/fhir-server/pull/2470) |
| IDG-7 low-assurance `Person.link` merged as confirmed | [#2471](https://github.com/icanbwell/fhir-server/pull/2471) (finding) + [#2488](https://github.com/icanbwell/fhir-server/pull/2488) (fix) |
| IDG-5 foreign person confirms link-graph membership | [#2472](https://github.com/icanbwell/fhir-server/pull/2472) (finding) + [#2481](https://github.com/icanbwell/fhir-server/pull/2481) (fix, merged) |
| CL-1 Consent authorizing actor never validated | [#2475](https://github.com/icanbwell/fhir-server/pull/2475) |
| SAE-6 client can grant itself consent to upstream data | [#2476](https://github.com/icanbwell/fhir-server/pull/2476) |
| INC-322 non-access tokens accepted | [#2477](https://github.com/icanbwell/fhir-server/pull/2477) + [#2463](https://github.com/icanbwell/fhir-server/pull/2463) |
| SAE-4 malformed `_sort` crashes with 500 | [#2478](https://github.com/icanbwell/fhir-server/pull/2478) |
| SAE-5 cross-tenant write breaks source-id reads | [#2479](https://github.com/icanbwell/fhir-server/pull/2479) |
| SAE-1 narrowing tags doesn't revoke history | [#2473](https://github.com/icanbwell/fhir-server/pull/2473) |
| SAE-3 end-user token reaches upstream PROA/IAS data | [#2474](https://github.com/icanbwell/fhir-server/pull/2474) |
| HH.5 #1 consent cache skips intermediate Person nodes | [#2487](https://github.com/icanbwell/fhir-server/pull/2487) |
| Composition unclassified denylist | [#2486](https://github.com/icanbwell/fhir-server/pull/2486) |
| Proxy-patient consented resources in Person `$everything` | [#2461](https://github.com/icanbwell/fhir-server/pull/2461) |
| Group roster / `Group.quantity` tenant filtering | [#2448](https://github.com/icanbwell/fhir-server/pull/2448), [#2442](https://github.com/icanbwell/fhir-server/pull/2442) |

## Skipped — already fixed on `main`

Verified against source, not assumed. Listed so the catalog can be pruned:

- **BB.5 #3** `_type` missing from `$everything` cache key (INC-331) — `keyParamsforCache = ['_type']`
  is present in `patientEverythingCacheKeyGenerator.js`.
- **BB.5 #4** PROA consent period not validated — `proaConsentManager.getConsentResources` filters on
  `status: 'active'`, `provision.type: 'permit'`, and both `provision.period.start`/`.end`
  absent-or-in-bounds clauses. Same construct in `cmsConsentManager` and `delegatedAccessRulesManager`.
- **BB.3 #4** PATCH can modify `meta.security` — `patch.js` runs `overWriteNonWritableFields` plus a
  post-patch access-tag-change check (added by the F2/F3 work).
- **BB.5 #7 / BB.4 #23** `canWriteResourceAsync` / `writeAllowedByScopesValidator` owner-tag and
  tag-change validation — `scopesManager.isAccessTagChangeAllowedByScopes` now handles this.
- **BB.3 #7** `$everything` stale for 600s after consent revocation — TTL is 300s, and revocation is
  immediate via the generation counter in the cache key, not TTL-bound.
- **HH.5 #3** delegated consent gated on `enableConsentedProaDataAccess` — the delegated filter in
  `searchManager` sits outside that config gate.

## Skipped — not a defect under the business-logic spec

- **HH.5 #7** `getDataSharingManagerCache` not keyed on `actor.reference` — traced every value stored
  in that map (`patientIdToImmediatePersonUuid`, `patientsList`, `personToLinkedPatientsMap`,
  `allowedPatientIds`); none are actor-derived, and `updateQueryConsideringDataSharing` does not even
  take an `actor`. The delegated rules memoize on the actor object itself. Not exploitable.
- **BB.4 #19 / BB.3 #14** `_metaUuid` and `Prefer: global_id` expose `_uuid` — §16 states `_uuid`/`id`
  are not secrets (deterministic UUIDv5, derivable), only that they must never be a sole authorization
  factor. Already adjudicated by #2399.
- **BB.5 #19** `referenceValidator` allows pipe characters — §16 lists `Practitioner/<id>|nppes` as a
  *valid* reference form, so the pipe itself is not the defect. Separately worth noting:
  `isRelativeUrl` is `value.split('/').length - 1 === 1` with no character validation at all, so
  `anything/anything` passes. Tightening that is a data-compatibility decision, not a security fix,
  and is left alone here.

## Deliberately left unfixed

- **BB.3 #9 `_includeHidden` is not scope-gated.** Still live: `_includeHidden` is consumed raw in
  `src/operations/query/r4.js` and the only admin-gated params are `_explain`, `_debug`,
  `_setIndexHint`. §6 says it should be reachable "only ... to callers with appropriate scope (not all
  users)". Not fixed here for two reasons: an existing integration test
  (`src/tests/bugs/search_with_clientfhirpersonid_and_includeHidden/`) asserts that a patient-scoped
  caller *can* use it, so changing this is a deliberate product/behavior decision and needs an owner;
  and it is already covered by a failing-by-design assertion (`VULN-1`) in the quarantined
  `searchQuery.crossTenant.test.js`. No new test added — it would duplicate existing coverage.
- **`Prefer` header parsing** in `globalIdEnrichmentProvider`. The predicate is
  `split('=')` then compare first and last segment, so `global_id=false, return=true` evaluates to
  *true* (the opposite of the requested directive) and `respond-async, global_id=true` evaluates to
  *false*. Real parsing bug, but the blast radius is `_uuid` exposure, which §16 says is not a secret,
  and a correct RFC 7240 parse regresses three existing test files that encode the current shape.
  Worth its own ticket rather than riding along here.

## CI

No expected-failure tests are added, so no `testPathIgnorePatterns` entry is needed and CI stays
green. Both new suites pass against the fixes; no assertion was inverted to achieve that.

## Verification performed

- `node node_modules/.bin/jest --config jest.unit.config.js src/tests/unit/preSaveHandlers src/tests/unit/searchParameters` — **14 suites / 296 tests pass**, including the corrected existing file.
- Full `jest.unit.config.js` run: the only failing suites are ones already listed in
  `jest.config.js`'s `testPathIgnorePatterns` (so they do not run in CI), plus
  `consentSelfGrantLinkGraft.test.js`, which I confirmed fails identically on unmodified `HEAD` —
  it is a module-load failure under the unit config, pre-existing and unrelated to this diff.
- `eslint` clean on all five changed files.

**Could not verify:** the full `jest.config.js` suite. Its `globalSetup` starts a ClickHouse
testcontainer, and no container runtime was available in the environment I ran in. The integration
layer is therefore unexercised by me — worth a CI run before merge, particularly for
`accessColumnHandler`, since the pre-save chain runs on every write.

## review.md

Touch points: resource write (pre-save chain) and search/read query construction, so §1, §3A and §3
of `review.md` apply.

- **Access-tag semantics** — the `_access` change only ever *removes* entries that have no
  corresponding access tag; it never adds an entry, never widens visibility, and never changes which
  tags are authoritative. Failure mode is fail-closed (fewer readers), matching §67.
- **Tenant filtering on query paths** — no query builder is modified. `getPropertyObject` returning
  `undefined` for a prototype-named parameter routes into the existing unknown-parameter branch; it
  does not remove or bypass any security-tag filter.
- **No new authorization branch** introduced, so there is no patient-scope vs access-scope
  mutual-exclusion hazard to reason about.
- **§0 sensitive values** — no pool IDs, client IDs, tokens, hostnames, or environment-specific
  values in the diff, commit messages, or this description. Test fixtures use synthetic tenant codes
  (`clientA`/`clientB`/`tenantA`) and no PHI.

Checked and found clean: pre-save handler ordering (unchanged), `securityTagManager` query
construction (untouched), owner/sourceAssigningAuthority immutability (untouched), patient-scope
expansion (untouched).