### PR TITLE
DCON-4975 Bump @hono/node-server to 2.1.0 (fixes GHSA-frvp-7c67-39w9 / AIKIDO-2026-120510)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
   },
   "resolutions": {
     "uuid": "^14.0.0",
-    "yargs": "^18.1.0"
+    "yargs": "^18.1.0",
+    "@hono/node-server": "^2.0.5"
   },
   "dependencies": {
     "@apollo/server": "5.5.1",
@@ -130,6 +131,7 @@
     "graphql-fields": "^2.0.3",
     "graphql-parse-resolve-info": "^4.14.1",
     "helmet": "^8.2.0",
+    "hono": "^4.13.1",
     "jwks-rsa": "^4.0.1",
     "kafkajs": "^2.2.4",
     "lru-cache": "^11.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,12 +1575,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hono/node-server@npm:^1.19.9":
-  version: 1.19.17
-  resolution: "@hono/node-server@npm:1.19.17"
+"@hono/node-server@npm:^2.0.5":
+  version: 2.1.0
+  resolution: "@hono/node-server@npm:2.1.0"
   peerDependencies:
     hono: ^4
-  checksum: 10c0/e77907e3b5db8ab68ed4f297ad84807bfdd698636408de86ab8d36dab4658504ac4c0ed9d9436bc272a0172b9b7a5a4b578532e0b5baf97674c7b420cb5cff4b
+  checksum: 10c0/907aa2cabb804cf6f9c6bc329a898803b0794992d1c2d1bea7e4ae803f5d205fd2733d684c9c87b28338964dc437341e3bee1544b4d504a6b19f9e65ba28b198
   languageName: node
   linkType: hard
 
@@ -5385,6 +5385,7 @@ __metadata:
     graphql-parse-resolve-info: "npm:^4.14.1"
     graphql-schema-linter: "npm:^3.0.1"
     helmet: "npm:^8.2.0"
+    hono: "npm:^4.13.1"
     jest: "npm:^30.4.2"
     jest-diff: "npm:^30.4.1"
     jest-extended: "npm:^7.0.0"
@@ -7327,6 +7328,13 @@ __metadata:
   version: 8.3.0
   resolution: "helmet@npm:8.3.0"
   checksum: 10c0/69f33ca716ed3ce34f1f2f48ce8618846dfa9c89e3a15d6bccefc882541e8b028517448c6b0e7450792fd23e5580bfe6d410d4f22bedc2a94f6b1188817a059a
+  languageName: node
+  linkType: hard
+
+"hono@npm:^4.13.1":
+  version: 4.13.1
+  resolution: "hono@npm:4.13.1"
+  checksum: 10c0/83524961f806293464e6c3b31a7fd2ab8cd8e9cb66e65dea1fbbefb70744844c13b7409ed9b49b43e8543e5c0f1b851f2586fa759eea9da0b69503b58cd0d985
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes two Aikido findings on the same package/version:
- GHSA-frvp-7c67-39w9 in @hono/node-server
- AIKIDO-2026-120510 in @hono/node-server

`@hono/node-server` was pinned transitively at 1.19.17 via `@modelcontextprotocol/node`'s `^1.19.9` range, which never reaches the patched 2.0.5+. Added a `resolutions` override forcing 2.1.0.

`@hono/node-server` 2.x now requires `hono` itself at runtime (previously only an optional peer) — without it the MCP route handler fails to load at require-time. Added `hono` as an explicit dependency.

## Verification
- All existing MCP unit test suites pass (`mcpServer.test.js`, `mcpToolHandler.test.js`, `mcpFeatureFlag.test.js` — 17/17).
- Manually verified a real MCP `initialize` JSON-RPC handshake round-trips correctly through `toNodeHandler` on the new version, since that's the actual runtime code path this bump affects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)