### PR TITLE
DCON-5016 Thread requestInfo into getParsedArgsAsync in AccessLogger and other latent call sites

### DIFF
--- a/src/admin/adminExportManager.js
+++ b/src/admin/adminExportManager.js
@@ -179,7 +179,7 @@ class AdminExportManager {
         const combined_args = get_all_args(req, args);
 
         const parsedArgs = await this.fhirOperationsManager.getParsedArgsAsync({
-            args: combined_args, resourceType: resourceType, headers: req.headers, operation: WRITE
+            args: combined_args, resourceType: resourceType, headers: req.headers, operation: WRITE, requestInfo
         });
 
         try {
@@ -263,7 +263,7 @@ class AdminExportManager {
         const combined_args = get_all_args(req, args);
 
         const parsedArgs = await this.fhirOperationsManager.getParsedArgsAsync({
-            args: combined_args, resourceType: resourceType, headers: req.headers, operation: WRITE
+            args: combined_args, resourceType: resourceType, headers: req.headers, operation: WRITE, requestInfo
         });
 
         try {

--- a/src/app.js
+++ b/src/app.js
@@ -203,6 +203,8 @@ function createApp({fnGetContainer}) {
                     statusCode: res.statusCode,
                     startTime,
                     authorizationHeader: logAuthContextOn401 ? req.headers.authorization : undefined
+                }).catch((e) => {
+                    logError('Error logging access log entry', { error: e.message });
                 });
             }
             logInfo('Request Completed', logData);

--- a/src/operations/fhirOperationsManager.js
+++ b/src/operations/fhirOperationsManager.js
@@ -650,7 +650,8 @@ class FhirOperationsManager {
                         args: combined_args,
                         resourceType,
                         headers: req.headers,
-                        operation: WRITE
+                        operation: WRITE,
+                        requestInfo
                     })
                 });
                 return { requestInfo, parsedArgs };

