### PR TITLE
DCON-5076 Centralize BaseSerializer.setConfigManager wiring in createContainer()

### DIFF
--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -161,6 +161,7 @@ const { GenericClickHouseQueryBuilder } = require('./dataLayer/builders/genericC
 const { GenericClickHouseRepository } = require('./dataLayer/repositories/genericClickHouseRepository');
 const { AccessHistoryClickHouseRepository } = require('./dataLayer/repositories/accessHistoryClickHouseRepository');
 const { AccessHistoryOperation } = require('./operations/accessHistory/accessHistory');
+const { BaseSerializer } = require('./fhir/writeSerializers/4_0_0/customSerializers');
 const deepcopy = require('deepcopy');
 
 /**
@@ -171,7 +172,23 @@ const createContainer = function () {
     // Note: the order of registration does NOT matter since everything is lazy evaluated
     const container = new SimpleContainer();
 
-    container.register('configManager', () => new ConfigManager());
+    container.register('configManager', () => {
+        const configManager = new ConfigManager();
+        // Every serializer in src/fhir/writeSerializers/4_0_0/ reads BaseSerializer.configManager
+        // (a static field, not something SimpleContainer wires per-instance), most notably
+        // CodingSerializer.writeSerialize. Wiring it here -- as a side effect of this factory,
+        // triggered lazily whenever anything first touches container.configManager, rather than
+        // an eager read right after registration -- means every createContainer() consumer gets
+        // it automatically without its own BaseSerializer.setConfigManager(...) call. Deliberately
+        // NOT read eagerly here: SimpleContainer.register() memoizes on first access, so eagerly
+        // reading container.configManager would permanently lock in this instance and silently
+        // defeat src/tests/createTestContainer.js's fnUpdateContainer pattern, which re-registers
+        // this exact factory with a test-specific ConfigManager subclass (used by 40+ test files)
+        // -- src/tests/common.js's own explicit setConfigManager call after that override runs is
+        // what covers the mocked case.
+        BaseSerializer.setConfigManager(configManager);
+        return configManager;
+    });
 
     container.register('kafkaClient', (c) => c.configManager.kafkaEnableEvents
         ? new KafkaClient({configManager: c.configManager})

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ const { createServer } = require('./server');
 const { createContainer } = require('./createContainer');
 const { getCircularReplacer } = require('./utils/getCircularReplacer');
 const { initialize } = require('./winstonInit');
-const { BaseSerializer } = require('./fhir/writeSerializers/4_0_0/customSerializers');
 const { fhirSchemaValidator } = require('./utils/fhirSchemaValidator');
 
 // Validates OpenTelemetry setup, which only this entrypoint (loaded via
@@ -19,8 +18,6 @@ const main = async function () {
     try {
         initialize();
         const container = createContainer();
-        // Initialize configManager for all serializers
-        BaseSerializer.setConfigManager(container.configManager);
         // Pre-compile FHIR schema validators for every resourceType off the request path
         fhirSchemaValidator.preWarm();
 

--- a/src/operations/asyncJobs/orchestrator.js
+++ b/src/operations/asyncJobs/orchestrator.js
@@ -11,7 +11,6 @@ const { createContainer } = require('../../createContainer');
 const { initialize } = require('../../winstonInit');
 const { logInfo, logError } = require('../common/logging');
 const { getCircularReplacer } = require('../../utils/getCircularReplacer');
-const { BaseSerializer } = require('../../fhir/writeSerializers/4_0_0/customSerializers');
 
 /**
  * Generic orchestrator entrypoint: one Kafka consumer per registered job below, each routing
@@ -40,11 +39,6 @@ async function main() {
     try {
         initialize();
         const container = createContainer();
-        // This entrypoint doesn't serialize resources itself today, but sets this for
-        // consistency with worker.js/index.js -- otherwise any future code path here that
-        // touches FhirResourceWriteSerializer would silently hit a null configManager
-        // (see worker.js's comment on this same call for the full failure mode).
-        BaseSerializer.setConfigManager(container.configManager);
         const { kafkaClientV2 } = container;
         const jobs = getJobs(container);
 

--- a/src/operations/asyncJobs/worker.js
+++ b/src/operations/asyncJobs/worker.js
@@ -11,7 +11,6 @@ const { createContainer } = require('../../createContainer');
 const { initialize } = require('../../winstonInit');
 const { logInfo, logError } = require('../common/logging');
 const { getCircularReplacer } = require('../../utils/getCircularReplacer');
-const { BaseSerializer } = require('../../fhir/writeSerializers/4_0_0/customSerializers');
 
 /**
  * Generic worker entrypoint: one Kafka consumer per registered job below, each routing its
@@ -40,12 +39,6 @@ async function main() {
     try {
         initialize();
         const container = createContainer();
-        // Without this, BaseSerializer.configManager stays null in this standalone
-        // entrypoint (only src/index.js's main() sets it otherwise) and every Coding
-        // serialization (meta.security, meta.tag, etc. -- present on virtually all
-        // real resources) throws when CodingSerializer.writeSerialize reads
-        // configManager.preSaveCodingIdUpdateResources off of null.
-        BaseSerializer.setConfigManager(container.configManager);
         const { kafkaClientV2 } = container;
         const jobs = getJobs(container);
 

--- a/src/tests/unit/createContainer.baseSerializer.test.js
+++ b/src/tests/unit/createContainer.baseSerializer.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * BaseSerializer.configManager is a static field every serializer in
+ * src/fhir/writeSerializers/4_0_0/ reads from (most notably CodingSerializer.writeSerialize),
+ * but nothing in the IoC container wired it automatically -- each process entrypoint
+ * (src/index.js, worker.js, orchestrator.js) had to remember to call
+ * BaseSerializer.setConfigManager(container.configManager) itself right after createContainer().
+ * That convention wasn't followed by ~48 other createContainer() call sites (admin scripts,
+ * cronJob.js, export/history scripts), which would hit a null configManager if they ever
+ * serialize a resource through the affected code path.
+ *
+ * The fix lives inside the `configManager` factory itself (not a read right after registration):
+ * SimpleContainer.register() memoizes on first access, so an eager read would permanently lock in
+ * that instance and defeat src/tests/createTestContainer.js's fnUpdateContainer pattern, which
+ * re-registers this exact factory with a test-specific ConfigManager subclass in 40+ test files.
+ * These tests prove both halves: the wiring happens automatically, and the override pattern still
+ * produces the overridden instance, not the original.
+ */
+const { describe, test, expect, afterEach } = require('@jest/globals');
+const { createContainer } = require('../../createContainer');
+const { createTestContainer } = require('../createTestContainer');
+const { BaseSerializer } = require('../../fhir/writeSerializers/4_0_0/customSerializers');
+const { ConfigManager } = require('../../utils/configManager');
+
+describe('createContainer BaseSerializer wiring', () => {
+    afterEach(() => {
+        BaseSerializer.setConfigManager(null);
+    });
+
+    test('accessing configManager wires BaseSerializer.configManager to the same instance', () => {
+        const container = createContainer();
+
+        const configManager = container.configManager;
+
+        expect(BaseSerializer.configManager).toBe(configManager);
+    });
+
+    test('a test-registered configManager override still ends up on BaseSerializer, not the original', () => {
+        class MockConfigManager extends ConfigManager {
+            get enableStatsEndpoint () {
+                return true;
+            }
+        }
+
+        const container = createTestContainer((c) => {
+            c.register('configManager', () => new MockConfigManager());
+            return c;
+        });
+        // Mirrors src/tests/common.js's createTestApp, which calls this after
+        // createTestContainer/fnUpdateContainer have both fully resolved.
+        BaseSerializer.setConfigManager(container.configManager);
+
+        expect(BaseSerializer.configManager).toBeInstanceOf(MockConfigManager);
+        expect(BaseSerializer.configManager).toBe(container.configManager);
+    });
+});


### PR DESCRIPTION
## Summary
Follow-up from a review comment on PR #2515 (out of scope for that PR since it's about pre-existing code from an unrelated merge, not the MCP tool additions).

- `BaseSerializer.configManager` is a static field every serializer in `src/fhir/writeSerializers/4_0_0/` reads from (most notably `CodingSerializer.writeSerialize`), but nothing in the IoC container wired it automatically — each process entrypoint (`src/index.js`, `worker.js`, `orchestrator.js`) had to remember its own `BaseSerializer.setConfigManager(container.configManager)` call. ~48 other `createContainer()` call sites (admin scripts, `cronJob.js`, export/history scripts) never did, and would hit a null `configManager` if they ever serialize a resource through the affected path.
- Fix: wire it as a side effect inside the `configManager` factory itself, triggered lazily on first real access.

## A subtlety worth flagging explicitly
The originally suggested fix (set it via an eager read right after `container.register('configManager', ...)`) is **not safe** for this codebase: `SimpleContainer.register()` memoizes on first access, so an eager read permanently locks in that instance and silently defeats `src/tests/createTestContainer.js`'s `fnUpdateContainer` pattern — 40+ test files re-register the `configManager` factory with a test-specific `ConfigManager` subclass, and an eager read would make that override a no-op.

I verified this empirically rather than assuming: temporarily patched in the eager version, confirmed the new regression test (`a test-registered configManager override still ends up on BaseSerializer, not the original`) fails against it, then restored the lazy-side-effect version and confirmed it passes.

## Test plan
- [x] Added `src/tests/unit/createContainer.baseSerializer.test.js` — covers both the automatic-wiring case and the override-safety case
- [x] Empirically confirmed the override-safety test fails against the naive eager-read approach and passes against the shipped fix
- [x] `yarn run lint` — clean
- [x] Ran `src/tests/mcp/`, `src/tests/admin/runners/runPreSave/`, `src/tests/patientScope/search_with_delegated_access/`, `src/tests/validate/remote_server/practitioner_remote_server_by_id.validate.test.js` (a mix of MCP, admin-script, patient-scope, and `configManager`-override-heavy suites) — 87/87 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)