### PR TITLE
BAI-431 restore source line order in bulk import result NDJSON output

### DIFF
--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -700,6 +700,12 @@ class BulkImportHandler {
         const { bucket, key } = this.s3NdjsonReader.parseS3Uri(filepath);
         const { resultKey, errorKey } = this.buildRangeOutputKeys({ key, rangeIndex });
 
+        // Entries land here in commit order, not source order -- an error is recorded the
+        // instant its line is read, but a success only once its whole batch flushes, so a
+        // later-flushing batch's successes can end up after an earlier error in the array.
+        // Restore source order before writing output so position always matches the input file.
+        mergeResultEntries.sort((a, b) => (a.sourceByteOffset ?? 0) - (b.sourceByteOffset ?? 0));
+
         const newOutputs = [];
         if (mergeResultEntries.length > 0) {
             const resultUri = `s3://${bucket}/${resultKey}`;
@@ -803,6 +809,14 @@ class BulkImportHandler {
         let skipped = 0;
         const mergeResultEntries = [];
 
+        // fastDatabaseBulkInserter buffers queued resources and only builds their
+        // MergeResultEntry once a batch actually flushes to Mongo, by which point the
+        // line's byteOffset is no longer in scope there -- so we track it here, keyed by
+        // resourceType+id, and re-attach it to the returned entry in flushBatchAsync below.
+        // Restores output ordering to match the source file regardless of when within a
+        // batch a given line's write actually commits.
+        const byteOffsetByUuid = new Map();
+
         // Set once this attempt's first flush actually writes to Mongo (and possibly
         // ClickHouse/Kafka-ClickPipe for clickHouseOnlyResources) -- see
         // readRangeWithRetryAsync's docstring for why retry must stop once this is true.
@@ -812,6 +826,7 @@ class BulkImportHandler {
             const mergeResults = await this.fastDatabaseBulkInserter.executeAsync({ requestInfo, base_version });
             hasFlushedThisAttempt = true;
             for (const mergeResult of mergeResults) {
+                mergeResult.sourceByteOffset = byteOffsetByUuid.get(`${mergeResult.resourceType}|${mergeResult.id}`);
                 mergeResultEntries.push(mergeResult);
                 if (mergeResult.created) {
                     created++;
@@ -834,6 +849,7 @@ class BulkImportHandler {
             failed = 0;
             skipped = 0;
             mergeResultEntries.length = 0;
+            byteOffsetByUuid.clear();
             hasFlushedThisAttempt = false;
 
             // ifNoneExist criteria "claimed" by a resource already queued for insert in this
@@ -918,7 +934,8 @@ class BulkImportHandler {
                                     created: false,
                                     updated: false,
                                     issue: null,
-                                    operationOutcome: null
+                                    operationOutcome: null,
+                                    sourceByteOffset: byteOffset
                                 }));
                                 logInfo('Skipped bulk import resource: matched existing via ifNoneExist', {
                                     taskId,
@@ -932,6 +949,12 @@ class BulkImportHandler {
                                 const contextData = buildContextDataForHybridStorage(
                                     fhirResource.resourceType, fhirResource, requestInfo
                                 );
+                                // Keyed by resourceType+id rather than _uuid -- _uuid isn't
+                                // reliably populated on fhirResource yet at this point (it's
+                                // derived by a pre-save handler further down the write
+                                // pipeline), while id is the caller-supplied value and is
+                                // already stable here.
+                                byteOffsetByUuid.set(`${fhirResource.resourceType}|${fhirResource.id}`, byteOffset);
                                 await this.fastDatabaseBulkInserter.insertOneAsync({
                                     base_version,
                                     requestInfo,

--- a/src/operations/common/mergeResultEntry.js
+++ b/src/operations/common/mergeResultEntry.js
@@ -21,6 +21,9 @@ class MergeResultEntry {
      * @param {string} resourceType
      * @param {boolean} updated
      * @param {string} sourceAssigningAuthority
+     * @param {number|undefined} [sourceByteOffset] - absolute byte offset of the source NDJSON
+     *   line this entry came from (bulk import only); used to restore output ordering to match
+     *   the source file. Not part of toJSON() -- internal-only, doesn't change the NDJSON schema.
      */
     constructor (
         {
@@ -31,7 +34,8 @@ class MergeResultEntry {
             uuid,
             resourceType,
             updated,
-            sourceAssigningAuthority
+            sourceAssigningAuthority,
+            sourceByteOffset
         }
     ) {
         /**
@@ -66,6 +70,10 @@ class MergeResultEntry {
          * @type {string}
          */
         this._sourceAssigningAuthority = sourceAssigningAuthority;
+        /**
+         * @type {number|undefined}
+         */
+        this.sourceByteOffset = sourceByteOffset;
     }
 
     toJSON () {
@@ -129,7 +137,8 @@ class MergeResultEntry {
                 updated: false,
                 issue,
                 operationOutcome,
-                resourceType: resource.resourceType
+                resourceType: resource.resourceType,
+                sourceByteOffset
             }
         );
         return mergeResultEntry;

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -482,6 +482,51 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         expect(errorWrite.data).toContain('Invalid JSON at line 2');
     });
 
+    test('handleMessageAsync preserves source line order in the result NDJSON even when an error is recorded before later successes flush', async () => {
+        const request = await createTestRequest();
+
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-consumer-order' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        // A per-line failure is recorded into mergeResultEntries the instant its line is
+        // read, but a success is only recorded once its batch flushes -- with the default
+        // batch size, all 3 successes below flush together in one batch at the very end of
+        // the range, after the error was already recorded. Without restoring source order,
+        // the error would end up first in the output instead of third.
+        container.s3NdjsonReader.setLinesToYield([
+            { resourceType: 'Patient', id: 'bulk-import-order-1', name: [{ family: 'One' }] },
+            { resourceType: 'Patient', id: 'bulk-import-order-2', name: [{ family: 'Two' }] },
+            { __parseError: 'Invalid JSON at line 3 in "s3://allowed-bucket/Patient.ndjson": Unexpected token' },
+            { resourceType: 'Patient', id: 'bulk-import-order-4', name: [{ family: 'Four' }] }
+        ]);
+
+        await handler.handleMessageAsync({
+            key: 'import-consumer-order-0',
+            value: makeCloudEvent({ taskId: 'import-consumer-order' }),
+            headers: []
+        });
+
+        const resultWrite = container.s3NdjsonReader.getWriteCalls()
+            .find((c) => c.filepath.includes('/output/') && !c.filepath.includes('/errors/'));
+        expect(resultWrite).toBeDefined();
+
+        const resultLines = resultWrite.data.trim().split('\n').map((line) => JSON.parse(line));
+        expect(resultLines.map((entry) => entry.id || entry.operationOutcome?.issue?.[0]?.extension?.[0]?.valueInteger))
+            .toEqual([
+                'bulk-import-order-1',
+                'bulk-import-order-2',
+                200, // the error entry's source-byte-offset, positioned between order-2 and order-4
+                'bulk-import-order-4'
+            ]);
+    });
+
     test('handleMessageAsync flushes postRequestProcessor and clears requestSpecificCache per range', async () => {
         const request = await createTestRequest();
 


### PR DESCRIPTION
## Summary
- Error/skipped entries were recorded into `mergeResultEntries` the instant their line was read, but success entries only once their batch flushed -- so a later-flushing batch's successes could end up after an earlier error in the output, misattributing position for anyone matching output rows to source lines.
- Tracks each queued resource's source byte offset (keyed by `resourceType+id`, since `_uuid` isn't populated yet at queue time) and re-attaches it to the returned `MergeResultEntry` on flush, then sorts by that offset before writing either output file.
- Found during a code audit of the bulk `$import` flow.

## Test plan
- [x] `src/tests/asyncJobs/bulkImport/handlerWorker.test.js` -- new regression test: an error mixed among several successes now lands at its correct source position in the result NDJSON instead of first
- [x] `src/tests/unit/operations/common/mergeResultEntry.test.js`, `mongoBulkWriteExecutor.test.js`, `handlerOrchestrator.test.js` -- unaffected, still passing
- [x] Full suite run for all touched files (110 tests total across both PRs' shared files) + lint clean