### PR TITLE
BAI-224 wire AuditEvent attribution for bulk-imported writes

### DIFF
--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -1251,7 +1251,8 @@ const createContainer = function () {
         fastDatabaseBulkInserter: c.fastDatabaseBulkInserter,
         s3NdjsonReader: c.s3NdjsonReader,
         postRequestProcessor: c.postRequestProcessor,
-        requestSpecificCache: c.requestSpecificCache
+        requestSpecificCache: c.requestSpecificCache,
+        auditLogger: c.auditLogger
     }));
 
     // Routes messages on kafkaBulkImportTaskCreatedTopic to their handler by CloudEvent

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -19,6 +19,8 @@ const { RequestSpecificCache } = require('../../../utils/requestSpecificCache');
 const { MergeResultEntry } = require('../../common/mergeResultEntry');
 const { logInfo, logError } = require('../../common/logging');
 const { retryWithBackoff } = require('../../../utils/retryWithBackoff');
+const { AuditLogger } = require('../../../utils/auditLogger');
+const { groupByLambda } = require('../../../utils/list.util');
 
 /**
  * Extension URL used to record a marker on the Task each time a byte-range finishes
@@ -54,6 +56,7 @@ class BulkImportHandler {
      * @property {S3NdjsonReader} s3NdjsonReader
      * @property {PostRequestProcessor} postRequestProcessor
      * @property {RequestSpecificCache} requestSpecificCache
+     * @property {AuditLogger} auditLogger
      *
      * @param {ConstructorParams}
      */
@@ -66,7 +69,8 @@ class BulkImportHandler {
         fastDatabaseBulkInserter,
         s3NdjsonReader,
         postRequestProcessor,
-        requestSpecificCache
+        requestSpecificCache,
+        auditLogger
     }) {
         this.configManager = configManager;
         assertTypeEquals(configManager, ConfigManager);
@@ -94,6 +98,9 @@ class BulkImportHandler {
 
         this.requestSpecificCache = requestSpecificCache;
         assertTypeEquals(requestSpecificCache, RequestSpecificCache);
+
+        this.auditLogger = auditLogger;
+        assertTypeEquals(auditLogger, AuditLogger);
     }
 
     /**
@@ -838,6 +845,16 @@ class BulkImportHandler {
                 mergeResultEntries,
                 requestInfo
             });
+
+            this.queueAuditEntriesForRangeAsync({
+                requestInfo,
+                base_version,
+                mergeResultEntries,
+                taskId,
+                filepath,
+                rangeIndex,
+                totalRanges
+            });
         } finally {
             // FastDatabaseBulkInserter defers history writes onto postRequestProcessor's
             // queue rather than writing them inline — without this, history writes for
@@ -845,8 +862,81 @@ class BulkImportHandler {
             // entries are also only ever freed by an explicit clearAsync, so skipping this
             // would leak one entry per Kafka message in this long-running consumer.
             await this.postRequestProcessor.executeAsync({ requestId: requestInfo.requestId });
+            // AuditLogger.logAuditEntryAsync only buffers AuditEvent docs in-memory --
+            // flushAsync() is what actually writes them via the bulk inserter. In the main
+            // FHIR server this runs on a periodic cron (see cronTasksProcessor.js), but this
+            // process never starts that cron (only src/index.js does), so nothing would ever
+            // persist these without flushing explicitly here.
+            await this.auditLogger.flushAsync();
             await this.requestSpecificCache.clearAsync({ requestId: requestInfo.requestId });
         }
+    }
+
+    /**
+     * Queues AuditEvent entries for every resource this range created/updated/failed,
+     * grouped by resourceType, mirroring MergeManager.logAuditEntriesForMergeResults --
+     * the same pattern the $merge operation uses. Deferred via postRequestProcessor so it
+     * runs alongside the other end-of-range cleanup in the finally block below.
+     * @param {Object} params
+     * @param {FhirRequestInfo} params.requestInfo
+     * @param {string} params.base_version
+     * @param {import('../../common/mergeResultEntry').MergeResultEntry[]} params.mergeResultEntries
+     * @param {string} params.taskId
+     * @param {string} params.filepath
+     * @param {number} params.rangeIndex
+     * @param {number} params.totalRanges
+     * @returns {void}
+     */
+    queueAuditEntriesForRangeAsync({
+        requestInfo, base_version, mergeResultEntries, taskId, filepath, rangeIndex, totalRanges
+    }) {
+        this.postRequestProcessor.add({
+            requestId: requestInfo.requestId,
+            fnTask: async () => {
+                const args = { taskId, filepath, rangeIndex, totalRanges };
+                const groupByResourceType = groupByLambda(mergeResultEntries, (entry) => entry.resourceType);
+
+                for (const [resourceType, entriesForResourceType] of Object.entries(groupByResourceType)) {
+                    const failedItems = entriesForResourceType.filter((r) => r.issue);
+
+                    if (resourceType !== 'AuditEvent') {
+                        // we don't log success (create/update) audits on AuditEvent itself
+                        const createdItems = entriesForResourceType.filter((r) => r.created === true);
+                        const updatedItems = entriesForResourceType.filter((r) => r.updated === true);
+                        if (createdItems.length > 0) {
+                            await this.auditLogger.logAuditEntryAsync({
+                                requestInfo,
+                                base_version,
+                                resourceType,
+                                operation: 'create',
+                                args,
+                                ids: createdItems.map((r) => r._uuid)
+                            });
+                        }
+                        if (updatedItems.length > 0) {
+                            await this.auditLogger.logAuditEntryAsync({
+                                requestInfo,
+                                base_version,
+                                resourceType,
+                                operation: 'update',
+                                args,
+                                ids: updatedItems.map((r) => r._uuid)
+                            });
+                        }
+                    }
+                    // error audits are logged for all resource types, including AuditEvent,
+                    // to match mergeManager's logAuditEntriesForMergeResults.
+                    for (const entry of failedItems) {
+                        await this.auditLogger.logErrorAuditEntryAsync({
+                            requestInfo,
+                            resourceType,
+                            errorCode: 400,
+                            errorMessage: `${resourceType}/${entry.id}: bulk import failure`
+                        });
+                    }
+                }
+            }
+        });
     }
 }
 

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -823,6 +823,21 @@ class BulkImportHandler {
                 if (currentTask && currentTask.status !== 'completed') {
                     await this.updateTaskStatusAsync(currentTask, 'failed', e.message, requestInfo);
                 }
+                // mergeResultEntries only ever gains entries once a batch actually commits
+                // (flushBatchAsync) or a per-line failure is recorded -- so on a partially-
+                // flushed range (bulkImportRangePartiallyFlushed), these resources are already
+                // durably persisted even though the range as a whole failed. This range won't
+                // be redelivered once the Task is 'failed', so without this the flushed
+                // resources would never get an AuditEvent.
+                this.queueAuditEntriesForRangeAsync({
+                    requestInfo,
+                    base_version,
+                    mergeResultEntries,
+                    taskId,
+                    filepath,
+                    rangeIndex,
+                    totalRanges
+                });
                 return;
             }
 
