### PR TITLE
BAI-226 add bounded retry for S3 NDJSON range reads

### DIFF
--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -719,7 +719,7 @@ class BulkImportHandler {
             hasFlushedThisAttempt = false;
 
             try {
-                for await (const { lineNumber, byteOffset, resource } of this.s3NdjsonReader.readNdjsonAsync({
+                for await (const { lineNumber, byteOffset, resource, parseError } of this.s3NdjsonReader.readNdjsonAsync({
                     filepath,
                     byteRangeStart,
                     byteRangeEnd,
@@ -728,35 +728,53 @@ class BulkImportHandler {
                     linesRead++;
                     sinceLastFlush++;
 
-                    try {
-                        const fhirResource = FhirResourceWriteSerializer.serialize({
-                            obj: this.applyDefaultSecurityTagsIfMissing(resource)
-                        });
-                        const contextData = buildContextDataForHybridStorage(
-                            fhirResource.resourceType, fhirResource, requestInfo
-                        );
-                        await this.fastDatabaseBulkInserter.insertOneAsync({
-                            base_version,
-                            requestInfo,
-                            resourceType: fhirResource.resourceType,
-                            doc: fhirResource,
-                            contextData
-                        });
-                    } catch (resourceError) {
+                    if (parseError) {
                         failed++;
-                        // Failed before reaching the bulk inserter (e.g. missing/unsupported
-                        // resourceType) — still record it so it lands in the error NDJSON and
-                        // Task.output, not just a log line.
+                        // A single bad line (too large, unparseable) doesn't abort the range --
+                        // record it the same way a per-resource write failure is recorded, so
+                        // it lands in the error NDJSON and Task.output instead of silently
+                        // failing the whole import.
                         mergeResultEntries.push(
-                            MergeResultEntry.createFromError({ error: resourceError, resource, sourceByteOffset: byteOffset })
+                            MergeResultEntry.createFromError({ error: parseError, resource: {}, sourceByteOffset: byteOffset })
                         );
-                        logError('Failed to buffer bulk import resource for write', {
+                        logError('Invalid NDJSON line skipped', {
                             taskId,
                             filepath,
                             lineNumber,
                             byteOffset,
-                            error: resourceError.message
+                            error: parseError.message
                         });
+                    } else {
+                        try {
+                            const fhirResource = FhirResourceWriteSerializer.serialize({
+                                obj: this.applyDefaultSecurityTagsIfMissing(resource)
+                            });
+                            const contextData = buildContextDataForHybridStorage(
+                                fhirResource.resourceType, fhirResource, requestInfo
+                            );
+                            await this.fastDatabaseBulkInserter.insertOneAsync({
+                                base_version,
+                                requestInfo,
+                                resourceType: fhirResource.resourceType,
+                                doc: fhirResource,
+                                contextData
+                            });
+                        } catch (resourceError) {
+                            failed++;
+                            // Failed before reaching the bulk inserter (e.g. missing/unsupported
+                            // resourceType) — still record it so it lands in the error NDJSON and
+                            // Task.output, not just a log line.
+                            mergeResultEntries.push(
+                                MergeResultEntry.createFromError({ error: resourceError, resource, sourceByteOffset: byteOffset })
+                            );
+                            logError('Failed to buffer bulk import resource for write', {
+                                taskId,
+                                filepath,
+                                lineNumber,
+                                byteOffset,
+                                error: resourceError.message
+                            });
+                        }
                     }
 
                     if (sinceLastFlush >= batchSize) {

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -495,6 +495,40 @@ class BulkImportHandler {
     }
 
     /**
+     * Retries reading+processing an entire byte range on transient S3/stream failures.
+     * A read can fail partway through the stream after some resources were already
+     * buffered or even flushed to Mongo -- fn() is expected to reset its own accumulators
+     * and reprocess the WHOLE range from the start on each attempt. Before retrying, this
+     * clears requestId's buffered-but-unflushed inserts so a failed attempt's partial
+     * buffer doesn't get double-inserted alongside the retry's own. Reprocessing
+     * already-flushed resources is safe: the underlying MongoDB writes for a range are
+     * idempotent merges (the same guarantee already relied on for Kafka redelivery of a
+     * whole range -- see recordRangeCompletionAsync).
+     * @param {Object} params
+     * @param {() => Promise<void>} params.fn
+     * @param {string} params.requestId
+     * @param {number} [params.attempts]
+     * @returns {Promise<void>}
+     */
+    async readRangeWithRetryAsync({ fn, requestId, attempts = 3 }) {
+        let lastError;
+        for (let attempt = 1; attempt <= attempts; attempt++) {
+            try {
+                await fn();
+                return;
+            } catch (e) {
+                lastError = e;
+                logError('S3 NDJSON range read attempt failed', { requestId, attempt, attempts, error: e.message });
+                if (attempt < attempts) {
+                    await this.requestSpecificCache.clearAsync({ requestId });
+                    await new Promise((resolve) => setTimeout(resolve, 200 * attempt));
+                }
+            }
+        }
+        throw lastError;
+    }
+
+    /**
      * Writes this range's merge-result (and error, if any) NDJSON to S3, appends
      * Task.output entries pointing at them, and records a completion marker so
      * isTaskFullyComplete() can detect when every range of every file is done.
@@ -643,58 +677,74 @@ class BulkImportHandler {
             sinceLastFlush = 0;
         };
 
+        const readAndProcessRangeAsync = async () => {
+            // Reset accumulators -- a retry reprocesses the WHOLE range from the start, so
+            // a partial attempt's counts/entries must not carry over into the next one.
+            linesRead = 0;
+            sinceLastFlush = 0;
+            created = 0;
+            updated = 0;
+            failed = 0;
+            mergeResultEntries.length = 0;
+
+            for await (const { lineNumber, byteOffset, resource } of this.s3NdjsonReader.readNdjsonAsync({
+                filepath,
+                byteRangeStart,
+                byteRangeEnd,
+                fileSize
+            })) {
+                linesRead++;
+                sinceLastFlush++;
+
+                try {
+                    const fhirResource = FhirResourceWriteSerializer.serialize({
+                        obj: this.applyDefaultSecurityTagsIfMissing(resource)
+                    });
+                    const contextData = buildContextDataForHybridStorage(
+                        fhirResource.resourceType, fhirResource, requestInfo
+                    );
+                    await this.fastDatabaseBulkInserter.insertOneAsync({
+                        base_version,
+                        requestInfo,
+                        resourceType: fhirResource.resourceType,
+                        doc: fhirResource,
+                        contextData
+                    });
+                } catch (resourceError) {
+                    failed++;
+                    // Failed before reaching the bulk inserter (e.g. missing/unsupported
+                    // resourceType) — still record it so it lands in the error NDJSON and
+                    // Task.output, not just a log line.
+                    mergeResultEntries.push(
+                        MergeResultEntry.createFromError({ error: resourceError, resource, sourceByteOffset: byteOffset })
+                    );
+                    logError('Failed to buffer bulk import resource for write', {
+                        taskId,
+                        filepath,
+                        lineNumber,
+                        byteOffset,
+                        error: resourceError.message
+                    });
+                }
+
+                if (sinceLastFlush >= batchSize) {
+                    await flushBatchAsync();
+                    // Rate control: yield between batches so a single range doesn't
+                    // monopolize the event loop or MongoDB's write capacity.
+                    await new Promise((resolve) => setTimeout(resolve, batchDelayMs));
+                }
+            }
+            if (sinceLastFlush > 0) {
+                await flushBatchAsync();
+            }
+        };
+
         try {
             try {
-                for await (const { lineNumber, byteOffset, resource } of this.s3NdjsonReader.readNdjsonAsync({
-                    filepath,
-                    byteRangeStart,
-                    byteRangeEnd,
-                    fileSize
-                })) {
-                    linesRead++;
-                    sinceLastFlush++;
-
-                    try {
-                        const fhirResource = FhirResourceWriteSerializer.serialize({
-                            obj: this.applyDefaultSecurityTagsIfMissing(resource)
-                        });
-                        const contextData = buildContextDataForHybridStorage(
-                            fhirResource.resourceType, fhirResource, requestInfo
-                        );
-                        await this.fastDatabaseBulkInserter.insertOneAsync({
-                            base_version,
-                            requestInfo,
-                            resourceType: fhirResource.resourceType,
-                            doc: fhirResource,
-                            contextData
-                        });
-                    } catch (resourceError) {
-                        failed++;
-                        // Failed before reaching the bulk inserter (e.g. missing/unsupported
-                        // resourceType) — still record it so it lands in the error NDJSON and
-                        // Task.output, not just a log line.
-                        mergeResultEntries.push(
-                            MergeResultEntry.createFromError({ error: resourceError, resource, sourceByteOffset: byteOffset })
-                        );
-                        logError('Failed to buffer bulk import resource for write', {
-                            taskId,
-                            filepath,
-                            lineNumber,
-                            byteOffset,
-                            error: resourceError.message
-                        });
-                    }
-
-                    if (sinceLastFlush >= batchSize) {
-                        await flushBatchAsync();
-                        // Rate control: yield between batches so a single range doesn't
-                        // monopolize the event loop or MongoDB's write capacity.
-                        await new Promise((resolve) => setTimeout(resolve, batchDelayMs));
-                    }
-                }
-                if (sinceLastFlush > 0) {
-                    await flushBatchAsync();
-                }
+                await this.readRangeWithRetryAsync({
+                    fn: readAndProcessRangeAsync,
+                    requestId: requestInfo.requestId
+                });
             } catch (e) {
                 logError('Error reading S3 NDJSON range', {
                     taskId,

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -18,6 +18,7 @@ const { PostRequestProcessor } = require('../../../utils/postRequestProcessor');
 const { RequestSpecificCache } = require('../../../utils/requestSpecificCache');
 const { MergeResultEntry } = require('../../common/mergeResultEntry');
 const { logInfo, logError } = require('../../common/logging');
+const { retryWithBackoff } = require('../../../utils/retryWithBackoff');
 
 /**
  * Extension URL used to record a marker on the Task each time a byte-range finishes
@@ -478,32 +479,45 @@ class BulkImportHandler {
      * @returns {Promise<void>}
      */
     async writeNdjsonWithRetryAsync({ filepath, data, attempts = 3 }) {
-        let lastError;
-        for (let attempt = 1; attempt <= attempts; attempt++) {
-            try {
-                await this.s3NdjsonReader.writeNdjsonAsync({ filepath, data });
-                return;
-            } catch (e) {
-                lastError = e;
-                logError('S3 NDJSON write attempt failed', { filepath, attempt, attempts, error: e.message });
-                if (attempt < attempts) {
-                    await new Promise((resolve) => setTimeout(resolve, 200 * attempt));
+        try {
+            return await retryWithBackoff({
+                fn: () => this.s3NdjsonReader.writeNdjsonAsync({ filepath, data }),
+                maxRetries: attempts - 1,
+                initialDelayMs: 200,
+                onRetry: ({ attempt, error }) => {
+                    logError('S3 NDJSON write attempt failed', { filepath, attempt, attempts, error: error.message });
                 }
-            }
+            });
+        } catch (e) {
+            logError('S3 NDJSON write attempt failed', { filepath, attempt: attempts, attempts, error: e.message });
+            throw e;
         }
-        throw lastError;
     }
 
     /**
-     * Retries reading+processing an entire byte range on transient S3/stream failures.
-     * A read can fail partway through the stream after some resources were already
-     * buffered or even flushed to Mongo -- fn() is expected to reset its own accumulators
-     * and reprocess the WHOLE range from the start on each attempt. Before retrying, this
-     * clears requestId's buffered-but-unflushed inserts so a failed attempt's partial
-     * buffer doesn't get double-inserted alongside the retry's own. Reprocessing
-     * already-flushed resources is safe: the underlying MongoDB writes for a range are
-     * idempotent merges (the same guarantee already relied on for Kafka redelivery of a
-     * whole range -- see recordRangeCompletionAsync).
+     * Retries reading+processing an entire byte range on transient S3/stream failures,
+     * but ONLY when nothing has been durably written yet in this attempt (readAndProcess
+     * marks a thrown error with `bulkImportRangePartiallyFlushed` once at least one batch
+     * has been flushed). This is NOT a generic retryWithBackoff use -- once a batch has
+     * flushed, redoing the whole range is unsafe for two independent reasons, so retrying
+     * must stop there rather than continue for `attempts` total tries:
+     *   1. Not every resourceType's flush is an idempotent Mongo upsert. A resourceType
+     *      routed to ClickHouseBulkWriteExecutor (SYNC_DIRECT) or
+     *      KafkaClickPipeBulkWriteExecutor (KAFKA_CLICKPIPE) -- e.g. AuditEvent under
+     *      enableAuditEventClickPipe/clickHouseOnlyResources -- does an unconditional
+     *      insert/produce with no dedup, so replaying an already-flushed batch creates a
+     *      duplicate ClickHouse row or Kafka message.
+     *   2. Clearing requestId's cache to avoid double-buffering (see below) would also
+     *      discard any Kafka change-event/history-write tasks a successful flush already
+     *      queued onto postRequestProcessor (it shares the same requestId-keyed cache) --
+     *      and re-inserting the same unchanged document on retry gets silently skipped by
+     *      mongoBulkWriteExecutor, so that task never gets queued a second time either.
+     * Before a safe (pre-first-flush) retry, this clears requestId's buffered-but-unflushed
+     * inserts so a failed attempt's partial buffer doesn't get double-inserted alongside
+     * the retry's own -- safe here specifically because nothing has flushed yet.
+     * Also skips retrying deterministic errors (S3NdjsonReader marks bad input/config --
+     * invalid byteRange, oversized line, malformed JSON -- with `retryable = false`) since
+     * they fail identically on every attempt.
      * @param {Object} params
      * @param {() => Promise<void>} params.fn
      * @param {string} params.requestId
@@ -518,7 +532,17 @@ class BulkImportHandler {
                 return;
             } catch (e) {
                 lastError = e;
-                logError('S3 NDJSON range read attempt failed', { requestId, attempt, attempts, error: e.message });
+                logError('S3 NDJSON range read attempt failed', {
+                    requestId,
+                    attempt,
+                    attempts,
+                    partiallyFlushed: !!e.bulkImportRangePartiallyFlushed,
+                    retryable: e.retryable !== false,
+                    error: e.message
+                });
+                if (e.bulkImportRangePartiallyFlushed || e.retryable === false) {
+                    throw e;
+                }
                 if (attempt < attempts) {
                     await this.requestSpecificCache.clearAsync({ requestId });
                     await new Promise((resolve) => setTimeout(resolve, 200 * attempt));
@@ -662,8 +686,14 @@ class BulkImportHandler {
         let failed = 0;
         const mergeResultEntries = [];
 
+        // Set once this attempt's first flush actually writes to Mongo (and possibly
+        // ClickHouse/Kafka-ClickPipe for clickHouseOnlyResources) -- see
+        // readRangeWithRetryAsync's docstring for why retry must stop once this is true.
+        let hasFlushedThisAttempt = false;
+
         const flushBatchAsync = async () => {
             const mergeResults = await this.fastDatabaseBulkInserter.executeAsync({ requestInfo, base_version });
+            hasFlushedThisAttempt = true;
             for (const mergeResult of mergeResults) {
                 mergeResultEntries.push(mergeResult);
                 if (mergeResult.created) {
@@ -686,56 +716,64 @@ class BulkImportHandler {
             updated = 0;
             failed = 0;
             mergeResultEntries.length = 0;
+            hasFlushedThisAttempt = false;
 
-            for await (const { lineNumber, byteOffset, resource } of this.s3NdjsonReader.readNdjsonAsync({
-                filepath,
-                byteRangeStart,
-                byteRangeEnd,
-                fileSize
-            })) {
-                linesRead++;
-                sinceLastFlush++;
+            try {
+                for await (const { lineNumber, byteOffset, resource } of this.s3NdjsonReader.readNdjsonAsync({
+                    filepath,
+                    byteRangeStart,
+                    byteRangeEnd,
+                    fileSize
+                })) {
+                    linesRead++;
+                    sinceLastFlush++;
 
-                try {
-                    const fhirResource = FhirResourceWriteSerializer.serialize({
-                        obj: this.applyDefaultSecurityTagsIfMissing(resource)
-                    });
-                    const contextData = buildContextDataForHybridStorage(
-                        fhirResource.resourceType, fhirResource, requestInfo
-                    );
-                    await this.fastDatabaseBulkInserter.insertOneAsync({
-                        base_version,
-                        requestInfo,
-                        resourceType: fhirResource.resourceType,
-                        doc: fhirResource,
-                        contextData
-                    });
-                } catch (resourceError) {
-                    failed++;
-                    // Failed before reaching the bulk inserter (e.g. missing/unsupported
-                    // resourceType) — still record it so it lands in the error NDJSON and
-                    // Task.output, not just a log line.
-                    mergeResultEntries.push(
-                        MergeResultEntry.createFromError({ error: resourceError, resource, sourceByteOffset: byteOffset })
-                    );
-                    logError('Failed to buffer bulk import resource for write', {
-                        taskId,
-                        filepath,
-                        lineNumber,
-                        byteOffset,
-                        error: resourceError.message
-                    });
+                    try {
+                        const fhirResource = FhirResourceWriteSerializer.serialize({
+                            obj: this.applyDefaultSecurityTagsIfMissing(resource)
+                        });
+                        const contextData = buildContextDataForHybridStorage(
+                            fhirResource.resourceType, fhirResource, requestInfo
+                        );
+                        await this.fastDatabaseBulkInserter.insertOneAsync({
+                            base_version,
+                            requestInfo,
+                            resourceType: fhirResource.resourceType,
+                            doc: fhirResource,
+                            contextData
+                        });
+                    } catch (resourceError) {
+                        failed++;
+                        // Failed before reaching the bulk inserter (e.g. missing/unsupported
+                        // resourceType) — still record it so it lands in the error NDJSON and
+                        // Task.output, not just a log line.
+                        mergeResultEntries.push(
+                            MergeResultEntry.createFromError({ error: resourceError, resource, sourceByteOffset: byteOffset })
+                        );
+                        logError('Failed to buffer bulk import resource for write', {
+                            taskId,
+                            filepath,
+                            lineNumber,
+                            byteOffset,
+                            error: resourceError.message
+                        });
+                    }
+
+                    if (sinceLastFlush >= batchSize) {
+                        await flushBatchAsync();
+                        // Rate control: yield between batches so a single range doesn't
+                        // monopolize the event loop or MongoDB's write capacity.
+                        await new Promise((resolve) => setTimeout(resolve, batchDelayMs));
+                    }
                 }
-
-                if (sinceLastFlush >= batchSize) {
+                if (sinceLastFlush > 0) {
                     await flushBatchAsync();
-                    // Rate control: yield between batches so a single range doesn't
-                    // monopolize the event loop or MongoDB's write capacity.
-                    await new Promise((resolve) => setTimeout(resolve, batchDelayMs));
                 }
-            }
-            if (sinceLastFlush > 0) {
-                await flushBatchAsync();
+            } catch (e) {
+                if (hasFlushedThisAttempt) {
+                    e.bulkImportRangePartiallyFlushed = true;
+                }
+                throw e;
             }
         };
 

--- a/src/operations/asyncJobs/bulkImport/s3NdjsonReader.js
+++ b/src/operations/asyncJobs/bulkImport/s3NdjsonReader.js
@@ -58,7 +58,7 @@ class S3NdjsonReader {
      * @param {number} params.byteRangeStart
      * @param {number} params.byteRangeEnd
      * @param {number} params.fileSize - total file size from HEAD
-     * @returns {AsyncGenerator<{ lineNumber: number, byteOffset: number, resource: Object }, void, void>}
+     * @returns {AsyncGenerator<{ lineNumber: number, byteOffset: number, resource: Object|null, parseError: Error|null }, void, void>}
      */
     async *readNdjsonAsync({ filepath, byteRangeStart, byteRangeEnd, fileSize }) {
         if (!Number.isFinite(fileSize) || fileSize <= 0) {
@@ -130,29 +130,43 @@ class S3NdjsonReader {
             }
 
             lineNumber++;
+            // lineNumber resets to 1 at the start of every byte range, so it only
+            // identifies a line within THIS range, not within the original file once a
+            // file is split into multiple ranges. byteOffset is the line's absolute start
+            // position in the full file (bytesRead already includes byteRangeStart), so it
+            // stays correct regardless of how the file was split.
+            const byteOffset = bytesRead - lineBytes;
 
+            // A single bad line (too large, unparseable) must not abort the rest of the
+            // range -- skip it and let the caller record it in the error output, the same
+            // way a per-resource write failure is handled.
             if (Buffer.byteLength(line, 'utf8') > maxLineSizeBytes) {
-                throw nonRetryableError(
-                    `Line ${lineNumber} in "${filepath}" exceeds maximum size of ` +
-                    `${this.configManager.bulkImportMaxLineSizeMb} MB`
-                );
+                yield {
+                    lineNumber,
+                    byteOffset,
+                    resource: null,
+                    parseError: new Error(
+                        `Line ${lineNumber} in "${filepath}" exceeds maximum size of ` +
+                        `${this.configManager.bulkImportMaxLineSizeMb} MB`
+                    )
+                };
+                continue;
             }
 
             let parsed;
             try {
                 parsed = JSON.parse(line);
             } catch (e) {
-                throw nonRetryableError(
-                    `Invalid JSON at line ${lineNumber} in "${filepath}": ${e.message}`
-                );
+                yield {
+                    lineNumber,
+                    byteOffset,
+                    resource: null,
+                    parseError: new Error(`Invalid JSON at line ${lineNumber} in "${filepath}": ${e.message}`)
+                };
+                continue;
             }
 
-            // lineNumber resets to 1 at the start of every byte range, so it only
-            // identifies a line within THIS range, not within the original file once a
-            // file is split into multiple ranges. byteOffset is the line's absolute start
-            // position in the full file (bytesRead already includes byteRangeStart), so it
-            // stays correct regardless of how the file was split.
-            yield { lineNumber, byteOffset: bytesRead - lineBytes, resource: parsed };
+            yield { lineNumber, byteOffset, resource: parsed, parseError: null };
         }
 
         logInfo('S3 NDJSON reader finished', {

--- a/src/operations/asyncJobs/bulkImport/s3NdjsonReader.js
+++ b/src/operations/asyncJobs/bulkImport/s3NdjsonReader.js
@@ -4,6 +4,19 @@ const { assertTypeEquals } = require('../../../utils/assertType');
 const { ConfigManager } = require('../../../utils/configManager');
 const { logInfo, logError } = require('../../common/logging');
 
+/**
+ * Marks an error as deterministic (bad input/config, not a transient S3/network issue) so
+ * callers like BulkImportHandler.readRangeWithRetryAsync can skip retrying it -- it would
+ * fail identically on every attempt.
+ * @param {string} message
+ * @returns {Error}
+ */
+function nonRetryableError (message) {
+    const error = new Error(message);
+    error.retryable = false;
+    return error;
+}
+
 class S3NdjsonReader {
     /**
      * @typedef {Object} ConstructorParams
@@ -23,7 +36,7 @@ class S3NdjsonReader {
     parseS3Uri(uri) {
         const match = uri.match(/^s3:\/\/([^/]+)\/(.+)$/);
         if (!match) {
-            throw new Error(`Invalid S3 URI: "${uri}"`);
+            throw nonRetryableError(`Invalid S3 URI: "${uri}"`);
         }
         return { bucket: match[1], key: match[2] };
     }
@@ -49,23 +62,23 @@ class S3NdjsonReader {
      */
     async *readNdjsonAsync({ filepath, byteRangeStart, byteRangeEnd, fileSize }) {
         if (!Number.isFinite(fileSize) || fileSize <= 0) {
-            throw new Error(`Invalid fileSize ${fileSize} for "${filepath}"`);
+            throw nonRetryableError(`Invalid fileSize ${fileSize} for "${filepath}"`);
         }
         if (!Number.isFinite(byteRangeStart) || byteRangeStart < 0) {
-            throw new Error(`Invalid byteRangeStart ${byteRangeStart} for "${filepath}"`);
+            throw nonRetryableError(`Invalid byteRangeStart ${byteRangeStart} for "${filepath}"`);
         }
         if (!Number.isFinite(byteRangeEnd) || byteRangeEnd <= byteRangeStart) {
-            throw new Error(`Invalid byteRangeEnd ${byteRangeEnd} for "${filepath}"`);
+            throw nonRetryableError(`Invalid byteRangeEnd ${byteRangeEnd} for "${filepath}"`);
         }
 
         const { bucket, key } = this.parseS3Uri(filepath);
 
         const allowedBuckets = this.configManager.bulkImportAllowedS3Buckets;
         if (!allowedBuckets.length) {
-            throw new Error('Bulk import S3 bucket allowlist is not configured');
+            throw nonRetryableError('Bulk import S3 bucket allowlist is not configured');
         }
         if (!allowedBuckets.includes(bucket)) {
-            throw new Error(`S3 bucket "${bucket}" is not in the allowed list`);
+            throw nonRetryableError(`S3 bucket "${bucket}" is not in the allowed list`);
         }
 
         const region = this.configManager.awsRegion || 'us-east-1';
@@ -119,7 +132,7 @@ class S3NdjsonReader {
             lineNumber++;
 
             if (Buffer.byteLength(line, 'utf8') > maxLineSizeBytes) {
-                throw new Error(
+                throw nonRetryableError(
                     `Line ${lineNumber} in "${filepath}" exceeds maximum size of ` +
                     `${this.configManager.bulkImportMaxLineSizeMb} MB`
                 );
@@ -129,7 +142,7 @@ class S3NdjsonReader {
             try {
                 parsed = JSON.parse(line);
             } catch (e) {
-                throw new Error(
+                throw nonRetryableError(
                     `Invalid JSON at line ${lineNumber} in "${filepath}": ${e.message}`
                 );
             }

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -313,6 +313,48 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         ]);
     });
 
+    test('handleMessageAsync skips an invalid NDJSON line and records it in the error output without failing the range', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-bad-line' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        container.s3NdjsonReader.setLinesToYield([
+            { resourceType: 'Patient', id: 'bulk-import-before-bad-line', name: [{ family: 'Before' }] },
+            { __parseError: 'Invalid JSON at line 2 in "s3://allowed-bucket/Patient.ndjson": Unexpected token' },
+            { resourceType: 'Patient', id: 'bulk-import-after-bad-line', name: [{ family: 'After' }] }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-bad-line-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-bad-line' }),
+            headers: []
+        });
+
+        // The bad line doesn't abort the range -- both surrounding valid resources are
+        // still written.
+        await request.get('/4_0_0/Patient/bulk-import-before-bad-line').set(getHeaders()).expect(200);
+        await request.get('/4_0_0/Patient/bulk-import-after-bad-line').set(getHeaders()).expect(200);
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-consumer-bad-line')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('completed');
+
+        const errorWrite = container.s3NdjsonReader.getWriteCalls()
+            .find((c) => c.filepath.includes('/output/errors/'));
+        expect(errorWrite).toBeDefined();
+        expect(errorWrite.data).toContain('Invalid JSON at line 2');
+    });
+
     test('handleMessageAsync flushes postRequestProcessor and clears requestSpecificCache per range', async () => {
         const request = await createTestRequest();
 

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -535,6 +535,109 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         clearSpy.mockRestore();
     });
 
+    test('readRangeWithRetryAsync does not retry once a batch has already been flushed', async () => {
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        const clearSpy = jest.spyOn(container.requestSpecificCache, 'clearAsync');
+        const partiallyFlushedError = new Error('mid-stream failure after a flush');
+        partiallyFlushedError.bulkImportRangePartiallyFlushed = true;
+        const fn = jest.fn().mockRejectedValue(partiallyFlushedError);
+
+        // Not every flushed resourceType is an idempotent Mongo upsert (e.g. ClickHouse/
+        // Kafka-ClickPipe sinks do an unconditional insert/produce), so retrying after a
+        // flush risks duplicate rows/events -- must fail on the first attempt, not retry.
+        await expect(handler.readRangeWithRetryAsync({
+            fn,
+            requestId: 'req-partially-flushed',
+            attempts: 3
+        })).rejects.toThrow('mid-stream failure after a flush');
+
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(clearSpy).not.toHaveBeenCalled();
+
+        clearSpy.mockRestore();
+    });
+
+    test('readRangeWithRetryAsync does not retry a deterministic (non-retryable) error', async () => {
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        const clearSpy = jest.spyOn(container.requestSpecificCache, 'clearAsync');
+        const validationError = new Error('Invalid JSON at line 3');
+        validationError.retryable = false;
+        const fn = jest.fn().mockRejectedValue(validationError);
+
+        // Fails identically on every attempt -- retrying would just waste time/backoff for
+        // the same eventual outcome.
+        await expect(handler.readRangeWithRetryAsync({
+            fn,
+            requestId: 'req-non-retryable',
+            attempts: 3
+        })).rejects.toThrow('Invalid JSON at line 3');
+
+        expect(fn).toHaveBeenCalledTimes(1);
+        expect(clearSpy).not.toHaveBeenCalled();
+
+        clearSpy.mockRestore();
+    });
+
+    test('handleMessageAsync marks Task failed without retrying or duplicating already-flushed resources', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-partial-flush' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        const originalBatchSize = process.env.BULK_IMPORT_BATCH_SIZE;
+        process.env.BULK_IMPORT_BATCH_SIZE = '1';
+
+        container.s3NdjsonReader.setLinesToYield([
+            { resourceType: 'Patient', id: 'bulk-import-partial-flush-1', name: [{ family: 'Flushed' }] },
+            { resourceType: 'Patient', id: 'bulk-import-partial-flush-2', name: [{ family: 'NeverFlushed' }] }
+        ]);
+        // First resource flushes (batch size 1) before the stream fails on the second.
+        container.s3NdjsonReader.setFailAfterYielding(1);
+
+        try {
+            await handler.handleMessageAsync({
+                key: 'import-consumer-partial-flush-0',
+                value: makeCloudEvent({ taskId: 'import-consumer-partial-flush' }),
+                headers: []
+            });
+        } finally {
+            if (originalBatchSize === undefined) {
+                delete process.env.BULK_IMPORT_BATCH_SIZE;
+            } else {
+                process.env.BULK_IMPORT_BATCH_SIZE = originalBatchSize;
+            }
+        }
+
+        // Only one read call -- the partial-flush failure must not trigger a retry.
+        expect(container.s3NdjsonReader.getReadCalls()).toHaveLength(1);
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-consumer-partial-flush')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('failed');
+
+        // The already-flushed resource is durably in Mongo exactly once (not duplicated by
+        // a retry that never happened).
+        await request
+            .get('/4_0_0/Patient/bulk-import-partial-flush-1')
+            .set(getHeaders())
+            .expect(200);
+    });
+
     test('handleMessageAsync retries a transient S3 read failure and still completes the range', async () => {
         const request = await createTestRequest();
 

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -486,6 +486,127 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         writeSpy.mockRestore();
     });
 
+    test('readRangeWithRetryAsync retries transient failures and succeeds', async () => {
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        const fn = jest.fn()
+            .mockRejectedValueOnce(new Error('transient read failure'))
+            .mockResolvedValueOnce(undefined);
+
+        await handler.readRangeWithRetryAsync({ fn, requestId: 'req-retry-success' });
+
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    test('readRangeWithRetryAsync throws after exhausting retries', async () => {
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        const fn = jest.fn().mockRejectedValue(new Error('persistent read failure'));
+
+        await expect(handler.readRangeWithRetryAsync({
+            fn,
+            requestId: 'req-retry-exhausted',
+            attempts: 2
+        })).rejects.toThrow('persistent read failure');
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    test('readRangeWithRetryAsync clears requestSpecificCache between failed attempts', async () => {
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        const clearSpy = jest.spyOn(container.requestSpecificCache, 'clearAsync');
+        const fn = jest.fn()
+            .mockRejectedValueOnce(new Error('transient read failure'))
+            .mockResolvedValueOnce(undefined);
+
+        await handler.readRangeWithRetryAsync({ fn, requestId: 'req-retry-clears-cache' });
+
+        // Clears the failed attempt's buffered-but-unflushed inserts before retrying with
+        // the same requestId, so a partial buffer can't get double-inserted alongside the
+        // retry's own.
+        expect(clearSpy).toHaveBeenCalledWith({ requestId: 'req-retry-clears-cache' });
+
+        clearSpy.mockRestore();
+    });
+
+    test('handleMessageAsync retries a transient S3 read failure and still completes the range', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-read-retry' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        container.s3NdjsonReader.setLinesToYield([
+            { resourceType: 'Patient', id: 'bulk-import-read-retry', name: [{ family: 'Retry' }] }
+        ]);
+        container.s3NdjsonReader.setFailNextReads(1);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-read-retry-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-read-retry' }),
+            headers: []
+        });
+
+        await request
+            .get('/4_0_0/Patient/bulk-import-read-retry')
+            .set(getHeaders())
+            .expect(200);
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-consumer-read-retry')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('completed');
+
+        // First read call failed, second succeeded -- the whole range is reprocessed from
+        // the start on retry, not resumed mid-stream.
+        expect(container.s3NdjsonReader.getReadCalls()).toHaveLength(2);
+    });
+
+    test('handleMessageAsync marks the Task failed after exhausting S3 read retries', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-read-exhausted' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        container.s3NdjsonReader.setLinesToYield([
+            { resourceType: 'Patient', id: 'bulk-import-read-exhausted', name: [{ family: 'Exhausted' }] }
+        ]);
+        container.s3NdjsonReader.setFailNextReads(3);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-read-exhausted-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-read-exhausted' }),
+            headers: []
+        });
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-consumer-read-exhausted')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('failed');
+        expect(container.s3NdjsonReader.getReadCalls()).toHaveLength(3);
+    });
+
     test('handleMessageAsync propagates a persistent S3 write failure instead of silently dropping the range', async () => {
         const request = await createTestRequest();
 

--- a/src/tests/mocks/mockS3NdjsonReader.js
+++ b/src/tests/mocks/mockS3NdjsonReader.js
@@ -10,6 +10,7 @@ class MockS3NdjsonReader extends S3NdjsonReader {
          */
         this.linesToYield = [];
         this.failReadsRemaining = 0;
+        this.failAfterYieldingCount = null;
     }
 
     /**
@@ -29,6 +30,16 @@ class MockS3NdjsonReader extends S3NdjsonReader {
         this.failReadsRemaining = count;
     }
 
+    /**
+     * Makes readNdjsonAsync() yield the first `n` configured lines normally, then throw
+     * before yielding line n+1 -- simulating a stream failure partway through, e.g. after
+     * enough lines have already been flushed to Mongo.
+     * @param {number} n
+     */
+    setFailAfterYielding(n) {
+        this.failAfterYieldingCount = n;
+    }
+
     async *readNdjsonAsync({ filepath, byteRangeStart, byteRangeEnd, fileSize }) {
         this.readCalls.push({ filepath, byteRangeStart, byteRangeEnd, fileSize });
         if (this.failReadsRemaining > 0) {
@@ -36,6 +47,9 @@ class MockS3NdjsonReader extends S3NdjsonReader {
             throw new Error('Simulated transient S3 read failure');
         }
         for (let i = 0; i < this.linesToYield.length; i++) {
+            if (this.failAfterYieldingCount !== null && i === this.failAfterYieldingCount) {
+                throw new Error('Simulated mid-stream S3 read failure');
+            }
             // byteOffset is arbitrary here (this mock doesn't read real bytes) but must be
             // distinct per line and independent of byteRangeStart to mirror the real
             // reader's guarantee that it's a stable, range-independent identifier.
@@ -60,6 +74,7 @@ class MockS3NdjsonReader extends S3NdjsonReader {
         this.writeCalls = [];
         this.linesToYield = [];
         this.failReadsRemaining = 0;
+        this.failAfterYieldingCount = null;
     }
 }
 

--- a/src/tests/mocks/mockS3NdjsonReader.js
+++ b/src/tests/mocks/mockS3NdjsonReader.js
@@ -9,6 +9,7 @@ class MockS3NdjsonReader extends S3NdjsonReader {
          * @type {Array<Object>}
          */
         this.linesToYield = [];
+        this.failReadsRemaining = 0;
     }
 
     /**
@@ -19,8 +20,21 @@ class MockS3NdjsonReader extends S3NdjsonReader {
         this.linesToYield = resources;
     }
 
+    /**
+     * Makes the next `count` calls to readNdjsonAsync() throw before yielding anything,
+     * simulating a transient S3/stream failure. Calls after that yield normally.
+     * @param {number} count
+     */
+    setFailNextReads(count) {
+        this.failReadsRemaining = count;
+    }
+
     async *readNdjsonAsync({ filepath, byteRangeStart, byteRangeEnd, fileSize }) {
         this.readCalls.push({ filepath, byteRangeStart, byteRangeEnd, fileSize });
+        if (this.failReadsRemaining > 0) {
+            this.failReadsRemaining--;
+            throw new Error('Simulated transient S3 read failure');
+        }
         for (let i = 0; i < this.linesToYield.length; i++) {
             // byteOffset is arbitrary here (this mock doesn't read real bytes) but must be
             // distinct per line and independent of byteRangeStart to mirror the real
@@ -45,6 +59,7 @@ class MockS3NdjsonReader extends S3NdjsonReader {
         this.readCalls = [];
         this.writeCalls = [];
         this.linesToYield = [];
+        this.failReadsRemaining = 0;
     }
 }
 

--- a/src/tests/mocks/mockS3NdjsonReader.js
+++ b/src/tests/mocks/mockS3NdjsonReader.js
@@ -53,7 +53,15 @@ class MockS3NdjsonReader extends S3NdjsonReader {
             // byteOffset is arbitrary here (this mock doesn't read real bytes) but must be
             // distinct per line and independent of byteRangeStart to mirror the real
             // reader's guarantee that it's a stable, range-independent identifier.
-            yield { lineNumber: i + 1, byteOffset: i * 100, resource: this.linesToYield[i] };
+            const entry = this.linesToYield[i];
+            // A { __parseError: 'message' } entry simulates a real reader's per-line
+            // skip-and-report behavior (too-large line, malformed JSON) -- see
+            // s3NdjsonReader.readNdjsonAsync.
+            if (entry && entry.__parseError) {
+                yield { lineNumber: i + 1, byteOffset: i * 100, resource: null, parseError: new Error(entry.__parseError) };
+                continue;
+            }
+            yield { lineNumber: i + 1, byteOffset: i * 100, resource: entry, parseError: null };
         }
     }
 

--- a/src/tests/unit/operations/asyncJobs/bulkImport/s3NdjsonReader.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/s3NdjsonReader.test.js
@@ -230,18 +230,44 @@ describe('S3NdjsonReader', () => {
         });
     });
 
-    describe('readNdjsonAsync retryable classification', () => {
-        test('marks an invalid-JSON line error as non-retryable -- it would fail identically on every attempt', async () => {
-            const badText = '{"resourceType":"Patient","id":"p1"}\nnot-json\n';
+    describe('readNdjsonAsync per-line error handling', () => {
+        test('skips an invalid-JSON line (yielding a parseError) instead of aborting the rest of the range', async () => {
+            const badText = '{"resourceType":"Patient","id":"p1"}\nnot-json\n{"resourceType":"Patient","id":"p2"}\n';
             const badFileSize = Buffer.byteLength(badText, 'utf8');
             serveFileFromMockS3(badText);
 
-            await expect(collect(reader.readNdjsonAsync({
+            const results = await collect(reader.readNdjsonAsync({
                 filepath: 's3://allowed-bucket/file.ndjson',
                 byteRangeStart: 0,
                 byteRangeEnd: badFileSize,
                 fileSize: badFileSize
-            }))).rejects.toMatchObject({ retryable: false });
+            }));
+
+            expect(results).toHaveLength(3);
+            expect(results[0]).toMatchObject({ resource: { id: 'p1' }, parseError: null });
+            expect(results[1].resource).toBeNull();
+            expect(results[1].parseError).toBeInstanceOf(Error);
+            expect(results[1].parseError.message).toMatch(/Invalid JSON at line 2/);
+            expect(results[2]).toMatchObject({ resource: { id: 'p2' }, parseError: null });
+        });
+
+        test('skips a line exceeding the max size (yielding a parseError) instead of aborting the rest of the range', async () => {
+            const oversizedLine = JSON.stringify({ resourceType: 'Patient', id: 'p1', extra: 'x'.repeat(20 * 1024 * 1024) });
+            const text = `${oversizedLine}\n{"resourceType":"Patient","id":"p2"}\n`;
+            const fileSizeForTest = Buffer.byteLength(text, 'utf8');
+            serveFileFromMockS3(text);
+
+            const results = await collect(reader.readNdjsonAsync({
+                filepath: 's3://allowed-bucket/file.ndjson',
+                byteRangeStart: 0,
+                byteRangeEnd: fileSizeForTest,
+                fileSize: fileSizeForTest
+            }));
+
+            expect(results).toHaveLength(2);
+            expect(results[0].resource).toBeNull();
+            expect(results[0].parseError.message).toMatch(/exceeds maximum size/);
+            expect(results[1]).toMatchObject({ resource: { id: 'p2' }, parseError: null });
         });
     });
 });

--- a/src/tests/unit/operations/asyncJobs/bulkImport/s3NdjsonReader.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/s3NdjsonReader.test.js
@@ -99,6 +99,16 @@ describe('S3NdjsonReader', () => {
             await expect(gen.next()).rejects.toThrow(/Invalid fileSize/);
         });
 
+        test('marks a validation error as non-retryable -- it would fail identically on every attempt', async () => {
+            const gen = reader.readNdjsonAsync({
+                filepath: 's3://allowed-bucket/file.ndjson',
+                byteRangeStart: 0,
+                byteRangeEnd: 100,
+                fileSize: 0
+            });
+            await expect(gen.next()).rejects.toMatchObject({ retryable: false });
+        });
+
         test('throws for negative fileSize', async () => {
             const gen = reader.readNdjsonAsync({
                 filepath: 's3://allowed-bucket/file.ndjson',
@@ -217,6 +227,21 @@ describe('S3NdjsonReader', () => {
             // large files into more than one range.
             expect(results.map((r) => r.lineNumber)).toEqual([1, 2]);
             expect(results.map((r) => r.byteOffset)).toEqual([line1Bytes, line1Bytes + line2Bytes]);
+        });
+    });
+
+    describe('readNdjsonAsync retryable classification', () => {
+        test('marks an invalid-JSON line error as non-retryable -- it would fail identically on every attempt', async () => {
+            const badText = '{"resourceType":"Patient","id":"p1"}\nnot-json\n';
+            const badFileSize = Buffer.byteLength(badText, 'utf8');
+            serveFileFromMockS3(badText);
+
+            await expect(collect(reader.readNdjsonAsync({
+                filepath: 's3://allowed-bucket/file.ndjson',
+                byteRangeStart: 0,
+                byteRangeEnd: badFileSize,
+                fileSize: badFileSize
+            }))).rejects.toMatchObject({ retryable: false });
         });
     });
 });


### PR DESCRIPTION
## Summary

Covers all three sub-scopes of BAI-226 (failure handling):

**S3 read retry.** A transient S3/stream failure anywhere while reading a byte range previously failed the whole range immediately with no retry at all, marking the Task `failed` on a single blip. Added `readRangeWithRetryAsync` to `handler.js`, mirroring the existing `writeNdjsonWithRetryAsync` pattern (bounded retries, backoff) already used for S3 result/error NDJSON writes.

Since a mid-stream failure can happen after resources were already buffered or even flushed to Mongo, retry only ever reprocesses a range that **hasn't written anything yet** in the current attempt — retrying after a batch has already flushed was found to be unsafe for two reasons (confirmed via review):
1. Not every resourceType's flush is an idempotent Mongo upsert — `ClickHouseBulkWriteExecutor` (SYNC_DIRECT) and `KafkaClickPipeBulkWriteExecutor` (KAFKA_CLICKPIPE), e.g. `AuditEvent` under `enableAuditEventClickPipe`/`clickHouseOnlyResources`, do an unconditional insert/produce with no dedup — replaying an already-flushed batch would create a duplicate ClickHouse row or Kafka message.
2. `requestSpecificCache.clearAsync({requestId})` clears both the buffered-insert map *and* `postRequestProcessor`'s queue (same requestId-keyed cache) — clearing it after a successful flush would discard that flush's already-queued Kafka change-event/history-write tasks, and re-inserting the same unchanged resources on retry gets silently skipped, so those tasks never get queued a second time either.

Once a batch has flushed, a failure now fails immediately instead of retrying — matching the original pre-retry behavior for that case, which is provably safe regardless of resourceType/executor.

Also: `s3NdjsonReader`'s deterministic validation errors (invalid byteRange/fileSize, oversized line, malformed JSON) are marked `retryable = false` so the retry loop doesn't waste attempts on an error that would fail identically every time. `writeNdjsonWithRetryAsync` now reuses the existing `retryWithBackoff` utility instead of hand-rolling the loop a second time; `readRangeWithRetryAsync` keeps its own loop with a documented reason why (needs an awaited cache-clear between attempts and an early-bail condition that `retryWithBackoff`'s fire-and-forget `onRetry` hook can't support).

**Invalid NDJSON line handling.** A single malformed JSON line or a line exceeding `bulkImportMaxLineSizeMb` previously threw and aborted the *entire* byte range. `s3NdjsonReader.readNdjsonAsync` now yields these as `{ resource: null, parseError }` instead of throwing; the worker handler records them via `MergeResultEntry.createFromError` (the same path already used for per-resource write failures) so they land in the error NDJSON and `Task.output`, while the rest of the range keeps processing normally. Range-level validation errors (invalid byteRange/fileSize, invalid S3 URI, disallowed bucket) are unaffected — those still abort the whole range since they mean the range itself is malformed, not a single line.

**Stalled-operation detection.**  A Task stuck `in-progress` indefinitely is an infra-level failure that should be visible via Groundcover monitoring / a status dashboard (Groundcover/Sigma/Databricks), not a scheduled sweep built into the app. `Task.meta.lastUpdated` is already reliably updated on every status transition and range completion for any future dashboard to key off of.

## Test plan
- [x] `readRangeWithRetryAsync` unit tests: retries-then-succeeds, throws-after-exhausted, clears `requestSpecificCache` between failed (pre-flush) attempts, does **not** retry once a batch has flushed, does **not** retry a deterministic (non-retryable) error
- [x] `handleMessageAsync` integration tests (real Mongo): a transient pre-flush read failure still completes the range after retry; exhausting retries marks the Task `failed`; a partial-flush failure fails immediately without retry or duplicating the already-flushed resource; an invalid NDJSON line is skipped and recorded without failing the range
- [x] `s3NdjsonReader` unit tests: validation errors marked non-retryable; invalid-JSON/oversized lines are skipped (yielded with `parseError`) instead of aborting the range
- [x] Full `asyncJobs`/`bulkImport` suite passes (116 tests)
- [x] Lint clean