--- a/src/tests/accessLog/accessLogs.everything_proxy_patient_cache_leak.test.js
+++ b/src/tests/accessLog/accessLogs.everything_proxy_patient_cache_leak.test.js
@@ -1,0 +1,122 @@
+// Regression test for a two-step production incident in AccessLogger's re-parse of a request's
+// own args for the access log's details.params field:
+//
+// 1. AccessLogger originally called fhirOperationsManager.getParsedArgsAsync() without
+//    threading requestInfo through (see accessLogs.graph_proxy_patient.test.js), which crashed
+//    for a $graph/$graphqlv2 request filtered by a person.<id> proxy id.
+// 2. Passing requestInfo through "fixed" the crash but surfaced a second bug: doing so let this
+//    re-parse run all the way through PatientProxyQueryRewriter for PROA-eligible $everything
+//    GETs, and writeProaSafeCache unconditionally recreates a RequestSpecificCache.mapCache
+//    entry keyed by that request's requestId
+//    (src/queryRewriters/rewriters/patientProxyQueryRewriter.js). AccessLogger runs from
+//    res.on('finish') in src/app.js, AFTER the real handler's own finally block
+//    (src/middleware/fhir/4_0_0/controllers/operations.controller.js) already called
+//    requestSpecificCache.clearAsync({requestId}) for that (never-reused) request id.
+//    Recreating the entry after that point means nothing will ever clear it again -- an
+//    unbounded, process-lifetime memory leak for every matching service-account PROA
+//    $everything request.
+//
+// The actual fix: AccessLogger no longer calls getParsedArgsAsync at all -- it logs the raw,
+// unrewritten args directly, so it never touches the query-rewriter pipeline (or any of its side
+// effects) in the first place. This test guards against that call being reintroduced.
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    createTestRequest,
+    getTestContainer
+} = require('../common');
+const { describe, beforeEach, afterEach, test, expect, jest } = require('@jest/globals');
+const { AccessLogger } = require('../../utils/accessLogger');
+
+const Person1 = {
+    id: 'person1',
+    resourceType: 'Person',
+    meta: {
+        source: 'test',
+        security: [{ system: 'https://www.icanbwell.com/owner', code: 'client' }]
+    },
+    link: [{ target: { reference: 'Patient/patient1' } }]
+};
+const Patient1 = {
+    id: 'patient1',
+    resourceType: 'Patient',
+    meta: {
+        source: 'test',
+        security: [{ system: 'https://www.icanbwell.com/owner', code: 'client' }]
+    }
+};
+
+describe('AccessLogs $everything proxy patient RequestSpecificCache leak Tests', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    test('does not recreate a RequestSpecificCache entry for an already-completed PROA-eligible $everything GET', async () => {
+        // registers the real AccessLogger (createTestRequest's default container uses
+        // MockAccessLogger, a no-op stub, so this test would trivially pass against it)
+        const request = await createTestRequest((container) => {
+            container.register('accessLogger', (c) => new AccessLogger({
+                scopesManager: c.scopesManager,
+                fhirOperationsManager: c.fhirOperationsManager,
+                configManager: c.configManager,
+                databaseBulkInserter: c.databaseBulkInserter
+            }));
+            return container;
+        });
+
+        const container = await getTestContainer();
+        /** @type {AccessLogger} */
+        const accessLogger = container.accessLogger;
+        const requestSpecificCache = container.requestSpecificCache;
+
+        let resp = await request.post('/4_0_0/Person/1/$merge').send(Person1).set(getHeaders());
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        resp = await request.post('/4_0_0/Patient/1/$merge').send(Patient1).set(getHeaders());
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        // capture the exact requestId the real request's own controller clears in its finally
+        // block, so we can assert on that same id after AccessLogger's re-parse settles -- set up
+        // after the merges above so this spy only sees the $everything call below
+        let clearedRequestId;
+        const clearAsyncSpy = jest.spyOn(requestSpecificCache, 'clearAsync');
+        const logAccessLogAsyncSpy = jest.spyOn(accessLogger, 'logAccessLogAsync');
+
+        // GET $everything (READ, PatientProxyQueryRewriter's isProaCacheEligibleRequest also
+        // requires the request NOT be user/patient-scoped -- getHeaders()'s default full-access
+        // token is a service-account-style scope) on the person.<id> proxy id, so
+        // PatientProxyQueryRewriter's proxy-patient branch actually runs. app.js only fires
+        // AccessLogger at all when req.body is truthy (or ACCESS_LOGS_ENTRY_DATA/a 401 auth-log
+        // is set, neither of which applies to a plain GET) -- a bare supertest .get() leaves
+        // req.body undefined, so .send({}) forces a real (empty) JSON body, matching a client
+        // that sends `Content-Type: application/fhir+json` with a body on every request
+        // regardless of method.
+        resp = await request
+            .get('/4_0_0/Patient/person.person1/$everything')
+            .send({})
+            .set(getHeaders());
+        expect(resp.statusCode).toBe(200);
+
+        // the real handler's own controller must have cleared its requestId by now (it happens
+        // synchronously as part of the request/response cycle, well before res.on('finish'))
+        expect(clearAsyncSpy).toHaveBeenCalled();
+        clearedRequestId = clearAsyncSpy.mock.calls[clearAsyncSpy.mock.calls.length - 1][0].requestId;
+        expect(clearedRequestId).toBeTruthy();
+        expect(requestSpecificCache.mapCache.has(clearedRequestId)).toBe(false);
+
+        // wait for the fire-and-forget res.on('finish') -> logAccessLogAsync(...) call to settle
+        expect(logAccessLogAsyncSpy).toHaveBeenCalledTimes(1);
+        await logAccessLogAsyncSpy.mock.results[0].value;
+
+        // the leak: if AccessLogger still ran this request's args through getParsedArgsAsync
+        // (and therefore PatientProxyQueryRewriter), writeProaSafeCache's
+        // requestSpecificCache.getMap(...) call would recreate mapCache's entry for the
+        // already-cleared requestId, and nothing would ever clear it again
+        expect(requestSpecificCache.mapCache.has(clearedRequestId)).toBe(false);
+    });
+});

