### PR TITLE
Trim unnecessary files from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,13 @@
 tmp
 .vscode
 node_modules
+
+# Claude Code / agent tooling (session data, worktrees, skill caches - not part of the app)
+.claude
+.worktrees
+.playwright-mcp
+.superpowers
+
 .yarn/cache
 .yarn/install-state.gz
 npm-debug.log
@@ -20,3 +27,14 @@ src/tests
 src/app.test.js
 generatorScripts
 generated.sdl
+
+# Not needed at runtime - docker-compose only bind-mounts src/package.json/yarn.lock/.yarnrc.yml,
+# and keycloak-config/clickhouse-init are bind-mounted into the keycloak/clickhouse containers
+# directly (not built into this image)
+docs
+policies
+readme
+clickhouse-init
+keycloak-config
+catalog-info.yaml
+service-catalog.yaml


### PR DESCRIPTION
## Summary
Mirrors [icanbwell/fhir-server-ui#252](https://github.com/icanbwell/fhir-server-ui/pull/252).

- `.claude/` and `.worktrees/` are gitignored but were not dockerignored, so they were being sent to the build context and copied into the image via `COPY . /srv/src`.
- Also excludes `.playwright-mcp/`, `.superpowers/`, `docs/`, `policies/`, `readme/`, `clickhouse-init/`, `keycloak-config/`, `catalog-info.yaml`, `service-catalog.yaml` — none of which are needed at runtime: `docker-compose.yml` only bind-mounts `src/`, `package.json`, `yarn.lock`, `.yarnrc.yml` into the `fhir` service, and `keycloak-config/realm-import.json` / `clickhouse-init` are bind-mounted directly into the `keycloak` / `clickhouse` containers, not this image.
- Verified no source code references `docs/`, `policies/`, `readme/`, `clickhouse-init`, or `keycloak-config` at runtime (searched `src/`) before excluding them. Left `clickhouse-migrations/` untouched since I couldn't find where (or whether) it's consumed, and didn't want to guess on that one.

## Test plan
- [ ] `docker build -t fhir-server-context-check .` — confirm the build still succeeds and `.env`/secrets remain excluded
- [ ] Confirm no runtime-needed files were dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)