### PR TITLE
BAI-423 set BaseSerializer.configManager in worker/orchestrator entrypoints

### DIFF
--- a/src/operations/asyncJobs/orchestrator.js
+++ b/src/operations/asyncJobs/orchestrator.js
@@ -11,6 +11,7 @@ const { createContainer } = require('../../createContainer');
 const { initialize } = require('../../winstonInit');
 const { logInfo, logError } = require('../common/logging');
 const { getCircularReplacer } = require('../../utils/getCircularReplacer');
+const { BaseSerializer } = require('../../fhir/writeSerializers/4_0_0/customSerializers');
 
 /**
  * Generic orchestrator entrypoint: one Kafka consumer per registered job below, each routing
@@ -39,6 +40,11 @@ async function main() {
     try {
         initialize();
         const container = createContainer();
+        // This entrypoint doesn't serialize resources itself today, but sets this for
+        // consistency with worker.js/index.js -- otherwise any future code path here that
+        // touches FhirResourceWriteSerializer would silently hit a null configManager
+        // (see worker.js's comment on this same call for the full failure mode).
+        BaseSerializer.setConfigManager(container.configManager);
         const { kafkaClientV2 } = container;
         const jobs = getJobs(container);
 

--- a/src/operations/asyncJobs/worker.js
+++ b/src/operations/asyncJobs/worker.js
@@ -11,6 +11,7 @@ const { createContainer } = require('../../createContainer');
 const { initialize } = require('../../winstonInit');
 const { logInfo, logError } = require('../common/logging');
 const { getCircularReplacer } = require('../../utils/getCircularReplacer');
+const { BaseSerializer } = require('../../fhir/writeSerializers/4_0_0/customSerializers');
 
 /**
  * Generic worker entrypoint: one Kafka consumer per registered job below, each routing its
@@ -39,6 +40,12 @@ async function main() {
     try {
         initialize();
         const container = createContainer();
+        // Without this, BaseSerializer.configManager stays null in this standalone
+        // entrypoint (only src/index.js's main() sets it otherwise) and every Coding
+        // serialization (meta.security, meta.tag, etc. -- present on virtually all
+        // real resources) throws when CodingSerializer.writeSerialize reads
+        // configManager.preSaveCodingIdUpdateResources off of null.
+        BaseSerializer.setConfigManager(container.configManager);
         const { kafkaClientV2 } = container;
         const jobs = getJobs(container);
 


### PR DESCRIPTION
## Summary
- Fixes 100% resource-write failures ("Failed to buffer bulk import resource for write") seen during the first live end-to-end `$import` smoke test on dev-use1-eks.
- Root cause: `BaseSerializer.configManager` is a static property only ever set by `src/index.js`'s `main()`. The standalone `worker.js`/`orchestrator.js` entrypoints never load `index.js`, so `configManager` stayed `null`, and `CodingSerializer.writeSerialize` threw on any resource with `meta.security`/`meta.tag` (i.e. virtually all real resources). `RethrownError` masked the real cause behind the generic "Error in serializing resource" message that showed up in GroundCover.
- Fix: call `BaseSerializer.setConfigManager(container.configManager)` in both entrypoints' `main()`, mirroring `index.js`. Added to `orchestrator.js` too for consistency even though it doesn't serialize resources today.

## Test plan
- [x] `eslint` clean on both files
- [x] Confirmed existing `worker.test.js`/`orchestrator.test.js` mock `createContainer` only (not the `customSerializers` module) — `setConfigManager` is a pure static-property assignment, so it's a no-op side effect there and doesn't affect those unit tests
- [ ] Re-run live `$import` smoke test on dev-use1-eks after deploy to confirm resources are now written to MongoDB

Ref: BAI-423 (under BAI-206 epic)