### PR TITLE
BAI-435 Route bulk import writes through mergeManager.mergeResourceAsync

### DIFF
--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -1288,7 +1288,11 @@ const createContainer = function () {
         requestSpecificCache: c.requestSpecificCache,
         auditLogger: c.auditLogger,
         r4ArgsParser: c.r4ArgsParser,
-        searchQueryBuilder: c.searchQueryBuilder
+        searchQueryBuilder: c.searchQueryBuilder,
+        mergeManager: c.mergeManager,
+        databaseBulkLoader: c.databaseBulkLoader,
+        sourceAssigningAuthorityColumnHandler: c.sourceAssigningAuthorityColumnHandler,
+        uuidColumnHandler: c.uuidColumnHandler
     }));
 
     // Routes messages on kafkaBulkImportTaskCreatedTopic and kafkaBulkImportRangeProgressTopic

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -550,6 +550,11 @@ const createContainer = function () {
         )
     );
 
+    container.register('writeAllowedByScopesValidator', (c) => new WriteAllowedByScopesValidator({
+        scopesValidator: c.scopesValidator,
+        databaseBulkLoader: c.databaseBulkLoader
+    }));
+
     container.register('mergeValidator', (c) => new MergeValidator(
         {
             validators: [
@@ -564,10 +569,7 @@ const createContainer = function () {
                     uuidColumnHandler: c.uuidColumnHandler,
                     customTracer: c.customTracer
                 }),
-                new WriteAllowedByScopesValidator({
-                    scopesValidator: c.scopesValidator,
-                    databaseBulkLoader: c.databaseBulkLoader
-                })
+                c.writeAllowedByScopesValidator
             ],
             configManager: c.configManager,
             customTracer: c.customTracer
@@ -1292,7 +1294,8 @@ const createContainer = function () {
         mergeManager: c.mergeManager,
         databaseBulkLoader: c.databaseBulkLoader,
         sourceAssigningAuthorityColumnHandler: c.sourceAssigningAuthorityColumnHandler,
-        uuidColumnHandler: c.uuidColumnHandler
+        uuidColumnHandler: c.uuidColumnHandler,
+        writeAllowedByScopesValidator: c.writeAllowedByScopesValidator
     }));
 
     // Routes messages on kafkaBulkImportTaskCreatedTopic and kafkaBulkImportRangeProgressTopic

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -11,8 +11,11 @@ const { BulkImportEventProducer } = require('./bulkImportEventProducer');
 const { BulkImportTaskStateMachine } = require('./bulkImportTaskStateMachine');
 const { FhirResourceWriteSerializer } = require('../../../fhir/fhirResourceWriteSerializer');
 const { FhirRequestInfo } = require('../../../utils/fhirRequestInfo');
-const { buildContextDataForHybridStorage } = require('../../../utils/contextDataBuilder');
-const { generateUUID } = require('../../../utils/uid.util');
+const { generateUUID, isUuid } = require('../../../utils/uid.util');
+const { MergeManager } = require('../../merge/mergeManager');
+const { DatabaseBulkLoader } = require('../../../dataLayer/databaseBulkLoader');
+const { SourceAssigningAuthorityColumnHandler } = require('../../../preSaveHandlers/handlers/sourceAssigningAuthorityColumnHandler');
+const { UuidColumnHandler } = require('../../../preSaveHandlers/handlers/uuidColumnHandler');
 const { SecurityTagSystem } = require('../../../utils/securityTagSystem');
 const { BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY, STRICT_SEARCH_HANDLING } = require('../../../constants');
 const { PostRequestProcessor } = require('../../../utils/postRequestProcessor');
