### PR TITLE
BAI-425 add explicit bucket boundaries to import file-size/throughput histograms

### DIFF
--- a/src/utils/metrics.js
+++ b/src/utils/metrics.js
@@ -231,12 +231,23 @@ const importRangeDurationHistogram = meter.createHistogram('fhir_import_range_du
 
 const importS3ReadThroughputHistogram = meter.createHistogram('fhir_import_s3_read_throughput_bytes_per_second', {
     description: 'Effective S3 read throughput for a bulk-import byte range: bytes read divided by read duration. Recorded even on partial/aborted reads.',
-    unit: 'By/s'
+    unit: 'By/s',
+    // Default OTel bucket boundaries top out around 10000 -- far too small for throughput
+    // measured in bytes/sec (real imports run in the hundreds of KB/s to tens of MB/s), which
+    // clamps every observation into the overflow bucket and makes quantile queries meaningless.
+    advice: {
+        explicitBucketBoundaries: [1000, 10000, 100000, 500000, 1000000, 5000000, 10000000, 50000000]
+    }
 });
 
 const importFileSizeHistogram = meter.createHistogram('fhir_import_file_size_bytes', {
     description: 'Size (bytes) of each S3 input file validated for bulk import.',
-    unit: 'By'
+    unit: 'By',
+    // Same overflow-bucket problem as the throughput histogram above -- file sizes run into the
+    // tens/hundreds of MB, well past the default boundaries' ~10000 ceiling.
+    advice: {
+        explicitBucketBoundaries: [1000, 10000, 100000, 1000000, 5000000, 10000000, 50000000, 100000000, 500000000]
+    }
 });
 
 /**


### PR DESCRIPTION
## Summary
- `fhir_import_file_size_bytes` and `fhir_import_s3_read_throughput_bytes_per_second` (added in BAI-229) were created without `advice.explicitBucketBoundaries`, unlike other byte/count histograms in the same file (e.g. `fhir_bundle_size_entries`).
- Without explicit boundaries, OTel falls back to default histogram buckets that top out around `10000` — far too small for file sizes (tens of MB) or throughput (hundreds of KB/s to MB/s), so every real observation lands in the overflow bucket and quantile queries are meaningless.
- Confirmed on a real GroundCover dashboard built from a live 53MB/~124K-resource smoke test: p50 file size and p50 S3 throughput both showed "10 KB" — an artifact of the bucket ceiling, not real data.
- Fix: add explicit bucket boundaries sized for realistic ranges (up to 500MB for file size, up to 50MB/s for throughput).

## Test plan
- [x] `eslint` clean
- [x] `metrics.test.js` (63 tests) passes unchanged — options object isn't asserted against, so this is a non-breaking addition
- [ ] Re-check the GroundCover dashboard after deploy to confirm p50/p95/p99 file size and throughput now show realistic values

Ref: BAI-42 under BAI-206 epic, follow-up to BAI-229