### PR TITLE
BAI-427 propagate OTel trace context across Kafka producer/consumer

### DIFF
--- a/src/tests/unit/utils/kafkaClientV2.test.js
+++ b/src/tests/unit/utils/kafkaClientV2.test.js
@@ -228,7 +228,12 @@ describe('KafkaClientV2', () => {
         test('sends messages successfully on first attempt', async () => {
             await kafkaClient.sendCloudEventMessageAsync({ topic, messages });
             expect(mockProducerConnect).toHaveBeenCalled();
-            expect(mockProducerSend).toHaveBeenCalledWith({ topic, messages });
+            // BAI-427: headers is always added (even if empty, absent an active trace context in
+            // this test env) -- see the trace-context injection in sendCloudEventMessageHelperAsync.
+            expect(mockProducerSend).toHaveBeenCalledWith({
+                topic,
+                messages: messages.map((m) => ({ ...m, headers: {} }))
+            });
         });
 
         test('retries on KafkaJSNonRetriableError with error code 72', async () => {
@@ -362,7 +367,12 @@ describe('KafkaClientV2', () => {
         test('sends messages via producer.send', async () => {
             kafkaClient.producerConnected = true;
             await kafkaClient.sendCloudEventMessageHelperAsync({ topic, messages });
-            expect(mockProducerSend).toHaveBeenCalledWith({ topic, messages });
+            // BAI-427: headers is always added (even if empty, absent an active trace context in
+            // this test env) -- see the trace-context injection above producer.send's call.
+            expect(mockProducerSend).toHaveBeenCalledWith({
+                topic,
+                messages: messages.map((m) => ({ ...m, headers: {} }))
+            });
         });
 
         test('throws RethrownError when producer connect fails', async () => {

--- a/src/tests/unit/utils/kafkaClientV2.test.js
+++ b/src/tests/unit/utils/kafkaClientV2.test.js
@@ -90,6 +90,13 @@ jestObj.mock('../../../utils/metrics', () => ({
 
 const { KafkaClientV2 } = require('../../../utils/kafkaClientV2');
 const { KafkaJSProtocolError, KafkaJSNonRetriableError } = require('kafkajs');
+const { trace, context: otelContext, propagation } = require('@opentelemetry/api');
+const { W3CTraceContextPropagator } = require('@opentelemetry/core');
+
+// The global propagator defaults to a no-op unless the real OTel SDK is initialized (which this
+// bare test process never does) -- register the real W3C propagator so BAI-427's trace-context
+// tests below actually exercise header parsing instead of silently no-op-ing.
+propagation.setGlobalPropagator(new W3CTraceContextPropagator());
 const { recordKafkaRetryExhausted } = require('../../../utils/metrics');
 const { logTraceSystemEventAsync, logSystemErrorAsync, logSystemEventAsync } = require('../../../operations/common/systemEventLogging');
 const { logError } = require('../../../operations/common/logging');
@@ -722,6 +729,83 @@ describe('KafkaClientV2', () => {
                 value: 'val',
                 headers: [{ key: 'empty_header', value: '' }]
             });
+        });
+
+        // These two tests verify the context VALUE passed to context.with() directly (via a spy)
+        // rather than reading context.active() from inside onMessageAsync -- @opentelemetry/api's
+        // context propagation across async boundaries only works once a real ContextManager is
+        // registered (e.g. AsyncHooksContextManager, which the real OTel SDK registers on startup
+        // via @opentelemetry/context-async-hooks). That's not initialized in this bare test
+        // process, so context.with()/.active() alone can't be used to observe propagation here --
+        // but trace.setSpanContext/getSpan are pure reads/writes on a given Context value and
+        // don't need a ContextManager, so asserting on the value itself is both simpler and
+        // independent of whether a ContextManager happens to be registered.
+        test('BAI-427: extracts trace context from headers into the active context when nothing is already active', async () => {
+            const traceparent = '00-11111111111111111111111111111111-2222222222222222-01';
+            const consumer = {
+                connect: mockConsumerConnect,
+                disconnect: mockConsumerDisconnect,
+                subscribe: mockConsumerSubscribe,
+                run: jestObj.fn().mockImplementation(async ({ eachMessage }) => {
+                    await eachMessage({
+                        topic: 'test-topic',
+                        partition: 0,
+                        message: {
+                            key: Buffer.from('key'),
+                            value: Buffer.from('val'),
+                            headers: { traceparent: Buffer.from(traceparent) }
+                        },
+                        heartbeat: jestObj.fn(),
+                        pause: jestObj.fn()
+                    });
+                })
+            };
+            const withSpy = jestObj.spyOn(otelContext, 'with');
+            await kafkaClient.receiveMessagesAsync({ consumer, topic: 'test-topic', onMessageAsync: jestObj.fn() });
+
+            expect(trace.getSpanContext(withSpy.mock.calls[0][0])).toMatchObject({
+                traceId: '11111111111111111111111111111111',
+                spanId: '2222222222222222'
+            });
+            withSpy.mockRestore();
+        });
+
+        test('BAI-427: does not override an already-active span (e.g. from auto-instrumentation) with one extracted from headers', async () => {
+            // Simulates @opentelemetry/instrumentation-kafkajs already having extracted from these
+            // same raw headers and activated its own consumer span before eachMessage runs.
+            const activeSpanContext = {
+                traceId: '33333333333333333333333333333333',
+                spanId: '4444444444444444',
+                traceFlags: 1
+            };
+            const activeContext = trace.setSpanContext(otelContext.active(), activeSpanContext);
+            const activeSpy = jestObj.spyOn(otelContext, 'active').mockReturnValue(activeContext);
+
+            const consumer = {
+                connect: mockConsumerConnect,
+                disconnect: mockConsumerDisconnect,
+                subscribe: mockConsumerSubscribe,
+                run: jestObj.fn().mockImplementation(async ({ eachMessage }) => {
+                    await eachMessage({
+                        topic: 'test-topic',
+                        partition: 0,
+                        message: {
+                            key: Buffer.from('key'),
+                            value: Buffer.from('val'),
+                            // Original producer's traceparent -- must NOT win over the already-active span.
+                            headers: { traceparent: Buffer.from('00-11111111111111111111111111111111-2222222222222222-01') }
+                        },
+                        heartbeat: jestObj.fn(),
+                        pause: jestObj.fn()
+                    });
+                })
+            };
+            const withSpy = jestObj.spyOn(otelContext, 'with');
+            await kafkaClient.receiveMessagesAsync({ consumer, topic: 'test-topic', onMessageAsync: jestObj.fn() });
+
+            expect(trace.getSpanContext(withSpy.mock.calls[0][0])).toMatchObject(activeSpanContext);
+            withSpy.mockRestore();
+            activeSpy.mockRestore();
         });
 
         test('logs error and rethrows when consumer.run fails', async () => {

--- a/src/tests/unit/utils/kafkaClientV2.test.js
+++ b/src/tests/unit/utils/kafkaClientV2.test.js
@@ -94,7 +94,7 @@ const { trace, context: otelContext, propagation } = require('@opentelemetry/api
 const { W3CTraceContextPropagator } = require('@opentelemetry/core');
 
 // The global propagator defaults to a no-op unless the real OTel SDK is initialized (which this
-// bare test process never does) -- register the real W3C propagator so BAI-427's trace-context
+// bare test process never does) -- register the real W3C propagator so the trace-context
 // tests below actually exercise header parsing instead of silently no-op-ing.
 propagation.setGlobalPropagator(new W3CTraceContextPropagator());
 const { recordKafkaRetryExhausted } = require('../../../utils/metrics');
@@ -235,7 +235,7 @@ describe('KafkaClientV2', () => {
         test('sends messages successfully on first attempt', async () => {
             await kafkaClient.sendCloudEventMessageAsync({ topic, messages });
             expect(mockProducerConnect).toHaveBeenCalled();
-            // BAI-427: headers is always added (even if empty, absent an active trace context in
+            // Headers is always added (even if empty, absent an active trace context in
             // this test env) -- see the trace-context injection in sendCloudEventMessageHelperAsync.
             expect(mockProducerSend).toHaveBeenCalledWith({
                 topic,
@@ -374,7 +374,7 @@ describe('KafkaClientV2', () => {
         test('sends messages via producer.send', async () => {
             kafkaClient.producerConnected = true;
             await kafkaClient.sendCloudEventMessageHelperAsync({ topic, messages });
-            // BAI-427: headers is always added (even if empty, absent an active trace context in
+            // Headers is always added (even if empty, absent an active trace context in
             // this test env) -- see the trace-context injection above producer.send's call.
             expect(mockProducerSend).toHaveBeenCalledWith({
                 topic,
@@ -740,7 +740,7 @@ describe('KafkaClientV2', () => {
         // but trace.setSpanContext/getSpan are pure reads/writes on a given Context value and
         // don't need a ContextManager, so asserting on the value itself is both simpler and
         // independent of whether a ContextManager happens to be registered.
-        test('BAI-427: extracts trace context from headers into the active context when nothing is already active', async () => {
+        test('Extracts trace context from headers into the active context when nothing is already active', async () => {
             const traceparent = '00-11111111111111111111111111111111-2222222222222222-01';
             const consumer = {
                 connect: mockConsumerConnect,
@@ -770,7 +770,7 @@ describe('KafkaClientV2', () => {
             withSpy.mockRestore();
         });
 
-        test('BAI-427: does not override an already-active span (e.g. from auto-instrumentation) with one extracted from headers', async () => {
+        test('Does not override an already-active span (e.g. from auto-instrumentation) with one extracted from headers', async () => {
             // Simulates @opentelemetry/instrumentation-kafkajs already having extracted from these
             // same raw headers and activated its own consumer span before eachMessage runs.
             const activeSpanContext = {

--- a/src/utils/kafkaClientV2.js
+++ b/src/utils/kafkaClientV2.js
@@ -184,7 +184,7 @@ class KafkaClientV2 {
                     args: { clientId: this.clientId, brokers: this.brokers, ssl: this.ssl, topic, messages }
                 });
             }
-            // BAI-427: inject the caller's active OTel trace context into every message's
+            // Inject the caller's active OTel trace context into every message's
             // headers as a defense-in-depth fallback -- @opentelemetry/instrumentation-kafkajs
             // auto-instrumentation is expected to do this on its own, but that depends on the
             // OTel Operator correctly injecting NODE_OPTIONS in every environment/pod, which
@@ -312,7 +312,7 @@ class KafkaClientV2 {
             await consumer.subscribe({ topics: [topic], fromBeginning });
             await consumer.run({
                 eachMessage: async ({ topic: t, partition, message, heartbeat, pause }) => {
-                    // BAI-427: one pass over the raw headers builds both the {key,value} array
+                    // One pass over the raw headers builds both the {key,value} array
                     // callers already expect and the string-keyed carrier propagation.extract needs.
                     const headerEntries = Object.entries(message.headers || {})
                         .map(([key, v]) => ({ key, value: v ? v.toString() : '' }));

--- a/src/utils/kafkaClientV2.js
+++ b/src/utils/kafkaClientV2.js
@@ -1,5 +1,5 @@
 const { Kafka, KafkaJSProtocolError, KafkaJSNonRetriableError } = require('kafkajs');
-const { propagation, context: otelContext } = require('@opentelemetry/api');
+const { propagation, context: otelContext, trace } = require('@opentelemetry/api');
 const { assertIsValid, assertTypeEquals } = require('./assertType');
 const { logSystemErrorAsync, logTraceSystemEventAsync, logSystemEventAsync } = require('../operations/common/systemEventLogging');
 const { logError } = require('../operations/common/logging');
@@ -200,7 +200,7 @@ class KafkaClientV2 {
                 await logTraceSystemEventAsync({
                     event: 'kafkaClientV2',
                     message: 'Sent CloudEvent messages',
-                    args: { clientId: this.clientId, brokers: this.brokers, ssl: this.ssl, topic, messages, result }
+                    args: { clientId: this.clientId, brokers: this.brokers, ssl: this.ssl, topic, messages: messagesWithTraceContext, result }
                 });
             }
         } catch (e) {
@@ -312,21 +312,31 @@ class KafkaClientV2 {
             await consumer.subscribe({ topics: [topic], fromBeginning });
             await consumer.run({
                 eachMessage: async ({ topic: t, partition, message, heartbeat, pause }) => {
-                    // BAI-427: string-ify headers once, both for the parsed message shape callers
-                    // already expect and as the carrier for propagation.extract below.
-                    const stringHeaders = Object.fromEntries(
-                        Object.entries(message.headers || {}).map(([k, v]) => [k, v ? v.toString() : ''])
-                    );
+                    // BAI-427: one pass over the raw headers builds both the {key,value} array
+                    // callers already expect and the string-keyed carrier propagation.extract needs.
+                    const headerEntries = Object.entries(message.headers || {})
+                        .map(([key, v]) => ({ key, value: v ? v.toString() : '' }));
                     const parsedMessage = {
                         key: message.key.toString(),
                         value: message.value.toString(),
-                        headers: Object.entries(stringHeaders).map(([key, value]) => ({ key, value }))
+                        headers: headerEntries
                     };
 
                     // Defense-in-depth fallback alongside the producer-side injection above --
-                    // see that comment. A missing/empty traceparent header is a safe no-op:
-                    // extract() just returns the current active context unchanged.
-                    const extractedContext = propagation.extract(otelContext.active(), stringHeaders);
+                    // see that comment. Only extract from headers when nothing is already active:
+                    // @opentelemetry/instrumentation-kafkajs (if loaded) already extracted from
+                    // these same raw headers to create and activate its own consumer span, and
+                    // re-extracting here would read the original PRODUCER's traceparent (headers
+                    // aren't rewritten by that instrumentation) and silently replace the active
+                    // consumer span with it -- making any span onMessageAsync creates a sibling of
+                    // the consumer span instead of its child. A missing/empty traceparent header
+                    // is a safe no-op: extract() just returns the context passed in unchanged.
+                    const activeContext = otelContext.active();
+                    const extractedContext = trace.getSpan(activeContext)
+                        ? activeContext
+                        : propagation.extract(activeContext, Object.fromEntries(
+                            headerEntries.map(({ key, value }) => [key, value])
+                        ));
 
                     await otelContext.with(extractedContext, async () => {
                         // Without a deadLetterTopic, behave exactly as before: a failure

--- a/src/utils/kafkaClientV2.js
+++ b/src/utils/kafkaClientV2.js
@@ -1,4 +1,5 @@
 const { Kafka, KafkaJSProtocolError, KafkaJSNonRetriableError } = require('kafkajs');
+const { propagation, context: otelContext } = require('@opentelemetry/api');
 const { assertIsValid, assertTypeEquals } = require('./assertType');
 const { logSystemErrorAsync, logTraceSystemEventAsync, logSystemEventAsync } = require('../operations/common/systemEventLogging');
 const { logError } = require('../operations/common/logging');
@@ -183,7 +184,18 @@ class KafkaClientV2 {
                     args: { clientId: this.clientId, brokers: this.brokers, ssl: this.ssl, topic, messages }
                 });
             }
-            const result = await this.producer.send({ topic, messages });
+            // BAI-427: inject the caller's active OTel trace context into every message's
+            // headers as a defense-in-depth fallback -- @opentelemetry/instrumentation-kafkajs
+            // auto-instrumentation is expected to do this on its own, but that depends on the
+            // OTel Operator correctly injecting NODE_OPTIONS in every environment/pod, which
+            // hasn't been verified. This manual injection makes propagation work regardless.
+            // A no-op (empty headers added) when no span/trace is active.
+            const messagesWithTraceContext = messages.map((m) => {
+                const headers = { ...(m.headers || {}) };
+                propagation.inject(otelContext.active(), headers);
+                return { ...m, headers };
+            });
+            const result = await this.producer.send({ topic, messages: messagesWithTraceContext });
             if (process.env.LOGLEVEL === 'DEBUG') {
                 await logTraceSystemEventAsync({
                     event: 'kafkaClientV2',
@@ -300,63 +312,72 @@ class KafkaClientV2 {
             await consumer.subscribe({ topics: [topic], fromBeginning });
             await consumer.run({
                 eachMessage: async ({ topic: t, partition, message, heartbeat, pause }) => {
+                    // BAI-427: string-ify headers once, both for the parsed message shape callers
+                    // already expect and as the carrier for propagation.extract below.
+                    const stringHeaders = Object.fromEntries(
+                        Object.entries(message.headers || {}).map(([k, v]) => [k, v ? v.toString() : ''])
+                    );
                     const parsedMessage = {
                         key: message.key.toString(),
                         value: message.value.toString(),
-                        headers: Object.entries(message.headers).map(([k, v]) => ({
-                            key: k,
-                            value: v ? v.toString() : ''
-                        }))
+                        headers: Object.entries(stringHeaders).map(([key, value]) => ({ key, value }))
                     };
 
-                    // Without a deadLetterTopic, behave exactly as before: a failure
-                    // propagates straight out of eachMessage, no retry, no DLT.
-                    if (!deadLetterTopic) {
-                        await onMessageAsync(parsedMessage);
-                        return;
-                    }
+                    // Defense-in-depth fallback alongside the producer-side injection above --
+                    // see that comment. A missing/empty traceparent header is a safe no-op:
+                    // extract() just returns the current active context unchanged.
+                    const extractedContext = propagation.extract(otelContext.active(), stringHeaders);
 
-                    try {
-                        await retryWithBackoff({
-                            // Heartbeat before every attempt (including the first), not just
-                            // during the backoff delay -- a handler's own processing time (e.g.
-                            // S3 reads + Mongo writes) can be several seconds per attempt, and
-                            // replaying that up to maxRetries+1 times with no heartbeat in
-                            // between risks exceeding the consumer's session timeout and
-                            // triggering a rebalance mid-retry, independent of how short the
-                            // backoff itself is.
-                            fn: async () => {
-                                await heartbeat();
-                                return onMessageAsync(parsedMessage);
-                            },
-                            maxRetries,
-                            initialDelayMs: retryInitialDelayMs,
-                            onRetry: ({ attempt, error }) => {
-                                // onRetry is invoked synchronously (not awaited) by retryWithBackoff,
-                                // so this log write races the retry delay -- best-effort only.
-                                logSystemEventAsync({
-                                    event: 'kafkaClientV2',
-                                    message: 'Retrying failed message processing',
-                                    args: { topic: t, partition, key: parsedMessage.key, attempt, maxRetries, error: error.message }
-                                }).catch(() => {});
-                            }
-                        });
-                    } catch (finalError) {
-                        // Retries exhausted -- this message can't be processed. Publish it to
-                        // the dead-letter topic (with the failure reason) and let eachMessage
-                        // return normally so the offset commits; otherwise a single poison
-                        // message would block this partition forever. If the DLT publish
-                        // itself fails, sendToDeadLetterTopicAsync rethrows so the offset does
-                        // NOT commit -- losing the message's only record would be worse than
-                        // redelivering it.
-                        await logSystemErrorAsync({
-                            event: 'kafkaClientV2',
-                            message: 'Message failed after exhausting retries, sending to dead-letter topic',
-                            args: { topic: t, partition, key: parsedMessage.key, deadLetterTopic, maxRetries },
-                            error: finalError
-                        });
-                        await this.sendToDeadLetterTopicAsync({ deadLetterTopic, message: parsedMessage, error: finalError });
-                    }
+                    await otelContext.with(extractedContext, async () => {
+                        // Without a deadLetterTopic, behave exactly as before: a failure
+                        // propagates straight out of eachMessage, no retry, no DLT.
+                        if (!deadLetterTopic) {
+                            await onMessageAsync(parsedMessage);
+                            return;
+                        }
+
+                        try {
+                            await retryWithBackoff({
+                                // Heartbeat before every attempt (including the first), not just
+                                // during the backoff delay -- a handler's own processing time (e.g.
+                                // S3 reads + Mongo writes) can be several seconds per attempt, and
+                                // replaying that up to maxRetries+1 times with no heartbeat in
+                                // between risks exceeding the consumer's session timeout and
+                                // triggering a rebalance mid-retry, independent of how short the
+                                // backoff itself is.
+                                fn: async () => {
+                                    await heartbeat();
+                                    return onMessageAsync(parsedMessage);
+                                },
+                                maxRetries,
+                                initialDelayMs: retryInitialDelayMs,
+                                onRetry: ({ attempt, error }) => {
+                                    // onRetry is invoked synchronously (not awaited) by retryWithBackoff,
+                                    // so this log write races the retry delay -- best-effort only.
+                                    logSystemEventAsync({
+                                        event: 'kafkaClientV2',
+                                        message: 'Retrying failed message processing',
+                                        args: { topic: t, partition, key: parsedMessage.key, attempt, maxRetries, error: error.message }
+                                    }).catch(() => {});
+                                }
+                            });
+                        } catch (finalError) {
+                            // Retries exhausted -- this message can't be processed. Publish it to
+                            // the dead-letter topic (with the failure reason) and let eachMessage
+                            // return normally so the offset commits; otherwise a single poison
+                            // message would block this partition forever. If the DLT publish
+                            // itself fails, sendToDeadLetterTopicAsync rethrows so the offset does
+                            // NOT commit -- losing the message's only record would be worse than
+                            // redelivering it.
+                            await logSystemErrorAsync({
+                                event: 'kafkaClientV2',
+                                message: 'Message failed after exhausting retries, sending to dead-letter topic',
+                                args: { topic: t, partition, key: parsedMessage.key, deadLetterTopic, maxRetries },
+                                error: finalError
+                            });
+                            await this.sendToDeadLetterTopicAsync({ deadLetterTopic, message: parsedMessage, error: finalError });
+                        }
+                    });
                 }
             });
         } catch (e) {


### PR DESCRIPTION
## Summary
- The `$import` flow (`HTTP → bulk_import.requested (Kafka) → orchestrator → bulk_import.events (Kafka) → worker`) had no manual trace-context propagation anywhere in the app code — it relied entirely on `@opentelemetry/instrumentation-kafkajs` auto-instrumentation, which depends on the OTel Operator correctly injecting `NODE_OPTIONS` into every pod. This was never empirically confirmed to actually link one trace ID across both Kafka hops.
- Adds defense-in-depth manual propagation directly in `kafkaClientV2.js` — the single choke point used by **every** Kafka producer/consumer in the app, not just bulk import:
  - **Producer** (`sendCloudEventMessageHelperAsync`): injects the caller's active OTel trace context into each message's headers before `producer.send`.
  - **Consumer** (`receiveMessagesAsync`'s `eachMessage`): extracts trace context from message headers and runs the message handler (including the retry/DLT path) within that extracted context via `context.with(...)`.
- Safe/no-op when no span is active or headers are missing — doesn't conflict with auto-instrumentation if that's also active; makes propagation work regardless of whether it is.

Closes out BAI-427.

## Test plan
- [x] `eslint` clean
- [x] `kafkaClientV2.test.js` — updated 2 existing tests that asserted exact `producer.send` call args (now includes an always-present `headers` object), added no new test scenarios beyond that since this is a structural change to an existing choke point already covered by the full existing suite (54/54 passing)
- [x] `handlerWorker.test.js` (integration, exercises the consumer path end-to-end) — 37/37 passing in an isolated clean run
- [ ] Live verification: trigger a `$import` on dev and confirm in GroundCover that one trace ID now spans the HTTP request, both Kafka topics, and the worker's processing