@@ -866,8 +881,21 @@ class BulkImportHandler {
             // flushAsync() is what actually writes them via the bulk inserter. In the main
             // FHIR server this runs on a periodic cron (see cronTasksProcessor.js), but this
             // process never starts that cron (only src/index.js does), so nothing would ever
-            // persist these without flushing explicitly here.
-            await this.auditLogger.flushAsync();
+            // persist these without flushing explicitly here. Guarded because it can throw
+            // (e.g. a transient Mongo write failure) -- the range's writes and Task completion
+            // have already succeeded by this point, so an audit-flush hiccup must not skip
+            // the cache cleanup below or propagate out and cause this already-completed range
+            // to be redelivered/reprocessed.
+            try {
+                await this.auditLogger.flushAsync();
+            } catch (auditFlushError) {
+                logError('Failed to flush AuditEvents for bulk import range', {
+                    taskId,
+                    filepath,
+                    rangeIndex,
+                    error: auditFlushError.message
+                });
+            }
             await this.requestSpecificCache.clearAsync({ requestId: requestInfo.requestId });
         }
     }

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -948,4 +948,118 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
 
         readSpy.mockRestore();
     });
+
+    test('handleMessageAsync completes the range and clears the request cache even when AuditLogger.flushAsync throws', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-audit-flush-error' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        jest.spyOn(container.auditLogger, 'flushAsync').mockRejectedValueOnce(
+            new Error('Simulated transient AuditEvent flush failure')
+        );
+        const clearAsyncSpy = jest.spyOn(container.requestSpecificCache, 'clearAsync');
+
+        container.s3NdjsonReader.setLinesToYield([
+            { resourceType: 'Patient', id: 'bulk-import-audit-flush-error', name: [{ family: 'Flushed' }] }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-audit-flush-error-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-audit-flush-error' }),
+            headers: []
+        });
+
+        // A transient audit-flush failure must not be mistaken for the range itself failing --
+        // the resource write and Task completion already succeeded by the time flushAsync runs.
+        await request
+            .get('/4_0_0/Patient/bulk-import-audit-flush-error')
+            .set(getHeaders())
+            .expect(200);
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-consumer-audit-flush-error')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('completed');
+
+        // Cache cleanup must still run after the guarded flushAsync rejection, not get skipped.
+        expect(clearAsyncSpy).toHaveBeenCalled();
+    });
+
+    test('handleMessageAsync still logs an AuditEvent for the already-flushed resource when a later batch fails the range', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-audit-partial-flush' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { AuditLogger } = require('../../../utils/auditLogger');
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer((c) => {
+            c.register('auditLogger', (cc) => new AuditLogger({
+                postRequestProcessor: cc.postRequestProcessor,
+                databaseBulkInserter: cc.fastDatabaseBulkInserter,
+                preSaveManager: cc.preSaveManager,
+                configManager: cc.configManager
+            }));
+            return c;
+        });
+        const handler = container.bulkImportHandler;
+
+        const originalBatchSize = process.env.BULK_IMPORT_BATCH_SIZE;
+        process.env.BULK_IMPORT_BATCH_SIZE = '1';
+
+        container.s3NdjsonReader.setLinesToYield([
+            { resourceType: 'Patient', id: 'bulk-import-audit-partial-flush', name: [{ family: 'Flushed' }] },
+            { resourceType: 'Patient', id: 'bulk-import-audit-partial-flush-2', name: [{ family: 'NeverFlushed' }] }
+        ]);
+        // First resource flushes (batch size 1) before the stream fails on the second --
+        // mirrors the "marks Task failed without retrying or duplicating already-flushed
+        // resources" scenario above, but here asserting the AuditEvent side effect.
+        container.s3NdjsonReader.setFailAfterYielding(1);
+
+        try {
+            await handler.handleMessageAsync({
+                key: 'import-consumer-audit-partial-flush-0',
+                value: makeCloudEvent({ taskId: 'import-consumer-audit-partial-flush' }),
+                headers: []
+            });
+        } finally {
+            if (originalBatchSize === undefined) {
+                delete process.env.BULK_IMPORT_BATCH_SIZE;
+            } else {
+                process.env.BULK_IMPORT_BATCH_SIZE = originalBatchSize;
+            }
+        }
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-consumer-audit-partial-flush')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('failed');
+
+        await container.auditLogger.flushAsync();
+
+        const auditEventDb = await container.mongoDatabaseManager.getAuditDbAsync();
+        const auditEvents = await auditEventDb.collection('AuditEvent_4_0_0').find({}).toArray();
+
+        // The resource that was already durably committed before the stream failed must
+        // still get an AuditEvent -- this range will never be redelivered once the Task is
+        // 'failed', so this is the only chance to record it.
+        const patientCreateAudit = auditEvents.find((a) =>
+            a.action === 'C' &&
+            a.entity?.some((e) => e.what?.reference?.startsWith('Patient/'))
+        );
+        expect(patientCreateAudit).toBeDefined();
+    });
 });

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -212,6 +212,115 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             });
     });
 