@@ -89,6 +92,10 @@ class BulkImportHandler {
      * @property {AuditLogger} auditLogger
      * @property {R4ArgsParser} r4ArgsParser
      * @property {SearchQueryBuilder} searchQueryBuilder
+     * @property {MergeManager} mergeManager
+     * @property {DatabaseBulkLoader} databaseBulkLoader
+     * @property {SourceAssigningAuthorityColumnHandler} sourceAssigningAuthorityColumnHandler
+     * @property {UuidColumnHandler} uuidColumnHandler
      *
      * @param {ConstructorParams}
      */
@@ -104,7 +111,11 @@ class BulkImportHandler {
         requestSpecificCache,
         auditLogger,
         r4ArgsParser,
-        searchQueryBuilder
+        searchQueryBuilder,
+        mergeManager,
+        databaseBulkLoader,
+        sourceAssigningAuthorityColumnHandler,
+        uuidColumnHandler
     }) {
         this.configManager = configManager;
         assertTypeEquals(configManager, ConfigManager);
@@ -141,6 +152,18 @@ class BulkImportHandler {
 
         this.searchQueryBuilder = searchQueryBuilder;
         assertTypeEquals(searchQueryBuilder, SearchQueryBuilder);
+
+        this.mergeManager = mergeManager;
+        assertTypeEquals(mergeManager, MergeManager);
+
+        this.databaseBulkLoader = databaseBulkLoader;
+        assertTypeEquals(databaseBulkLoader, DatabaseBulkLoader);
+
+        this.sourceAssigningAuthorityColumnHandler = sourceAssigningAuthorityColumnHandler;
+        assertTypeEquals(sourceAssigningAuthorityColumnHandler, SourceAssigningAuthorityColumnHandler);
+
+        this.uuidColumnHandler = uuidColumnHandler;
+        assertTypeEquals(uuidColumnHandler, UuidColumnHandler);
     }
 
     /**
@@ -763,21 +786,101 @@ class BulkImportHandler {
         // readRangeWithRetryAsync's docstring for why retry must stop once this is true.
         let hasFlushedThisAttempt = false;
 
+        // Buffers a batch's successfully-serialized (non-skipped) resources so their
+        // create/update status can be resolved with one pre-loaded databaseBulkLoader lookup
+        // per resourceType instead of a fastFindOneAsync round trip per line -- see Shubham's
+        // PR #2528 review comment (per-line existence-check cost tradeoff).
+        let pendingMergeResources = [];
+
         const flushBatchAsync = async () => {
-            const mergeResults = await this.fastDatabaseBulkInserter.executeAsync({ requestInfo, base_version });
-            hasFlushedThisAttempt = true;
-            for (const mergeResult of mergeResults) {
-                mergeResult.sourceByteOffset = byteOffsetByUuid.get(`${mergeResult.resourceType}|${mergeResult.id}`);
-                mergeResultEntries.push(mergeResult);
-                if (mergeResult.created) {
-                    created++;
-                } else if (mergeResult.updated) {
-                    updated++;
-                } else if (mergeResult.operationOutcome) {
-                    failed++;
+            if (pendingMergeResources.length > 0) {
+                // Pre-load once for the whole batch (grouped by resourceType internally) so
+                // mergeBufferedResourceAsync's getResourceFromExistingList() calls below are
+                // in-memory lookups instead of a query per line.
+                await this.databaseBulkLoader.loadResourcesAsync({
+                    requestId: requestInfo.requestId,
+                    base_version,
+                    requestedResources: pendingMergeResources.map((p) => p.fhirResource)
+                });
+                for (const { fhirResource, byteOffset } of pendingMergeResources) {
+                    await mergeBufferedResourceAsync({ fhirResource, byteOffset });
                 }
+                pendingMergeResources = [];
             }
+            await this.fastDatabaseBulkInserter.executeAsync({ requestInfo, base_version });
+            hasFlushedThisAttempt = true;
             sinceLastFlush = 0;
+        };
+
+        /**
+         * Merges one already-serialized resource via mergeManager.mergeResourceAsync
+         * (schema validation + real upsert, instead of fastDatabaseBulkInserter.insertOneAsync's
+         * unconditional $setOnInsert) and folds its null/MergeResultEntry return contract into
+         * this range's counters/mergeResultEntries.
+         * @param {Object} params
+         * @param {Object} params.fhirResource
+         * @param {number} params.byteOffset
+         * @returns {Promise<void>}
+         */
+        const mergeBufferedResourceAsync = async ({ fhirResource, byteOffset }) => {
+            const wasExisting = !!this.databaseBulkLoader.getResourceFromExistingList({
+                requestId: requestInfo.requestId,
+                resourceType: fhirResource.resourceType,
+                uuid: fhirResource._uuid
+            });
+
+            try {
+                const validationFailure = await this.mergeManager.mergeResourceAsync({
+                    resourceToMerge: fhirResource,
+                    resourceType: fhirResource.resourceType,
+                    base_version,
+                    requestInfo
+                });
+
+                if (validationFailure) {
+                    failed++;
+                    mergeResultEntries.push(validationFailure);
+                } else if (wasExisting) {
+                    updated++;
+                    mergeResultEntries.push(new MergeResultEntry({
+                        id: fhirResource.id,
+                        uuid: fhirResource._uuid,
+                        sourceAssigningAuthority: fhirResource._sourceAssigningAuthority,
+                        resourceType: fhirResource.resourceType,
+                        created: false,
+                        updated: true,
+                        issue: null,
+                        operationOutcome: null
+                    }));
+                } else {
+                    created++;
+                    mergeResultEntries.push(new MergeResultEntry({
+                        id: fhirResource.id,
+                        uuid: fhirResource._uuid,
+                        sourceAssigningAuthority: fhirResource._sourceAssigningAuthority,
+                        resourceType: fhirResource.resourceType,
+                        created: true,
+                        updated: false,
+                        issue: null,
+                        operationOutcome: null
+                    }));
+                }
+            } catch (mergeError) {
+                failed++;
+                const entryFromError = mergeError.args instanceof MergeResultEntry
+                    ? mergeError.args
+                    : MergeResultEntry.createFromError({
+                        error: mergeError, resource: fhirResource, sourceByteOffset: byteOffset
+                    });
+                mergeResultEntries.push(entryFromError);
+                logError('Failed to merge bulk import resource', {
+                    taskId,
+                    filepath,
+                    resourceType: fhirResource.resourceType,
+                    byteOffset,
+                    error: mergeError.message
+                });
+            }
         };
 
         const readAndProcessRangeAsync = async () => {
@@ -792,6 +895,7 @@ class BulkImportHandler {
             mergeResultEntries.length = 0;
             byteOffsetByUuid.clear();
             hasFlushedThisAttempt = false;
+            pendingMergeResources = [];
 
             // ifNoneExist criteria "claimed" by a resource already queued for insert in this
             // attempt but not yet flushed to Mongo. findExistingResourceForIfNoneExistAsync
@@ -838,6 +942,16 @@ class BulkImportHandler {
                             const fhirResource = FhirResourceWriteSerializer.serialize({
                                 obj: this.applyDefaultSecurityTagsIfMissing(innerResource)
                             });
+
+                            // mergeManager.mergeResourceAsync requires _uuid to already be set --
+                            // mirrors MergeResourceValidator's own pre-merge assignment (the same
+                            // rule $merge's API path uses) since serialize() doesn't compute it.
+                            if (isUuid(fhirResource.id)) {
+                                fhirResource._uuid = fhirResource.id;
+                            } else {
+                                await this.sourceAssigningAuthorityColumnHandler.preSaveAsync({ resource: fhirResource });
+                                await this.uuidColumnHandler.preSaveAsync({ resource: fhirResource });
+                            }
 
                             let existingResource = null;
                             let ifNoneExistKey = null;
@@ -887,25 +1001,10 @@ class BulkImportHandler {
                                     ifNoneExist: resource.ifNoneExist
                                 });
                             } else {
-                                const contextData = buildContextDataForHybridStorage(
-                                    fhirResource.resourceType, fhirResource, requestInfo
-                                );
-                                // Keyed by resourceType+id rather than _uuid -- _uuid isn't
-                                // reliably populated on fhirResource yet at this point (it's
-                                // derived by a pre-save handler further down the write
-                                // pipeline), while id is the caller-supplied value and is
-                                // already stable here.
-                                byteOffsetByUuid.set(`${fhirResource.resourceType}|${fhirResource.id}`, byteOffset);
-                                await this.fastDatabaseBulkInserter.insertOneAsync({
-                                    base_version,
-                                    requestInfo,
-                                    resourceType: fhirResource.resourceType,
-                                    doc: fhirResource,
-                                    contextData
-                                });
-                                // Only claim the criteria once the insert is actually queued --
-                                // if insertOneAsync had thrown instead, nothing was created, so a
-                                // later duplicate line in this batch must still be free to try.
+                                pendingMergeResources.push({ fhirResource, byteOffset });
+                                // Only claim the criteria once the merge is actually queued --
+                                // if mergeBufferedResourceAsync later fails, nothing was created,
+                                // so a later duplicate line in this batch must still be free to try.
                                 if (ifNoneExistKey) {
                                     claimedIfNoneExistKeys.add(ifNoneExistKey);
                                 }

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -16,6 +16,7 @@ const { MergeManager } = require('../../merge/mergeManager');
 const { DatabaseBulkLoader } = require('../../../dataLayer/databaseBulkLoader');
 const { SourceAssigningAuthorityColumnHandler } = require('../../../preSaveHandlers/handlers/sourceAssigningAuthorityColumnHandler');
 const { UuidColumnHandler } = require('../../../preSaveHandlers/handlers/uuidColumnHandler');
+const { WriteAllowedByScopesValidator } = require('../../merge/validators/writeAllowedByScopesValidator');
 const { SecurityTagSystem } = require('../../../utils/securityTagSystem');
 const { BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY, STRICT_SEARCH_HANDLING } = require('../../../constants');
 const { PostRequestProcessor } = require('../../../utils/postRequestProcessor');
@@ -96,6 +97,7 @@ class BulkImportHandler {
      * @property {DatabaseBulkLoader} databaseBulkLoader
      * @property {SourceAssigningAuthorityColumnHandler} sourceAssigningAuthorityColumnHandler
      * @property {UuidColumnHandler} uuidColumnHandler
+     * @property {WriteAllowedByScopesValidator} writeAllowedByScopesValidator
      *
      * @param {ConstructorParams}
      */
@@ -115,7 +117,8 @@ class BulkImportHandler {
         mergeManager,
         databaseBulkLoader,
         sourceAssigningAuthorityColumnHandler,
-        uuidColumnHandler
+        uuidColumnHandler,
+        writeAllowedByScopesValidator
     }) {
         this.configManager = configManager;
         assertTypeEquals(configManager, ConfigManager);
@@ -164,6 +167,9 @@ class BulkImportHandler {
 
         this.uuidColumnHandler = uuidColumnHandler;
         assertTypeEquals(uuidColumnHandler, UuidColumnHandler);
+
+        this.writeAllowedByScopesValidator = writeAllowedByScopesValidator;
+        assertTypeEquals(writeAllowedByScopesValidator, WriteAllowedByScopesValidator);
     }
 
     /**
@@ -792,6 +798,15 @@ class BulkImportHandler {
         // PR #2528 review comment (per-line existence-check cost tradeoff).
         let pendingMergeResources = [];
 
+        // ifNoneExist criteria "claimed" by a resource already queued for merge in this
+        // attempt but not yet flushed to Mongo. findExistingResourceForIfNoneExistAsync only
+        // sees committed state, so two wrapped lines with the same match criteria landing in
+        // the same unflushed batch would otherwise both pass the existence check and both get
+        // created. Declared here (not inside readAndProcessRangeAsync) so
+        // mergeBufferedResourceAsync -- a sibling closure, invoked later from
+        // flushBatchAsync -- can unclaim a key if the deferred merge it queued fails.
+        let claimedIfNoneExistKeys = new Set();
+
         const flushBatchAsync = async () => {
             if (pendingMergeResources.length > 0) {
                 // Pre-load once for the whole batch (grouped by resourceType internally) so
@@ -802,8 +817,19 @@ class BulkImportHandler {
                     base_version,
                     requestedResources: pendingMergeResources.map((p) => p.fhirResource)
                 });
-                for (const { fhirResource, byteOffset } of pendingMergeResources) {
-                    await mergeBufferedResourceAsync({ fhirResource, byteOffset });
+                // Tracks _uuids already processed earlier in THIS flush -- databaseBulkLoader's
+                // preload only reflects committed DB state, so two lines in the same unflushed
+                // batch that resolve to the same _uuid (a literal duplicate, or two lines whose
+                // id+sourceAssigningAuthority hash to the same UUID) would otherwise both see
+                // wasExisting=false and both get counted/audited as created, even though
+                // fastDatabaseBulkInserter correctly routes the second write to an update.
+                const uuidsSeenThisFlush = new Set();
+                for (const { fhirResource, byteOffset, ifNoneExistKey } of pendingMergeResources) {
+                    const wasSeenEarlierThisFlush = uuidsSeenThisFlush.has(fhirResource._uuid);
+                    uuidsSeenThisFlush.add(fhirResource._uuid);
+                    await mergeBufferedResourceAsync({
+                        fhirResource, byteOffset, ifNoneExistKey, forceUpdated: wasSeenEarlierThisFlush
+                    });
                 }
                 pendingMergeResources = [];
             }
@@ -820,16 +846,46 @@ class BulkImportHandler {
          * @param {Object} params
          * @param {Object} params.fhirResource
          * @param {number} params.byteOffset
+         * @param {string|null} [params.ifNoneExistKey] - already claimed in
+         *   claimedIfNoneExistKeys by the caller; unclaimed here on any failure path so a
+         *   later duplicate line in this same range isn't permanently blocked from trying
+         *   again for a resource that was never actually created.
+         * @param {boolean} [params.forceUpdated] - true when an earlier line in this same
+         *   unflushed batch already resolved to the same _uuid. databaseBulkLoader's preload
+         *   only reflects committed state, so without this override every same-batch
+         *   duplicate would see wasExisting=false and get double-counted/audited as created,
+         *   even though the underlying ordered bulk write correctly applies the second one as
+         *   an update against the first's just-buffered document.
          * @returns {Promise<void>}
          */
-        const mergeBufferedResourceAsync = async ({ fhirResource, byteOffset }) => {
-            const wasExisting = !!this.databaseBulkLoader.getResourceFromExistingList({
+        const mergeBufferedResourceAsync = async ({ fhirResource, byteOffset, ifNoneExistKey = null, forceUpdated = false }) => {
+            const wasExisting = forceUpdated || !!this.databaseBulkLoader.getResourceFromExistingList({
                 requestId: requestInfo.requestId,
                 resourceType: fhirResource.resourceType,
                 uuid: fhirResource._uuid
             });
 
             try {
+                // mergeManager.mergeResourceAsync trusts its caller to have already enforced
+                // scopes -- the real $merge API path always runs WriteAllowedByScopesValidator
+                // before ever reaching mergeManager. Without this, an id colliding with
+                // another tenant's real _uuid (e.g. isUuid(fhirResource.id) above) could be
+                // merged into that tenant's resource with no access-tag check at all.
+                const { preCheckErrors: scopeErrors } = await this.writeAllowedByScopesValidator.validate({
+                    requestInfo,
+                    incomingResources: [fhirResource],
+                    base_version,
+                    effectiveSmartMerge: true
+                });
+                if (scopeErrors.length > 0) {
+                    failed++;
+                    mergeResultEntries.push(...scopeErrors);
+                    if (ifNoneExistKey) {
+                        claimedIfNoneExistKeys.delete(ifNoneExistKey);
+                    }
+                    return;
+                }
+
                 const validationFailure = await this.mergeManager.mergeResourceAsync({
                     resourceToMerge: fhirResource,
                     resourceType: fhirResource.resourceType,
@@ -840,6 +896,9 @@ class BulkImportHandler {
                 if (validationFailure) {
                     failed++;
                     mergeResultEntries.push(validationFailure);
+                    if (ifNoneExistKey) {
+                        claimedIfNoneExistKeys.delete(ifNoneExistKey);
+                    }
                 } else if (wasExisting) {
                     updated++;
                     mergeResultEntries.push(new MergeResultEntry({
@@ -873,6 +932,9 @@ class BulkImportHandler {
                         error: mergeError, resource: fhirResource, sourceByteOffset: byteOffset
                     });
                 mergeResultEntries.push(entryFromError);
+                if (ifNoneExistKey) {
+                    claimedIfNoneExistKeys.delete(ifNoneExistKey);
+                }
                 logError('Failed to merge bulk import resource', {
                     taskId,
                     filepath,
@@ -896,13 +958,7 @@ class BulkImportHandler {
             byteOffsetByUuid.clear();
             hasFlushedThisAttempt = false;
             pendingMergeResources = [];
-
-            // ifNoneExist criteria "claimed" by a resource already queued for insert in this
-            // attempt but not yet flushed to Mongo. findExistingResourceForIfNoneExistAsync
-            // only sees committed state, so two wrapped lines with the same match criteria
-            // landing in the same unflushed batch would otherwise both pass the existence
-            // check and both get created.
-            const claimedIfNoneExistKeys = new Set();
+            claimedIfNoneExistKeys = new Set();
 
             try {
                 for await (const { lineNumber, byteOffset, resource, parseError } of this.s3NdjsonReader.readNdjsonAsync({
@@ -1001,13 +1057,18 @@ class BulkImportHandler {
                                     ifNoneExist: resource.ifNoneExist
                                 });
                             } else {
-                                pendingMergeResources.push({ fhirResource, byteOffset });
-                                // Only claim the criteria once the merge is actually queued --
-                                // if mergeBufferedResourceAsync later fails, nothing was created,
-                                // so a later duplicate line in this batch must still be free to try.
+                                // Claim immediately so a duplicate line later in this same
+                                // unflushed batch sees it, but pass the key through to
+                                // mergeBufferedResourceAsync (run later, from flushBatchAsync)
+                                // so it can UNCLAIM if the deferred merge itself fails --
+                                // otherwise a validation/scope failure here would permanently
+                                // (for the rest of this range) block any later duplicate line
+                                // with the same criteria from ever being tried again, since
+                                // nothing was actually created.
                                 if (ifNoneExistKey) {
                                     claimedIfNoneExistKeys.add(ifNoneExistKey);
                                 }
+                                pendingMergeResources.push({ fhirResource, byteOffset, ifNoneExistKey });
                             }
                         } catch (resourceError) {
                             failed++;

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -909,7 +909,8 @@ class BulkImportHandler {
                         created: false,
                         updated: true,
                         issue: null,
-                        operationOutcome: null
+                        operationOutcome: null,
+                        sourceByteOffset: byteOffset
                     }));
                 } else {
                     created++;
@@ -921,7 +922,8 @@ class BulkImportHandler {
                         created: true,
                         updated: false,
                         issue: null,
-                        operationOutcome: null
+                        operationOutcome: null,
+                        sourceByteOffset: byteOffset
                     }));
                 }
             } catch (mergeError) {

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -12,7 +12,10 @@ const makeCloudEvent = (overrides = {}) => {
         totalRanges: 1,
         taskTotalRanges: 1,
         requestId: 'req-001',
-        scope: 'user/*.write',
+        // mergeManager.mergeResourceAsync is now scope-checked the same way $merge's API
+        // path is (WriteAllowedByScopesValidator) -- a plain 'user/*.write' scope has no
+        // access-tag grant and gets rejected as forbidden, same as it would via $merge.
+        scope: 'user/*.write access/*.*',
         user: 'test-user',
         ...overrides
     };
@@ -290,7 +293,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             value: makeCloudEvent({
                 taskId: 'import-consumer-audit',
                 user: 'bulk-import-service-account',
-                scope: 'user/*.write',
+                scope: 'user/*.write access/*.*',
                 alternateUserId: 'bulk-import-alt-id',
                 isUser: true,
                 remoteIpAddress: '10.0.0.1'


### PR DESCRIPTION
## Summary
- `$import`'s per-resource write previously went through `fastDatabaseBulkInserter.insertOneAsync`, which skips FHIR schema validation and silently no-ops (while still reporting `created: true`) when a line's `_uuid` already exists in Mongo.
- Routes the write through `mergeManager.mergeResourceAsync` instead — the same entrypoint `$merge`/direct API writes use, so `$import` and `$merge` now share validation, existence-check, and write semantics (per Shubham's review on #2528).
- Adds a per-batch `databaseBulkLoader.loadResourcesAsync` preload so the existence check that `mergeResourceAsync` does is one query per resourceType per batch, not one `fastFindOneAsync` round trip per line.
- `ifNoneExist` conditional-create skip logic is unchanged (orthogonal to this swap).

## Test plan
- [x] `src/tests/asyncJobs/bulkImport/handlerWorker.test.js` — 37/37 pass
- [x] Regression sweep: bulk import (worker + orchestrator), `merge.test.js`, `mergeManager.test.js` — 151/151 pass
- [x] Lint clean on changed files