### PR TITLE
BAI-225 support ifNoneExist conditional-create for bulk-imported resources

### DIFF
--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -1252,7 +1252,9 @@ const createContainer = function () {
         s3NdjsonReader: c.s3NdjsonReader,
         postRequestProcessor: c.postRequestProcessor,
         requestSpecificCache: c.requestSpecificCache,
-        auditLogger: c.auditLogger
+        auditLogger: c.auditLogger,
+        r4ArgsParser: c.r4ArgsParser,
+        searchQueryBuilder: c.searchQueryBuilder
     }));
 
     // Routes messages on kafkaBulkImportTaskCreatedTopic to their handler by CloudEvent

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -14,7 +14,7 @@ const { FhirRequestInfo } = require('../../../utils/fhirRequestInfo');
 const { buildContextDataForHybridStorage } = require('../../../utils/contextDataBuilder');
 const { generateUUID } = require('../../../utils/uid.util');
 const { SecurityTagSystem } = require('../../../utils/securityTagSystem');
-const { BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY } = require('../../../constants');
+const { BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY, STRICT_SEARCH_HANDLING } = require('../../../constants');
 const { PostRequestProcessor } = require('../../../utils/postRequestProcessor');
 const { RequestSpecificCache } = require('../../../utils/requestSpecificCache');
 const { MergeResultEntry } = require('../../common/mergeResultEntry');
@@ -166,9 +166,12 @@ class BulkImportHandler {
      * not a scoped user search) but still restricts the match to the importing resource's own
      * owner tenant -- otherwise this existence check would be a cross-tenant oracle: a match
      * belonging to a different tenant would silently suppress this tenant's create and leak
-     * that a same-identifier resource exists elsewhere. Every resource has exactly one owner
-     * tag by the time this runs (applyDefaultSecurityTagsIfMissing guarantees it), so this is
-     * never an unscoped/empty filter.
+     * that a same-identifier resource exists elsewhere.
+     *
+     * Requires a resolved ownerCode and parses with strict search-parameter handling: an
+     * unrecognized/mistyped query parameter (e.g. "identifer=...") would otherwise silently
+     * drop out of the filter entirely, collapsing the query to "any resource of this type
+     * owned by this tenant" -- a fail-open match that would wrongly skip the create.
      * @param {Object} params
      * @param {string} params.resourceType
      * @param {string} params.ifNoneExist - a FHIR search-query string, e.g.