+    test('handleMessageAsync creates an AuditEvent for a bulk-imported resource', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-audit' })
+            .set(getHeaders())
+            .expect(202);
+
+        // The default test container swaps in a no-op MockAuditLogger (see
+        // src/tests/mocks/mockAuditLogger.js) so unrelated tests don't pay for real audit
+        // writes -- override it back to the real AuditLogger here, the same way
+        // auditLogIsCreated.test.js does, since this test needs to observe real behavior.
+        const { AuditLogger } = require('../../../utils/auditLogger');
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer((c) => {
+            c.register('auditLogger', (cc) => new AuditLogger({
+                postRequestProcessor: cc.postRequestProcessor,
+                databaseBulkInserter: cc.fastDatabaseBulkInserter,
+                preSaveManager: cc.preSaveManager,
+                configManager: cc.configManager
+            }));
+            return c;
+        });
+        const handler = container.bulkImportHandler;
+
+        container.s3NdjsonReader.setLinesToYield([
+            { resourceType: 'Patient', id: 'bulk-import-audit-check', name: [{ family: 'Audited' }] }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-audit-0',
+            value: makeCloudEvent({
+                taskId: 'import-consumer-audit',
+                user: 'bulk-import-service-account',
+                scope: 'user/*.write'
+            }),
+            headers: []
+        });
+
+        await request.get('/4_0_0/Patient/bulk-import-audit-check').set(getHeaders()).expect(200);
+
+        // AuditLogger.logAuditEntryAsync only buffers in-memory; flushAsync() is what
+        // actually persists via the bulk inserter. In production this is called explicitly
+        // in handleImportRangeRequestedAsync's finally block (no cron runs in this process,
+        // unlike the main FHIR server) -- flushing again here is just to be safe against timing.
+        await container.auditLogger.flushAsync();
+
+        const auditEventDb = await container.mongoDatabaseManager.getAuditDbAsync();
+        const auditEvents = await auditEventDb.collection('AuditEvent_4_0_0').find({}).toArray();
+
+        // entity[].what.reference uses the resource's internal _uuid, not its plain id, so
+        // match on the resourceType prefix rather than the exact reference.
+        const patientCreateAudit = auditEvents.find((a) =>
+            a.action === 'C' &&
+            a.entity?.some((e) => e.what?.reference?.startsWith('Patient/'))
+        );
+        expect(patientCreateAudit).toBeDefined();
+        // originalUrl is threaded through as '$import' (there's no real HTTP request for this
+        // Kafka-driven write) -- confirms this AuditEvent came from the bulk import path.
+        expect(patientCreateAudit.entity[0].detail).toContainEqual(
+            { type: 'requestUrl', valueString: '$import' }
+        );
+    });
+
+    test('handleMessageAsync creates an error AuditEvent for a per-resource write failure', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-audit-error' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { AuditLogger } = require('../../../utils/auditLogger');
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer((c) => {
+            c.register('auditLogger', (cc) => new AuditLogger({
+                postRequestProcessor: cc.postRequestProcessor,
+                databaseBulkInserter: cc.fastDatabaseBulkInserter,
+                preSaveManager: cc.preSaveManager,
+                configManager: cc.configManager
+            }));
+            return c;
+        });
+        const handler = container.bulkImportHandler;
+
+        container.s3NdjsonReader.setLinesToYield([
+            { id: 'missing-resource-type' }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-audit-error-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-audit-error' }),
+            headers: []
+        });
+
+        await container.auditLogger.flushAsync();
+
+        const auditEventDb = await container.mongoDatabaseManager.getAuditDbAsync();
+        const auditEvents = await auditEventDb.collection('AuditEvent_4_0_0').find({}).toArray();
+
+        // logErrorAuditEntryAsync's AuditEvents use action 'E' (execute) and a
+        // "Security Alert"/"RESTful Operation" type rather than entity.what -- see
+        // AuditLogger.createErrorAuditEntry.
+        const errorAudit = auditEvents.find((a) => a.action === 'E' && a.outcomeDesc?.includes('missing-resource-type'));
+        expect(errorAudit).toBeDefined();
+    });
+
     test('handleMessageAsync flushes across multiple batches without dropping resources', async () => {
         process.env.BULK_IMPORT_BATCH_SIZE = '2';
         const request = await createTestRequest();


### PR DESCRIPTION
## Summary
- Bulk-imported resources go through the same `FastDatabaseBulkInserter` path as `$merge`, but were never audited. Confirmed via investigation: `AuditLogger` is never invoked automatically by that shared write path (`fastDatabaseBulkInserter.js`/`mongoBulkWriteExecutor.js` have zero references to it) — every top-level operation (`create.js`, `update.js`, `remove.js`, `mergeManager.js`) calls `auditLogger.logAuditEntryAsync`/`logErrorAuditEntryAsync` explicitly after its own write succeeds. `BulkImportHandler` simply never did.
- Added an `auditLogger` dependency to `BulkImportHandler` (wired via `createContainer.js`, reusing the existing singleton also used by `$merge`) and, after each byte range finishes, queue create/update/error AuditEvent entries grouped by `resourceType` — mirroring `MergeManager.logAuditEntriesForMergeResults` exactly (same grouping logic, same operation-code mapping, same "skip AuditEvent success audits but not error audits" rule).
- `requestInfo.user`/`scope` are already threaded through end-to-end from the original `$import` request's Bearer token via the `TaskCreated`/`ImportRangeRequested` Kafka payloads — this satisfies the ticket's literal scope (attribution for a service-principal caller). Full HTTP-request-level fidelity (`actor`/`purposeOfUse`/`remoteIpAddress`, delegated-user agent info) is a separate, larger design question — it would require widening those CloudEvent payloads to carry more of the original `requestInfo` — and is intentionally not addressed here.
- **Important fix also required:** `AuditLogger.logAuditEntryAsync` only buffers `AuditEvent` docs in-memory; `flushAsync()` is what actually persists them, and it's normally called by a periodic cron (`cronTasksProcessor.js`) that **only runs in the main FHIR server process** (`src/index.js` calls `cronTasksProcessor.initiateTasks()`; `orchestrator.js`/`worker.js` never do). Without an explicit `flushAsync()` call added to `handleImportRangeRequestedAsync`'s `finally` block, every queued audit entry would sit in memory and never actually write to Mongo.

Based on `BAI-226-s3-read-retry` since it touches the same file/method and that branch is still unmerged.

## Test plan
- [x] New test: a bulk-imported resource create produces a matching AuditEvent (`action: 'C'`, correct `entity[].what.reference`, `entity[0].detail` tagged with `requestUrl: '$import'`) — verified against real Mongo via the real `AuditLogger` (overriding the test container's default no-op `MockAuditLogger`, same pattern as `auditLogIsCreated.test.js`)
- [x] New test: a per-resource write failure produces a matching error AuditEvent (`action: 'E'`, `outcomeDesc` referencing the failing resource)
- [x] Full `asyncJobs`/`bulkImport` suite passes (118 tests)
- [x] Lint clean