--- a/src/tests/accessLog/accessLogs.graph_proxy_patient.test.js
+++ b/src/tests/accessLog/accessLogs.graph_proxy_patient.test.js
@@ -1,0 +1,113 @@
+// Regression test for a production incident: any request whose URL contains "$graph"
+// (this matches BOTH the REST $graph operation AND the /4_0_0/$graphqlv2 endpoint, since
+// String.prototype.includes('$graph') is a substring match) is classified as a READ operation
+// by AccessLogger.logAccessLogAsync, which re-parses the request's own args a second time --
+// independently of the real request handling -- to populate the access log's `details.params`.
+// That re-parse calls fhirOperationsManager.getParsedArgsAsync() without threading requestInfo
+// through, even though logAccessLogAsync already computes it a few lines earlier. When the
+// request carries a `person.<id>` proxy-patient value anywhere in its args, this reaches
+// PatientProxyQueryRewriter -> PersonToPatientIdsExpander.getPatientProxyIdsAsync(), which
+// asserts requestInfo is defined (see src/utils/personToPatientIdsExpander.js) and throws.
+//
+// Because AccessLogger.logAccessLogAsync is invoked fire-and-forget from a res.on('finish')
+// handler (src/app.js), the real request still succeeds -- but the access log entry for it is
+// silently dropped (the throw happens before the entry is pushed onto AccessLogger's queue), and
+// the rejection escapes as an unhandled promise rejection in production.
+//
+// This test proves the regression the way it's externally observable: after a $graph request
+// filtered by a person.<id> proxy id, the corresponding access log entry must actually exist.
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeadersWithAdmin,
+    getJsonHeadersWithAdminToken,
+    createTestRequest,
+    getTestContainer
+} = require('../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+const { AccessLogger } = require('../../utils/accessLogger');
+
+const Person1 = {
+    id: 'person1',
+    resourceType: 'Person',
+    meta: {
+        source: 'test',
+        security: [{ system: 'https://www.icanbwell.com/owner', code: 'client' }]
+    },
+    link: [{ target: { reference: 'Patient/patient1' } }]
+};
+const Patient1 = {
+    id: 'patient1',
+    resourceType: 'Patient',
+    meta: {
+        source: 'test',
+        security: [{ system: 'https://www.icanbwell.com/owner', code: 'client' }]
+    }
+};
+const graphDefinition = {
+    resourceType: 'GraphDefinition',
+    id: 'o',
+    name: 'patient_references',
+    status: 'active',
+    start: 'Patient',
+    link: [{ target: [{ type: 'Observation', params: 'patient={ref}' }] }]
+};
+
+describe('AccessLogs $graph with proxy patient id Tests', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    test('access log entry for a $graph request filtered by a person.<id> proxy id is not silently dropped', async () => {
+        // registers the real AccessLogger (createTestRequest's default container uses
+        // MockAccessLogger, a no-op stub, so this test would trivially pass against it)
+        const request = await createTestRequest((container) => {
+            container.register('accessLogger', (c) => new AccessLogger({
+                scopesManager: c.scopesManager,
+                fhirOperationsManager: c.fhirOperationsManager,
+                configManager: c.configManager,
+                databaseBulkInserter: c.databaseBulkInserter
+            }));
+            return container;
+        });
+
+        const container = await getTestContainer();
+        /** @type {AccessLogger} */
+        const accessLogger = container.accessLogger;
+
+        let resp = await request.post('/4_0_0/Person/1/$merge').send(Person1).set(getHeadersWithAdmin());
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        resp = await request.post('/4_0_0/Patient/1/$merge').send(Patient1).set(getHeadersWithAdmin());
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        // the request itself succeeds regardless of the bug -- $graph's own requestInfo
+        // threading (fhirOperationsManager.js's graph()) was already correct
+        resp = await request
+            .post('/4_0_0/Patient/$graph?id=person.person1')
+            .set({ ...getHeadersWithAdmin(), 'x-request-id': 'graph-proxy-patient-request-id' })
+            .send(graphDefinition);
+        expect(resp.statusCode).toBe(200);
+
+        // flush AccessLogger's in-memory queue to the store queryable via /admin/searchLogResults.
+        // If logAccessLogAsync threw while re-parsing this request's args, no entry was ever
+        // pushed onto the queue in the first place -- flushAsync has nothing to flush for it.
+        await accessLogger.flushAsync();
+
+        const logsResp = await request
+            .get('/admin/searchLogResults?id=graph-proxy-patient-request-id')
+            .set(getJsonHeadersWithAdminToken());
+
+        expect(logsResp.statusCode).toBe(200);
+        expect(logsResp.body).toHaveLength(1);
+        expect(logsResp.body[0].request.url).toBe('/4_0_0/Patient/$graph?id=person.person1');
+        expect(logsResp.body[0].request.operation).toBe('READ');
+        // proves getParsedArgsAsync ran end-to-end (through PatientProxyQueryRewriter) instead
+        // of throwing before ever reaching the point where these params are recorded
+        expect(logsResp.body[0].details.params).toBeDefined();
+    });
+});