@@ -178,9 +181,19 @@ class BulkImportHandler {
      * @returns {Promise<Object|null>}
      */
     async findExistingResourceForIfNoneExistAsync({ resourceType, ifNoneExist, ownerCode }) {
+        if (!ifNoneExist || !ifNoneExist.trim()) {
+            throw new Error('ifNoneExist is empty');
+        }
+        if (!ownerCode) {
+            throw new Error('Cannot resolve an owner tag to scope the ifNoneExist existence check');
+        }
+
         const base_version = '4_0_0';
         const args = querystring.parse(ifNoneExist);
         args.base_version = base_version;
+        // Strict handling: an unrecognized search parameter must throw rather than silently
+        // no-op out of the query (see class docstring above).
+        args.handling = STRICT_SEARCH_HANDLING;
         const parsedArgs = this.r4ArgsParser.parseArgs({ resourceType, args });
         const { query } = this.searchQueryBuilder.buildSearchQueryBasedOnVersion({
             base_version,
@@ -200,7 +213,10 @@ class BulkImportHandler {
             ]
         };
 
-        const databaseQueryManager = this.databaseQueryFactory.createQuery({ resourceType, base_version });
+        const databaseQueryManager = this.databaseQueryFactory.createQuery({
+            resourceType,
+            base_version
+        });
         return databaseQueryManager.findOneAsync({ query: scopedQuery });
     }
 
@@ -785,6 +801,13 @@ class BulkImportHandler {
             mergeResultEntries.length = 0;
             hasFlushedThisAttempt = false;
 
+            // ifNoneExist criteria "claimed" by a resource already queued for insert in this
+            // attempt but not yet flushed to Mongo. findExistingResourceForIfNoneExistAsync
+            // only sees committed state, so two wrapped lines with the same match criteria
+            // landing in the same unflushed batch would otherwise both pass the existence
+            // check and both get created.
+            const claimedIfNoneExistKeys = new Set();
+
             try {
                 for await (const { lineNumber, byteOffset, resource, parseError } of this.s3NdjsonReader.readNdjsonAsync({
                     filepath,
@@ -825,14 +848,29 @@ class BulkImportHandler {
                             });
 
                             let existingResource = null;
+                            let ifNoneExistKey = null;
                             if (isIfNoneExistWrapper) {
-                                const ownerTag = (fhirResource.meta?.security || [])
-                                    .find((tag) => tag.system === SecurityTagSystem.owner);
-                                existingResource = await this.findExistingResourceForIfNoneExistAsync({
-                                    resourceType: fhirResource.resourceType,
-                                    ifNoneExist: resource.ifNoneExist,
-                                    ownerCode: ownerTag?.code
-                                });
+                                const securityTags = fhirResource.meta?.security || [];
+                                // Mirrors OwnerColumnHandler's own fallback rule -- a resource
+                                // may arrive with only an access tag and no owner tag yet
+                                // (OwnerColumnHandler backfills the owner from the first access
+                                // tag, but only later during preSave, after this check runs).
+                                const ownerCode = securityTags.find((tag) => tag.system === SecurityTagSystem.owner)?.code ||
+                                    securityTags.find((tag) => tag.system === SecurityTagSystem.access)?.code;
+
+                                ifNoneExistKey = `${fhirResource.resourceType}|${ownerCode}|${resource.ifNoneExist}`;
+                                if (claimedIfNoneExistKeys.has(ifNoneExistKey)) {
+                                    // Another line earlier in this same unflushed batch already
+                                    // claimed this criteria -- treat as a match without a redundant
+                                    // (and stale, since the earlier insert isn't committed yet) query.
+                                    existingResource = true;
+                                } else {
+                                    existingResource = await this.findExistingResourceForIfNoneExistAsync({
+                                        resourceType: fhirResource.resourceType,
+                                        ifNoneExist: resource.ifNoneExist,
+                                        ownerCode
+                                    });
+                                }
                             }
 
                             if (existingResource) {
@@ -866,6 +904,12 @@ class BulkImportHandler {
                                     doc: fhirResource,
                                     contextData
                                 });
+                                // Only claim the criteria once the insert is actually queued --
+                                // if insertOneAsync had thrown instead, nothing was created, so a
+                                // later duplicate line in this batch must still be free to try.
+                                if (ifNoneExistKey) {
+                                    claimedIfNoneExistKeys.add(ifNoneExistKey);
+                                }
                             }
                         } catch (resourceError) {
                             failed++;

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -1,4 +1,5 @@
 const { S3Client: S3, HeadObjectCommand } = require('@aws-sdk/client-s3');
+const querystring = require('querystring');
 const moment = require('moment-timezone');
 const { assertTypeEquals } = require('../../../utils/assertType');
 const { ConfigManager } = require('../../../utils/configManager');
@@ -21,6 +22,8 @@ const { logInfo, logError } = require('../../common/logging');
 const { retryWithBackoff } = require('../../../utils/retryWithBackoff');
 const { AuditLogger } = require('../../../utils/auditLogger');
 const { groupByLambda } = require('../../../utils/list.util');
+const { R4ArgsParser } = require('../../query/r4ArgsParser');
+const { SearchQueryBuilder } = require('../../search/searchQueryBuilder');
 
 /**
  * Extension URL used to record a marker on the Task each time a byte-range finishes
@@ -57,6 +60,8 @@ class BulkImportHandler {
      * @property {PostRequestProcessor} postRequestProcessor
      * @property {RequestSpecificCache} requestSpecificCache
      * @property {AuditLogger} auditLogger
+     * @property {R4ArgsParser} r4ArgsParser
+     * @property {SearchQueryBuilder} searchQueryBuilder
      *
      * @param {ConstructorParams}
      */
@@ -70,7 +75,9 @@ class BulkImportHandler {
         s3NdjsonReader,
         postRequestProcessor,
         requestSpecificCache,
-        auditLogger
+        auditLogger,
+        r4ArgsParser,
+        searchQueryBuilder
     }) {
         this.configManager = configManager;
         assertTypeEquals(configManager, ConfigManager);
@@ -101,6 +108,12 @@ class BulkImportHandler {
 
         this.auditLogger = auditLogger;
         assertTypeEquals(auditLogger, AuditLogger);
+
+        this.r4ArgsParser = r4ArgsParser;
+        assertTypeEquals(r4ArgsParser, R4ArgsParser);
+
+        this.searchQueryBuilder = searchQueryBuilder;
+        assertTypeEquals(searchQueryBuilder, SearchQueryBuilder);
     }
 
     /**
@@ -144,6 +157,51 @@ class BulkImportHandler {
         return databaseQueryManager.findOneAsync({
             query: { id: taskId }
         });
+    }
+
+    /**
+     * Checks whether a resource matching an `ifNoneExist` search query already exists, for
+     * the `{ ifNoneExist, resource }` NDJSON line wrapper's conditional-create semantics.
+     * Bypasses SearchManager's user-scope filtering (bulk import runs as a service principal,
+     * not a scoped user search) but still restricts the match to the importing resource's own
+     * owner tenant -- otherwise this existence check would be a cross-tenant oracle: a match
+     * belonging to a different tenant would silently suppress this tenant's create and leak
+     * that a same-identifier resource exists elsewhere. Every resource has exactly one owner
+     * tag by the time this runs (applyDefaultSecurityTagsIfMissing guarantees it), so this is
+     * never an unscoped/empty filter.
+     * @param {Object} params
+     * @param {string} params.resourceType
+     * @param {string} params.ifNoneExist - a FHIR search-query string, e.g.
+     *   "identifier=http://example.com|12345", the same format as the If-None-Exist header.
+     * @param {string} params.ownerCode - the owner-tag code from the importing resource's own
+     *   meta.security; the existence check is restricted to resources owned by this tenant.
+     * @returns {Promise<Object|null>}
+     */
+    async findExistingResourceForIfNoneExistAsync({ resourceType, ifNoneExist, ownerCode }) {
+        const base_version = '4_0_0';
+        const args = querystring.parse(ifNoneExist);
+        args.base_version = base_version;
+        const parsedArgs = this.r4ArgsParser.parseArgs({ resourceType, args });
+        const { query } = this.searchQueryBuilder.buildSearchQueryBasedOnVersion({
+            base_version,
+            parsedArgs,
+            resourceType,
+            operation: 'read'
+        });
+
+        const scopedQuery = {
+            $and: [
+                query,
+                {
+                    'meta.security': {
+                        $elemMatch: { system: SecurityTagSystem.owner, code: ownerCode }
+                    }
+                }
+            ]
+        };
+
+        const databaseQueryManager = this.databaseQueryFactory.createQuery({ resourceType, base_version });
+        return databaseQueryManager.findOneAsync({ query: scopedQuery });
     }
 
     // ── TaskCreated (orchestrator side, topic fhir_server.bulk_import.requested) ───────────
@@ -691,6 +749,7 @@ class BulkImportHandler {
         let created = 0;
         let updated = 0;
         let failed = 0;
+        let skipped = 0;
         const mergeResultEntries = [];
 
         // Set once this attempt's first flush actually writes to Mongo (and possibly
@@ -722,6 +781,7 @@ class BulkImportHandler {
             created = 0;
             updated = 0;
             failed = 0;
+            skipped = 0;
             mergeResultEntries.length = 0;
             hasFlushedThisAttempt = false;
 
@@ -752,27 +812,68 @@ class BulkImportHandler {
                             error: parseError.message
                         });
                     } else {
+                        // Duplicate-prevention wrapper: { ifNoneExist, resource } instead of a
+                        // plain resource line. A real FHIR resource never has a top-level
+                        // "ifNoneExist" field, so this check doesn't collide with plain lines.
+                        const isIfNoneExistWrapper = resource && typeof resource.ifNoneExist === 'string' &&
+                            resource.resource && typeof resource.resource === 'object';
+                        const innerResource = isIfNoneExistWrapper ? resource.resource : resource;
+
                         try {
                             const fhirResource = FhirResourceWriteSerializer.serialize({
-                                obj: this.applyDefaultSecurityTagsIfMissing(resource)
+                                obj: this.applyDefaultSecurityTagsIfMissing(innerResource)
                             });
-                            const contextData = buildContextDataForHybridStorage(
-                                fhirResource.resourceType, fhirResource, requestInfo
-                            );
-                            await this.fastDatabaseBulkInserter.insertOneAsync({
-                                base_version,
-                                requestInfo,
-                                resourceType: fhirResource.resourceType,
-                                doc: fhirResource,
-                                contextData
-                            });
+
+                            let existingResource = null;
+                            if (isIfNoneExistWrapper) {
+                                const ownerTag = (fhirResource.meta?.security || [])
+                                    .find((tag) => tag.system === SecurityTagSystem.owner);
+                                existingResource = await this.findExistingResourceForIfNoneExistAsync({
+                                    resourceType: fhirResource.resourceType,
+                                    ifNoneExist: resource.ifNoneExist,
+                                    ownerCode: ownerTag?.code
+                                });
+                            }
+
+                            if (existingResource) {
+                                skipped++;
+                                mergeResultEntries.push(new MergeResultEntry({
+                                    id: fhirResource.id,
+                                    uuid: fhirResource._uuid,
+                                    sourceAssigningAuthority: fhirResource._sourceAssigningAuthority,
+                                    resourceType: fhirResource.resourceType,
+                                    created: false,
+                                    updated: false,
+                                    issue: null,
+                                    operationOutcome: null
+                                }));
+                                logInfo('Skipped bulk import resource: matched existing via ifNoneExist', {
+                                    taskId,
+                                    filepath,
+                                    lineNumber,
+                                    byteOffset,
+                                    resourceType: fhirResource.resourceType,
+                                    ifNoneExist: resource.ifNoneExist
+                                });
+                            } else {
+                                const contextData = buildContextDataForHybridStorage(
+                                    fhirResource.resourceType, fhirResource, requestInfo
+                                );
+                                await this.fastDatabaseBulkInserter.insertOneAsync({
+                                    base_version,
+                                    requestInfo,
+                                    resourceType: fhirResource.resourceType,
+                                    doc: fhirResource,
+                                    contextData
+                                });
+                            }
                         } catch (resourceError) {
                             failed++;
                             // Failed before reaching the bulk inserter (e.g. missing/unsupported
                             // resourceType) — still record it so it lands in the error NDJSON and
                             // Task.output, not just a log line.
                             mergeResultEntries.push(
-                                MergeResultEntry.createFromError({ error: resourceError, resource, sourceByteOffset: byteOffset })
+                                MergeResultEntry.createFromError({ error: resourceError, resource: innerResource, sourceByteOffset: byteOffset })
                             );
                             logError('Failed to buffer bulk import resource for write', {
                                 taskId,
@@ -834,7 +935,8 @@ class BulkImportHandler {
                 linesRead,
                 created,
                 updated,
-                failed
+                failed,
+                skipped
             });
 
             await this.recordRangeCompletionAsync({

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -948,4 +948,196 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
 
         readSpy.mockRestore();
     });
+
+    test('handleMessageAsync creates a resource from an ifNoneExist-wrapped line when no match exists', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-ine-create' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        container.s3NdjsonReader.setLinesToYield([
+            {
+                ifNoneExist: 'identifier=http://example.com|ine-create-12345',
+                resource: {
+                    resourceType: 'Patient',
+                    id: 'bulk-import-ine-create',
+                    identifier: [{ system: 'http://example.com', value: 'ine-create-12345' }],
+                    name: [{ family: 'Created' }]
+                }
+            }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-ine-create-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-ine-create' }),
+            headers: []
+        });
+
+        await request
+            .get('/4_0_0/Patient/bulk-import-ine-create')
+            .set(getHeaders())
+            .expect(200)
+            .then((res) => {
+                expect(res.body.name[0].family).toBe('Created');
+            });
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-consumer-ine-create')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('completed');
+    });
+
+    test('handleMessageAsync skips an ifNoneExist-wrapped line when a matching resource already exists', async () => {
+        const request = await createTestRequest();
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        // Pre-existing resource with the identifier the bulk-imported line's ifNoneExist
+        // query will match against. Created via a separate bulk-import task (rather than
+        // a plain HTTP PUT) so it doesn't need explicit meta.security tags -- bulk-imported
+        // resources get default security tags applied by the handler itself.
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-ine-preexisting' })
+            .set(getHeaders())
+            .expect(202);
+
+        container.s3NdjsonReader.setLinesToYield([
+            {
+                resourceType: 'Patient',
+                id: 'bulk-import-ine-preexisting',
+                identifier: [{ system: 'http://example.com', value: 'ine-skip-98765' }],
+                name: [{ family: 'PreExisting' }]
+            }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-ine-preexisting-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-ine-preexisting' }),
+            headers: []
+        });
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-ine-skip' })
+            .set(getHeaders())
+            .expect(202);
+
+        container.s3NdjsonReader.setLinesToYield([
+            {
+                ifNoneExist: 'identifier=http://example.com|ine-skip-98765',
+                resource: {
+                    resourceType: 'Patient',
+                    id: 'bulk-import-ine-should-not-be-created',
+                    identifier: [{ system: 'http://example.com', value: 'ine-skip-98765' }],
+                    name: [{ family: 'ShouldNotBeCreated' }]
+                }
+            }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-ine-skip-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-ine-skip' }),
+            headers: []
+        });
+
+        // The wrapped resource's own id must NOT have been created -- ifNoneExist matched
+        // the pre-existing resource, so the write was skipped.
+        await request
+            .get('/4_0_0/Patient/bulk-import-ine-should-not-be-created')
+            .set(getHeaders())
+            .expect(404);
+
+        // The pre-existing resource is unaffected.
+        await request
+            .get('/4_0_0/Patient/bulk-import-ine-preexisting')
+            .set(getHeaders())
+            .expect(200)
+            .then((res) => {
+                expect(res.body.name[0].family).toBe('PreExisting');
+            });
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-consumer-ine-skip')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('completed');
+    });
+
+    test('handleMessageAsync creates a resource from an ifNoneExist-wrapped line when the only identifier match belongs to a different tenant', async () => {
+        const request = await createTestRequest();
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        // Pre-existing resource with the same identifier, but owned by a different tenant.
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-ine-other-tenant-setup' })
+            .set(getHeaders())
+            .expect(202);
+
+        container.s3NdjsonReader.setLinesToYield([
+            {
+                resourceType: 'Patient',
+                id: 'bulk-import-ine-other-tenant',
+                meta: { security: [{ system: 'https://www.icanbwell.com/owner', code: 'clientA' }] },
+                identifier: [{ system: 'http://example.com', value: 'ine-cross-tenant-55555' }],
+                name: [{ family: 'OtherTenant' }]
+            }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-ine-other-tenant-setup-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-ine-other-tenant-setup' }),
+            headers: []
+        });
+
+        // Own-tenant import whose ifNoneExist query matches only the other tenant's resource
+        // above. The existence check must not consider that cross-tenant match, so this
+        // resource should still be created rather than skipped.
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-ine-own-tenant' })
+            .set(getHeaders())
+            .expect(202);
+
+        container.s3NdjsonReader.setLinesToYield([
+            {
+                ifNoneExist: 'identifier=http://example.com|ine-cross-tenant-55555',
+                resource: {
+                    resourceType: 'Patient',
+                    id: 'bulk-import-ine-own-tenant',
+                    meta: { security: [{ system: 'https://www.icanbwell.com/owner', code: 'clientB' }] },
+                    identifier: [{ system: 'http://example.com', value: 'ine-cross-tenant-55555' }],
+                    name: [{ family: 'OwnTenant' }]
+                }
+            }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-ine-own-tenant-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-ine-own-tenant' }),
+            headers: []
+        });
+
+        await request
+            .get('/4_0_0/Patient/bulk-import-ine-own-tenant')
+            .set(getHeaders())
+            .expect(200)
+            .then((res) => {
+                expect(res.body.name[0].family).toBe('OwnTenant');
+            });
+    });
 });

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -1140,4 +1140,173 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
                 expect(res.body.name[0].family).toBe('OwnTenant');
             });
     });
