### PR TITLE
BAI-432 thread requester identity through bulk import AuditEvents

### DIFF
--- a/src/operations/asyncJobs/bulkImport/bulkImportEventProducer.js
+++ b/src/operations/asyncJobs/bulkImport/bulkImportEventProducer.js
@@ -45,9 +45,12 @@ class BulkImportEventProducer {
      * @param {string} params.requestId
      * @param {string} params.scope
      * @param {string} params.user
+     * @param {string|undefined} [params.alternateUserId]
+     * @param {boolean|undefined} [params.isUser]
+     * @param {string|undefined} [params.remoteIpAddress]
      * @returns {Promise<number>} total number of messages published
      */
-    async publishImportEventsAsync({ taskId, inputs, requestId, scope, user }) {
+    async publishImportEventsAsync({ taskId, inputs, requestId, scope, user, alternateUserId, isUser, remoteIpAddress }) {
         if (!this.configManager.kafkaV2EnableEvents) {
             return 0;
         }
@@ -79,7 +82,10 @@ class BulkImportEventProducer {
                         totalRanges: ranges.length,
                         requestId,
                         scope,
-                        user
+                        user,
+                        alternateUserId,
+                        isUser,
+                        remoteIpAddress
                     }
                 };
 

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -375,7 +375,7 @@ class BulkImportHandler {
             return;
         }
 
-        const { taskId, inputs, requestId, scope, user } = eventData;
+        const { taskId, inputs, requestId, scope, user, alternateUserId, isUser, remoteIpAddress } = eventData;
 
         logInfo('Orchestrator received TaskCreated event', {
             taskId,
@@ -409,7 +409,10 @@ class BulkImportHandler {
             inputs: inputsWithSizes,
             requestId,
             scope,
-            user
+            user,
+            alternateUserId,
+            isUser,
+            remoteIpAddress
         });
 
         logInfo('Orchestrator published byte-range messages', {
@@ -424,14 +427,15 @@ class BulkImportHandler {
      * Builds a request-scoped FhirRequestInfo for a single byte-range's writes.
      * A fresh requestId is required per range so concurrent ranges don't share
      * the singleton FastDatabaseBulkInserter's buffered-operations map.
-     * @param {{ user: string|null, scope: string|null }} params
+     * @param {{ user: string|null, scope: string|null, alternateUserId: string|undefined,
+     *   isUser: boolean|undefined, remoteIpAddress: string|undefined }} params
      * @returns {FhirRequestInfo}
      */
-    buildRangeRequestInfo({ user, scope }) {
+    buildRangeRequestInfo({ user, scope, alternateUserId, isUser, remoteIpAddress }) {
         return new FhirRequestInfo({
             user: user || null,
             scope: scope || null,
-            remoteIpAddress: null,
+            remoteIpAddress: remoteIpAddress || null,
             requestId: generateUUID(),
             userRequestId: null,
             protocol: 'kafka',
@@ -440,7 +444,7 @@ class BulkImportHandler {
             host: null,
             body: null,
             accept: 'application/fhir+json',
-            isUser: false,
+            isUser: Boolean(isUser),
             userType: null,
             personIdFromJwtToken: null,
             masterPersonIdFromJwtToken: null,
@@ -448,7 +452,7 @@ class BulkImportHandler {
             headers: {},
             method: 'POST',
             contentTypeFromHeader: null,
-            alternateUserId: null,
+            alternateUserId: alternateUserId || null,
             actor: null,
             purposeOfUse: null
         });
@@ -767,7 +771,10 @@ class BulkImportHandler {
             return;
         }
 
-        const { taskId, filepath, byteRangeStart, byteRangeEnd, rangeIndex, totalRanges, fileSize, user, scope } = eventData;
+        const {
+            taskId, filepath, byteRangeStart, byteRangeEnd, rangeIndex, totalRanges, fileSize,
+            user, scope, alternateUserId, isUser, remoteIpAddress
+        } = eventData;
         const rangeStartTimeMs = Date.now();
 
         logInfo('Processing bulk import range', {
@@ -785,7 +792,7 @@ class BulkImportHandler {
             return;
         }
 
-        const requestInfo = this.buildRangeRequestInfo({ user, scope });
+        const requestInfo = this.buildRangeRequestInfo({ user, scope, alternateUserId, isUser, remoteIpAddress });
 
         if (task.status === 'requested') {
             await this.updateTaskStatusAsync(task, 'in-progress', undefined, requestInfo);

--- a/src/operations/import/import.js
+++ b/src/operations/import/import.js
@@ -328,7 +328,10 @@ class ImportOperation {
                         inputs,
                         requestId,
                         scope,
-                        user: requestInfo.user
+                        user: requestInfo.user,
+                        alternateUserId: requestInfo.alternateUserId,
+                        isUser: requestInfo.isUser,
+                        remoteIpAddress: requestInfo.remoteIpAddress
                     }
                 };
 

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -257,7 +257,10 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             value: makeCloudEvent({
                 taskId: 'import-consumer-audit',
                 user: 'bulk-import-service-account',
-                scope: 'user/*.write'
+                scope: 'user/*.write',
+                alternateUserId: 'bulk-import-alt-id',
+                isUser: true,
+                remoteIpAddress: '10.0.0.1'
             }),
             headers: []
         });
@@ -285,6 +288,13 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         expect(patientCreateAudit.entity[0].detail).toContainEqual(
             { type: 'requestUrl', valueString: '$import' }
         );
+        // The requester's identity (alternateUserId/isUser/remoteIpAddress) must be threaded
+        // all the way from the ImportRangeRequested event into buildRangeRequestInfo, not
+        // hardcoded to null/false -- otherwise every bulk-import AuditEvent would be missing
+        // who actually triggered the import.
+        expect(patientCreateAudit.agent[0].altId).toBe('bulk-import-alt-id');
+        expect(patientCreateAudit.agent[0].network.address).toBe('10.0.0.1');
+        expect(patientCreateAudit.agent[0].who.reference).toContain('bulk-import-service-account');
     });
 
     test('handleMessageAsync creates an error AuditEvent for a per-resource write failure', async () => {

--- a/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
@@ -120,7 +120,10 @@ function createTaskCreatedMessage({
     inputs = [{ url: 's3://allowed-bucket/data/patients.ndjson' }],
     requestId = 'req-001',
     scope = 'system/*.read',
-    user = 'practitioner/dr-smith'
+    user = 'practitioner/dr-smith',
+    alternateUserId = 'alt-dr-smith',
+    isUser = true,
+    remoteIpAddress = '10.0.0.1'
 } = {}) {
     return JSON.stringify({
         specversion: '1.0',
@@ -128,7 +131,7 @@ function createTaskCreatedMessage({
         source: 'https://www.icanbwell.com/fhir-server',
         type: 'TaskCreated',
         datacontenttype: 'application/json',
-        data: { taskId, inputs, requestId, scope, user }
+        data: { taskId, inputs, requestId, scope, user, alternateUserId, isUser, remoteIpAddress }
     });
 }
 
@@ -575,12 +578,18 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
 
             await handler.handleMessageAsync(message);
 
+            // alternateUserId/isUser/remoteIpAddress must be forwarded to the event producer
+            // unchanged -- these are what ultimately populate AuditEvent.agent[0].altId/who/
+            // network.address for every resource this Task's ranges write (see BAI-432).
             expect(publishImportEventsAsync).toHaveBeenCalledWith({
                 taskId: 'task-abc-123',
                 inputs: [{ url: 's3://allowed-bucket/data/patients.ndjson', fileSize: 10 * 1024 * 1024 }],
                 requestId: 'req-001',
                 scope: 'system/*.read',
-                user: 'practitioner/dr-smith'
+                user: 'practitioner/dr-smith',
+                alternateUserId: 'alt-dr-smith',
+                isUser: true,
+                remoteIpAddress: '10.0.0.1'
             });
             expect(logInfo).toHaveBeenCalledWith(
                 'Orchestrator published byte-range messages',

--- a/src/tests/unit/operations/import/import.test.js
+++ b/src/tests/unit/operations/import/import.test.js
@@ -316,4 +316,54 @@ describe('ImportOperation - null safety and error handling', () => {
             expect(mocks.databaseQueryFactory.createQuery).toHaveBeenCalledTimes(2);
         });
     });
+
+    // ========== importAsync - TaskCreated event carries requester identity (BAI-432) ==========
+    describe('importAsync - TaskCreated event identity fields', () => {
+        test('publishes alternateUserId/isUser/remoteIpAddress from requestInfo on the TaskCreated event', async () => {
+            Object.defineProperty(mocks.configManager, 'kafkaV2EnableEvents', {
+                get: () => true,
+                configurable: true
+            });
+            importOp = new ImportOperation(mocks);
+
+            const mockDatabaseQueryManager = {
+                findOneAsync: jest.fn().mockResolvedValue(null)
+            };
+            const mockDatabaseUpdateManager = {
+                insertOneAsync: jest.fn().mockResolvedValue(undefined),
+                updateOneAsync: jest.fn().mockResolvedValue(undefined)
+            };
+            mocks.databaseQueryFactory.createQuery = jest.fn().mockReturnValue(mockDatabaseQueryManager);
+            mocks.databaseUpdateFactory.createDatabaseUpdateManager = jest.fn().mockReturnValue(mockDatabaseUpdateManager);
+            mocks.kafkaClientV2.sendCloudEventMessageAsync = jest.fn().mockResolvedValue(undefined);
+
+            const requestInfo = {
+                requestId: 'req-1',
+                scope: 'user/*.*',
+                user: 'admin',
+                alternateUserId: 'admin-alt-id',
+                isUser: true,
+                remoteIpAddress: '203.0.113.5'
+            };
+
+            await importOp.importAsync({
+                requestInfo,
+                args: {
+                    base_version: '4_0_0',
+                    resource: {
+                        resourceType: 'Parameters',
+                        id: 'job-identity',
+                        parameter: [{ name: 'input', valueUri: 's3://my-bucket/file.ndjson' }]
+                    }
+                }
+            });
+
+            expect(mocks.kafkaClientV2.sendCloudEventMessageAsync).toHaveBeenCalledTimes(1);
+            const publishedMessage = mocks.kafkaClientV2.sendCloudEventMessageAsync.mock.calls[0][0].messages[0];
+            const publishedEvent = JSON.parse(publishedMessage.value);
+            expect(publishedEvent.data.alternateUserId).toBe('admin-alt-id');
+            expect(publishedEvent.data.isUser).toBe(true);
+            expect(publishedEvent.data.remoteIpAddress).toBe('203.0.113.5');
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- `altId` (and the rest of the requester identity) was missing from every AuditEvent the bulk-import flow produces -- `buildRangeRequestInfo` hardcoded `alternateUserId`/`isUser`/`remoteIpAddress` to null/false, and the identity was never carried in the `TaskCreated`/`ImportRangeRequested` event payloads that feed it.
- Threads `alternateUserId`, `isUser`, and `remoteIpAddress` from the original `$import` request's `requestInfo`, through `import.js`'s TaskCreated event -> `handleTaskCreatedAsync` -> `bulkImportEventProducer`'s ImportRangeRequested event -> `buildRangeRequestInfo`, so `AuditLogger.buildAgents` has real values to work with.
- Found during a code audit of the bulk `$import` flow.

## Test plan
- [x] `src/tests/unit/operations/import/import.test.js` -- new test asserting the published TaskCreated event carries `alternateUserId`/`isUser`/`remoteIpAddress` from `requestInfo`
- [x] `src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js` -- updated to assert `handleTaskCreatedAsync` forwards these fields to `publishImportEventsAsync`
- [x] `src/tests/asyncJobs/bulkImport/handlerWorker.test.js` -- updated AuditEvent test to assert `agent[0].altId`/`network.address`/`who.reference` are populated from the event, not null
- [x] Full suite run for all touched files (118 tests) + lint clean