--- a/src/tests/accessLog/fixtures/access-logs4.json
+++ b/src/tests/accessLog/fixtures/access-logs4.json
@@ -16,7 +16,7 @@
     "body": "[{\"op\":\"replace\",\"path\":\"/subject/reference\",\"value\":\"Patient/123\"}]",
     "operationResult": "[{\"id\":\"1\",\"uuid\":\"61abdd48-df46-5e98-ac6c-fde3cace4d07\",\"sourceAssigningAuthority\":\"bwell\",\"resourceType\":\"Observation\",\"operationOutcome\":{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"error\",\"code\":\"invalid\",\"details\":{\"text\":\"Patient Reference Patient/123 did not match with patient reference Patient/1 reference present in database\"}}]},\"created\":false,\"updated\":false}]",
     "params": {
-      "_id": "61abdd48-df46-5e98-ac6c-fde3cace4d07"
+      "id": "61abdd48-df46-5e98-ac6c-fde3cace4d07"
     }
   },
   "request": {

--- a/src/tests/unit/admin/adminExportManagerRequestInfo.test.js
+++ b/src/tests/unit/admin/adminExportManagerRequestInfo.test.js
@@ -1,0 +1,63 @@
+// Regression test for AdminExportManager.updateExportStatus/triggerExportJob: both compute
+// requestInfo via fhirOperationsManager.getRequestInfo(req) and then call
+// fhirOperationsManager.getParsedArgsAsync() without threading it through, unlike every real
+// FHIR operation entry point (see src/operations/fhirOperationsManager.js). This is the same
+// "new caller wired up without the requestInfo guarantee" shape as the AccessLogger bug (see
+// src/tests/accessLog/accessLogs.graph_proxy_patient.test.js), just currently latent: both calls
+// pass operation: WRITE, and PatientProxyQueryRewriter is only registered for READ (see
+// src/createContainer.js), so getPatientProxyIdsAsync's requestInfo assertion can't fire here
+// today. A future WRITE-side rewriter needing requestInfo would silently get undefined instead.
+const { describe, test, expect, beforeEach, jest } = require('@jest/globals');
+
+jest.mock('express-http-context', () => ({ get: jest.fn(), set: jest.fn() }));
+jest.mock('../../../operations/common/logging', () => ({
+    logError: jest.fn(),
+    logInfo: jest.fn()
+}));
+
+const { AdminExportManager } = require('../../../admin/adminExportManager');
+
+describe('AdminExportManager requestInfo threading (regression)', () => {
+    let manager;
+    let mockFhirOperationsManager;
+    let requestInfo;
+
+    beforeEach(() => {
+        requestInfo = { user: 'u', requestId: 'r' };
+        mockFhirOperationsManager = {
+            getRequestInfo: jest.fn().mockReturnValue(requestInfo),
+            getParsedArgsAsync: jest.fn().mockResolvedValue({ base_version: '4_0_0' })
+        };
+
+        manager = Object.create(AdminExportManager.prototype);
+        manager.fhirOperationsManager = mockFhirOperationsManager;
+        manager.scopesValidator = { verifyHasValidScopesAsync: jest.fn().mockResolvedValue(undefined) };
+        // resolves to null so both methods short-circuit on the same NotFoundError, before ever
+        // touching resourceMerger/exportManager -- irrelevant to what's under test here
+        manager.databaseExportManager = { getExportStatusResourceWithId: jest.fn().mockResolvedValue(null) };
+        manager.postRequestProcessor = { executeAsync: jest.fn().mockResolvedValue(undefined) };
+        manager.requestSpecificCache = { clearAsync: jest.fn().mockResolvedValue(undefined) };
+    });
+
+    test('updateExportStatus threads requestInfo into getParsedArgsAsync', async () => {
+        const req = { params: { id: 'export-1' }, headers: {}, id: 'req-1', header: () => undefined };
+        const res = {};
+
+        await expect(manager.updateExportStatus({ req, res })).rejects.toThrow();
+
+        expect(mockFhirOperationsManager.getParsedArgsAsync).toHaveBeenCalledWith(
+            expect.objectContaining({ requestInfo })
+        );
+    });
+
+    test('triggerExportJob threads requestInfo into getParsedArgsAsync', async () => {
+        const req = { params: { id: 'export-1' }, headers: {} };
+        const res = {};
+
+        await expect(manager.triggerExportJob({ req, res })).rejects.toThrow();
+
+        expect(mockFhirOperationsManager.getParsedArgsAsync).toHaveBeenCalledWith(
+            expect.objectContaining({ requestInfo })
+        );
+    });
+});

--- a/src/tests/unit/operations/fhirOperationsManager.test.js
+++ b/src/tests/unit/operations/fhirOperationsManager.test.js
@@ -459,6 +459,28 @@ describe('FhirOperationsManager', () => {
             expect(mockMergeOperation.mergeAsyncStream).toHaveBeenCalled();
             expect(mockMergeOperation.mergeAsync).not.toHaveBeenCalled();
         });
+
+        // Regression: merge()'s nested getParsedArgsAsync call (inside its
+        // customTracer.trace(() => ...) closure) never threaded requestInfo through to
+        // queryRewriterManager.rewriteArgsAsync, unlike every other operation in this class.
+        // Harmless today only because PatientProxyQueryRewriter is registered for READ, not
+        // WRITE (see src/createContainer.js) -- but a future WRITE-side rewriter needing
+        // requestInfo would silently get undefined here.
+        test('threads requestInfo into getParsedArgsAsync', async () => {
+            const requestInfo = { user: 'u', requestId: 'r', method: 'POST', headers: {} };
+            manager.getRequestInfo = jest.fn().mockReturnValue(requestInfo);
+            manager.parseParametersFromBody = jest.fn().mockImplementation(({ combined_args }) => combined_args);
+
+            const { get_all_args } = require('../../../operations/common/get_all_args');
+            get_all_args.mockReturnValue({ base_version: '4_0_0' });
+
+            const req = { headers: { 'content-type': 'application/json' }, body: {} };
+            await manager.merge([], { req }, 'Patient');
+
+            expect(mockQueryRewriterManager.rewriteArgsAsync).toHaveBeenCalledWith(
+                expect.objectContaining({ requestInfo })
+            );
+        });
     });
 
     describe('everything', () => {

--- a/src/utils/accessLogger.js
+++ b/src/utils/accessLogger.js
@@ -138,24 +138,29 @@ class AccessLogger {
         };
 
         // Args parsing requires a resourceType; on a 401 the URL may not carry one (e.g. /$graphql).
+        //
+        // Deliberately does NOT call fhirOperationsManager.getParsedArgsAsync() here: that runs
+        // the full query-rewriter pipeline (proxy-patient expansion, reference rewriting, etc.),
+        // which is meant for the real request, not a post-hoc logging pass over one that has
+        // already fully completed. Doing so once caused two production bugs -- an
+        // assertion crash (PersonToPatientIdsExpander.getPatientProxyIdsAsync requires a
+        // requestInfo the rewriters here had no legitimate one to give) and, once that was
+        // "fixed" by passing requestInfo through, a permanent memory leak (PatientProxyQueryRewriter's
+        // writeProaSafeCache recreating a RequestSpecificCache entry for a requestId the real
+        // handler had already cleared, which nothing would ever clear again). Logging the raw,
+        // unrewritten args below avoids the entire rewriter pipeline -- and its side effects --
+        // for this logging-only pass.
         if (resourceType) {
             let combined_args = get_all_args(req, req.sanitized_args);
             combined_args = this.fhirOperationsManager.parseParametersFromBody({ req, combined_args });
-            if (!combined_args.base_version) {
-                combined_args.base_version = '4_0_0';
-            }
-            /**
-             * @type {ParsedArgs}
-             */
-            const args = await this.fhirOperationsManager.getParsedArgsAsync({
-                args: combined_args,
-                resourceType,
-                operation
-            });
 
             const params = {};
-            Object.entries(args.getRawArgs())
-                .filter(([k, _]) => !['resource', 'base_version'].includes(k))
+            Object.entries(combined_args)
+                // 'handling' is a request-processing hint get_all_args() always injects (defaulted
+                // to lenient when the caller doesn't set it), not a real search parameter --
+                // r4ArgsParser.parseArgs() consumes and deletes it the same way before building
+                // parsedArgItems, so it never appeared in the old getParsedArgsAsync()-derived params
+                .filter(([k, _]) => !['resource', 'base_version', 'handling'].includes(k))
                 .forEach(([k, v]) => {
                     params[k] = !v || typeof v === 'string' ? v : JSON.stringify(v, getCircularReplacer());
                 });


### PR DESCRIPTION
## Jira
[DCON-5016](https://icanbwell.atlassian.net/browse/DCON-5016)

## Root cause

`AccessLogger.logAccessLogAsync` (`src/utils/accessLogger.js`) re-parses each request's args a second time, independently of the real request handling, to populate the access log's `details.params`. That re-parse called `fhirOperationsManager.getParsedArgsAsync({args, resourceType, operation})` without threading `requestInfo` through, even though `logAccessLogAsync` already computes it a few lines earlier.

`operation` is classified `READ` for `req.method === 'GET'` or `req.method === 'POST' && req.url.includes('$graph')` — a substring match that covers both the REST `$graph` operation and `/4_0_0/$graphqlv2` (since `$graphqlv2` contains `$graph`). `PatientProxyQueryRewriter` is registered for `READ` operations. When such a request carries a `person.<id>` proxy-patient value anywhere in its args (e.g. `POST /4_0_0/Patient/$graph?id=person.<id>`), the rewriter calls `PersonToPatientIdsExpander.getPatientProxyIdsAsync({requestInfo: undefined, ...})`, which asserts `requestInfo` is defined and throws.

Because `logAccessLogAsync` is invoked fire-and-forget from a `res.on('finish', ...)` handler in `src/app.js` with no `.catch()`, the real request still succeeds — but its access log entry is silently dropped (the throw happens before the entry is queued), and the rejection escapes as an unhandled promise rejection in production. Root-caused via a production stack trace: `assertType.js` → `personToPatientIdsExpander.js:156` → `patientProxyQueryRewriter.js` → `queryRewriterManager.js` → `fhirOperationsManager.js:327` → `AccessLogger.logAccessLogAsync`.

## Fix

`AccessLogger` no longer calls `getParsedArgsAsync` at all — it logs the raw, unrewritten request args directly (filtering out `resource`, `base_version`, and `handling`, the same processing-hint `get_all_args()` always injects and `r4ArgsParser` used to strip). This re-parse is purely for logging an already-completed request, so it has no business running the full query-rewriter pipeline (proxy-patient expansion, reference rewriting) in the first place.

An earlier version of this fix threaded `requestInfo` through instead, which closed the crash but surfaced a second bug: doing so let this re-parse reach `PatientProxyQueryRewriter.writeProaSafeCache` for PROA-eligible `$everything` GETs, which unconditionally recreates a `RequestSpecificCache` entry keyed by `requestInfo.requestId` — a `requestId` the real handler's own controller (`operations.controller.js`) already cleared in its `finally` block by the time `res.on('finish')` fires. Nothing would ever clear that entry again: an unbounded, process-lifetime memory leak. Removing the `getParsedArgsAsync` call entirely avoids that whole class of side effect rather than patching around it.

Also fixed, same "compute `requestInfo`, forget to pass it to `getParsedArgsAsync`" pattern (currently latent — both are `WRITE`-classified, and `PatientProxyQueryRewriter` only runs for `READ`):
- `app.js` — add `.catch()` to the `res.on('finish')` call so any future error here logs instead of becoming an unhandled rejection
- `adminExportManager.js` (`updateExportStatus`, `triggerExportJob`)
- `fhirOperationsManager.js`'s `merge()`

## Tests

Verified to fail against the pre-fix code and pass against the fix (via `git stash`):
- `src/tests/accessLog/accessLogs.graph_proxy_patient.test.js` — integration test reproducing the original crash end-to-end (real Person→Patient data, real `AccessLogger`, `POST /4_0_0/Patient/$graph?id=person.<id>`)
- `src/tests/accessLog/accessLogs.everything_proxy_patient_cache_leak.test.js` — integration test reproducing the `RequestSpecificCache` leak from the intermediate requestInfo-threading approach; guards against `getParsedArgsAsync` being reintroduced into `AccessLogger`
- `src/tests/unit/operations/fhirOperationsManager.test.js` — `merge()` threads `requestInfo` into `getParsedArgsAsync`
- `src/tests/unit/admin/adminExportManagerRequestInfo.test.js` — new file, covers both `AdminExportManager` call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DCON-5016]: https://icanbwell.atlassian.net/browse/DCON-5016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