+
+    test('handleMessageAsync fails (does not skip or create) an ifNoneExist-wrapped line referencing an unrecognized search parameter', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-ine-bad-param' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        container.s3NdjsonReader.setLinesToYield([
+            {
+                // "identifer" is a typo of "identifier" -- an unrecognized search parameter
+                // must fail the line rather than silently matching every Patient for this
+                // tenant (which would wrongly skip the create).
+                ifNoneExist: 'identifer=http://example.com|ine-bad-param-11111',
+                resource: {
+                    resourceType: 'Patient',
+                    id: 'bulk-import-ine-bad-param',
+                    identifier: [{ system: 'http://example.com', value: 'ine-bad-param-11111' }],
+                    name: [{ family: 'BadParam' }]
+                }
+            }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-ine-bad-param-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-ine-bad-param' }),
+            headers: []
+        });
+
+        // Not created -- the ifNoneExist check errored out rather than silently succeeding.
+        await request
+            .get('/4_0_0/Patient/bulk-import-ine-bad-param')
+            .set(getHeaders())
+            .expect(404);
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-consumer-ine-bad-param')
+            .set(getHeaders())
+            .expect(200);
+        // The bad line is recorded as a per-resource failure, not silently dropped.
+        expect(taskResp.body.output.some((o) => o.type?.text === 'error')).toBe(true);
+    });
+
+    test('handleMessageAsync skips an ifNoneExist-wrapped line with only an access tag when a same-owner match exists', async () => {
+        const request = await createTestRequest();
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        // Pre-existing resource owned by "clientC" (the owner tag OwnerColumnHandler would
+        // derive from an access-tag-only resource's first access code).
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-ine-access-only-setup' })
+            .set(getHeaders())
+            .expect(202);
+
+        container.s3NdjsonReader.setLinesToYield([
+            {
+                resourceType: 'Patient',
+                id: 'bulk-import-ine-access-only-preexisting',
+                meta: { security: [{ system: 'https://www.icanbwell.com/owner', code: 'clientC' }] },
+                identifier: [{ system: 'http://example.com', value: 'ine-access-only-22222' }],
+                name: [{ family: 'AccessOnlyPreExisting' }]
+            }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-ine-access-only-setup-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-ine-access-only-setup' }),
+            headers: []
+        });
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-ine-access-only' })
+            .set(getHeaders())
+            .expect(202);
+
+        container.s3NdjsonReader.setLinesToYield([
+            {
+                ifNoneExist: 'identifier=http://example.com|ine-access-only-22222',
+                resource: {
+                    resourceType: 'Patient',
+                    id: 'bulk-import-ine-access-only-should-not-be-created',
+                    // No owner tag -- only an access tag, which OwnerColumnHandler would
+                    // normally backfill to an owner tag of "clientC" during preSave (too
+                    // late for the ifNoneExist existence check to see it).
+                    meta: { security: [{ system: 'https://www.icanbwell.com/access', code: 'clientC' }] },
+                    identifier: [{ system: 'http://example.com', value: 'ine-access-only-22222' }],
+                    name: [{ family: 'AccessOnlyShouldNotBeCreated' }]
+                }
+            }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-ine-access-only-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-ine-access-only' }),
+            headers: []
+        });
+
+        await request
+            .get('/4_0_0/Patient/bulk-import-ine-access-only-should-not-be-created')
+            .set(getHeaders())
+            .expect(404);
+    });
+
+    test('handleMessageAsync only creates one resource when two ifNoneExist-wrapped lines with the same criteria land in the same unflushed batch', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-ine-same-batch' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        // Both lines share the same ifNoneExist criteria and land in the same batch (default
+        // BULK_IMPORT_BATCH_SIZE is well above 2), so the second one is only in memory --
+        // not yet committed to Mongo -- when its own existence check would otherwise run.
+        container.s3NdjsonReader.setLinesToYield([
+            {
+                ifNoneExist: 'identifier=http://example.com|ine-same-batch-33333',
+                resource: {
+                    resourceType: 'Patient',
+                    id: 'bulk-import-ine-same-batch-first',
+                    identifier: [{ system: 'http://example.com', value: 'ine-same-batch-33333' }],
+                    name: [{ family: 'SameBatchFirst' }]
+                }
+            },
+            {
+                ifNoneExist: 'identifier=http://example.com|ine-same-batch-33333',
+                resource: {
+                    resourceType: 'Patient',
+                    id: 'bulk-import-ine-same-batch-second',
+                    identifier: [{ system: 'http://example.com', value: 'ine-same-batch-33333' }],
+                    name: [{ family: 'SameBatchSecond' }]
+                }
+            }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-ine-same-batch-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-ine-same-batch' }),
+            headers: []
+        });
+
+        await request
+            .get('/4_0_0/Patient/bulk-import-ine-same-batch-first')
+            .set(getHeaders())
+            .expect(200);
+
+        // The second line claimed the same criteria while the first was still buffered
+        // in-memory (not yet committed), so it must be skipped rather than also created.
+        await request
+            .get('/4_0_0/Patient/bulk-import-ine-same-batch-second')
+            .set(getHeaders())
+            .expect(404);
+    });
 });


### PR DESCRIPTION
## Summary
- Adds support for FHIR's conditional-create (`If-None-Exist`) semantics to bulk import: an NDJSON line can be wrapped as `{ ifNoneExist, resource }` to skip creating `resource` when a search using the `ifNoneExist` query already matches an existing resource.
- The existence check reuses `R4ArgsParser`/`SearchQueryBuilder` (the same low-level query-building building blocks GraphQL already uses outside HTTP context) to turn the `ifNoneExist` query string into a raw Mongo filter, then restricts matches to the importing resource's own owner tenant so the check can't be used as a cross-tenant existence oracle (a match belonging to a different tenant would otherwise silently suppress this tenant's create and leak that a same-identifier resource exists elsewhere).
- Skipped lines are tracked with a new `skipped` counter and recorded as a no-op `MergeResultEntry` (all three success/fail flags unset) so they show up in per-range logging without being counted as `created`, `updated`, or `failed`.

## Test plan
- [x] New tests in `handlerWorker.test.js`: creates when no match exists, skips when a same-tenant match exists, still creates when the only identifier match belongs to a different tenant (regression test for the tenant-scoping fix)
- [x] Full `src/tests/asyncJobs` + `src/tests/unit/operations/asyncJobs` suites pass (121/121, `--runInBand`)
- [x] `eslint` clean on all touched files