### PR TITLE
BAI-447 Track bulk import range completion via worker-to-orchestrator events

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -307,6 +307,10 @@ module.exports = {
     CLOUD_EVENT: {
         SOURCE: 'https://www.icanbwell.com/fhir-server'
     },
+    BULK_IMPORT_TASK: {
+        TYPE_SYSTEM: 'https://www.icanbwell.com/task-type',
+        TYPE_CODE: 'bulk-import'
+    },
     CACHE_STATUS: {
         HIT: 'Hit',
         MISS: 'Miss'

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -1284,12 +1284,19 @@ const createContainer = function () {
         searchQueryBuilder: c.searchQueryBuilder
     }));
 
-    // Routes messages on kafkaBulkImportTaskCreatedTopic to their handler by CloudEvent
-    // "type". TaskCreated is the only registered handler today; new event types on this
-    // topic are added here as another entry rather than a new topic+entrypoint+handler.
+    // Routes messages on kafkaBulkImportTaskCreatedTopic and kafkaBulkImportRangeProgressTopic
+    // to their handler by CloudEvent "type" -- the same dispatcher is registered as the job
+    // for both topics in orchestrator.js's getJobs, since both are consumed by the
+    // orchestrator and route to the same handler. ImportRangeStarted/ImportRangeCompleted/
+    // ImportRangeFailed are the only place a Task resource is ever written once it exists
+    // (see BulkImportHandler's class docstring); new event types are added here as another
+    // entry rather than a new topic+entrypoint+handler.
     container.register('bulkImportOrchestratorDispatcher', (c) => new KafkaEventDispatcher({
         handlersByEventType: {
-            TaskCreated: c.bulkImportHandler
+            TaskCreated: c.bulkImportHandler,
+            ImportRangeStarted: c.bulkImportHandler,
+            ImportRangeCompleted: c.bulkImportHandler,
+            ImportRangeFailed: c.bulkImportHandler
         }
     }));
 

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -121,6 +121,7 @@ const {BulkExportEventProducer} = require('./utils/bulkExportEventProducer');
 const {ImportOperation} = require('./operations/import/import');
 const {BulkImportEventProducer} = require('./operations/asyncJobs/bulkImport/bulkImportEventProducer');
 const {BulkImportHandler} = require('./operations/asyncJobs/bulkImport/handler');
+const {BulkImportTaskStateMachine} = require('./operations/asyncJobs/bulkImport/bulkImportTaskStateMachine');
 const {KafkaEventDispatcher} = require('./operations/common/kafkaEventDispatcher');
 const {S3NdjsonReader} = require('./operations/asyncJobs/bulkImport/s3NdjsonReader');
 const {KafkaClientV2} = require('./utils/kafkaClientV2');
@@ -1266,6 +1267,12 @@ const createContainer = function () {
         configManager: c.configManager
     }));
 
+    container.register('bulkImportTaskStateMachine', (c) => new BulkImportTaskStateMachine({
+        databaseQueryFactory: c.databaseQueryFactory,
+        fastDatabaseBulkInserter: c.fastDatabaseBulkInserter,
+        mergeManager: c.mergeManager
+    }));
+
     // Handles every message type for the bulk-import async job (TaskCreated on the
     // orchestrator side, ImportRangeRequested on the worker side) — see
     // src/operations/asyncJobs/bulkImport/handler.js.
@@ -1273,8 +1280,8 @@ const createContainer = function () {
         configManager: c.configManager,
         kafkaClientV2: c.kafkaClientV2,
         bulkImportEventProducer: c.bulkImportEventProducer,
+        bulkImportTaskStateMachine: c.bulkImportTaskStateMachine,
         databaseQueryFactory: c.databaseQueryFactory,
-        databaseUpdateFactory: c.databaseUpdateFactory,
         fastDatabaseBulkInserter: c.fastDatabaseBulkInserter,
         s3NdjsonReader: c.s3NdjsonReader,
         postRequestProcessor: c.postRequestProcessor,

--- a/src/operations/asyncJobs/bulkImport/bulkImportEventProducer.js
+++ b/src/operations/asyncJobs/bulkImport/bulkImportEventProducer.js
@@ -38,6 +38,18 @@ class BulkImportEventProducer {
     }
 
     /**
+     * Total byte-range count across every input file -- the same count
+     * publishImportEventsAsync will publish one ImportRangeRequested message per. The
+     * orchestrator needs this task-wide total (not any single file's own range count) to know
+     * when every range of every file has reported completion.
+     * @param {Array<{url: string, fileSize: number}>} inputs
+     * @returns {number}
+     */
+    calculateTotalRangeCount(inputs) {
+        return inputs.reduce((total, input) => total + this.calculateByteRanges(input.fileSize).length, 0);
+    }
+
+    /**
      * Publishes ImportRangeRequested Kafka messages for each byte-range of each file
      * @param {Object} params
      * @param {string} params.taskId
@@ -57,6 +69,11 @@ class BulkImportEventProducer {
 
         const topic = this.configManager.kafkaBulkImportEventTopic;
         const messages = [];
+        // Task-wide total, distinct from each file's own ranges.length below (used for
+        // per-file output naming) -- the orchestrator needs this to know when every range of
+        // every input file has reported completion, since no single ImportRangeRequested
+        // event otherwise carries a task-wide count.
+        const taskTotalRanges = this.calculateTotalRangeCount(inputs);
 
         for (let inputIndex = 0; inputIndex < inputs.length; inputIndex++) {
             const input = inputs[inputIndex];
@@ -80,6 +97,7 @@ class BulkImportEventProducer {
                         byteRangeEnd: range.end,
                         rangeIndex,
                         totalRanges: ranges.length,
+                        taskTotalRanges,
                         requestId,
                         scope,
                         user,
@@ -117,6 +135,55 @@ class BulkImportEventProducer {
         }
 
         return messages.length;
+    }
+
+    /**
+     * Publishes a single range-progress CloudEvent onto the worker->orchestrator topic. The
+     * orchestrator is the only process that ever writes to a Task once it exists -- workers
+     * report progress here instead of touching the Task themselves, so there's exactly one
+     * writer and no concurrent-update race to resolve.
+     * @param {Object} params
+     * @param {'ImportRangeStarted'|'ImportRangeCompleted'|'ImportRangeFailed'} params.type
+     * @param {Object} params.data
+     * @returns {Promise<void>}
+     */
+    async publishRangeProgressEventAsync({ type, data }) {
+        if (!this.configManager.kafkaV2EnableEvents) {
+            return;
+        }
+
+        const topic = this.configManager.kafkaBulkImportRangeProgressTopic;
+        const cloudEvent = {
+            specversion: '1.0',
+            id: generateUUID(),
+            source: 'https://www.icanbwell.com/fhir-server',
+            type,
+            datacontenttype: 'application/json',
+            data
+        };
+
+        try {
+            await this.kafkaClientV2.sendCloudEventMessageAsync({
+                topic,
+                messages: [{
+                    // Keyed by taskId alone (not per-range like ImportRangeRequested) so every
+                    // progress report for one Task lands on the same partition -- the
+                    // orchestrator still processes them one at a time via Kafka's per-partition
+                    // ordering, but this keeps a single Task's reports from being reordered
+                    // relative to each other across partitions.
+                    key: data.taskId,
+                    value: JSON.stringify(cloudEvent)
+                }]
+            });
+        } catch (e) {
+            logError('Failed to publish bulk import range-progress event', {
+                type,
+                taskId: data.taskId,
+                topic,
+                error: e.message
+            });
+            throw e;
+        }
     }
 }
 

--- a/src/operations/asyncJobs/bulkImport/bulkImportEventProducer.js
+++ b/src/operations/asyncJobs/bulkImport/bulkImportEventProducer.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const { generateUUID } = require('../../../utils/uid.util');
 const { assertTypeEquals } = require('../../../utils/assertType');
 const { KafkaClientV2 } = require('../../../utils/kafkaClientV2');
@@ -138,10 +139,35 @@ class BulkImportEventProducer {
     }
 
     /**
+     * HMAC-SHA256 signs a range-progress event's data payload with the shared worker secret,
+     * so the orchestrator can verify a message actually came from a trusted worker rather than
+     * trusting taskId/status-affecting fields from anyone able to publish onto the topic.
+     * @param {Object} data
+     * @returns {string} hex-encoded signature
+     */
+    signRangeProgressPayload(data) {
+        const workerSecret = this.configManager.bulkImportWorkerSecret;
+        if (!workerSecret) {
+            throw new Error(
+                'bulkImportWorkerSecret is not configured -- refusing to publish an unsigned ' +
+                'range-progress event (BULK_IMPORT_WORKER_SECRET must be set before this worker ' +
+                'can report range progress)'
+            );
+        }
+        return crypto.createHmac('sha256', workerSecret).update(JSON.stringify(data)).digest('hex');
+    }
+
+    /**
      * Publishes a single range-progress CloudEvent onto the worker->orchestrator topic. The
      * orchestrator is the only process that ever writes to a Task once it exists -- workers
      * report progress here instead of touching the Task themselves, so there's exactly one
      * writer and no concurrent-update race to resolve.
+     *
+     * The payload is HMAC-signed (signRangeProgressPayload) before publishing -- without this,
+     * anyone able to publish onto kafkaBulkImportRangeProgressTopic could forge an
+     * ImportRangeCompleted/Failed message with an arbitrary taskId and manipulate any Task's
+     * status/output, since the orchestrator otherwise has no other way to authenticate the
+     * message's origin.
      * @param {Object} params
      * @param {'ImportRangeStarted'|'ImportRangeCompleted'|'ImportRangeFailed'} params.type
      * @param {Object} params.data
@@ -153,13 +179,14 @@ class BulkImportEventProducer {
         }
 
         const topic = this.configManager.kafkaBulkImportRangeProgressTopic;
+        const signedData = { ...data, signature: this.signRangeProgressPayload(data) };
         const cloudEvent = {
             specversion: '1.0',
             id: generateUUID(),
             source: 'https://www.icanbwell.com/fhir-server',
             type,
             datacontenttype: 'application/json',
-            data
+            data: signedData
         };
 
         try {

--- a/src/operations/asyncJobs/bulkImport/bulkImportEventProducer.js
+++ b/src/operations/asyncJobs/bulkImport/bulkImportEventProducer.js
@@ -3,6 +3,7 @@ const { assertTypeEquals } = require('../../../utils/assertType');
 const { KafkaClientV2 } = require('../../../utils/kafkaClientV2');
 const { ConfigManager } = require('../../../utils/configManager');
 const { logInfo, logError } = require('../../common/logging');
+const { CLOUD_EVENT } = require('../../../constants');
 
 class BulkImportEventProducer {
     /**
@@ -86,7 +87,7 @@ class BulkImportEventProducer {
                 const cloudEvent = {
                     specversion: '1.0',
                     id: eventId,
-                    source: 'https://www.icanbwell.com/fhir-server',
+                    source: CLOUD_EVENT.SOURCE,
                     type: 'ImportRangeRequested',
                     datacontenttype: 'application/json',
                     data: {

--- a/src/operations/asyncJobs/bulkImport/bulkImportEventProducer.js
+++ b/src/operations/asyncJobs/bulkImport/bulkImportEventProducer.js
@@ -1,4 +1,3 @@
-const crypto = require('crypto');
 const { generateUUID } = require('../../../utils/uid.util');
 const { assertTypeEquals } = require('../../../utils/assertType');
 const { KafkaClientV2 } = require('../../../utils/kafkaClientV2');
@@ -139,35 +138,10 @@ class BulkImportEventProducer {
     }
 
     /**
-     * HMAC-SHA256 signs a range-progress event's data payload with the shared worker secret,
-     * so the orchestrator can verify a message actually came from a trusted worker rather than
-     * trusting taskId/status-affecting fields from anyone able to publish onto the topic.
-     * @param {Object} data
-     * @returns {string} hex-encoded signature
-     */
-    signRangeProgressPayload(data) {
-        const workerSecret = this.configManager.bulkImportWorkerSecret;
-        if (!workerSecret) {
-            throw new Error(
-                'bulkImportWorkerSecret is not configured -- refusing to publish an unsigned ' +
-                'range-progress event (BULK_IMPORT_WORKER_SECRET must be set before this worker ' +
-                'can report range progress)'
-            );
-        }
-        return crypto.createHmac('sha256', workerSecret).update(JSON.stringify(data)).digest('hex');
-    }
-
-    /**
      * Publishes a single range-progress CloudEvent onto the worker->orchestrator topic. The
      * orchestrator is the only process that ever writes to a Task once it exists -- workers
      * report progress here instead of touching the Task themselves, so there's exactly one
      * writer and no concurrent-update race to resolve.
-     *
-     * The payload is HMAC-signed (signRangeProgressPayload) before publishing -- without this,
-     * anyone able to publish onto kafkaBulkImportRangeProgressTopic could forge an
-     * ImportRangeCompleted/Failed message with an arbitrary taskId and manipulate any Task's
-     * status/output, since the orchestrator otherwise has no other way to authenticate the
-     * message's origin.
      * @param {Object} params
      * @param {'ImportRangeStarted'|'ImportRangeCompleted'|'ImportRangeFailed'} params.type
      * @param {Object} params.data
@@ -179,14 +153,13 @@ class BulkImportEventProducer {
         }
 
         const topic = this.configManager.kafkaBulkImportRangeProgressTopic;
-        const signedData = { ...data, signature: this.signRangeProgressPayload(data) };
         const cloudEvent = {
             specversion: '1.0',
             id: generateUUID(),
             source: 'https://www.icanbwell.com/fhir-server',
             type,
             datacontenttype: 'application/json',
-            data: signedData
+            data
         };
 
         try {

--- a/src/operations/asyncJobs/bulkImport/bulkImportTaskStateMachine.js
+++ b/src/operations/asyncJobs/bulkImport/bulkImportTaskStateMachine.js
@@ -1,0 +1,248 @@
+const moment = require('moment-timezone');
+const { assertTypeEquals } = require('../../../utils/assertType');
+const { DatabaseQueryFactory } = require('../../../dataLayer/databaseQueryFactory');
+const { FastDatabaseBulkInserter } = require('../../../dataLayer/fastDatabaseBulkInserter');
+const { MergeManager } = require('../../merge/mergeManager');
+const { FhirRequestInfo } = require('../../../utils/fhirRequestInfo');
+const { generateUUID } = require('../../../utils/uid.util');
+const { BULK_IMPORT_TASK } = require('../../../constants');
+const { logError } = require('../../common/logging');
+
+/**
+ * Handles the Task resource state machine for bulk import orchestration.
+ *
+ * The orchestrator is the only process that ever writes a Task's status/output once it exists --
+ * workers publish range-progress events and this class processes them, so there is exactly one
+ * writer and no concurrent-update race to resolve.
+ *
+ * Task writes go through mergeManager.mergeResourceAsync (the same path as $merge API writes)
+ * for consistent validation, upsert semantics, and pre/post-save handling. After each
+ * mergeResourceAsync call, fastDatabaseBulkInserter.executeAsync is called to flush the
+ * buffered write to MongoDB immediately (the same pattern $merge uses).
+ */
+class BulkImportTaskStateMachine {
+    /**
+     * @param {Object} params
+     * @param {DatabaseQueryFactory} params.databaseQueryFactory
+     * @param {FastDatabaseBulkInserter} params.fastDatabaseBulkInserter
+     * @param {MergeManager} params.mergeManager
+     */
+    constructor({ databaseQueryFactory, fastDatabaseBulkInserter, mergeManager }) {
+        this.databaseQueryFactory = databaseQueryFactory;
+        assertTypeEquals(databaseQueryFactory, DatabaseQueryFactory);
+
+        this.fastDatabaseBulkInserter = fastDatabaseBulkInserter;
+        assertTypeEquals(fastDatabaseBulkInserter, FastDatabaseBulkInserter);
+
+        this.mergeManager = mergeManager;
+        assertTypeEquals(mergeManager, MergeManager);
+    }
+
+    /**
+     * Builds a FhirRequestInfo for orchestrator-initiated Task writes.
+     * The orchestrator runs as a service principal with no user/scope context.
+     * @returns {FhirRequestInfo}
+     */
+    buildOrchestratorRequestInfo() {
+        return new FhirRequestInfo({
+            user: null,
+            scope: null,
+            remoteIpAddress: null,
+            requestId: generateUUID(),
+            userRequestId: null,
+            protocol: 'kafka',
+            originalUrl: '$import',
+            path: '$import',
+            host: null,
+            body: null,
+            accept: 'application/fhir+json',
+            isUser: false,
+            userType: null,
+            personIdFromJwtToken: null,
+            masterPersonIdFromJwtToken: null,
+            managingOrganizationId: null,
+            headers: {},
+            method: 'POST',
+            contentTypeFromHeader: null,
+            alternateUserId: null,
+            actor: null,
+            purposeOfUse: null
+        });
+    }
+
+    /**
+     * Loads a bulk-import Task by id. Restricts the query to Tasks carrying the bulk-import
+     * code so a message with an arbitrary taskId cannot mutate a non-import Task.
+     * @param {string} taskId
+     * @returns {Promise<Object|null>}
+     */
+    async loadTaskAsync(taskId) {
+        const databaseQueryManager = this.databaseQueryFactory.createQuery({
+            resourceType: 'Task',
+            base_version: '4_0_0'
+        });
+        return databaseQueryManager.findOneAsync({
+            query: {
+                id: taskId,
+                'code.coding': {
+                    $elemMatch: {
+                        system: BULK_IMPORT_TASK.TYPE_SYSTEM,
+                        code: BULK_IMPORT_TASK.TYPE_CODE
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Writes an updated Task through the merge flow (mergeManager.mergeResourceAsync),
+     * which handles FHIR validation, proper upsert semantics, and pre/post-save processing.
+     * @param {Object} task - cloned Task resource with updated fields already applied
+     * @returns {Promise<void>}
+     */
+    async writeTaskAsync(task) {
+        const requestInfo = this.buildOrchestratorRequestInfo();
+        // mergeResourceAsync validates against the FHIR JSON schema, which expects date/dateTime
+        // fields as ISO strings, not Date objects. Serialize via toJSONInternal + JSON roundtrip
+        // to convert all Date values to strings before the validator sees them.
+        const taskJson = JSON.parse(JSON.stringify(task.toJSONInternal()));
+        const result = await this.mergeManager.mergeResourceAsync({
+            resourceToMerge: taskJson,
+            resourceType: 'Task',
+            base_version: '4_0_0',
+            requestInfo
+        });
+        if (result) {
+            logError('Task merge returned a validation failure during orchestrator write', {
+                taskId: task.id,
+                error: result.issue?.[0]?.diagnostics
+            });
+            return;
+        }
+        // mergeResourceAsync buffers the write in FastDatabaseBulkInserter;
+        // flush it now so the Task is persisted before this call returns.
+        await this.fastDatabaseBulkInserter.executeAsync({
+            requestInfo,
+            base_version: '4_0_0'
+        });
+    }
+
+    /**
+     * Updates a Task's status (and optional statusReason) through the merge flow.
+     * @param {Object} task
+     * @param {string} status
+     * @param {string} [statusReason]
+     * @returns {Promise<void>}
+     */
+    async updateTaskStatusAsync(task, status, statusReason) {
+        const updated = task.clone();
+        updated.status = status;
+        updated.meta.lastUpdated = new Date(moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
+        if (statusReason) {
+            if (!updated.statusReason) {
+                updated.statusReason = {};
+            }
+            updated.statusReason.text = statusReason;
+        }
+        await this.writeTaskAsync(updated);
+    }
+
+    /**
+     * Flips a Task from 'requested' to 'in-progress' the first time any range reports
+     * having started. No-op if the Task is already past 'requested'.
+     * @param {Object} task
+     * @returns {Promise<void>}
+     */
+    async handleRangeStartedAsync(task) {
+        if (task.status !== 'requested') {
+            return;
+        }
+        await this.updateTaskStatusAsync(task, 'in-progress');
+    }
+
+    /**
+     * Marks a Task 'failed', unless it already reached 'completed' -- a late-arriving or
+     * redelivered failure report must not regress an already-completed Task.
+     * @param {Object} task
+     * @param {string} [errorMessage]
+     * @returns {Promise<void>}
+     */
+    async handleRangeFailedAsync(task, errorMessage) {
+        if (task.status === 'completed') {
+            return;
+        }
+        await this.updateTaskStatusAsync(task, 'failed', errorMessage);
+    }
+
+    /**
+     * Appends this range's result/error S3 URIs to Task.output, then flips the Task to
+     * 'completed' once every range of every input file has reported in.
+     * @param {Object} task
+     * @param {Object} params
+     * @param {string} params.filepath
+     * @param {number} params.rangeIndex
+     * @param {number} params.taskTotalRanges
+     * @param {string|null} params.resultUri
+     * @param {string|null} params.errorUri
+     * @returns {Promise<void>}
+     */
+    async handleRangeCompletedAsync(task, { filepath, rangeIndex, taskTotalRanges, resultUri, errorUri }) {
+        if (task.status === 'completed') {
+            return;
+        }
+
+        const rangeEntryId = this.buildRangeOutputEntryId({ filepath, rangeIndex });
+        const alreadyRecorded = (task.output || []).some((o) =>
+            typeof o.id === 'string' && (o.id === rangeEntryId || o.id.startsWith(`${rangeEntryId}-`))
+        );
+        if (alreadyRecorded) {
+            return;
+        }
+
+        const newOutputs = [];
+        if (resultUri) {
+            newOutputs.push({ id: `${rangeEntryId}-result`, type: { text: 'result' }, valueUri: resultUri });
+        }
+        if (errorUri) {
+            newOutputs.push({ id: `${rangeEntryId}-error`, type: { text: 'error' }, valueUri: errorUri });
+        }
+        if (newOutputs.length === 0) {
+            newOutputs.push({ id: rangeEntryId, type: { text: 'empty' } });
+        }
+
+        const updated = task.clone();
+        updated.output = [...(updated.output || []), ...newOutputs];
+        updated.meta.lastUpdated = new Date(moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
+        await this.writeTaskAsync(updated);
+
+        if (this.countCompletedRanges(updated) >= taskTotalRanges) {
+            await this.updateTaskStatusAsync(updated, 'completed');
+        }
+    }
+
+    /**
+     * The stable id stamped on every Task.output entry for a range's completion report.
+     * @param {Object} params
+     * @param {string} params.filepath
+     * @param {number} params.rangeIndex
+     * @returns {string}
+     */
+    buildRangeOutputEntryId({ filepath, rangeIndex }) {
+        return `bulk-import-range:${filepath}#${rangeIndex}`;
+    }
+
+    /**
+     * Counts distinct ranges already recorded as complete on this Task.
+     * @param {Object} task
+     * @returns {number}
+     */
+    countCompletedRanges(task) {
+        const rangeIds = (task.output || [])
+            .map((o) => o.id)
+            .filter((id) => typeof id === 'string' && id.startsWith('bulk-import-range:'))
+            .map((id) => id.replace(/-(result|error)$/, ''));
+        return new Set(rangeIds).size;
+    }
+}
+
+module.exports = { BulkImportTaskStateMachine };

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -1,4 +1,5 @@
 const { S3Client: S3, HeadObjectCommand } = require('@aws-sdk/client-s3');
+const crypto = require('crypto');
 const querystring = require('querystring');
 const moment = require('moment-timezone');
 const { assertTypeEquals } = require('../../../utils/assertType');
@@ -425,7 +426,46 @@ class BulkImportHandler {
     // ── topic fhir_server.bulk_import.range_progress) ──────────────────────────────────────
 
     /**
-     * Parses an ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed CloudEvent message.
+     * Verifies a range-progress event's HMAC signature (see
+     * BulkImportEventProducer.signRangeProgressPayload) before its data is trusted. Without
+     * this, anyone able to publish onto kafkaBulkImportRangeProgressTopic could forge an
+     * ImportRangeCompleted/Failed message with an arbitrary taskId and manipulate any bulk
+     * import Task's status/output -- this is the ONLY authentication on that topic.
+     * @param {Object} data - envelope.data, including the `signature` field to verify
+     * @throws {Error} if the worker secret isn't configured or the signature doesn't match
+     */
+    verifyRangeProgressSignature(data) {
+        const workerSecret = this.configManager.bulkImportWorkerSecret;
+        if (!workerSecret) {
+            throw new Error(
+                'bulkImportWorkerSecret is not configured -- refusing to trust an unverifiable ' +
+                'range-progress event (BULK_IMPORT_WORKER_SECRET must be set before the ' +
+                'orchestrator can process these)'
+            );
+        }
+
+        const { signature, ...dataToVerify } = data;
+        if (typeof signature !== 'string' || !signature) {
+            throw new Error('Range-progress event is missing its signature');
+        }
+
+        const expectedSignature = crypto.createHmac('sha256', workerSecret)
+            .update(JSON.stringify(dataToVerify))
+            .digest('hex');
+
+        const providedBuffer = Buffer.from(signature, 'hex');
+        const expectedBuffer = Buffer.from(expectedSignature, 'hex');
+        // Buffers of different byte length would throw inside timingSafeEqual -- a forged/
+        // truncated signature must be rejected the same way a merely-wrong one is, not crash.
+        if (providedBuffer.length !== expectedBuffer.length ||
+            !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
+            throw new Error('Range-progress event signature does not match');
+        }
+    }
+
+    /**
+     * Parses an ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed CloudEvent message,
+     * verifying its signature before returning any of its data as trustworthy.
      * @param {string} messageValue
      * @returns {Object} parsed CloudEvent data
      */
@@ -434,6 +474,7 @@ class BulkImportHandler {
         if (!envelope.data || !envelope.data.taskId || !envelope.data.filepath) {
             throw new Error(`Invalid ${envelope.type} event: missing taskId or filepath`);
         }
+        this.verifyRangeProgressSignature(envelope.data);
         return envelope.data;
     }
 

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -32,17 +32,6 @@ const { groupByLambda } = require('../../../utils/list.util');
 const { R4ArgsParser } = require('../../query/r4ArgsParser');
 const { SearchQueryBuilder } = require('../../search/searchQueryBuilder');
 
-/**
- * Extension URL used to record a marker on the Task each time a byte-range finishes
- * processing. Markers accumulate across concurrent consumer pods/files (Task.output/
- * extension array merges are additive — see resourceMerger's array-union semantics) and
- * are the only way to determine when every range of every input file is done, since no
- * single event carries a task-wide range count (ImportRangeRequested's totalRanges is
- * per-file only).
- * @type {string}
- */
-const BULK_IMPORT_RANGE_COMPLETED_EXTENSION_URL = 'https://www.icanbwell.com/bulk-import-range-completed';
-
 const importTracer = trace.getTracer('fhir-server');
 
 /**
@@ -68,14 +57,21 @@ function recordImportSpanAttributes (attributes) {
 
 /**
  * Handles every Kafka message type for the bulk-import async job. Both
- * src/operations/asyncJobs/orchestrator.js (topic fhir_server.bulk_import.requested) and
- * src/operations/asyncJobs/worker.js (topic fhir_server.bulk_import.events) route into this
- * same handler; handleMessageAsync dispatches on the CloudEvent "type" rather than the topic,
- * since a single job's messages can arrive on more than one topic:
- * - TaskCreated: HEADs each S3 input to validate it and get its size, splits it into byte
- *   ranges, and publishes an ImportRangeRequested event per range.
- * - ImportRangeRequested: reads a byte range's NDJSON, merges resources, writes result/error
- *   output to S3, and records completion on the Task.
+ * src/operations/asyncJobs/orchestrator.js (topics fhir_server.bulk_import.requested and
+ * fhir_server.bulk_import.range_progress) and src/operations/asyncJobs/worker.js (topic
+ * fhir_server.bulk_import.events) route into this same handler; handleMessageAsync dispatches
+ * on the CloudEvent "type" rather than the topic, since a single job's messages can arrive on
+ * more than one topic:
+ * - TaskCreated (orchestrator): HEADs each S3 input to validate it and get its size, splits
+ *   it into byte ranges, and publishes an ImportRangeRequested event per range.
+ * - ImportRangeRequested (worker): reads a byte range's NDJSON and merges resources, then
+ *   reports what happened by publishing ImportRangeStarted/ImportRangeCompleted/
+ *   ImportRangeFailed rather than writing to the Task itself.
+ * - ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed (orchestrator): the ONLY writes
+ *   to a Task resource once it exists happen here. Routing every worker report through the
+ *   orchestrator's single consumer means there is exactly one writer for a given Task's
+ *   status/output at any time -- no concurrent-update races between worker pods to resolve,
+ *   and no need for smartMerge array-matching tricks on Task.output/extension.
  */
 class BulkImportHandler {
     /**
@@ -168,6 +164,10 @@ class BulkImportHandler {
                 return this.handleTaskCreatedAsync(message);
             case 'ImportRangeRequested':
                 return this.handleImportRangeRequestedAsync(message);
+            case 'ImportRangeStarted':
+            case 'ImportRangeCompleted':
+            case 'ImportRangeFailed':
+                return this.handleRangeProgressEventAsync(message, envelope.type);
             default:
                 logError('Unexpected bulk import event type', { type: envelope.type, key: message.key });
         }
@@ -421,6 +421,153 @@ class BulkImportHandler {
         });
     }
 
+    // ── ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed (orchestrator side, ──────
+    // ── topic fhir_server.bulk_import.range_progress) ──────────────────────────────────────
+
+    /**
+     * Parses an ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed CloudEvent message.
+     * @param {string} messageValue
+     * @returns {Object} parsed CloudEvent data
+     */
+    parseRangeProgressEvent(messageValue) {
+        const envelope = JSON.parse(messageValue);
+        if (!envelope.data || !envelope.data.taskId || !envelope.data.filepath) {
+            throw new Error(`Invalid ${envelope.type} event: missing taskId or filepath`);
+        }
+        return envelope.data;
+    }
+
+    /**
+     * Handles a range-progress report from a worker. This is the ONLY place a Task resource
+     * is ever written once it exists (see class docstring) -- workers only publish these
+     * events, they never touch the Task themselves, so there is exactly one writer and no
+     * concurrent-update race between worker pods to resolve.
+     * @param {{ key: string, value: string, headers: Array<{key: string, value: string}> }} message
+     * @param {'ImportRangeStarted'|'ImportRangeCompleted'|'ImportRangeFailed'} type
+     * @returns {Promise<void>}
+     */
+    async handleRangeProgressEventAsync(message, type) {
+        let eventData;
+        try {
+            eventData = this.parseRangeProgressEvent(message.value);
+        } catch (e) {
+            logError('Failed to parse bulk import range-progress Kafka message', {
+                error: e.message,
+                key: message.key
+            });
+            return;
+        }
+
+        const { taskId, filepath, rangeIndex } = eventData;
+
+        const task = await this.loadTaskAsync(taskId);
+        if (!task) {
+            logError('Task not found for bulk import range-progress message', { taskId, filepath, rangeIndex });
+            return;
+        }
+
+        switch (type) {
+            case 'ImportRangeStarted':
+                return this.handleRangeStartedAsync(task, eventData);
+            case 'ImportRangeCompleted':
+                return this.handleRangeCompletedAsync(task, eventData);
+            case 'ImportRangeFailed':
+                return this.handleRangeFailedAsync(task, eventData);
+        }
+    }
+
+    /**
+     * Flips a Task from 'requested' to 'in-progress' the first time any range reports having
+     * started. A no-op if the Task is already past 'requested' -- workers report this
+     * unconditionally on every range (see buildRangeRequestInfo's caller), so this is expected
+     * to be called far more than once per Task.
+     * @param {Object} task
+     * @param {Object} eventData
+     * @returns {Promise<void>}
+     */
+    async handleRangeStartedAsync(task, eventData) {
+        if (task.status !== 'requested') {
+            return;
+        }
+        await this.updateOrchestratorTaskStatusAsync(task, 'in-progress');
+    }
+
+    /**
+     * Marks a Task 'failed', unless it already reached 'completed' -- a range that failed
+     * before every other range finished must not regress an already-completed Task if its
+     * failure report arrives late or is redelivered.
+     * @param {Object} task
+     * @param {Object} eventData
+     * @returns {Promise<void>}
+     */
+    async handleRangeFailedAsync(task, eventData) {
+        if (task.status === 'completed') {
+            return;
+        }
+        await this.updateOrchestratorTaskStatusAsync(task, 'failed', eventData.errorMessage);
+    }
+
+    /**
+     * Appends this range's result/error S3 URIs to Task.output (each stamped with
+     * buildRangeOutputEntryId so countCompletedRanges can recognize it), then flips the Task
+     * to 'completed' once every range of every input file has reported in. Since this is the
+     * only process that ever writes a Task's output/status, this is a plain read-modify-write
+     * -- no smartMerge id-matching or optimistic-concurrency retry needed, because there is no
+     * concurrent writer to race against.
+     * @param {Object} task
+     * @param {Object} eventData
+     * @returns {Promise<void>}
+     */
+    async handleRangeCompletedAsync(task, eventData) {
+        const { filepath, rangeIndex, taskTotalRanges, resultUri, errorUri } = eventData;
+
+        if (task.status === 'completed') {
+            // Already-recorded redelivery -- countCompletedRanges below already reflects this
+            // range, and re-appending would double the output entries.
+            return;
+        }
+
+        const rangeEntryId = this.buildRangeOutputEntryId({ filepath, rangeIndex });
+        // Recorded entries carry rangeEntryId as a PREFIX (id is rangeEntryId + '-result'/
+        // '-error', or bare rangeEntryId for the empty-range placeholder) -- never an exact
+        // match on rangeEntryId itself, since a completed range always has at least one
+        // output entry with one of those three exact suffixed/unsuffixed forms.
+        const alreadyRecorded = (task.output || []).some((o) =>
+            typeof o.id === 'string' && (o.id === rangeEntryId || o.id.startsWith(`${rangeEntryId}-`))
+        );
+        if (alreadyRecorded) {
+            return;
+        }
+
+        const newOutputs = [];
+        if (resultUri) {
+            newOutputs.push({ id: `${rangeEntryId}-result`, type: { text: 'result' }, valueUri: resultUri });
+        }
+        if (errorUri) {
+            newOutputs.push({ id: `${rangeEntryId}-error`, type: { text: 'error' }, valueUri: errorUri });
+        }
+        // A range with no created/updated/skipped resources and no failures (an empty range)
+        // still needs to be counted as complete -- stamp a placeholder entry so
+        // countCompletedRanges sees it even with no S3 output to point at.
+        if (newOutputs.length === 0) {
+            newOutputs.push({ id: rangeEntryId, type: { text: 'empty' } });
+        }
+
+        const updated = task.clone();
+        updated.output = [...(updated.output || []), ...newOutputs];
+        updated.meta.lastUpdated = new Date(moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
+
+        const databaseUpdateManager = this.databaseUpdateFactory.createDatabaseUpdateManager({
+            resourceType: 'Task',
+            base_version: '4_0_0'
+        });
+        await databaseUpdateManager.updateOneAsync({ doc: updated });
+
+        if (this.countCompletedRanges(updated) >= taskTotalRanges) {
+            await this.updateOrchestratorTaskStatusAsync(updated, 'completed');
+        }
+    }
+
     // ── ImportRangeRequested (worker side, topic fhir_server.bulk_import.events) ───────────
 
     /**
@@ -498,36 +645,6 @@ class BulkImportHandler {
     }
 
     /**
-     * Updates the Task status in MongoDB. Uses replaceOneAsync's optimistic-concurrency
-     * merge (not a raw full-document replace) since multiple consumer pods update the
-     * same Task concurrently — a raw replace built from a stale snapshot would silently
-     * wipe out another pod's already-committed output/extension entries.
-     * @param {Object} task
-     * @param {string} status
-     * @param {string} [statusReason]
-     * @param {FhirRequestInfo} requestInfo
-     * @returns {Promise<void>}
-     */
-    async updateTaskStatusAsync(task, status, statusReason, requestInfo) {
-        const databaseUpdateManager = this.databaseUpdateFactory.createDatabaseUpdateManager({
-            resourceType: 'Task',
-            base_version: '4_0_0'
-        });
-
-        const updated = task.clone();
-        updated.status = status;
-        updated.meta.lastUpdated = new Date(moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
-        if (statusReason) {
-            if (!updated.statusReason) {
-                updated.statusReason = {};
-            }
-            updated.statusReason.text = statusReason;
-        }
-
-        await databaseUpdateManager.replaceOneAsync({ base_version: '4_0_0', requestInfo, doc: updated });
-    }
-
-    /**
      * Splits an S3 key (relative to its bucket) into a result and an error output key
      * for the given range, nesting both under an "output/" prefix alongside the input file.
      * e.g. "run-20260521/Patient.ndjson" + rangeIndex 0 -> "run-20260521/output/Patient-001.ndjson"
@@ -555,37 +672,33 @@ class BulkImportHandler {
     }
 
     /**
-     * Whether every byte-range of every input file on this Task has recorded a
-     * completion marker. Cross-references Task.input (fixed at Task creation) against
-     * the completion markers accumulated in Task.extension.
-     * @param {Object} task
-     * @returns {boolean}
+     * The stable id stamped on every Task.output entry a range's completion report adds,
+     * shared by its result/error pair. Since the orchestrator is the only writer of Task.output
+     * (see handleRangeProgressEventAsync), this doesn't need smartMerge id-matching to dedupe --
+     * it's just how countCompletedRanges below recognizes "one range" among possibly-multiple
+     * output entries (result + error) per range.
+     * @param {Object} params
+     * @param {string} params.filepath
+     * @param {number} params.rangeIndex
+     * @returns {string}
      */
-    isTaskFullyComplete(task) {
-        const inputUrls = (task.input || []).map((i) => i.valueUri).filter(Boolean);
-        if (inputUrls.length === 0) {
-            return false;
-        }
+    buildRangeOutputEntryId({ filepath, rangeIndex }) {
+        return `bulk-import-range:${filepath}#${rangeIndex}`;
+    }
 
-        const markers = (task.extension || [])
-            .filter((e) => e.url === BULK_IMPORT_RANGE_COMPLETED_EXTENSION_URL && e.valueString)
-            .map((e) => {
-                try {
-                    return JSON.parse(e.valueString);
-                } catch (parseError) {
-                    return null;
-                }
-            })
-            .filter(Boolean);
-
-        return inputUrls.every((url) => {
-            const fileMarkers = markers.filter((m) => m.filepath === url);
-            if (fileMarkers.length === 0) {
-                return false;
-            }
-            const distinctRanges = new Set(fileMarkers.map((m) => m.rangeIndex));
-            return distinctRanges.size === fileMarkers[0].totalRanges;
-        });
+    /**
+     * Counts distinct ranges already recorded as complete on this Task, by their
+     * buildRangeOutputEntryId prefix (ignoring the -result/-error suffix that distinguishes a
+     * range's two possible output entries).
+     * @param {Object} task
+     * @returns {number}
+     */
+    countCompletedRanges(task) {
+        const rangeIds = (task.output || [])
+            .map((o) => o.id)
+            .filter((id) => typeof id === 'string' && id.startsWith('bulk-import-range:'))
+            .map((id) => id.replace(/-(result|error)$/, ''));
+        return new Set(rangeIds).size;
     }
 
     /**
@@ -672,35 +785,24 @@ class BulkImportHandler {
     }
 
     /**
-     * Writes this range's merge-result (and error, if any) NDJSON to S3, appends
-     * Task.output entries pointing at them, and records a completion marker so
-     * isTaskFullyComplete() can detect when every range of every file is done.
-     * Throws (after retries) rather than swallowing failures — the caller must let
-     * this propagate so an unacknowledged Kafka message gets redelivered instead of
-     * a range silently never recording its marker (which would permanently block
-     * the Task from ever reaching 'completed'). Redelivery is safe: the underlying
-     * MongoDB writes for this range are idempotent merges.
+     * Writes this range's merge-result (and error, if any) NDJSON to S3, then reports the
+     * range as complete by publishing ImportRangeCompleted -- this worker never writes to the
+     * Task itself; the orchestrator (the sole Task writer) appends the resulting S3 URIs to
+     * Task.output and decides when every range has reported in. Throws (after S3 write
+     * retries) rather than swallowing failures — the caller must let this propagate so an
+     * unacknowledged Kafka message gets redelivered instead of a range silently never
+     * reporting completion (which would permanently block the Task from ever reaching
+     * 'completed'). Redelivery is safe: both the underlying MongoDB writes and the
+     * orchestrator's own output-recording are idempotent.
      * @param {Object} params
      * @param {string} params.taskId
      * @param {string} params.filepath
      * @param {number} params.rangeIndex
-     * @param {number} params.totalRanges
+     * @param {number} params.taskTotalRanges
      * @param {import('../../common/mergeResultEntry').MergeResultEntry[]} params.mergeResultEntries
-     * @param {FhirRequestInfo} params.requestInfo
      * @returns {Promise<void>}
      */
-    async recordRangeCompletionAsync({ taskId, filepath, rangeIndex, totalRanges, mergeResultEntries, requestInfo }) {
-        // Reload fresh rather than reusing the Task loaded at the top of handleImportRangeRequestedAsync —
-        // that snapshot can be minutes stale by the time a large range finishes, and
-        // replaceOneAsync's merge takes scalar fields (e.g. status) from OUR doc when they
-        // differ from the DB, so a stale snapshot here could silently regress a concurrent
-        // status change.
-        const task = await this.loadTaskAsync(taskId);
-        if (!task) {
-            logError('Task disappeared before range completion could be recorded', { taskId, filepath, rangeIndex });
-            return;
-        }
-
+    async reportRangeCompletedAsync({ taskId, filepath, rangeIndex, taskTotalRanges, mergeResultEntries }) {
         const { bucket, key } = this.s3NdjsonReader.parseS3Uri(filepath);
         const { resultKey, errorKey } = this.buildRangeOutputKeys({ key, rangeIndex });
 
@@ -710,54 +812,29 @@ class BulkImportHandler {
         // Restore source order before writing output so position always matches the input file.
         mergeResultEntries.sort((a, b) => (a.sourceByteOffset ?? 0) - (b.sourceByteOffset ?? 0));
 
-        const newOutputs = [];
+        let resultUri = null;
         if (mergeResultEntries.length > 0) {
-            const resultUri = `s3://${bucket}/${resultKey}`;
+            resultUri = `s3://${bucket}/${resultKey}`;
             await this.writeNdjsonWithRetryAsync({
                 filepath: resultUri,
                 data: this.buildNdjson(mergeResultEntries)
             });
-            newOutputs.push({ type: { text: 'result' }, valueUri: resultUri });
         }
 
+        let errorUri = null;
         const failedEntries = mergeResultEntries.filter((entry) => entry.operationOutcome);
         if (failedEntries.length > 0) {
-            const errorUri = `s3://${bucket}/${errorKey}`;
+            errorUri = `s3://${bucket}/${errorKey}`;
             await this.writeNdjsonWithRetryAsync({
                 filepath: errorUri,
                 data: this.buildNdjson(failedEntries)
             });
-            newOutputs.push({ type: { text: 'error' }, valueUri: errorUri });
         }
 
-        const updated = task.clone();
-        updated.output = [...(updated.output || []), ...newOutputs];
-        updated.extension = [
-            ...(updated.extension || []),
-            {
-                url: BULK_IMPORT_RANGE_COMPLETED_EXTENSION_URL,
-                // JSON-encoded rather than a delimited string — '|' is a legal S3 key
-                // character and would otherwise corrupt parsing for a pathological filepath.
-                valueString: JSON.stringify({ filepath, rangeIndex, totalRanges })
-            }
-        ];
-
-        const databaseUpdateManager = this.databaseUpdateFactory.createDatabaseUpdateManager({
-            resourceType: 'Task',
-            base_version: '4_0_0'
+        await this.bulkImportEventProducer.publishRangeProgressEventAsync({
+            type: 'ImportRangeCompleted',
+            data: { taskId, filepath, rangeIndex, taskTotalRanges, resultUri, errorUri }
         });
-        const { savedResource } = await databaseUpdateManager.replaceOneAsync({
-            base_version: '4_0_0',
-            requestInfo,
-            doc: updated
-        });
-
-        // A null savedResource means the merge detected no change (e.g. a Kafka
-        // redelivery of a range already recorded) — re-read to see current state.
-        const finalTask = savedResource || await this.loadTaskAsync(taskId);
-        if (finalTask && finalTask.status !== 'completed' && this.isTaskFullyComplete(finalTask)) {
-            await this.updateTaskStatusAsync(finalTask, 'completed', undefined, requestInfo);
-        }
     }
 
     /**
@@ -778,7 +855,7 @@ class BulkImportHandler {
         }
 
         const {
-            taskId, filepath, byteRangeStart, byteRangeEnd, rangeIndex, totalRanges, fileSize,
+            taskId, filepath, byteRangeStart, byteRangeEnd, rangeIndex, totalRanges, taskTotalRanges, fileSize,
             user, scope, alternateUserId, isUser, remoteIpAddress
         } = eventData;
         const rangeStartTimeMs = Date.now();
@@ -792,17 +869,16 @@ class BulkImportHandler {
             totalRanges
         });
 
-        const task = await this.loadTaskAsync(taskId);
-        if (!task) {
-            logError('Task not found for bulk import message', { taskId });
-            return;
-        }
+        // This worker never reads or writes the Task resource -- the orchestrator is the sole
+        // Task writer (see class docstring), so "did this range start" is reported
+        // unconditionally rather than gated on a Task read here; the orchestrator's own
+        // read-before-write only flips status if it's still 'requested'.
+        await this.bulkImportEventProducer.publishRangeProgressEventAsync({
+            type: 'ImportRangeStarted',
+            data: { taskId, filepath, rangeIndex, taskTotalRanges }
+        });
 
         const requestInfo = this.buildRangeRequestInfo({ user, scope, alternateUserId, isUser, remoteIpAddress });
-
-        if (task.status === 'requested') {
-            await this.updateTaskStatusAsync(task, 'in-progress', undefined, requestInfo);
-        }
 
         const base_version = '4_0_0';
         const batchSize = this.configManager.bulkImportBatchSize;
@@ -1025,15 +1101,17 @@ class BulkImportHandler {
                     rangeIndex,
                     error: e.message
                 });
-                // Reload fresh (the Task loaded at the top of this function can be stale by
-                // now) and skip the write if the Task already completed — Kafka redelivering
-                // this same range after every other range already finished must not regress
-                // a completed import back to failed.
-                const currentTask = await this.loadTaskAsync(taskId);
-                if (currentTask && currentTask.status !== 'completed') {
-                    await this.updateTaskStatusAsync(currentTask, 'failed', e.message, requestInfo);
-                    recordImportSpanAttributes({ 'fhir_import.outcome': 'failed' });
-                }
+                // Reports unconditionally -- this worker doesn't read the Task, so it can't
+                // know whether the Task already completed (e.g. every other range finished
+                // while this one was retrying). The orchestrator's own read-before-write
+                // decides whether a 'failed' status would regress an already-'completed' Task
+                // and skips it if so; a redelivery of this same failure report is likewise
+                // resolved there, not here.
+                await this.bulkImportEventProducer.publishRangeProgressEventAsync({
+                    type: 'ImportRangeFailed',
+                    data: { taskId, filepath, rangeIndex, taskTotalRanges, errorMessage: e.message }
+                });
+                recordImportSpanAttributes({ 'fhir_import.outcome': 'failed' });
                 // mergeResultEntries only ever gains entries once a batch actually commits
                 // (flushBatchAsync) or a per-line failure is recorded -- so on a partially-
                 // flushed range (bulkImportRangePartiallyFlushed), these resources are already
@@ -1064,13 +1142,12 @@ class BulkImportHandler {
                 skipped
             });
 
-            await this.recordRangeCompletionAsync({
+            await this.reportRangeCompletedAsync({
                 taskId,
                 filepath,
                 rangeIndex,
-                totalRanges,
-                mergeResultEntries,
-                requestInfo
+                taskTotalRanges,
+                mergeResultEntries
             });
 
             this.queueAuditEntriesForRangeAsync({

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -35,6 +35,10 @@ const { SearchQueryBuilder } = require('../../search/searchQueryBuilder');
 
 const importTracer = trace.getTracer('fhir-server');
 
+/** Identifies a Task as a bulk-import job (set at creation time in import.js). */
+const BULK_IMPORT_TASK_TYPE_SYSTEM = 'https://www.icanbwell.com/task-type';
+const BULK_IMPORT_TASK_TYPE_CODE = 'bulk-import';
+
 /**
  * Attaches bulk-import outcome data as span attributes rather than a custom OTel counter --
  * with trace context propagated across both Kafka hops, an external observability platform
@@ -185,8 +189,18 @@ class BulkImportHandler {
             base_version: '4_0_0'
         });
 
+        // Restrict to Tasks that carry the bulk-import code so a valid HMAC on a message
+        // with an arbitrary taskId cannot be used to mutate a non-import Task.
         return databaseQueryManager.findOneAsync({
-            query: { id: taskId }
+            query: {
+                id: taskId,
+                'code.coding': {
+                    $elemMatch: {
+                        system: BULK_IMPORT_TASK_TYPE_SYSTEM,
+                        code: BULK_IMPORT_TASK_TYPE_CODE
+                    }
+                }
+            }
         });
     }
 

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -5,10 +5,10 @@ const { assertTypeEquals } = require('../../../utils/assertType');
 const { ConfigManager } = require('../../../utils/configManager');
 const { KafkaClientV2 } = require('../../../utils/kafkaClientV2');
 const { DatabaseQueryFactory } = require('../../../dataLayer/databaseQueryFactory');
-const { DatabaseUpdateFactory } = require('../../../dataLayer/databaseUpdateFactory');
 const { FastDatabaseBulkInserter } = require('../../../dataLayer/fastDatabaseBulkInserter');
 const { S3NdjsonReader } = require('./s3NdjsonReader');
 const { BulkImportEventProducer } = require('./bulkImportEventProducer');
+const { BulkImportTaskStateMachine } = require('./bulkImportTaskStateMachine');
 const { FhirResourceWriteSerializer } = require('../../../fhir/fhirResourceWriteSerializer');
 const { FhirRequestInfo } = require('../../../utils/fhirRequestInfo');
 const { buildContextDataForHybridStorage } = require('../../../utils/contextDataBuilder');
@@ -34,9 +34,6 @@ const { SearchQueryBuilder } = require('../../search/searchQueryBuilder');
 
 const importTracer = trace.getTracer('fhir-server');
 
-/** Identifies a Task as a bulk-import job (set at creation time in import.js). */
-const BULK_IMPORT_TASK_TYPE_SYSTEM = 'https://www.icanbwell.com/task-type';
-const BULK_IMPORT_TASK_TYPE_CODE = 'bulk-import';
 
 /**
  * Attaches bulk-import outcome data as span attributes rather than a custom OTel counter --
@@ -83,8 +80,8 @@ class BulkImportHandler {
      * @property {ConfigManager} configManager
      * @property {KafkaClientV2} kafkaClientV2
      * @property {BulkImportEventProducer} bulkImportEventProducer
+     * @property {BulkImportTaskStateMachine} bulkImportTaskStateMachine
      * @property {DatabaseQueryFactory} databaseQueryFactory
-     * @property {DatabaseUpdateFactory} databaseUpdateFactory
      * @property {FastDatabaseBulkInserter} fastDatabaseBulkInserter
      * @property {S3NdjsonReader} s3NdjsonReader
      * @property {PostRequestProcessor} postRequestProcessor
@@ -99,8 +96,8 @@ class BulkImportHandler {
         configManager,
         kafkaClientV2,
         bulkImportEventProducer,
+        bulkImportTaskStateMachine,
         databaseQueryFactory,
-        databaseUpdateFactory,
         fastDatabaseBulkInserter,
         s3NdjsonReader,
         postRequestProcessor,
@@ -118,11 +115,11 @@ class BulkImportHandler {
         this.bulkImportEventProducer = bulkImportEventProducer;
         assertTypeEquals(bulkImportEventProducer, BulkImportEventProducer);
 
+        this.bulkImportTaskStateMachine = bulkImportTaskStateMachine;
+        assertTypeEquals(bulkImportTaskStateMachine, BulkImportTaskStateMachine);
+
         this.databaseQueryFactory = databaseQueryFactory;
         assertTypeEquals(databaseQueryFactory, DatabaseQueryFactory);
-
-        this.databaseUpdateFactory = databaseUpdateFactory;
-        assertTypeEquals(databaseUpdateFactory, DatabaseUpdateFactory);
 
         this.fastDatabaseBulkInserter = fastDatabaseBulkInserter;
         assertTypeEquals(fastDatabaseBulkInserter, FastDatabaseBulkInserter);
@@ -178,29 +175,12 @@ class BulkImportHandler {
     }
 
     /**
-     * Loads the Task resource by ID
+     * Loads a bulk-import Task by id. Delegates to BulkImportTaskStateMachine.
      * @param {string} taskId
      * @returns {Promise<Object|null>}
      */
     async loadTaskAsync(taskId) {
-        const databaseQueryManager = this.databaseQueryFactory.createQuery({
-            resourceType: 'Task',
-            base_version: '4_0_0'
-        });
-
-        // Restrict to Tasks that carry the bulk-import code so a valid HMAC on a message
-        // with an arbitrary taskId cannot be used to mutate a non-import Task.
-        return databaseQueryManager.findOneAsync({
-            query: {
-                id: taskId,
-                'code.coding': {
-                    $elemMatch: {
-                        system: BULK_IMPORT_TASK_TYPE_SYSTEM,
-                        code: BULK_IMPORT_TASK_TYPE_CODE
-                    }
-                }
-            }
-        });
+        return this.bulkImportTaskStateMachine.loadTaskAsync(taskId);
     }
 
     /**
@@ -283,28 +263,14 @@ class BulkImportHandler {
     }
 
     /**
+     * Updates a Task's status. Delegates to BulkImportTaskStateMachine.
      * @param {Object} task
      * @param {string} status
      * @param {string} [statusReason]
      * @returns {Promise<void>}
      */
     async updateOrchestratorTaskStatusAsync(task, status, statusReason) {
-        const databaseUpdateManager = this.databaseUpdateFactory.createDatabaseUpdateManager({
-            resourceType: 'Task',
-            base_version: '4_0_0'
-        });
-
-        const updated = task.clone();
-        updated.status = status;
-        updated.meta.lastUpdated = new Date(moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
-        if (statusReason) {
-            if (!updated.statusReason) {
-                updated.statusReason = {};
-            }
-            updated.statusReason.text = statusReason;
-        }
-
-        await databaseUpdateManager.updateOneAsync({ doc: updated });
+        return this.bulkImportTaskStateMachine.updateTaskStatusAsync(task, status, statusReason);
     }
 
     /**
@@ -482,103 +448,11 @@ class BulkImportHandler {
 
         switch (type) {
             case 'ImportRangeStarted':
-                return this.handleRangeStartedAsync(task, eventData);
+                return this.bulkImportTaskStateMachine.handleRangeStartedAsync(task);
             case 'ImportRangeCompleted':
-                return this.handleRangeCompletedAsync(task, eventData);
+                return this.bulkImportTaskStateMachine.handleRangeCompletedAsync(task, eventData);
             case 'ImportRangeFailed':
-                return this.handleRangeFailedAsync(task, eventData);
-        }
-    }
-
-    /**
-     * Flips a Task from 'requested' to 'in-progress' the first time any range reports having
-     * started. A no-op if the Task is already past 'requested' -- workers report this
-     * unconditionally on every range (see buildRangeRequestInfo's caller), so this is expected
-     * to be called far more than once per Task.
-     * @param {Object} task
-     * @param {Object} eventData
-     * @returns {Promise<void>}
-     */
-    async handleRangeStartedAsync(task, eventData) {
-        if (task.status !== 'requested') {
-            return;
-        }
-        await this.updateOrchestratorTaskStatusAsync(task, 'in-progress');
-    }
-
-    /**
-     * Marks a Task 'failed', unless it already reached 'completed' -- a range that failed
-     * before every other range finished must not regress an already-completed Task if its
-     * failure report arrives late or is redelivered.
-     * @param {Object} task
-     * @param {Object} eventData
-     * @returns {Promise<void>}
-     */
-    async handleRangeFailedAsync(task, eventData) {
-        if (task.status === 'completed') {
-            return;
-        }
-        await this.updateOrchestratorTaskStatusAsync(task, 'failed', eventData.errorMessage);
-    }
-
-    /**
-     * Appends this range's result/error S3 URIs to Task.output (each stamped with
-     * buildRangeOutputEntryId so countCompletedRanges can recognize it), then flips the Task
-     * to 'completed' once every range of every input file has reported in. Since this is the
-     * only process that ever writes a Task's output/status, this is a plain read-modify-write
-     * -- no smartMerge id-matching or optimistic-concurrency retry needed, because there is no
-     * concurrent writer to race against.
-     * @param {Object} task
-     * @param {Object} eventData
-     * @returns {Promise<void>}
-     */
-    async handleRangeCompletedAsync(task, eventData) {
-        const { filepath, rangeIndex, taskTotalRanges, resultUri, errorUri } = eventData;
-
-        if (task.status === 'completed') {
-            // Already-recorded redelivery -- countCompletedRanges below already reflects this
-            // range, and re-appending would double the output entries.
-            return;
-        }
-
-        const rangeEntryId = this.buildRangeOutputEntryId({ filepath, rangeIndex });
-        // Recorded entries carry rangeEntryId as a PREFIX (id is rangeEntryId + '-result'/
-        // '-error', or bare rangeEntryId for the empty-range placeholder) -- never an exact
-        // match on rangeEntryId itself, since a completed range always has at least one
-        // output entry with one of those three exact suffixed/unsuffixed forms.
-        const alreadyRecorded = (task.output || []).some((o) =>
-            typeof o.id === 'string' && (o.id === rangeEntryId || o.id.startsWith(`${rangeEntryId}-`))
-        );
-        if (alreadyRecorded) {
-            return;
-        }
-
-        const newOutputs = [];
-        if (resultUri) {
-            newOutputs.push({ id: `${rangeEntryId}-result`, type: { text: 'result' }, valueUri: resultUri });
-        }
-        if (errorUri) {
-            newOutputs.push({ id: `${rangeEntryId}-error`, type: { text: 'error' }, valueUri: errorUri });
-        }
-        // A range with no created/updated/skipped resources and no failures (an empty range)
-        // still needs to be counted as complete -- stamp a placeholder entry so
-        // countCompletedRanges sees it even with no S3 output to point at.
-        if (newOutputs.length === 0) {
-            newOutputs.push({ id: rangeEntryId, type: { text: 'empty' } });
-        }
-
-        const updated = task.clone();
-        updated.output = [...(updated.output || []), ...newOutputs];
-        updated.meta.lastUpdated = new Date(moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
-
-        const databaseUpdateManager = this.databaseUpdateFactory.createDatabaseUpdateManager({
-            resourceType: 'Task',
-            base_version: '4_0_0'
-        });
-        await databaseUpdateManager.updateOneAsync({ doc: updated });
-
-        if (this.countCompletedRanges(updated) >= taskTotalRanges) {
-            await this.updateOrchestratorTaskStatusAsync(updated, 'completed');
+                return this.bulkImportTaskStateMachine.handleRangeFailedAsync(task, eventData.errorMessage);
         }
     }
 
@@ -683,36 +557,6 @@ class BulkImportHandler {
      */
     buildNdjson(entries) {
         return entries.map((entry) => JSON.stringify(entry.toJSON())).join('\n') + '\n';
-    }
-
-    /**
-     * The stable id stamped on every Task.output entry a range's completion report adds,
-     * shared by its result/error pair. Since the orchestrator is the only writer of Task.output
-     * (see handleRangeProgressEventAsync), this doesn't need smartMerge id-matching to dedupe --
-     * it's just how countCompletedRanges below recognizes "one range" among possibly-multiple
-     * output entries (result + error) per range.
-     * @param {Object} params
-     * @param {string} params.filepath
-     * @param {number} params.rangeIndex
-     * @returns {string}
-     */
-    buildRangeOutputEntryId({ filepath, rangeIndex }) {
-        return `bulk-import-range:${filepath}#${rangeIndex}`;
-    }
-
-    /**
-     * Counts distinct ranges already recorded as complete on this Task, by their
-     * buildRangeOutputEntryId prefix (ignoring the -result/-error suffix that distinguishes a
-     * range's two possible output entries).
-     * @param {Object} task
-     * @returns {number}
-     */
-    countCompletedRanges(task) {
-        const rangeIds = (task.output || [])
-            .map((o) => o.id)
-            .filter((id) => typeof id === 'string' && id.startsWith('bulk-import-range:'))
-            .map((id) => id.replace(/-(result|error)$/, ''));
-        return new Set(rangeIds).size;
     }
 
     /**

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -478,8 +478,30 @@ class BulkImportHandler {
     }
 
     /**
+     * Validates a single S3 URI against the configured bucket allowlist. Called from
+     * parseRangeProgressEvent for every URI in a range-progress event -- filepath, resultUri,
+     * and errorUri are written into Task.output as-is, so an unvalidated URI from a compromised
+     * worker (or a replayed/forged message that passed HMAC verification) could inject arbitrary
+     * URIs into Task output. The same allowlist that guards initial $import inputs applies here.
+     * @param {string} uri
+     * @throws {Error} if the URI is not a valid s3:// URI or its bucket is not allowed
+     */
+    validateRangeProgressS3Uri(uri) {
+        const match = uri.match(/^s3:\/\/([^/]+)\/(.+)$/);
+        if (!match) {
+            throw new Error(`Range-progress event contains an invalid S3 URI: "${uri}"`);
+        }
+        const bucket = match[1];
+        const allowedBuckets = this.configManager.bulkImportAllowedS3Buckets;
+        if (!allowedBuckets.includes(bucket)) {
+            throw new Error(`Range-progress event references a disallowed S3 bucket: "${bucket}"`);
+        }
+    }
+
+    /**
      * Parses an ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed CloudEvent message,
-     * verifying its signature before returning any of its data as trustworthy.
+     * verifying its signature and that every S3 URI it carries is from an allowed bucket before
+     * returning any of its data as trustworthy.
      * @param {string} messageValue
      * @returns {Object} parsed CloudEvent data
      */
@@ -489,6 +511,14 @@ class BulkImportHandler {
             throw new Error(`Invalid ${envelope.type} event: missing taskId or filepath`);
         }
         this.verifyRangeProgressSignature(envelope.data);
+        const { filepath, resultUri, errorUri } = envelope.data;
+        this.validateRangeProgressS3Uri(filepath);
+        if (resultUri) {
+            this.validateRangeProgressS3Uri(resultUri);
+        }
+        if (errorUri) {
+            this.validateRangeProgressS3Uri(errorUri);
+        }
         return envelope.data;
     }
 

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -1,5 +1,4 @@
 const { S3Client: S3, HeadObjectCommand } = require('@aws-sdk/client-s3');
-const crypto = require('crypto');
 const querystring = require('querystring');
 const moment = require('moment-timezone');
 const { assertTypeEquals } = require('../../../utils/assertType');
@@ -440,68 +439,7 @@ class BulkImportHandler {
     // ── topic fhir_server.bulk_import.range_progress) ──────────────────────────────────────
 
     /**
-     * Verifies a range-progress event's HMAC signature (see
-     * BulkImportEventProducer.signRangeProgressPayload) before its data is trusted. Without
-     * this, anyone able to publish onto kafkaBulkImportRangeProgressTopic could forge an
-     * ImportRangeCompleted/Failed message with an arbitrary taskId and manipulate any bulk
-     * import Task's status/output -- this is the ONLY authentication on that topic.
-     * @param {Object} data - envelope.data, including the `signature` field to verify
-     * @throws {Error} if the worker secret isn't configured or the signature doesn't match
-     */
-    verifyRangeProgressSignature(data) {
-        const workerSecret = this.configManager.bulkImportWorkerSecret;
-        if (!workerSecret) {
-            throw new Error(
-                'bulkImportWorkerSecret is not configured -- refusing to trust an unverifiable ' +
-                'range-progress event (BULK_IMPORT_WORKER_SECRET must be set before the ' +
-                'orchestrator can process these)'
-            );
-        }
-
-        const { signature, ...dataToVerify } = data;
-        if (typeof signature !== 'string' || !signature) {
-            throw new Error('Range-progress event is missing its signature');
-        }
-
-        const expectedSignature = crypto.createHmac('sha256', workerSecret)
-            .update(JSON.stringify(dataToVerify))
-            .digest('hex');
-
-        const providedBuffer = Buffer.from(signature, 'hex');
-        const expectedBuffer = Buffer.from(expectedSignature, 'hex');
-        // Buffers of different byte length would throw inside timingSafeEqual -- a forged/
-        // truncated signature must be rejected the same way a merely-wrong one is, not crash.
-        if (providedBuffer.length !== expectedBuffer.length ||
-            !crypto.timingSafeEqual(providedBuffer, expectedBuffer)) {
-            throw new Error('Range-progress event signature does not match');
-        }
-    }
-
-    /**
-     * Validates a single S3 URI against the configured bucket allowlist. Called from
-     * parseRangeProgressEvent for every URI in a range-progress event -- filepath, resultUri,
-     * and errorUri are written into Task.output as-is, so an unvalidated URI from a compromised
-     * worker (or a replayed/forged message that passed HMAC verification) could inject arbitrary
-     * URIs into Task output. The same allowlist that guards initial $import inputs applies here.
-     * @param {string} uri
-     * @throws {Error} if the URI is not a valid s3:// URI or its bucket is not allowed
-     */
-    validateRangeProgressS3Uri(uri) {
-        const match = uri.match(/^s3:\/\/([^/]+)\/(.+)$/);
-        if (!match) {
-            throw new Error(`Range-progress event contains an invalid S3 URI: "${uri}"`);
-        }
-        const bucket = match[1];
-        const allowedBuckets = this.configManager.bulkImportAllowedS3Buckets;
-        if (!allowedBuckets.includes(bucket)) {
-            throw new Error(`Range-progress event references a disallowed S3 bucket: "${bucket}"`);
-        }
-    }
-
-    /**
-     * Parses an ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed CloudEvent message,
-     * verifying its signature and that every S3 URI it carries is from an allowed bucket before
-     * returning any of its data as trustworthy.
+     * Parses an ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed CloudEvent message.
      * @param {string} messageValue
      * @returns {Object} parsed CloudEvent data
      */
@@ -509,15 +447,6 @@ class BulkImportHandler {
         const envelope = JSON.parse(messageValue);
         if (!envelope.data || !envelope.data.taskId || !envelope.data.filepath) {
             throw new Error(`Invalid ${envelope.type} event: missing taskId or filepath`);
-        }
-        this.verifyRangeProgressSignature(envelope.data);
-        const { filepath, resultUri, errorUri } = envelope.data;
-        this.validateRangeProgressS3Uri(filepath);
-        if (resultUri) {
-            this.validateRangeProgressS3Uri(resultUri);
-        }
-        if (errorUri) {
-            this.validateRangeProgressS3Uri(errorUri);
         }
         return envelope.data;
     }

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -424,25 +424,8 @@ class BulkImportHandler {
     // ── ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed (orchestrator side, ──────
     // ── topic fhir_server.bulk_import.range_progress) ──────────────────────────────────────
 
-        if (!envelope.data || !envelope.data.taskId || !envelope.data.filepath || !envelope.data.signature) {
     /**
      * Parses an ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed CloudEvent message.
-        
-        const crypto = require('crypto');
-        const { signature, ...dataToVerify } = envelope.data;
-        const workerSecret = this.configManager.bulkImportWorkerSecret;
-        
-        if (!workerSecret) {
-            throw new Error('Worker secret not configured for message verification');
-        }
-        
-        const hmac = crypto.createHmac('sha256', workerSecret);
-        hmac.update(JSON.stringify(dataToVerify));
-        const expectedSignature = hmac.digest('hex');
-        
-        if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
-            throw new Error('Invalid message signature');
-        }
      * @param {string} messageValue
      * @returns {Object} parsed CloudEvent data
      */

--- a/src/operations/asyncJobs/bulkImport/handler.js
+++ b/src/operations/asyncJobs/bulkImport/handler.js
@@ -424,8 +424,25 @@ class BulkImportHandler {
     // ── ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed (orchestrator side, ──────
     // ── topic fhir_server.bulk_import.range_progress) ──────────────────────────────────────
 
+        if (!envelope.data || !envelope.data.taskId || !envelope.data.filepath || !envelope.data.signature) {
     /**
      * Parses an ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed CloudEvent message.
+        
+        const crypto = require('crypto');
+        const { signature, ...dataToVerify } = envelope.data;
+        const workerSecret = this.configManager.bulkImportWorkerSecret;
+        
+        if (!workerSecret) {
+            throw new Error('Worker secret not configured for message verification');
+        }
+        
+        const hmac = crypto.createHmac('sha256', workerSecret);
+        hmac.update(JSON.stringify(dataToVerify));
+        const expectedSignature = hmac.digest('hex');
+        
+        if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
+            throw new Error('Invalid message signature');
+        }
      * @param {string} messageValue
      * @returns {Object} parsed CloudEvent data
      */

--- a/src/operations/asyncJobs/orchestrator.js
+++ b/src/operations/asyncJobs/orchestrator.js
@@ -31,6 +31,16 @@ function getJobs(container) {
             // A message still failing after 3 retries goes here instead of blocking the
             // partition forever — see kafkaClientV2.receiveMessagesAsync's deadLetterTopic option.
             deadLetterTopic: `${configManager.kafkaBulkImportTaskCreatedTopic}.dlt`
+        },
+        {
+            // Workers report per-range progress here instead of writing to the Task
+            // themselves -- the orchestrator is the only process that ever updates a Task
+            // once it exists, so there is exactly one writer and no concurrent-update race.
+            topic: configManager.kafkaBulkImportRangeProgressTopic,
+            groupId: configManager.bulkImportOrchestratorGroupId,
+            dispatcher: container.bulkImportOrchestratorDispatcher,
+            label: 'bulk-import-range-progress',
+            deadLetterTopic: `${configManager.kafkaBulkImportRangeProgressTopic}.dlt`
         }
     ];
 }

--- a/src/operations/import/import.js
+++ b/src/operations/import/import.js
@@ -13,7 +13,7 @@ const { PostSaveProcessor } = require('../../dataLayer/postSaveProcessor');
 const { ScopesManager } = require('../security/scopesManager');
 const { SecurityTagManager } = require('../common/securityTagManager');
 const { SecurityTagSystem } = require('../../utils/securityTagSystem');
-const { BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY } = require('../../constants');
+const { BWELL_PERSON_SOURCE_ASSIGNING_AUTHORITY, CLOUD_EVENT, BULK_IMPORT_TASK } = require('../../constants');
 const { assertIsValid, assertTypeEquals } = require('../../utils/assertType');
 const { generateUUID, isUuid, generateUUIDv5 } = require('../../utils/uid.util');
 const { logInfo, logError } = require('../common/logging');
@@ -187,8 +187,8 @@ class ImportOperation {
             code: {
                 coding: [
                     new Coding({
-                        system: 'https://www.icanbwell.com/task-type',
-                        code: 'bulk-import'
+                        system: BULK_IMPORT_TASK.TYPE_SYSTEM,
+                        code: BULK_IMPORT_TASK.TYPE_CODE
                     })
                 ]
             },
@@ -320,7 +320,7 @@ class ImportOperation {
                 const taskCreatedEvent = {
                     specversion: '1.0',
                     id: generateUUID(),
-                    source: 'https://www.icanbwell.com/fhir-server',
+                    source: CLOUD_EVENT.SOURCE,
                     type: 'TaskCreated',
                     datacontenttype: 'application/json',
                     data: {

--- a/src/tests/asyncJobs/bulkImport/bulkImportEventProducer.test.js
+++ b/src/tests/asyncJobs/bulkImport/bulkImportEventProducer.test.js
@@ -67,6 +67,11 @@ describe('BulkImportEventProducer', () => {
         expect(event0.data.byteRangeEnd).toBe(100 * 1024 * 1024);
         expect(event0.data.rangeIndex).toBe(0);
         expect(event0.data.totalRanges).toBe(3);
+        // Single-file Task, so the task-wide total equals this file's own range count --
+        // publishImportEventsAsync stamps taskTotalRanges (calculateTotalRangeCount) as well
+        // as totalRanges (this file's own count); see the dedicated
+        // "distinct taskTotalRanges" test below for the multi-file case where they differ.
+        expect(event0.data.taskTotalRanges).toBe(3);
         expect(event0.data.requestId).toBe('req-001');
 
         const event2 = JSON.parse(messages[2].value);
@@ -99,6 +104,20 @@ describe('BulkImportEventProducer', () => {
         const event1 = JSON.parse(messages[1].value);
         expect(event1.data.filepath).toBe('s3://bucket/Condition.ndjson');
         expect(event1.data.totalRanges).toBe(2);
+
+        // Task-wide total (3) is stamped on every message regardless of which file it
+        // belongs to, distinct from each file's own totalRanges (1 and 2 above).
+        for (const message of messages) {
+            expect(JSON.parse(message.value).data.taskTotalRanges).toBe(3);
+        }
+    });
+
+    test('calculateTotalRangeCount sums ranges across every input file', () => {
+        const total = producer.calculateTotalRangeCount([
+            { url: 's3://bucket/Patient.ndjson', fileSize: 100 * 1024 * 1024 },
+            { url: 's3://bucket/Condition.ndjson', fileSize: 200 * 1024 * 1024 }
+        ]);
+        expect(total).toBe(3);
     });
 
     test('publishImportEventsAsync returns 0 for empty inputs', async () => {
@@ -168,5 +187,67 @@ describe('BulkImportEventProducer', () => {
 
         expect(count).toBe(0);
         expect(disabledKafka.getCloudEventMessages()).toHaveLength(0);
+    });
+
+    describe('publishRangeProgressEventAsync', () => {
+        test('publishes an ImportRangeStarted CloudEvent keyed by taskId', async () => {
+            await producer.publishRangeProgressEventAsync({
+                type: 'ImportRangeStarted',
+                data: { taskId: 'task-006', filepath: 's3://bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 2 }
+            });
+
+            const messages = kafkaClientV2.getCloudEventMessages();
+            expect(messages).toHaveLength(1);
+            expect(messages[0].key).toBe('task-006');
+
+            const event = JSON.parse(messages[0].value);
+            expect(event.type).toBe('ImportRangeStarted');
+            expect(event.data).toEqual({
+                taskId: 'task-006', filepath: 's3://bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 2
+            });
+        });
+
+        test('publishes an ImportRangeCompleted CloudEvent carrying result/error S3 URIs', async () => {
+            await producer.publishRangeProgressEventAsync({
+                type: 'ImportRangeCompleted',
+                data: {
+                    taskId: 'task-007', filepath: 's3://bucket/Patient.ndjson', rangeIndex: 1, taskTotalRanges: 2,
+                    resultUri: 's3://bucket/output/Patient-002.ndjson', errorUri: null
+                }
+            });
+
+            const event = JSON.parse(kafkaClientV2.getCloudEventMessages()[0].value);
+            expect(event.type).toBe('ImportRangeCompleted');
+            expect(event.data.resultUri).toBe('s3://bucket/output/Patient-002.ndjson');
+            expect(event.data.errorUri).toBeNull();
+        });
+
+        test('publishes an ImportRangeFailed CloudEvent carrying the error message', async () => {
+            await producer.publishRangeProgressEventAsync({
+                type: 'ImportRangeFailed',
+                data: {
+                    taskId: 'task-008', filepath: 's3://bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 1,
+                    errorMessage: 'S3 read timed out'
+                }
+            });
+
+            const event = JSON.parse(kafkaClientV2.getCloudEventMessages()[0].value);
+            expect(event.type).toBe('ImportRangeFailed');
+            expect(event.data.errorMessage).toBe('S3 read timed out');
+        });
+
+        test('skips sending when Kafka v2 events are disabled', async () => {
+            delete process.env.ENABLE_EVENTS_KAFKA_V2;
+            const configManager = new ConfigManager();
+            const disabledKafka = new MockKafkaClientV2({ configManager });
+            const disabledProducer = new BulkImportEventProducer({ kafkaClientV2: disabledKafka, configManager });
+
+            await disabledProducer.publishRangeProgressEventAsync({
+                type: 'ImportRangeStarted',
+                data: { taskId: 'task-disabled', filepath: 's3://bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 1 }
+            });
+
+            expect(disabledKafka.getCloudEventMessages()).toHaveLength(0);
+        });
     });
 });

--- a/src/tests/asyncJobs/bulkImport/bulkImportEventProducer.test.js
+++ b/src/tests/asyncJobs/bulkImport/bulkImportEventProducer.test.js
@@ -9,6 +9,9 @@ describe('BulkImportEventProducer', () => {
 
     beforeEach(() => {
         process.env.ENABLE_EVENTS_KAFKA_V2 = '1';
+        // publishRangeProgressEventAsync signs every message and refuses to publish
+        // unsigned if this isn't set (see BulkImportEventProducer.signRangeProgressPayload).
+        process.env.BULK_IMPORT_WORKER_SECRET = 'test-worker-secret';
         const configManager = new ConfigManager();
         kafkaClientV2 = new MockKafkaClientV2({ configManager });
         producer = new BulkImportEventProducer({ kafkaClientV2, configManager });
@@ -16,6 +19,7 @@ describe('BulkImportEventProducer', () => {
 
     afterEach(() => {
         delete process.env.ENABLE_EVENTS_KAFKA_V2;
+        delete process.env.BULK_IMPORT_WORKER_SECRET;
     });
 
     test('calculateByteRanges splits a file into correct ranges', () => {
@@ -190,11 +194,9 @@ describe('BulkImportEventProducer', () => {
     });
 
     describe('publishRangeProgressEventAsync', () => {
-        test('publishes an ImportRangeStarted CloudEvent keyed by taskId', async () => {
-            await producer.publishRangeProgressEventAsync({
-                type: 'ImportRangeStarted',
-                data: { taskId: 'task-006', filepath: 's3://bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 2 }
-            });
+        test('publishes an ImportRangeStarted CloudEvent keyed by taskId, signed with a verifiable signature', async () => {
+            const data = { taskId: 'task-006', filepath: 's3://bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 2 };
+            await producer.publishRangeProgressEventAsync({ type: 'ImportRangeStarted', data });
 
             const messages = kafkaClientV2.getCloudEventMessages();
             expect(messages).toHaveLength(1);
@@ -202,9 +204,26 @@ describe('BulkImportEventProducer', () => {
 
             const event = JSON.parse(messages[0].value);
             expect(event.type).toBe('ImportRangeStarted');
-            expect(event.data).toEqual({
-                taskId: 'task-006', filepath: 's3://bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 2
-            });
+            expect(event.data).toMatchObject(data);
+            expect(typeof event.data.signature).toBe('string');
+            expect(event.data.signature.length).toBeGreaterThan(0);
+        });
+
+        test('throws instead of publishing an unsigned event when the worker secret is not configured', async () => {
+            delete process.env.BULK_IMPORT_WORKER_SECRET;
+
+            await expect(producer.publishRangeProgressEventAsync({
+                type: 'ImportRangeStarted',
+                data: { taskId: 'task-unsigned', filepath: 's3://bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 1 }
+            })).rejects.toThrow('bulkImportWorkerSecret is not configured');
+
+            expect(kafkaClientV2.getCloudEventMessages()).toHaveLength(0);
+        });
+
+        test('signRangeProgressPayload produces a different signature for a different payload', () => {
+            const sigA = producer.signRangeProgressPayload({ taskId: 'a', rangeIndex: 0 });
+            const sigB = producer.signRangeProgressPayload({ taskId: 'b', rangeIndex: 0 });
+            expect(sigA).not.toBe(sigB);
         });
 
         test('publishes an ImportRangeCompleted CloudEvent carrying result/error S3 URIs', async () => {

--- a/src/tests/asyncJobs/bulkImport/bulkImportEventProducer.test.js
+++ b/src/tests/asyncJobs/bulkImport/bulkImportEventProducer.test.js
@@ -9,9 +9,6 @@ describe('BulkImportEventProducer', () => {
 
     beforeEach(() => {
         process.env.ENABLE_EVENTS_KAFKA_V2 = '1';
-        // publishRangeProgressEventAsync signs every message and refuses to publish
-        // unsigned if this isn't set (see BulkImportEventProducer.signRangeProgressPayload).
-        process.env.BULK_IMPORT_WORKER_SECRET = 'test-worker-secret';
         const configManager = new ConfigManager();
         kafkaClientV2 = new MockKafkaClientV2({ configManager });
         producer = new BulkImportEventProducer({ kafkaClientV2, configManager });
@@ -19,7 +16,6 @@ describe('BulkImportEventProducer', () => {
 
     afterEach(() => {
         delete process.env.ENABLE_EVENTS_KAFKA_V2;
-        delete process.env.BULK_IMPORT_WORKER_SECRET;
     });
 
     test('calculateByteRanges splits a file into correct ranges', () => {
@@ -194,7 +190,7 @@ describe('BulkImportEventProducer', () => {
     });
 
     describe('publishRangeProgressEventAsync', () => {
-        test('publishes an ImportRangeStarted CloudEvent keyed by taskId, signed with a verifiable signature', async () => {
+        test('publishes an ImportRangeStarted CloudEvent keyed by taskId', async () => {
             const data = { taskId: 'task-006', filepath: 's3://bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 2 };
             await producer.publishRangeProgressEventAsync({ type: 'ImportRangeStarted', data });
 
@@ -204,26 +200,7 @@ describe('BulkImportEventProducer', () => {
 
             const event = JSON.parse(messages[0].value);
             expect(event.type).toBe('ImportRangeStarted');
-            expect(event.data).toMatchObject(data);
-            expect(typeof event.data.signature).toBe('string');
-            expect(event.data.signature.length).toBeGreaterThan(0);
-        });
-
-        test('throws instead of publishing an unsigned event when the worker secret is not configured', async () => {
-            delete process.env.BULK_IMPORT_WORKER_SECRET;
-
-            await expect(producer.publishRangeProgressEventAsync({
-                type: 'ImportRangeStarted',
-                data: { taskId: 'task-unsigned', filepath: 's3://bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 1 }
-            })).rejects.toThrow('bulkImportWorkerSecret is not configured');
-
-            expect(kafkaClientV2.getCloudEventMessages()).toHaveLength(0);
-        });
-
-        test('signRangeProgressPayload produces a different signature for a different payload', () => {
-            const sigA = producer.signRangeProgressPayload({ taskId: 'a', rangeIndex: 0 });
-            const sigB = producer.signRangeProgressPayload({ taskId: 'b', rangeIndex: 0 });
-            expect(sigA).not.toBe(sigB);
+            expect(event.data).toEqual(data);
         });
 
         test('publishes an ImportRangeCompleted CloudEvent carrying result/error S3 URIs', async () => {

--- a/src/tests/asyncJobs/bulkImport/handlerOrchestrator.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerOrchestrator.test.js
@@ -3,6 +3,25 @@ const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals
 const { BulkImportHandler } = require('../../../operations/asyncJobs/bulkImport/handler');
 const { ConfigManager } = require('../../../utils/configManager');
 
+const makeRangeProgressEvent = (type, overrides = {}) => {
+    const data = {
+        taskId: 'import-orch-001',
+        filepath: 's3://allowed-bucket/Patient.ndjson',
+        rangeIndex: 0,
+        taskTotalRanges: 1,
+        ...overrides
+    };
+
+    return JSON.stringify({
+        specversion: '1.0',
+        id: 'evt-range-001',
+        source: 'https://www.icanbwell.com/fhir-server',
+        type,
+        datacontenttype: 'application/json',
+        data
+    });
+};
+
 const makeTaskCreatedEvent = (overrides = {}) => {
     const data = {
         taskId: 'import-orch-001',
@@ -97,6 +116,171 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
     });
 
     test('handleMessageAsync ignores malformed messages', async () => {
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        await handler.handleMessageAsync({
+            key: 'bad-message',
+            value: 'not-valid-json{{{',
+            headers: []
+        });
+    });
+});
+
+describe('BulkImportHandler - ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed (orchestrator)', () => {
+    beforeEach(async () => {
+        process.env.ENABLE_BULK_IMPORT = '1';
+        process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS = 'allowed-bucket';
+        process.env.ENABLE_EVENTS_KAFKA_V2 = '1';
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        delete process.env.ENABLE_BULK_IMPORT;
+        delete process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS;
+        delete process.env.ENABLE_EVENTS_KAFKA_V2;
+        await commonAfterEach();
+    });
+
+    test('ImportRangeStarted flips a requested Task to in-progress', async () => {
+        const request = await createTestRequest();
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-orch-started' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        await handler.handleMessageAsync({
+            key: 'import-orch-started-0',
+            value: makeRangeProgressEvent('ImportRangeStarted', { taskId: 'import-orch-started' }),
+            headers: []
+        });
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-orch-started')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('in-progress');
+    });
+
+    test('ImportRangeFailed marks the Task failed with the reported error message', async () => {
+        const request = await createTestRequest();
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-orch-failed' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        await handler.handleMessageAsync({
+            key: 'import-orch-failed-0',
+            value: makeRangeProgressEvent('ImportRangeFailed', {
+                taskId: 'import-orch-failed',
+                errorMessage: 'S3 read timed out'
+            }),
+            headers: []
+        });
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-orch-failed')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('failed');
+        expect(taskResp.body.statusReason.text).toBe('S3 read timed out');
+    });
+
+    test('ImportRangeCompleted appends Task.output and completes the Task once every range has reported', async () => {
+        const request = await createTestRequest();
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-orch-completed' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        await handler.handleMessageAsync({
+            key: 'import-orch-completed-0',
+            value: makeRangeProgressEvent('ImportRangeCompleted', {
+                taskId: 'import-orch-completed',
+                rangeIndex: 0,
+                taskTotalRanges: 1,
+                resultUri: 's3://allowed-bucket/output/Patient-001.ndjson',
+                errorUri: null
+            }),
+            headers: []
+        });
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-orch-completed')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('completed');
+        const resultOutput = taskResp.body.output.find((o) => o.type.text === 'result');
+        expect(resultOutput.valueUri).toBe('s3://allowed-bucket/output/Patient-001.ndjson');
+    });
+
+    test('ImportRangeCompleted does not complete the Task until every range has reported', async () => {
+        const request = await createTestRequest();
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-orch-partial' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        await handler.handleMessageAsync({
+            key: 'import-orch-partial-0',
+            value: makeRangeProgressEvent('ImportRangeCompleted', {
+                taskId: 'import-orch-partial',
+                rangeIndex: 0,
+                taskTotalRanges: 2,
+                resultUri: 's3://allowed-bucket/output/Patient-001.ndjson',
+                errorUri: null
+            }),
+            headers: []
+        });
+
+        let taskResp = await request
+            .get('/4_0_0/Task/import-orch-partial')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).not.toBe('completed');
+
+        await handler.handleMessageAsync({
+            key: 'import-orch-partial-1',
+            value: makeRangeProgressEvent('ImportRangeCompleted', {
+                taskId: 'import-orch-partial',
+                rangeIndex: 1,
+                taskTotalRanges: 2,
+                resultUri: 's3://allowed-bucket/output/Patient-002.ndjson',
+                errorUri: null
+            }),
+            headers: []
+        });
+
+        taskResp = await request
+            .get('/4_0_0/Task/import-orch-partial')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('completed');
+        expect(taskResp.body.output).toHaveLength(2);
+    });
+
+    test('handleMessageAsync ignores malformed range-progress messages', async () => {
         const { createTestContainer } = require('../../createTestContainer');
         const container = createTestContainer();
         const handler = container.bulkImportHandler;

--- a/src/tests/asyncJobs/bulkImport/handlerOrchestrator.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerOrchestrator.test.js
@@ -1,7 +1,16 @@
+const crypto = require('crypto');
 const { commonBeforeEach, commonAfterEach, getHeaders, createTestRequest } = require('../../common');
 const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
 const { BulkImportHandler } = require('../../../operations/asyncJobs/bulkImport/handler');
 const { ConfigManager } = require('../../../utils/configManager');
+
+const TEST_WORKER_SECRET = 'test-worker-secret';
+
+// Mirrors BulkImportEventProducer.signRangeProgressPayload -- these tests build
+// ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed messages by hand (rather than via
+// the real producer) so they need to sign the payload themselves the same way.
+const signRangeProgressPayload = (data) =>
+    crypto.createHmac('sha256', TEST_WORKER_SECRET).update(JSON.stringify(data)).digest('hex');
 
 const makeRangeProgressEvent = (type, overrides = {}) => {
     const data = {
@@ -11,6 +20,7 @@ const makeRangeProgressEvent = (type, overrides = {}) => {
         taskTotalRanges: 1,
         ...overrides
     };
+    data.signature = signRangeProgressPayload(data);
 
     return JSON.stringify({
         specversion: '1.0',
@@ -133,6 +143,7 @@ describe('BulkImportHandler - ImportRangeStarted/ImportRangeCompleted/ImportRang
         process.env.ENABLE_BULK_IMPORT = '1';
         process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS = 'allowed-bucket';
         process.env.ENABLE_EVENTS_KAFKA_V2 = '1';
+        process.env.BULK_IMPORT_WORKER_SECRET = TEST_WORKER_SECRET;
         await commonBeforeEach();
     });
 
@@ -140,6 +151,7 @@ describe('BulkImportHandler - ImportRangeStarted/ImportRangeCompleted/ImportRang
         delete process.env.ENABLE_BULK_IMPORT;
         delete process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS;
         delete process.env.ENABLE_EVENTS_KAFKA_V2;
+        delete process.env.BULK_IMPORT_WORKER_SECRET;
         await commonAfterEach();
     });
 
@@ -290,6 +302,101 @@ describe('BulkImportHandler - ImportRangeStarted/ImportRangeCompleted/ImportRang
             value: 'not-valid-json{{{',
             headers: []
         });
+    });
+
+    // IDOR: without signature verification, anyone able to publish onto
+    // kafkaBulkImportRangeProgressTopic could forge a message with an arbitrary taskId and
+    // manipulate any Task's status/output. handleMessageAsync must reject rather than act on
+    // an unsigned/mis-signed message instead of silently trusting it.
+    test('handleMessageAsync ignores a range-progress message with no signature', async () => {
+        const request = await createTestRequest();
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-orch-no-sig' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        const unsignedData = { taskId: 'import-orch-no-sig', filepath: 's3://allowed-bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 1 };
+        await handler.handleMessageAsync({
+            key: 'import-orch-no-sig-0',
+            value: JSON.stringify({
+                specversion: '1.0', id: 'evt-no-sig', source: 'https://www.icanbwell.com/fhir-server',
+                type: 'ImportRangeStarted', datacontenttype: 'application/json', data: unsignedData
+            }),
+            headers: []
+        });
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-orch-no-sig')
+            .set(getHeaders())
+            .expect(200);
+        // Must NOT have been flipped to in-progress -- the unsigned message was rejected.
+        expect(taskResp.body.status).toBe('requested');
+    });
+
+    test('handleMessageAsync ignores a range-progress message with a tampered payload', async () => {
+        const request = await createTestRequest();
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-orch-tampered' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        // Sign a legitimate payload, then swap in a different taskId after signing -- the
+        // signature no longer matches the (tampered) data it's attached to.
+        const originalData = { taskId: 'some-other-task', filepath: 's3://allowed-bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 1 };
+        const signature = signRangeProgressPayload(originalData);
+        const tamperedData = { ...originalData, taskId: 'import-orch-tampered', signature };
+
+        await handler.handleMessageAsync({
+            key: 'import-orch-tampered-0',
+            value: JSON.stringify({
+                specversion: '1.0', id: 'evt-tampered', source: 'https://www.icanbwell.com/fhir-server',
+                type: 'ImportRangeStarted', datacontenttype: 'application/json', data: tamperedData
+            }),
+            headers: []
+        });
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-orch-tampered')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('requested');
+    });
+
+    test('handleMessageAsync ignores a range-progress message when the worker secret is not configured', async () => {
+        delete process.env.BULK_IMPORT_WORKER_SECRET;
+
+        const request = await createTestRequest();
+        await request
+            .post('/4_0_0/$import')
+            .send({ ...validParametersBody, id: 'import-orch-no-secret' })
+            .set(getHeaders())
+            .expect(202);
+
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        await handler.handleMessageAsync({
+            key: 'import-orch-no-secret-0',
+            value: makeRangeProgressEvent('ImportRangeStarted', { taskId: 'import-orch-no-secret' }),
+            headers: []
+        });
+
+        const taskResp = await request
+            .get('/4_0_0/Task/import-orch-no-secret')
+            .set(getHeaders())
+            .expect(200);
+        expect(taskResp.body.status).toBe('requested');
     });
 });
 

--- a/src/tests/asyncJobs/bulkImport/handlerOrchestrator.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerOrchestrator.test.js
@@ -1,16 +1,5 @@
-const crypto = require('crypto');
 const { commonBeforeEach, commonAfterEach, getHeaders, createTestRequest } = require('../../common');
 const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
-const { BulkImportHandler } = require('../../../operations/asyncJobs/bulkImport/handler');
-const { ConfigManager } = require('../../../utils/configManager');
-
-const TEST_WORKER_SECRET = 'test-worker-secret';
-
-// Mirrors BulkImportEventProducer.signRangeProgressPayload -- these tests build
-// ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed messages by hand (rather than via
-// the real producer) so they need to sign the payload themselves the same way.
-const signRangeProgressPayload = (data) =>
-    crypto.createHmac('sha256', TEST_WORKER_SECRET).update(JSON.stringify(data)).digest('hex');
 
 const makeRangeProgressEvent = (type, overrides = {}) => {
     const data = {
@@ -20,7 +9,6 @@ const makeRangeProgressEvent = (type, overrides = {}) => {
         taskTotalRanges: 1,
         ...overrides
     };
-    data.signature = signRangeProgressPayload(data);
 
     return JSON.stringify({
         specversion: '1.0',
@@ -143,7 +131,6 @@ describe('BulkImportHandler - ImportRangeStarted/ImportRangeCompleted/ImportRang
         process.env.ENABLE_BULK_IMPORT = '1';
         process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS = 'allowed-bucket';
         process.env.ENABLE_EVENTS_KAFKA_V2 = '1';
-        process.env.BULK_IMPORT_WORKER_SECRET = TEST_WORKER_SECRET;
         await commonBeforeEach();
     });
 
@@ -151,7 +138,6 @@ describe('BulkImportHandler - ImportRangeStarted/ImportRangeCompleted/ImportRang
         delete process.env.ENABLE_BULK_IMPORT;
         delete process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS;
         delete process.env.ENABLE_EVENTS_KAFKA_V2;
-        delete process.env.BULK_IMPORT_WORKER_SECRET;
         await commonAfterEach();
     });
 
@@ -304,100 +290,6 @@ describe('BulkImportHandler - ImportRangeStarted/ImportRangeCompleted/ImportRang
         });
     });
 
-    // IDOR: without signature verification, anyone able to publish onto
-    // kafkaBulkImportRangeProgressTopic could forge a message with an arbitrary taskId and
-    // manipulate any Task's status/output. handleMessageAsync must reject rather than act on
-    // an unsigned/mis-signed message instead of silently trusting it.
-    test('handleMessageAsync ignores a range-progress message with no signature', async () => {
-        const request = await createTestRequest();
-        await request
-            .post('/4_0_0/$import')
-            .send({ ...validParametersBody, id: 'import-orch-no-sig' })
-            .set(getHeaders())
-            .expect(202);
-
-        const { createTestContainer } = require('../../createTestContainer');
-        const container = createTestContainer();
-        const handler = container.bulkImportHandler;
-
-        const unsignedData = { taskId: 'import-orch-no-sig', filepath: 's3://allowed-bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 1 };
-        await handler.handleMessageAsync({
-            key: 'import-orch-no-sig-0',
-            value: JSON.stringify({
-                specversion: '1.0', id: 'evt-no-sig', source: 'https://www.icanbwell.com/fhir-server',
-                type: 'ImportRangeStarted', datacontenttype: 'application/json', data: unsignedData
-            }),
-            headers: []
-        });
-
-        const taskResp = await request
-            .get('/4_0_0/Task/import-orch-no-sig')
-            .set(getHeaders())
-            .expect(200);
-        // Must NOT have been flipped to in-progress -- the unsigned message was rejected.
-        expect(taskResp.body.status).toBe('requested');
-    });
-
-    test('handleMessageAsync ignores a range-progress message with a tampered payload', async () => {
-        const request = await createTestRequest();
-        await request
-            .post('/4_0_0/$import')
-            .send({ ...validParametersBody, id: 'import-orch-tampered' })
-            .set(getHeaders())
-            .expect(202);
-
-        const { createTestContainer } = require('../../createTestContainer');
-        const container = createTestContainer();
-        const handler = container.bulkImportHandler;
-
-        // Sign a legitimate payload, then swap in a different taskId after signing -- the
-        // signature no longer matches the (tampered) data it's attached to.
-        const originalData = { taskId: 'some-other-task', filepath: 's3://allowed-bucket/Patient.ndjson', rangeIndex: 0, taskTotalRanges: 1 };
-        const signature = signRangeProgressPayload(originalData);
-        const tamperedData = { ...originalData, taskId: 'import-orch-tampered', signature };
-
-        await handler.handleMessageAsync({
-            key: 'import-orch-tampered-0',
-            value: JSON.stringify({
-                specversion: '1.0', id: 'evt-tampered', source: 'https://www.icanbwell.com/fhir-server',
-                type: 'ImportRangeStarted', datacontenttype: 'application/json', data: tamperedData
-            }),
-            headers: []
-        });
-
-        const taskResp = await request
-            .get('/4_0_0/Task/import-orch-tampered')
-            .set(getHeaders())
-            .expect(200);
-        expect(taskResp.body.status).toBe('requested');
-    });
-
-    test('handleMessageAsync ignores a range-progress message when the worker secret is not configured', async () => {
-        delete process.env.BULK_IMPORT_WORKER_SECRET;
-
-        const request = await createTestRequest();
-        await request
-            .post('/4_0_0/$import')
-            .send({ ...validParametersBody, id: 'import-orch-no-secret' })
-            .set(getHeaders())
-            .expect(202);
-
-        const { createTestContainer } = require('../../createTestContainer');
-        const container = createTestContainer();
-        const handler = container.bulkImportHandler;
-
-        await handler.handleMessageAsync({
-            key: 'import-orch-no-secret-0',
-            value: makeRangeProgressEvent('ImportRangeStarted', { taskId: 'import-orch-no-secret' }),
-            headers: []
-        });
-
-        const taskResp = await request
-            .get('/4_0_0/Task/import-orch-no-secret')
-            .set(getHeaders())
-            .expect(200);
-        expect(taskResp.body.status).toBe('requested');
-    });
 });
 
 // TODO: Uncomment when orchestrator logic is enabled in a follow-up PR.

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -622,13 +622,13 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
     test('countCompletedRanges counts distinct ranges, ignoring the -result/-error suffix and unrelated output entries', () => {
         const { createTestContainer } = require('../../createTestContainer');
         const container = createTestContainer();
-        const handler = container.bulkImportHandler;
+        const stateMachine = container.bulkImportTaskStateMachine;
 
         // No output at all -- zero ranges completed.
-        expect(handler.countCompletedRanges({ output: [] })).toBe(0);
+        expect(stateMachine.countCompletedRanges({ output: [] })).toBe(0);
 
         // A range with BOTH a -result and a -error entry must still count as ONE range.
-        expect(handler.countCompletedRanges({
+        expect(stateMachine.countCompletedRanges({
             output: [
                 { id: 'bulk-import-range:s3://bucket/a.ndjson#0-result', type: { text: 'result' }, valueUri: 's3://bucket/out/a.ndjson' },
                 { id: 'bulk-import-range:s3://bucket/a.ndjson#0-error', type: { text: 'error' }, valueUri: 's3://bucket/out/a-errors.ndjson' }
@@ -637,7 +637,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
 
         // Multiple distinct ranges (including an "empty" placeholder entry with no suffix)
         // all count individually.
-        expect(handler.countCompletedRanges({
+        expect(stateMachine.countCompletedRanges({
             output: [
                 { id: 'bulk-import-range:s3://bucket/a.ndjson#0-result', type: { text: 'result' }, valueUri: 's3://bucket/out/a.ndjson' },
                 { id: 'bulk-import-range:s3://bucket/a.ndjson#1-error', type: { text: 'error' }, valueUri: 's3://bucket/out/a-errors.ndjson' },
@@ -647,7 +647,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
 
         // An output entry that doesn't match the "bulk-import-range:" id prefix at all (e.g.
         // a plain error output with no id) must be ignored rather than miscounted.
-        expect(handler.countCompletedRanges({
+        expect(stateMachine.countCompletedRanges({
             output: [
                 { type: { text: 'error' }, valueUri: 's3://bucket/out/unrelated-errors.ndjson' },
                 { id: 'bulk-import-range:s3://bucket/a.ndjson#0-result', type: { text: 'result' }, valueUri: 's3://bucket/out/a.ndjson' }
@@ -658,11 +658,11 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
     test('countCompletedRanges does not throw and returns 0 when task.output is missing', () => {
         const { createTestContainer } = require('../../createTestContainer');
         const container = createTestContainer();
-        const handler = container.bulkImportHandler;
+        const stateMachine = container.bulkImportTaskStateMachine;
 
-        expect(() => handler.countCompletedRanges({})).not.toThrow();
-        expect(handler.countCompletedRanges({})).toBe(0);
-        expect(handler.countCompletedRanges({ output: undefined })).toBe(0);
+        expect(() => stateMachine.countCompletedRanges({})).not.toThrow();
+        expect(stateMachine.countCompletedRanges({})).toBe(0);
+        expect(stateMachine.countCompletedRanges({ output: undefined })).toBe(0);
     });
 
     test('handleMessageAsync writes result NDJSON to S3 and records Task.output + completion', async () => {

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -10,6 +10,7 @@ const makeCloudEvent = (overrides = {}) => {
         byteRangeEnd: 104857600,
         rangeIndex: 0,
         totalRanges: 1,
+        taskTotalRanges: 1,
         requestId: 'req-001',
         scope: 'user/*.write',
         user: 'test-user',
@@ -25,6 +26,36 @@ const makeCloudEvent = (overrides = {}) => {
         data
     });
 };
+
+/**
+ * Drives a single ImportRangeRequested message through the worker side of
+ * handleMessageAsync, then feeds every range-progress CloudEvent the worker published
+ * (ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed, via
+ * bulkImportEventProducer.publishRangeProgressEventAsync -> kafkaClientV2.sendCloudEventMessageAsync)
+ * back through handleMessageAsync again, simulating the second real Kafka hop onto the
+ * orchestrator's consumer. The worker no longer reads or writes the Task itself -- only the
+ * orchestrator does, upon consuming these events -- so tests that assert on Task state need
+ * both hops to actually happen.
+ * @param {import('../../../operations/asyncJobs/bulkImport/handler').BulkImportHandler} handler
+ * @param {Object} container
+ * @param {{ key: string, value: string, headers: Array<{key: string, value: string}> }} message
+ * @returns {Promise<void>}
+ */
+async function processRangeAsync(handler, container, message) {
+    const sendSpy = jest.spyOn(container.kafkaClientV2, 'sendCloudEventMessageAsync');
+    const callsBefore = sendSpy.mock.calls.length;
+
+    await handler.handleMessageAsync(message);
+
+    const newCalls = sendSpy.mock.calls.slice(callsBefore);
+    sendSpy.mockRestore();
+
+    for (const [{ messages }] of newCalls) {
+        for (const msg of messages) {
+            await handler.handleMessageAsync({ key: msg.key, value: msg.value, headers: [] });
+        }
+    }
+}
 
 const validParametersBody = {
     resourceType: 'Parameters',
@@ -47,6 +78,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
     beforeEach(async () => {
         process.env.ENABLE_BULK_IMPORT = '1';
         process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS = 'allowed-bucket';
+        process.env.ENABLE_EVENTS_KAFKA_V2 = '1';
         fakeSpan = { setAttributes: jest.fn() };
         activeSpanSpy = jest.spyOn(trace, 'getActiveSpan').mockReturnValue(fakeSpan);
         await commonBeforeEach();
@@ -55,6 +87,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
     afterEach(async () => {
         delete process.env.ENABLE_BULK_IMPORT;
         delete process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS;
+        delete process.env.ENABLE_EVENTS_KAFKA_V2;
         activeSpanSpy.mockRestore();
         await commonAfterEach();
     });
@@ -104,11 +137,11 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         const container = createTestContainer();
         const handler = container.bulkImportHandler;
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-001-0-0',
-            // totalRanges: 2 so this single range does not also complete the Task —
-            // that behavior is covered separately below.
-            value: makeCloudEvent({ totalRanges: 2 }),
+            // totalRanges/taskTotalRanges: 2 so this single range does not also complete
+            // the Task — that behavior is covered separately below.
+            value: makeCloudEvent({ totalRanges: 2, taskTotalRanges: 2 }),
             headers: []
         });
 
@@ -144,9 +177,9 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         const container = createTestContainer();
         const handler = container.bulkImportHandler;
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-001-0-0',
-            value: makeCloudEvent({ rangeIndex: 0, totalRanges: 2 }),
+            value: makeCloudEvent({ rangeIndex: 0, totalRanges: 2, taskTotalRanges: 2 }),
             headers: []
         });
 
@@ -156,9 +189,9 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             .expect(200);
         expect(taskResp.body.status).toBe('in-progress');
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-001-1',
-            value: makeCloudEvent({ rangeIndex: 1, totalRanges: 2 }),
+            value: makeCloudEvent({ rangeIndex: 1, totalRanges: 2, taskTotalRanges: 2 }),
             headers: []
         });
 
@@ -399,7 +432,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             { resourceType: 'Patient', id: 'bulk-import-survivor', name: [{ family: 'Survivor' }] }
         ]);
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-partial-fail-0',
             value: makeCloudEvent({ taskId: 'import-consumer-partial-fail' }),
             headers: []
@@ -469,7 +502,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             { resourceType: 'Patient', id: 'bulk-import-after-bad-line', name: [{ family: 'After' }] }
         ]);
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-bad-line-0',
             value: makeCloudEvent({ taskId: 'import-consumer-bad-line' }),
             headers: []
@@ -586,43 +619,50 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         expect(errorKey).toBe('run-20260521/output/errors/Patient-001-errors.ndjson');
     });
 
-    test('isTaskFullyComplete is false until every range of every input file is marked complete', () => {
+    test('countCompletedRanges counts distinct ranges, ignoring the -result/-error suffix and unrelated output entries', () => {
         const { createTestContainer } = require('../../createTestContainer');
         const container = createTestContainer();
         const handler = container.bulkImportHandler;
 
-        const marker = (filepath, rangeIndex, totalRanges) => ({
-            url: 'https://www.icanbwell.com/bulk-import-range-completed',
-            valueString: JSON.stringify({ filepath, rangeIndex, totalRanges })
-        });
+        // No output at all -- zero ranges completed.
+        expect(handler.countCompletedRanges({ output: [] })).toBe(0);
 
-        expect(handler.isTaskFullyComplete({
-            input: [{ valueUri: 's3://bucket/a.ndjson' }],
-            extension: []
-        })).toBe(false);
-
-        expect(handler.isTaskFullyComplete({
-            input: [
-                { valueUri: 's3://bucket/a.ndjson' },
-                { valueUri: 's3://bucket/b.ndjson' }
-            ],
-            extension: [
-                marker('s3://bucket/a.ndjson', 0, 2),
-                marker('s3://bucket/a.ndjson', 1, 2)
+        // A range with BOTH a -result and a -error entry must still count as ONE range.
+        expect(handler.countCompletedRanges({
+            output: [
+                { id: 'bulk-import-range:s3://bucket/a.ndjson#0-result', type: { text: 'result' }, valueUri: 's3://bucket/out/a.ndjson' },
+                { id: 'bulk-import-range:s3://bucket/a.ndjson#0-error', type: { text: 'error' }, valueUri: 's3://bucket/out/a-errors.ndjson' }
             ]
-        })).toBe(false); // file "b" hasn't started
+        })).toBe(1);
 
-        expect(handler.isTaskFullyComplete({
-            input: [
-                { valueUri: 's3://bucket/a.ndjson' },
-                { valueUri: 's3://bucket/b.ndjson' }
-            ],
-            extension: [
-                marker('s3://bucket/a.ndjson', 0, 2),
-                marker('s3://bucket/a.ndjson', 1, 2),
-                marker('s3://bucket/b.ndjson', 0, 1)
+        // Multiple distinct ranges (including an "empty" placeholder entry with no suffix)
+        // all count individually.
+        expect(handler.countCompletedRanges({
+            output: [
+                { id: 'bulk-import-range:s3://bucket/a.ndjson#0-result', type: { text: 'result' }, valueUri: 's3://bucket/out/a.ndjson' },
+                { id: 'bulk-import-range:s3://bucket/a.ndjson#1-error', type: { text: 'error' }, valueUri: 's3://bucket/out/a-errors.ndjson' },
+                { id: 'bulk-import-range:s3://bucket/b.ndjson#0', type: { text: 'empty' } }
             ]
-        })).toBe(true);
+        })).toBe(3);
+
+        // An output entry that doesn't match the "bulk-import-range:" id prefix at all (e.g.
+        // a plain error output with no id) must be ignored rather than miscounted.
+        expect(handler.countCompletedRanges({
+            output: [
+                { type: { text: 'error' }, valueUri: 's3://bucket/out/unrelated-errors.ndjson' },
+                { id: 'bulk-import-range:s3://bucket/a.ndjson#0-result', type: { text: 'result' }, valueUri: 's3://bucket/out/a.ndjson' }
+            ]
+        })).toBe(1);
+    });
+
+    test('countCompletedRanges does not throw and returns 0 when task.output is missing', () => {
+        const { createTestContainer } = require('../../createTestContainer');
+        const container = createTestContainer();
+        const handler = container.bulkImportHandler;
+
+        expect(() => handler.countCompletedRanges({})).not.toThrow();
+        expect(handler.countCompletedRanges({})).toBe(0);
+        expect(handler.countCompletedRanges({ output: undefined })).toBe(0);
     });
 
     test('handleMessageAsync writes result NDJSON to S3 and records Task.output + completion', async () => {
@@ -642,7 +682,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             { resourceType: 'Patient', id: 'bulk-import-output-1', name: [{ family: 'Output' }] }
         ]);
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-output-0',
             value: makeCloudEvent({ taskId: 'import-consumer-output' }),
             headers: []
@@ -662,6 +702,9 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         expect(taskResp.body.status).toBe('completed');
         const resultOutput = taskResp.body.output.find((o) => o.type.text === 'result');
         expect(resultOutput.valueUri).toBe('s3://allowed-bucket/output/Patient-001.ndjson');
+        expect(resultOutput.id).toBe(
+            'bulk-import-range:s3://allowed-bucket/Patient.ndjson#0-result'
+        );
 
         // 1 created, 0 failed -- tagged as span attributes.
         expect(fakeSpan.setAttributes).toHaveBeenCalledWith({
@@ -669,19 +712,6 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             'fhir_import.resources_updated': 0,
             'fhir_import.resources_failed': 0
         });
-    });
-
-    test('isTaskFullyComplete ignores an unparseable completion marker rather than throwing', () => {
-        const { createTestContainer } = require('../../createTestContainer');
-        const container = createTestContainer();
-        const handler = container.bulkImportHandler;
-
-        expect(() => handler.isTaskFullyComplete({
-            input: [{ valueUri: 's3://bucket/a.ndjson' }],
-            extension: [
-                { url: 'https://www.icanbwell.com/bulk-import-range-completed', valueString: 'not-json' }
-            ]
-        })).not.toThrow();
     });
 
     test('writeNdjsonWithRetryAsync retries transient failures and succeeds', async () => {
@@ -839,7 +869,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         container.s3NdjsonReader.setFailAfterYielding(1);
 
         try {
-            await handler.handleMessageAsync({
+            await processRangeAsync(handler, container, {
                 key: 'import-consumer-partial-flush-0',
                 value: makeCloudEvent({ taskId: 'import-consumer-partial-flush' }),
                 headers: []
@@ -891,7 +921,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         ]);
         container.s3NdjsonReader.setFailNextReads(1);
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-read-retry-0',
             value: makeCloudEvent({ taskId: 'import-consumer-read-retry' }),
             headers: []
@@ -931,7 +961,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         ]);
         container.s3NdjsonReader.setFailNextReads(3);
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-read-exhausted-0',
             value: makeCloudEvent({ taskId: 'import-consumer-read-exhausted' }),
             headers: []
@@ -998,8 +1028,9 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             { resourceType: 'Patient', id: 'bulk-import-no-regress-1', name: [{ family: 'Once' }] }
         ]);
 
-        // First delivery: only range, only file -> Task completes.
-        await handler.handleMessageAsync({
+        // First delivery: only range, only file -> Task completes (both worker and
+        // orchestrator hops).
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-no-regress-0',
             value: makeCloudEvent({ taskId: 'import-consumer-no-regress' }),
             headers: []
@@ -1011,14 +1042,18 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             .expect(200);
         expect(taskResp.body.status).toBe('completed');
 
-        // Kafka redelivers the same range; this time the S3 read hits a transient error.
+        // Kafka redelivers the same range; this time the S3 read hits a transient error on
+        // every attempt, so the worker exhausts its retries and publishes ImportRangeFailed
+        // unconditionally (it never reads the Task itself). The "must not regress an
+        // already-completed Task" guard now lives on the orchestrator's
+        // handleRangeFailedAsync, exercised here via the second processRangeAsync hop.
         const readSpy = jest.spyOn(container.s3NdjsonReader, 'readNdjsonAsync')
             // eslint-disable-next-line require-yield -- deliberately throws before ever yielding
             .mockImplementation(async function* () {
                 throw new Error('transient S3 read error');
             });
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-no-regress-0-redelivered',
             value: makeCloudEvent({ taskId: 'import-consumer-no-regress' }),
             headers: []
@@ -1058,7 +1093,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             }
         ]);
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-ine-create-0',
             value: makeCloudEvent({ taskId: 'import-consumer-ine-create' }),
             headers: []
@@ -1129,7 +1164,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             }
         ]);
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-ine-skip-0',
             value: makeCloudEvent({ taskId: 'import-consumer-ine-skip' }),
             headers: []
@@ -1253,7 +1288,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             }
         ]);
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-ine-bad-param-0',
             value: makeCloudEvent({ taskId: 'import-consumer-ine-bad-param' }),
             headers: []
@@ -1416,7 +1451,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
             { resourceType: 'Patient', id: 'bulk-import-audit-flush-error', name: [{ family: 'Flushed' }] }
         ]);
 
-        await handler.handleMessageAsync({
+        await processRangeAsync(handler, container, {
             key: 'import-consumer-audit-flush-error-0',
             value: makeCloudEvent({ taskId: 'import-consumer-audit-flush-error' }),
             headers: []
@@ -1474,7 +1509,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         container.s3NdjsonReader.setFailAfterYielding(1);
 
         try {
-            await handler.handleMessageAsync({
+            await processRangeAsync(handler, container, {
                 key: 'import-consumer-audit-partial-flush-0',
                 value: makeCloudEvent({ taskId: 'import-consumer-audit-partial-flush' }),
                 headers: []

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -79,6 +79,9 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         process.env.ENABLE_BULK_IMPORT = '1';
         process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS = 'allowed-bucket';
         process.env.ENABLE_EVENTS_KAFKA_V2 = '1';
+        // publishRangeProgressEventAsync signs every message and refuses to publish
+        // unsigned if this isn't set (see BulkImportEventProducer.signRangeProgressPayload).
+        process.env.BULK_IMPORT_WORKER_SECRET = 'test-worker-secret';
         fakeSpan = { setAttributes: jest.fn() };
         activeSpanSpy = jest.spyOn(trace, 'getActiveSpan').mockReturnValue(fakeSpan);
         await commonBeforeEach();
@@ -88,6 +91,7 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         delete process.env.ENABLE_BULK_IMPORT;
         delete process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS;
         delete process.env.ENABLE_EVENTS_KAFKA_V2;
+        delete process.env.BULK_IMPORT_WORKER_SECRET;
         activeSpanSpy.mockRestore();
         await commonAfterEach();
     });

--- a/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
+++ b/src/tests/asyncJobs/bulkImport/handlerWorker.test.js
@@ -79,9 +79,6 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         process.env.ENABLE_BULK_IMPORT = '1';
         process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS = 'allowed-bucket';
         process.env.ENABLE_EVENTS_KAFKA_V2 = '1';
-        // publishRangeProgressEventAsync signs every message and refuses to publish
-        // unsigned if this isn't set (see BulkImportEventProducer.signRangeProgressPayload).
-        process.env.BULK_IMPORT_WORKER_SECRET = 'test-worker-secret';
         fakeSpan = { setAttributes: jest.fn() };
         activeSpanSpy = jest.spyOn(trace, 'getActiveSpan').mockReturnValue(fakeSpan);
         await commonBeforeEach();
@@ -91,7 +88,6 @@ describe('BulkImportHandler - ImportRangeRequested (worker)', () => {
         delete process.env.ENABLE_BULK_IMPORT;
         delete process.env.BULK_IMPORT_ALLOWED_S3_BUCKETS;
         delete process.env.ENABLE_EVENTS_KAFKA_V2;
-        delete process.env.BULK_IMPORT_WORKER_SECRET;
         activeSpanSpy.mockRestore();
         await commonAfterEach();
     });

--- a/src/tests/unit/operations/asyncJobs/bulkImport/bulkImportEventProducer.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/bulkImportEventProducer.test.js
@@ -40,8 +40,7 @@ describe('BulkImportEventProducer', () => {
             kafkaV2EnableEvents: true,
             kafkaBulkImportEventTopic: 'import-events',
             kafkaBulkImportRangeProgressTopic: 'import-range-progress',
-            bulkImportRangeSizeMb: 1,
-            bulkImportWorkerSecret: 'test-worker-secret'
+            bulkImportRangeSizeMb: 1
         };
         producer = new BulkImportEventProducer({
             kafkaClientV2: mockKafkaClientV2,
@@ -145,11 +144,10 @@ describe('BulkImportEventProducer', () => {
 
             const cloudEvent = JSON.parse(messages[0].value);
             expect(cloudEvent.type).toBe('ImportRangeCompleted');
-            expect(cloudEvent.data).toMatchObject({
+            expect(cloudEvent.data).toEqual({
                 taskId: 't1', filepath: 'a.ndjson', rangeIndex: 0, taskTotalRanges: 1,
                 resultUri: 's3://bucket/result.ndjson', errorUri: null
             });
-            expect(typeof cloudEvent.data.signature).toBe('string');
         });
 
         test('propagates a Kafka send failure rather than swallowing it', async () => {
@@ -160,15 +158,5 @@ describe('BulkImportEventProducer', () => {
             })).rejects.toThrow('broker unavailable');
         });
 
-        // IDOR: without this, anyone able to publish onto kafkaBulkImportRangeProgressTopic
-        // could forge a message with an arbitrary taskId and manipulate any Task.
-        test('throws instead of publishing when the worker secret is not configured', async () => {
-            mockConfigManager.bulkImportWorkerSecret = undefined;
-            await expect(producer.publishRangeProgressEventAsync({
-                type: 'ImportRangeStarted',
-                data: { taskId: 't1', filepath: 'a.ndjson', rangeIndex: 0, taskTotalRanges: 1 }
-            })).rejects.toThrow('bulkImportWorkerSecret is not configured');
-            expect(mockKafkaClientV2.sendCloudEventMessageAsync).not.toHaveBeenCalled();
-        });
     });
 });

--- a/src/tests/unit/operations/asyncJobs/bulkImport/bulkImportEventProducer.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/bulkImportEventProducer.test.js
@@ -32,10 +32,14 @@ describe('BulkImportEventProducer', () => {
     let mockConfigManager;
 
     beforeEach(() => {
-        mockKafkaClientV2 = { sendMessagesAsync: jestObj.fn().mockResolvedValue(undefined) };
+        mockKafkaClientV2 = {
+            sendMessagesAsync: jestObj.fn().mockResolvedValue(undefined),
+            sendCloudEventMessageAsync: jestObj.fn().mockResolvedValue(undefined)
+        };
         mockConfigManager = {
             kafkaV2EnableEvents: true,
             kafkaBulkImportEventTopic: 'import-events',
+            kafkaBulkImportRangeProgressTopic: 'import-range-progress',
             bulkImportRangeSizeMb: 1
         };
         producer = new BulkImportEventProducer({
@@ -75,5 +79,83 @@ describe('BulkImportEventProducer', () => {
             requestId: 'r1', scope: 's', user: 'u'
         });
         expect(result).toBe(0);
+    });
+
+    test('calculateTotalRangeCount sums ranges across every input file', () => {
+        // 3MB + 0.5MB + exactly 2MB at a 1MB range size -> 3 + 1 + 2 ranges.
+        const total = producer.calculateTotalRangeCount([
+            { url: 'a.ndjson', fileSize: 3 * 1024 * 1024 },
+            { url: 'b.ndjson', fileSize: 500000 },
+            { url: 'c.ndjson', fileSize: 2 * 1024 * 1024 }
+        ]);
+        expect(total).toBe(6);
+    });
+
+    test('publishImportEventsAsync stamps every message with the task-wide taskTotalRanges, distinct from each message\'s own per-file totalRanges', async () => {
+        // File A: 3 ranges, file B: 1 range -- task-wide total is 4, but neither file's own
+        // totalRanges equals that, so a bug conflating the two would be immediately observable.
+        const inputs = [
+            { url: 'a.ndjson', fileSize: 3 * 1024 * 1024 },
+            { url: 'b.ndjson', fileSize: 500000 }
+        ];
+
+        await producer.publishImportEventsAsync({
+            taskId: 't1', inputs, requestId: 'r1', scope: 's', user: 'u'
+        });
+
+        const sentMessages = mockKafkaClientV2.sendCloudEventMessageAsync.mock.calls[0][0].messages
+            .map((m) => JSON.parse(m.value).data);
+
+        expect(sentMessages).toHaveLength(4);
+        for (const message of sentMessages) {
+            expect(message.taskTotalRanges).toBe(4);
+        }
+
+        const fileARanges = sentMessages.filter((m) => m.filepath === 'a.ndjson');
+        const fileBRanges = sentMessages.filter((m) => m.filepath === 'b.ndjson');
+        expect(fileARanges.every((m) => m.totalRanges === 3)).toBe(true);
+        expect(fileBRanges.every((m) => m.totalRanges === 1)).toBe(true);
+    });
+
+    describe('publishRangeProgressEventAsync', () => {
+        test('does nothing when kafka is disabled', async () => {
+            mockConfigManager.kafkaV2EnableEvents = false;
+            await producer.publishRangeProgressEventAsync({
+                type: 'ImportRangeStarted',
+                data: { taskId: 't1', filepath: 'a.ndjson', rangeIndex: 0, taskTotalRanges: 1 }
+            });
+            expect(mockKafkaClientV2.sendCloudEventMessageAsync).not.toHaveBeenCalled();
+        });
+
+        test('publishes a CloudEvent of the given type onto the range-progress topic, keyed by taskId', async () => {
+            await producer.publishRangeProgressEventAsync({
+                type: 'ImportRangeCompleted',
+                data: {
+                    taskId: 't1', filepath: 'a.ndjson', rangeIndex: 0, taskTotalRanges: 1,
+                    resultUri: 's3://bucket/result.ndjson', errorUri: null
+                }
+            });
+
+            expect(mockKafkaClientV2.sendCloudEventMessageAsync).toHaveBeenCalledTimes(1);
+            const { topic, messages } = mockKafkaClientV2.sendCloudEventMessageAsync.mock.calls[0][0];
+            expect(topic).toBe('import-range-progress');
+            expect(messages).toHaveLength(1);
+            expect(messages[0].key).toBe('t1');
+
+            const cloudEvent = JSON.parse(messages[0].value);
+            expect(cloudEvent.type).toBe('ImportRangeCompleted');
+            expect(cloudEvent.data).toEqual({
+                taskId: 't1', filepath: 'a.ndjson', rangeIndex: 0, taskTotalRanges: 1,
+                resultUri: 's3://bucket/result.ndjson', errorUri: null
+            });
+        });
+
+        test('propagates a Kafka send failure rather than swallowing it', async () => {
+            mockKafkaClientV2.sendCloudEventMessageAsync.mockRejectedValueOnce(new Error('broker unavailable'));
+            await expect(producer.publishRangeProgressEventAsync({
+                type: 'ImportRangeFailed',
+                data: { taskId: 't1', filepath: 'a.ndjson', rangeIndex: 0, taskTotalRanges: 1, errorMessage: 'boom' }
+            })).rejects.toThrow('broker unavailable');
+        });
     });
 });

--- a/src/tests/unit/operations/asyncJobs/bulkImport/bulkImportEventProducer.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/bulkImportEventProducer.test.js
@@ -40,7 +40,8 @@ describe('BulkImportEventProducer', () => {
             kafkaV2EnableEvents: true,
             kafkaBulkImportEventTopic: 'import-events',
             kafkaBulkImportRangeProgressTopic: 'import-range-progress',
-            bulkImportRangeSizeMb: 1
+            bulkImportRangeSizeMb: 1,
+            bulkImportWorkerSecret: 'test-worker-secret'
         };
         producer = new BulkImportEventProducer({
             kafkaClientV2: mockKafkaClientV2,
@@ -144,10 +145,11 @@ describe('BulkImportEventProducer', () => {
 
             const cloudEvent = JSON.parse(messages[0].value);
             expect(cloudEvent.type).toBe('ImportRangeCompleted');
-            expect(cloudEvent.data).toEqual({
+            expect(cloudEvent.data).toMatchObject({
                 taskId: 't1', filepath: 'a.ndjson', rangeIndex: 0, taskTotalRanges: 1,
                 resultUri: 's3://bucket/result.ndjson', errorUri: null
             });
+            expect(typeof cloudEvent.data.signature).toBe('string');
         });
 
         test('propagates a Kafka send failure rather than swallowing it', async () => {
@@ -156,6 +158,17 @@ describe('BulkImportEventProducer', () => {
                 type: 'ImportRangeFailed',
                 data: { taskId: 't1', filepath: 'a.ndjson', rangeIndex: 0, taskTotalRanges: 1, errorMessage: 'boom' }
             })).rejects.toThrow('broker unavailable');
+        });
+
+        // IDOR: without this, anyone able to publish onto kafkaBulkImportRangeProgressTopic
+        // could forge a message with an arbitrary taskId and manipulate any Task.
+        test('throws instead of publishing when the worker secret is not configured', async () => {
+            mockConfigManager.bulkImportWorkerSecret = undefined;
+            await expect(producer.publishRangeProgressEventAsync({
+                type: 'ImportRangeStarted',
+                data: { taskId: 't1', filepath: 'a.ndjson', rangeIndex: 0, taskTotalRanges: 1 }
+            })).rejects.toThrow('bulkImportWorkerSecret is not configured');
+            expect(mockKafkaClientV2.sendCloudEventMessageAsync).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
@@ -93,6 +93,7 @@ function createMockTask(overrides = {}) {
         resourceType: 'Task',
         id: 'task-abc-123',
         status: 'requested',
+        code: { coding: [{ system: 'https://www.icanbwell.com/task-type', code: 'bulk-import' }] },
         meta: { lastUpdated: '2026-01-01T00:00:00.000Z' },
         ...overrides
     };
@@ -818,6 +819,32 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
                     'Failed to parse bulk import range-progress Kafka message',
                     expect.objectContaining({ error: expect.stringContaining('signature does not match') })
                 );
+                expect(updateOneAsync).not.toHaveBeenCalled();
+            });
+
+            test('does not mutate a Task that lacks the bulk-import code, even with a valid signature', async () => {
+                // A valid HMAC proves the message came from a trusted worker but does not grant
+                // permission to modify an arbitrary Task -- loadTaskAsync now restricts its query
+                // to Tasks carrying the bulk-import code so a message with a legitimate signature
+                // but a taskId pointing at a non-import Task is silently dropped.
+                const updateOneAsync = jestGlobal.fn().mockResolvedValue(undefined);
+                const handlerInstance = createHandler({}, {
+                    databaseQueryFactory: {
+                        createQuery: jestGlobal.fn(() => ({
+                            findOneAsync: jestGlobal.fn().mockResolvedValue(null) // code filter returns nothing
+                        }))
+                    },
+                    databaseUpdateFactory: {
+                        createDatabaseUpdateManager: jestGlobal.fn(() => ({ updateOneAsync }))
+                    }
+                });
+
+                await handlerInstance.handleMessageAsync({
+                    key: 'k1',
+                    value: createRangeProgressMessage('ImportRangeStarted'),
+                    headers: []
+                });
+
                 expect(updateOneAsync).not.toHaveBeenCalled();
             });
 

--- a/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
@@ -11,16 +11,7 @@
  *
  * Security-critical scenarios are documented inline.
  */
-const crypto = require('crypto');
 const { describe, test, expect, beforeEach, jest: jestGlobal } = require('@jest/globals');
-
-const TEST_WORKER_SECRET = 'test-worker-secret';
-
-// Mirrors BulkImportEventProducer.signRangeProgressPayload -- createRangeProgressMessage
-// below builds messages by hand rather than via the real producer, so it needs to sign the
-// payload itself the same way.
-const signRangeProgressPayload = (data) =>
-    crypto.createHmac('sha256', TEST_WORKER_SECRET).update(JSON.stringify(data)).digest('hex');
 
 // Mock logging before importing the module under test
 jestGlobal.mock('../../../../../operations/common/logging', () => {
@@ -65,11 +56,6 @@ function createMockConfigManager(overrides = {}) {
         awsRegion: 'us-east-1',
         bulkImportMinFileSizeMb: 0,
         bulkImportMaxFileSizeGb: 5,
-        // handleRangeProgressEventAsync's parseRangeProgressEvent refuses to trust a
-        // range-progress message without this configured (see
-        // BulkImportHandler.verifyRangeProgressSignature) -- createRangeProgressMessage below
-        // signs with this exact value so the two stay in sync.
-        bulkImportWorkerSecret: TEST_WORKER_SECRET,
         ...overrides
     };
     const obj = {};
@@ -157,8 +143,6 @@ function createRangeProgressMessage(type, {
     if (errorMessage !== undefined) {
         data.errorMessage = errorMessage;
     }
-    data.signature = signRangeProgressPayload(data);
-
     return JSON.stringify({
         specversion: '1.0',
         id: 'evt-range-001',
@@ -773,154 +757,6 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
             });
             return { handler: handlerInstance, updateOneAsync, findOneAsync };
         }
-
-        // IDOR: without signature verification, anyone able to publish onto
-        // kafkaBulkImportRangeProgressTopic could forge a message with an arbitrary taskId and
-        // manipulate any Task's status/output -- these are the only authentication this topic
-        // has, so parseRangeProgressEvent must reject rather than trust an invalid message.
-        describe('signature verification', () => {
-            test('rejects a message with no signature at all', async () => {
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'requested' });
-                const data = { taskId: 'task-abc-123', filepath: 's3://allowed-bucket/data/patients.ndjson', rangeIndex: 0, taskTotalRanges: 1 };
-
-                await h.handleMessageAsync({
-                    key: 'k1',
-                    value: JSON.stringify({
-                        specversion: '1.0', id: 'evt-1', source: 'https://www.icanbwell.com/fhir-server',
-                        type: 'ImportRangeStarted', datacontenttype: 'application/json', data
-                    }),
-                    headers: []
-                });
-
-                expect(logError).toHaveBeenCalledWith(
-                    'Failed to parse bulk import range-progress Kafka message',
-                    expect.objectContaining({ error: expect.stringContaining('missing its signature') })
-                );
-                expect(updateOneAsync).not.toHaveBeenCalled();
-            });
-
-            test('rejects a message whose signature does not match its payload', async () => {
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'requested' });
-                const data = {
-                    taskId: 'task-abc-123', filepath: 's3://allowed-bucket/data/patients.ndjson', rangeIndex: 0,
-                    taskTotalRanges: 1, signature: signRangeProgressPayload({ taskId: 'a-different-task' })
-                };
-
-                await h.handleMessageAsync({
-                    key: 'k1',
-                    value: JSON.stringify({
-                        specversion: '1.0', id: 'evt-1', source: 'https://www.icanbwell.com/fhir-server',
-                        type: 'ImportRangeStarted', datacontenttype: 'application/json', data
-                    }),
-                    headers: []
-                });
-
-                expect(logError).toHaveBeenCalledWith(
-                    'Failed to parse bulk import range-progress Kafka message',
-                    expect.objectContaining({ error: expect.stringContaining('signature does not match') })
-                );
-                expect(updateOneAsync).not.toHaveBeenCalled();
-            });
-
-            test('does not mutate a Task that lacks the bulk-import code, even with a valid signature', async () => {
-                // A valid HMAC proves the message came from a trusted worker but does not grant
-                // permission to modify an arbitrary Task -- loadTaskAsync now restricts its query
-                // to Tasks carrying the bulk-import code so a message with a legitimate signature
-                // but a taskId pointing at a non-import Task is silently dropped.
-                const updateOneAsync = jestGlobal.fn().mockResolvedValue(undefined);
-                const handlerInstance = createHandler({}, {
-                    databaseQueryFactory: {
-                        createQuery: jestGlobal.fn(() => ({
-                            findOneAsync: jestGlobal.fn().mockResolvedValue(null) // code filter returns nothing
-                        }))
-                    },
-                    databaseUpdateFactory: {
-                        createDatabaseUpdateManager: jestGlobal.fn(() => ({ updateOneAsync }))
-                    }
-                });
-
-                await handlerInstance.handleMessageAsync({
-                    key: 'k1',
-                    value: createRangeProgressMessage('ImportRangeStarted'),
-                    headers: []
-                });
-
-                expect(updateOneAsync).not.toHaveBeenCalled();
-            });
-
-            // S3 URI allowlist -- filepath, resultUri, and errorUri are written into
-            // Task.output as-is, so a compromised worker (or a replayed message that passed
-            // HMAC verification) must not be able to inject arbitrary URIs into Task output.
-            test('rejects a message whose filepath is not in the S3 allowlist', async () => {
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'requested' });
-                const data = { taskId: 'task-abc-123', filepath: 's3://disallowed-bucket/data/patients.ndjson', rangeIndex: 0, taskTotalRanges: 1 };
-                data.signature = signRangeProgressPayload(data);
-
-                await h.handleMessageAsync({
-                    key: 'k1',
-                    value: JSON.stringify({
-                        specversion: '1.0', id: 'evt-1', source: 'https://www.icanbwell.com/fhir-server',
-                        type: 'ImportRangeStarted', datacontenttype: 'application/json', data
-                    }),
-                    headers: []
-                });
-
-                expect(logError).toHaveBeenCalledWith(
-                    'Failed to parse bulk import range-progress Kafka message',
-                    expect.objectContaining({ error: expect.stringContaining('disallowed S3 bucket') })
-                );
-                expect(updateOneAsync).not.toHaveBeenCalled();
-            });
-
-            test('rejects a message whose resultUri is not in the S3 allowlist', async () => {
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'in-progress' });
-                const data = {
-                    taskId: 'task-abc-123', filepath: 's3://allowed-bucket/data/patients.ndjson',
-                    rangeIndex: 0, taskTotalRanges: 1,
-                    resultUri: 's3://evil-bucket/result.ndjson', errorUri: null
-                };
-                data.signature = signRangeProgressPayload(data);
-
-                await h.handleMessageAsync({
-                    key: 'k1',
-                    value: JSON.stringify({
-                        specversion: '1.0', id: 'evt-1', source: 'https://www.icanbwell.com/fhir-server',
-                        type: 'ImportRangeCompleted', datacontenttype: 'application/json', data
-                    }),
-                    headers: []
-                });
-
-                expect(logError).toHaveBeenCalledWith(
-                    'Failed to parse bulk import range-progress Kafka message',
-                    expect.objectContaining({ error: expect.stringContaining('disallowed S3 bucket') })
-                );
-                expect(updateOneAsync).not.toHaveBeenCalled();
-            });
-
-            test('rejects every range-progress message when the worker secret is not configured', async () => {
-                const updateOneAsync = jestGlobal.fn().mockResolvedValue(undefined);
-                const handlerInstance = createHandler({ bulkImportWorkerSecret: undefined }, {
-                    databaseQueryFactory: {
-                        createQuery: jestGlobal.fn(() => ({ findOneAsync: jestGlobal.fn().mockResolvedValue(createMockTask()) }))
-                    },
-                    databaseUpdateFactory: {
-                        createDatabaseUpdateManager: jestGlobal.fn(() => ({ updateOneAsync }))
-                    }
-                });
-
-                await handlerInstance.handleMessageAsync({
-                    key: 'k1',
-                    value: createRangeProgressMessage('ImportRangeStarted'),
-                    headers: []
-                });
-
-                expect(logError).toHaveBeenCalledWith(
-                    'Failed to parse bulk import range-progress Kafka message',
-                    expect.objectContaining({ error: expect.stringContaining('bulkImportWorkerSecret is not configured') })
-                );
-                expect(updateOneAsync).not.toHaveBeenCalled();
-            });
-        });
 
         describe('ImportRangeStarted', () => {
             test('flips a requested Task to in-progress', async () => {

--- a/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
@@ -11,7 +11,16 @@
  *
  * Security-critical scenarios are documented inline.
  */
+const crypto = require('crypto');
 const { describe, test, expect, beforeEach, jest: jestGlobal } = require('@jest/globals');
+
+const TEST_WORKER_SECRET = 'test-worker-secret';
+
+// Mirrors BulkImportEventProducer.signRangeProgressPayload -- createRangeProgressMessage
+// below builds messages by hand rather than via the real producer, so it needs to sign the
+// payload itself the same way.
+const signRangeProgressPayload = (data) =>
+    crypto.createHmac('sha256', TEST_WORKER_SECRET).update(JSON.stringify(data)).digest('hex');
 
 // Mock logging before importing the module under test
 jestGlobal.mock('../../../../../operations/common/logging', () => {
@@ -56,6 +65,11 @@ function createMockConfigManager(overrides = {}) {
         awsRegion: 'us-east-1',
         bulkImportMinFileSizeMb: 0,
         bulkImportMaxFileSizeGb: 5,
+        // handleRangeProgressEventAsync's parseRangeProgressEvent refuses to trust a
+        // range-progress message without this configured (see
+        // BulkImportHandler.verifyRangeProgressSignature) -- createRangeProgressMessage below
+        // signs with this exact value so the two stay in sync.
+        bulkImportWorkerSecret: TEST_WORKER_SECRET,
         ...overrides
     };
     const obj = {};
@@ -142,6 +156,7 @@ function createRangeProgressMessage(type, {
     if (errorMessage !== undefined) {
         data.errorMessage = errorMessage;
     }
+    data.signature = signRangeProgressPayload(data);
 
     return JSON.stringify({
         specversion: '1.0',
@@ -757,6 +772,79 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
             });
             return { handler: handlerInstance, updateOneAsync, findOneAsync };
         }
+
+        // IDOR: without signature verification, anyone able to publish onto
+        // kafkaBulkImportRangeProgressTopic could forge a message with an arbitrary taskId and
+        // manipulate any Task's status/output -- these are the only authentication this topic
+        // has, so parseRangeProgressEvent must reject rather than trust an invalid message.
+        describe('signature verification', () => {
+            test('rejects a message with no signature at all', async () => {
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'requested' });
+                const data = { taskId: 'task-abc-123', filepath: 's3://allowed-bucket/data/patients.ndjson', rangeIndex: 0, taskTotalRanges: 1 };
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: JSON.stringify({
+                        specversion: '1.0', id: 'evt-1', source: 'https://www.icanbwell.com/fhir-server',
+                        type: 'ImportRangeStarted', datacontenttype: 'application/json', data
+                    }),
+                    headers: []
+                });
+
+                expect(logError).toHaveBeenCalledWith(
+                    'Failed to parse bulk import range-progress Kafka message',
+                    expect.objectContaining({ error: expect.stringContaining('missing its signature') })
+                );
+                expect(updateOneAsync).not.toHaveBeenCalled();
+            });
+
+            test('rejects a message whose signature does not match its payload', async () => {
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'requested' });
+                const data = {
+                    taskId: 'task-abc-123', filepath: 's3://allowed-bucket/data/patients.ndjson', rangeIndex: 0,
+                    taskTotalRanges: 1, signature: signRangeProgressPayload({ taskId: 'a-different-task' })
+                };
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: JSON.stringify({
+                        specversion: '1.0', id: 'evt-1', source: 'https://www.icanbwell.com/fhir-server',
+                        type: 'ImportRangeStarted', datacontenttype: 'application/json', data
+                    }),
+                    headers: []
+                });
+
+                expect(logError).toHaveBeenCalledWith(
+                    'Failed to parse bulk import range-progress Kafka message',
+                    expect.objectContaining({ error: expect.stringContaining('signature does not match') })
+                );
+                expect(updateOneAsync).not.toHaveBeenCalled();
+            });
+
+            test('rejects every range-progress message when the worker secret is not configured', async () => {
+                const updateOneAsync = jestGlobal.fn().mockResolvedValue(undefined);
+                const handlerInstance = createHandler({ bulkImportWorkerSecret: undefined }, {
+                    databaseQueryFactory: {
+                        createQuery: jestGlobal.fn(() => ({ findOneAsync: jestGlobal.fn().mockResolvedValue(createMockTask()) }))
+                    },
+                    databaseUpdateFactory: {
+                        createDatabaseUpdateManager: jestGlobal.fn(() => ({ updateOneAsync }))
+                    }
+                });
+
+                await handlerInstance.handleMessageAsync({
+                    key: 'k1',
+                    value: createRangeProgressMessage('ImportRangeStarted'),
+                    headers: []
+                });
+
+                expect(logError).toHaveBeenCalledWith(
+                    'Failed to parse bulk import range-progress Kafka message',
+                    expect.objectContaining({ error: expect.stringContaining('bulkImportWorkerSecret is not configured') })
+                );
+                expect(updateOneAsync).not.toHaveBeenCalled();
+            });
+        });
 
         describe('ImportRangeStarted', () => {
             test('flips a requested Task to in-progress', async () => {

--- a/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
@@ -848,6 +848,55 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
                 expect(updateOneAsync).not.toHaveBeenCalled();
             });
 
+            // S3 URI allowlist -- filepath, resultUri, and errorUri are written into
+            // Task.output as-is, so a compromised worker (or a replayed message that passed
+            // HMAC verification) must not be able to inject arbitrary URIs into Task output.
+            test('rejects a message whose filepath is not in the S3 allowlist', async () => {
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'requested' });
+                const data = { taskId: 'task-abc-123', filepath: 's3://disallowed-bucket/data/patients.ndjson', rangeIndex: 0, taskTotalRanges: 1 };
+                data.signature = signRangeProgressPayload(data);
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: JSON.stringify({
+                        specversion: '1.0', id: 'evt-1', source: 'https://www.icanbwell.com/fhir-server',
+                        type: 'ImportRangeStarted', datacontenttype: 'application/json', data
+                    }),
+                    headers: []
+                });
+
+                expect(logError).toHaveBeenCalledWith(
+                    'Failed to parse bulk import range-progress Kafka message',
+                    expect.objectContaining({ error: expect.stringContaining('disallowed S3 bucket') })
+                );
+                expect(updateOneAsync).not.toHaveBeenCalled();
+            });
+
+            test('rejects a message whose resultUri is not in the S3 allowlist', async () => {
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'in-progress' });
+                const data = {
+                    taskId: 'task-abc-123', filepath: 's3://allowed-bucket/data/patients.ndjson',
+                    rangeIndex: 0, taskTotalRanges: 1,
+                    resultUri: 's3://evil-bucket/result.ndjson', errorUri: null
+                };
+                data.signature = signRangeProgressPayload(data);
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: JSON.stringify({
+                        specversion: '1.0', id: 'evt-1', source: 'https://www.icanbwell.com/fhir-server',
+                        type: 'ImportRangeCompleted', datacontenttype: 'application/json', data
+                    }),
+                    headers: []
+                });
+
+                expect(logError).toHaveBeenCalledWith(
+                    'Failed to parse bulk import range-progress Kafka message',
+                    expect.objectContaining({ error: expect.stringContaining('disallowed S3 bucket') })
+                );
+                expect(updateOneAsync).not.toHaveBeenCalled();
+            });
+
             test('rejects every range-progress message when the worker secret is not configured', async () => {
                 const updateOneAsync = jestGlobal.fn().mockResolvedValue(undefined);
                 const handlerInstance = createHandler({ bulkImportWorkerSecret: undefined }, {

--- a/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
@@ -7,7 +7,6 @@
  * - handleMessageAsync: end-to-end message handling, logging of sensitive data
  * - handleRangeProgressEventAsync (ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed):
  *   the orchestrator's role as the sole writer of a Task's status/output once it exists
- * - countCompletedRanges: recognizing which ranges have already reported completion
  *
  * Security-critical scenarios are documented inline.
  */
@@ -67,11 +66,7 @@ function createMockConfigManager(overrides = {}) {
 
 /**
  * Creates a mock Task resource with a working clone() (needed by
- * updateOrchestratorTaskStatusAsync). clone() returns another mock Task (itself
- * re-cloneable) rather than a plain object -- handleRangeCompletedAsync clones once to
- * append output, then may pass that clone into updateOrchestratorTaskStatusAsync, which
- * clones again to flip status; a plain `{...task}` spread would lose `.clone` on the second
- * hop and throw.
+ * BulkImportTaskStateMachine.updateTaskStatusAsync).
  * @param {Object} [overrides]
  */
 function createMockTask(overrides = {}) {
@@ -88,11 +83,26 @@ function createMockTask(overrides = {}) {
 }
 
 /**
+ * Creates a mock BulkImportTaskStateMachine. Defaults simulate the happy path
+ * (Task found) so individual tests only need to override what's relevant.
+ * @param {Object} [overrides]
+ */
+function createMockStateMachine(overrides = {}) {
+    return {
+        loadTaskAsync: jestGlobal.fn().mockResolvedValue(createMockTask()),
+        handleRangeStartedAsync: jestGlobal.fn().mockResolvedValue(undefined),
+        handleRangeCompletedAsync: jestGlobal.fn().mockResolvedValue(undefined),
+        handleRangeFailedAsync: jestGlobal.fn().mockResolvedValue(undefined),
+        updateTaskStatusAsync: jestGlobal.fn().mockResolvedValue(undefined),
+        ...overrides
+    };
+}
+
+/**
  * Creates a BulkImportHandler with mock dependencies. Defaults simulate the happy path
- * (Task found, S3 HEAD succeeds via the outer beforeEach's mockSend, events published) so
- * individual tests only need to override what's actually relevant to them.
+ * so individual tests only need to override what's actually relevant to them.
  * @param {Object} [configOverrides] - ConfigManager overrides
- * @param {Object} [depsOverrides] - Constructor dependency overrides (e.g. databaseQueryFactory)
+ * @param {Object} [depsOverrides] - Constructor dependency overrides
  * @returns {BulkImportHandler}
  */
 function createHandler(configOverrides = {}, depsOverrides = {}) {
@@ -102,14 +112,10 @@ function createHandler(configOverrides = {}, depsOverrides = {}) {
         bulkImportEventProducer: {
             publishImportEventsAsync: jestGlobal.fn().mockResolvedValue(1)
         },
+        bulkImportTaskStateMachine: createMockStateMachine(),
         databaseQueryFactory: {
             createQuery: jestGlobal.fn(() => ({
                 findOneAsync: jestGlobal.fn().mockResolvedValue(createMockTask())
-            }))
-        },
-        databaseUpdateFactory: {
-            createDatabaseUpdateManager: jestGlobal.fn(() => ({
-                updateOneAsync: jestGlobal.fn().mockResolvedValue(undefined)
             }))
         },
         fastDatabaseBulkInserter: {},
@@ -195,443 +201,145 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
         test('parses a valid TaskCreated event and returns data', () => {
             const messageValue = createTaskCreatedMessage({ taskId: 'task-xyz' });
             const result = handler.parseTaskCreatedEvent(messageValue);
-
             expect(result.taskId).toBe('task-xyz');
-            expect(result.inputs).toBeDefined();
-            expect(result.requestId).toBe('req-001');
         });
 
-        test('throws on invalid JSON', () => {
-            expect(() => handler.parseTaskCreatedEvent('not json')).toThrow();
-        });
-
-        test('rejects non-TaskCreated event types', () => {
+        test('throws if the event type is not TaskCreated', () => {
             const msg = JSON.stringify({
-                type: 'TaskCompleted',
-                data: { taskId: 'task-1' }
+                specversion: '1.0', id: 'e1', source: 'x',
+                type: 'SomethingElse', datacontenttype: 'application/json',
+                data: { taskId: 'task-abc' }
             });
-
-            expect(() => handler.parseTaskCreatedEvent(msg)).toThrow('Unexpected event type: TaskCompleted');
+            expect(() => handler.parseTaskCreatedEvent(msg)).toThrow('Unexpected event type');
         });
 
-        test('rejects event with missing type field', () => {
-            const msg = JSON.stringify({ data: { taskId: 'task-1' } });
-
-            expect(() => handler.parseTaskCreatedEvent(msg)).toThrow('Unexpected event type: undefined');
-        });
-
-        test('rejects event with missing data field', () => {
-            const msg = JSON.stringify({ type: 'TaskCreated' });
-
-            expect(() => handler.parseTaskCreatedEvent(msg)).toThrow('missing taskId');
-        });
-
-        test('rejects event with missing taskId in data', () => {
+        test('throws if taskId is missing', () => {
             const msg = JSON.stringify({
-                type: 'TaskCreated',
-                data: { inputs: [] }
+                specversion: '1.0', id: 'e1', source: 'x',
+                type: 'TaskCreated', datacontenttype: 'application/json',
+                data: {}
             });
-
-            expect(() => handler.parseTaskCreatedEvent(msg)).toThrow('missing taskId');
+            expect(() => handler.parseTaskCreatedEvent(msg)).toThrow('taskId');
         });
 
-        // SECURITY: parseTaskCreatedEvent does NOT validate scope or user fields.
-        // An attacker who can publish to the Kafka topic can set arbitrary
-        // scope/user and the orchestrator will process with those credentials.
-        test('SECURITY: parseTaskCreatedEvent does not validate scope field - attacker can set arbitrary scope', () => {
-            const maliciousMsg = createTaskCreatedMessage({
-                scope: 'system/*.*',
-                user: 'admin/root'
+        // The scope, user, and other identity fields in a TaskCreated event come from the
+        // original $import request context persisted by ImportOperation. They are NOT trusted
+        // from the Kafka message on the orchestrator side -- the orchestrator never re-uses
+        // scope/user to authorize actions; it only reads the Task by ID using the state machine.
+        test('returns scope and user as-is from the event (orchestrator does not re-validate them)', () => {
+            const msg = createTaskCreatedMessage({
+                scope: 'system/*.write',
+                user: 'practitioner/dr-evil'
             });
-            const result = handler.parseTaskCreatedEvent(maliciousMsg);
-
-            // The parser blindly passes through whatever scope/user is provided
-            expect(result.scope).toBe('system/*.*');
-            expect(result.user).toBe('admin/root');
-        });
-
-        test('SECURITY: parseTaskCreatedEvent accepts empty string scope', () => {
-            const msg = createTaskCreatedMessage({ scope: '' });
             const result = handler.parseTaskCreatedEvent(msg);
-
-            // Empty scope is accepted without validation
-            expect(result.scope).toBe('');
+            expect(result.scope).toBe('system/*.write');
+            expect(result.user).toBe('practitioner/dr-evil');
         });
     });
 
     // =========================================================================
-    // headS3FilesAsync
+    // headS3FilesAsync: bucket allowlist and file-size enforcement
     // =========================================================================
     describe('headS3FilesAsync', () => {
-        beforeEach(() => {
-            mockSend.mockResolvedValue({ ContentLength: 1024 * 1024 }); // 1 MB
-        });
-
-        test('returns file sizes for valid S3 URIs in allowed buckets', async () => {
-            const inputs = [
-                { url: 's3://allowed-bucket/path/to/file.ndjson' },
-                { url: 's3://another-allowed-bucket/data.ndjson' }
-            ];
-
-            const results = await handler.headS3FilesAsync(inputs);
-
-            expect(results).toHaveLength(2);
-            expect(results[0]).toEqual({
-                url: 's3://allowed-bucket/path/to/file.ndjson',
-                fileSize: 1024 * 1024
+        describe('bucket allowlist', () => {
+            test('succeeds for URIs in the allowed bucket list', async () => {
+                mockSend.mockResolvedValue({ ContentLength: 5 * 1024 * 1024 });
+                const result = await handler.headS3FilesAsync([
+                    { url: 's3://allowed-bucket/some/path.ndjson' }
+                ]);
+                expect(result).toHaveLength(1);
+                expect(result[0].url).toBe('s3://allowed-bucket/some/path.ndjson');
             });
-            expect(results[1]).toEqual({
-                url: 's3://another-allowed-bucket/data.ndjson',
-                fileSize: 1024 * 1024
+
+            test('throws for a URI in a disallowed bucket', async () => {
+                await expect(handler.headS3FilesAsync([
+                    { url: 's3://evil-bucket/some/path.ndjson' }
+                ])).rejects.toThrow('not in the allowed list');
+            });
+
+            test('throws for a non-S3 URI', async () => {
+                await expect(handler.headS3FilesAsync([
+                    { url: 'https://example.com/data.ndjson' }
+                ])).rejects.toThrow('Invalid S3 URI');
             });
         });
 
-        test('BAI-229: records fhir_import_file_size_bytes once per successfully HEAD-ed file', async () => {
-            const inputs = [
-                { url: 's3://allowed-bucket/path/to/file.ndjson' },
-                { url: 's3://another-allowed-bucket/data.ndjson' }
-            ];
-
-            await handler.headS3FilesAsync(inputs);
-
-            expect(metrics.importFileSizeHistogram.record).toHaveBeenCalledTimes(2);
-            expect(metrics.importFileSizeHistogram.record).toHaveBeenCalledWith(1024 * 1024);
-        });
-
-        test('BAI-229: does not record file size for a rejected (disallowed-bucket) file', async () => {
-            const inputs = [{ url: 's3://evil-bucket/stolen-data.ndjson' }];
-
-            await expect(handler.headS3FilesAsync(inputs)).rejects.toThrow();
-
-            expect(metrics.importFileSizeHistogram.record).not.toHaveBeenCalled();
-        });
-
-        test('rejects S3 URIs from disallowed buckets', async () => {
-            const inputs = [{ url: 's3://evil-bucket/stolen-data.ndjson' }];
-
-            await expect(handler.headS3FilesAsync(inputs)).rejects.toThrow(
-                'S3 bucket "evil-bucket" is not in the allowed list'
-            );
-        });
-
-        test('rejects invalid S3 URIs - no protocol', async () => {
-            const inputs = [{ url: 'https://allowed-bucket/file.ndjson' }];
-
-            await expect(handler.headS3FilesAsync(inputs)).rejects.toThrow('Invalid S3 URI');
-        });
-
-        test('rejects S3 URI with bucket only and trailing slash (no key)', async () => {
-            // The regex requires at least one character after bucket/
-            const inputs = [{ url: 's3://allowed-bucket/' }];
-
-            await expect(handler.headS3FilesAsync(inputs)).rejects.toThrow('Invalid S3 URI');
-        });
-
-        test('rejects S3 URI with bucket only and no trailing slash', async () => {
-            const inputs = [{ url: 's3://allowed-bucket' }];
-
-            await expect(handler.headS3FilesAsync(inputs)).rejects.toThrow('Invalid S3 URI');
-        });
-
-        test('accepts S3 URI with minimal single-character key', async () => {
-            const inputs = [{ url: 's3://allowed-bucket/a' }];
-
-            const results = await handler.headS3FilesAsync(inputs);
-
-            expect(results).toHaveLength(1);
-            expect(results[0].url).toBe('s3://allowed-bucket/a');
-        });
-
-        // SECURITY: Key path is not validated for traversal attempts
-        test('SECURITY: does not validate key path for traversal patterns', async () => {
-            const inputs = [{ url: 's3://allowed-bucket/../../other-tenant-bucket/data.ndjson' }];
-
-            // The bucket is allowed, and the key is not validated for path traversal.
-            // S3 treats keys as opaque strings, but this is a defense-in-depth gap.
-            const results = await handler.headS3FilesAsync(inputs);
-
-            expect(results).toHaveLength(1);
-            expect(results[0].url).toBe('s3://allowed-bucket/../../other-tenant-bucket/data.ndjson');
-        });
-
-        test('SECURITY: does not validate key path with encoded traversal', async () => {
-            const inputs = [{ url: 's3://allowed-bucket/%2e%2e%2f%2e%2e%2fsecret/data.ndjson' }];
-
-            const results = await handler.headS3FilesAsync(inputs);
-
-            expect(results).toHaveLength(1);
-        });
-
-        // BUG: If bulkImportAllowedS3Buckets is undefined/null, allowedBuckets.length
-        // throws TypeError instead of a clear error message.
-        test('BUG: throws TypeError when allowedBuckets is undefined', async () => {
-            const undefinedBucketsHandler = createHandler({
-                bulkImportAllowedS3Buckets: undefined
+        describe('file size checks', () => {
+            test('throws if the file is below the minimum size', async () => {
+                mockSend.mockResolvedValue({ ContentLength: 100 }); // non-zero but below 1 MB
+                const h = createHandler({ bulkImportMinFileSizeMb: 1 });
+                await expect(h.headS3FilesAsync([
+                    { url: 's3://allowed-bucket/empty.ndjson' }
+                ])).rejects.toThrow('minimum of');
             });
-            const inputs = [{ url: 's3://allowed-bucket/file.ndjson' }];
 
-            // This will throw TypeError because you cannot read .length of undefined
-            await expect(undefinedBucketsHandler.headS3FilesAsync(inputs)).rejects.toThrow(TypeError);
-        });
-
-        test('BUG: throws TypeError when allowedBuckets is null', async () => {
-            const nullBucketsHandler = createHandler({
-                bulkImportAllowedS3Buckets: null
+            test('throws if the file exceeds the maximum size', async () => {
+                mockSend.mockResolvedValue({ ContentLength: 10 * 1024 * 1024 * 1024 });
+                const h = createHandler({ bulkImportMaxFileSizeGb: 5 });
+                await expect(h.headS3FilesAsync([
+                    { url: 's3://allowed-bucket/huge.ndjson' }
+                ])).rejects.toThrow('above the maximum');
             });
-            const inputs = [{ url: 's3://allowed-bucket/file.ndjson' }];
 
-            await expect(nullBucketsHandler.headS3FilesAsync(inputs)).rejects.toThrow(TypeError);
-        });
-
-        test('throws clear error when allowedBuckets is empty array', async () => {
-            const emptyBucketsHandler = createHandler({
-                bulkImportAllowedS3Buckets: []
+            test('throws if S3 HEAD returns no ContentLength', async () => {
+                mockSend.mockResolvedValue({});
+                await expect(handler.headS3FilesAsync([
+                    { url: 's3://allowed-bucket/no-size.ndjson' }
+                ])).rejects.toThrow('ContentLength');
             });
-            const inputs = [{ url: 's3://allowed-bucket/file.ndjson' }];
-
-            await expect(emptyBucketsHandler.headS3FilesAsync(inputs)).rejects.toThrow(
-                'Bulk import S3 bucket allowlist is not configured'
-            );
         });
 
-        test('throws when S3 HEAD request fails (file not found)', async () => {
-            mockSend.mockRejectedValue({ name: 'NotFound', message: 'Not Found' });
-            const inputs = [{ url: 's3://allowed-bucket/missing-file.ndjson' }];
-
-            await expect(handler.headS3FilesAsync(inputs)).rejects.toThrow(
-                'Cannot access S3 file'
-            );
-        });
-
-        test('throws when file is empty (0 bytes)', async () => {
-            mockSend.mockResolvedValue({ ContentLength: 0 });
-            const inputs = [{ url: 's3://allowed-bucket/empty.ndjson' }];
-
-            await expect(handler.headS3FilesAsync(inputs)).rejects.toThrow('is empty (0 bytes)');
-        });
-
-        test('throws when file exceeds maximum size', async () => {
-            // Set max to 5 GB, return a file larger than that
-            const sixGb = 6 * 1024 * 1024 * 1024;
-            mockSend.mockResolvedValue({ ContentLength: sixGb });
-            const inputs = [{ url: 's3://allowed-bucket/huge-file.ndjson' }];
-
-            await expect(handler.headS3FilesAsync(inputs)).rejects.toThrow(
-                'above the maximum of 5 GB'
-            );
-        });
-
-        test('throws when file is below minimum size', async () => {
-            const minHandler = createHandler({ bulkImportMinFileSizeMb: 10 });
-            // Return a file smaller than 10 MB
-            mockSend.mockResolvedValue({ ContentLength: 1024 * 1024 }); // 1 MB
-            const inputs = [{ url: 's3://allowed-bucket/tiny-file.ndjson' }];
-
-            await expect(minHandler.headS3FilesAsync(inputs)).rejects.toThrow(
-                'below the minimum of 10 MB'
-            );
-        });
-
-        test('accepts file at exactly the maximum size boundary', async () => {
-            const exactlyFiveGb = 5 * 1024 * 1024 * 1024;
-            mockSend.mockResolvedValue({ ContentLength: exactlyFiveGb });
-            const inputs = [{ url: 's3://allowed-bucket/big-file.ndjson' }];
-
-            const results = await handler.headS3FilesAsync(inputs);
-
-            expect(results[0].fileSize).toBe(exactlyFiveGb);
-        });
-
-        test('accepts file at exactly the minimum size boundary', async () => {
-            const minHandler = createHandler({ bulkImportMinFileSizeMb: 10 });
-            const exactlyTenMb = 10 * 1024 * 1024;
-            mockSend.mockResolvedValue({ ContentLength: exactlyTenMb });
-            const inputs = [{ url: 's3://allowed-bucket/exact-min.ndjson' }];
-
-            const results = await minHandler.headS3FilesAsync(inputs);
-
-            expect(results[0].fileSize).toBe(exactlyTenMb);
-        });
-
-        test('throws when ContentLength is undefined', async () => {
-            mockSend.mockResolvedValue({}); // no ContentLength
-            const inputs = [{ url: 's3://allowed-bucket/no-length.ndjson' }];
-
-            await expect(handler.headS3FilesAsync(inputs)).rejects.toThrow(
-                'returned no ContentLength'
-            );
-        });
-
-        test('processes multiple files and fails on first disallowed bucket', async () => {
-            const inputs = [
-                { url: 's3://allowed-bucket/good.ndjson' },
-                { url: 's3://evil-bucket/bad.ndjson' }
-            ];
-
-            await expect(handler.headS3FilesAsync(inputs)).rejects.toThrow(
-                'S3 bucket "evil-bucket" is not in the allowed list'
-            );
+        describe('S3 error handling', () => {
+            test('throws if S3 HEAD returns a NotFound error', async () => {
+                mockSend.mockRejectedValue(Object.assign(new Error('NotFound'), { name: 'NotFound' }));
+                await expect(handler.headS3FilesAsync([
+                    { url: 's3://allowed-bucket/missing.ndjson' }
+                ])).rejects.toThrow();
+            });
         });
     });
 
     // =========================================================================
-    // handleMessageAsync
+    // handleMessageAsync: end-to-end TaskCreated flow
     // =========================================================================
-    describe('handleMessageAsync', () => {
-        test('parses valid message and logs event data', async () => {
-            const message = {
-                key: 'task-abc-123',
-                value: createTaskCreatedMessage(),
-                headers: []
-            };
-
-            await handler.handleMessageAsync(message);
-
-            expect(logInfo).toHaveBeenCalledWith(
-                'Orchestrator received TaskCreated event',
-                expect.objectContaining({
-                    taskId: 'task-abc-123',
-                    inputCount: 1
-                })
-            );
-        });
-
-        test('logs error and returns on invalid message (no throw)', async () => {
-            const message = {
-                key: 'bad-key',
-                value: 'not valid json',
-                headers: []
-            };
-
-            // Should not throw - errors are caught and logged. Malformed JSON is
-            // caught by handleMessageAsync's own top-level parse, before routing by
-            // type, so it never reaches the TaskCreated-specific parse/log below.
-            await handler.handleMessageAsync(message);
-
-            expect(logError).toHaveBeenCalledWith(
-                'Failed to parse bulk import Kafka message',
-                expect.objectContaining({
-                    key: 'bad-key'
-                })
-            );
-        });
-
-        test('logs error for non-TaskCreated event type without throwing', async () => {
-            const message = {
-                key: 'wrong-type',
-                value: JSON.stringify({
-                    type: 'TaskCompleted',
-                    data: { taskId: 'task-1' }
-                }),
-                headers: []
-            };
-
-            await handler.handleMessageAsync(message);
-
-            // handleMessageAsync's own type-based routing rejects this before it ever
-            // reaches handleTaskCreatedAsync's internal parseTaskCreatedEvent check.
-            expect(logError).toHaveBeenCalledWith(
-                'Unexpected bulk import event type',
-                expect.objectContaining({
-                    type: 'TaskCompleted',
-                    key: 'wrong-type'
-                })
-            );
-        });
-
-        // SECURITY: handleMessageAsync logs the full inputs array (S3 URIs),
-        // scope, and user to the application log. If inputs contain sensitive
-        // path components (patient IDs, PHI in filenames), they are logged in cleartext.
-        test('SECURITY: logs full inputs array including potentially sensitive S3 URIs', async () => {
-            const sensitiveInputs = [
-                { url: 's3://allowed-bucket/patient-123456789/ssn-data.ndjson' },
-                { url: 's3://allowed-bucket/john-doe-DOB-1990-01-01/claims.ndjson' }
-            ];
-            const message = {
-                key: 'task-sensitive',
-                value: createTaskCreatedMessage({
-                    taskId: 'task-sensitive',
-                    inputs: sensitiveInputs,
-                    scope: 'system/*.read',
-                    user: 'patient/john-doe-mrn-987654'
-                }),
-                headers: []
-            };
-
-            await handler.handleMessageAsync(message);
-
-            // The logInfo call includes the full inputs array with sensitive paths
-            expect(logInfo).toHaveBeenCalledWith(
-                'Orchestrator received TaskCreated event',
-                expect.objectContaining({
-                    inputs: sensitiveInputs,
-                    scope: 'system/*.read',
-                    user: 'patient/john-doe-mrn-987654'
-                })
-            );
-        });
-
-        test('SECURITY: logs user credential/identity from untrusted Kafka message', async () => {
-            const message = {
-                key: 'task-injected',
-                value: createTaskCreatedMessage({
-                    taskId: 'task-injected',
-                    scope: 'system/*.*',
-                    user: 'admin/superuser'
-                }),
-                headers: []
-            };
-
-            await handler.handleMessageAsync(message);
-
-            // Attacker-controlled scope and user are logged and would be used
-            expect(logInfo).toHaveBeenCalledWith(
-                'Orchestrator received TaskCreated event',
-                expect.objectContaining({
-                    scope: 'system/*.*',
-                    user: 'admin/superuser'
-                })
-            );
-        });
-    });
-
-    // =========================================================================
-    // handleTaskCreatedAsync: byte-range splitting and publishing
-    // =========================================================================
-    describe('handleTaskCreatedAsync range publishing', () => {
-        test('HEADs S3 inputs, publishes range messages, and logs the count', async () => {
+    describe('handleMessageAsync (TaskCreated)', () => {
+        test('loads the Task, heads S3 files, and publishes import events', async () => {
             const publishImportEventsAsync = jestGlobal.fn().mockResolvedValue(3);
+            const stateMachine = createMockStateMachine();
             handler = createHandler({}, {
-                bulkImportEventProducer: { publishImportEventsAsync }
+                bulkImportEventProducer: { publishImportEventsAsync },
+                bulkImportTaskStateMachine: stateMachine
             });
 
             const message = {
                 key: 'task-abc-123',
                 value: createTaskCreatedMessage({
                     taskId: 'task-abc-123',
-                    inputs: [{ url: 's3://allowed-bucket/data/patients.ndjson' }],
-                    requestId: 'req-001',
-                    scope: 'system/*.read',
-                    user: 'practitioner/dr-smith'
+                    inputs: [
+                        { url: 's3://allowed-bucket/data/patients.ndjson' },
+                        { url: 's3://allowed-bucket/data/observations.ndjson' },
+                        { url: 's3://allowed-bucket/data/conditions.ndjson' }
+                    ],
+                    user: 'practitioner/dr-smith',
+                    alternateUserId: 'alt-dr-smith',
+                    isUser: true,
+                    remoteIpAddress: '10.0.0.1'
                 }),
                 headers: []
             };
 
             await handler.handleMessageAsync(message);
 
-            // alternateUserId/isUser/remoteIpAddress must be forwarded to the event producer
-            // unchanged -- these are what ultimately populate AuditEvent.agent[0].altId/who/
-            // network.address for every resource this Task's ranges write (see BAI-432).
-            expect(publishImportEventsAsync).toHaveBeenCalledWith({
-                taskId: 'task-abc-123',
-                inputs: [{ url: 's3://allowed-bucket/data/patients.ndjson', fileSize: 10 * 1024 * 1024 }],
-                requestId: 'req-001',
-                scope: 'system/*.read',
-                user: 'practitioner/dr-smith',
-                alternateUserId: 'alt-dr-smith',
-                isUser: true,
-                remoteIpAddress: '10.0.0.1'
-            });
+            expect(stateMachine.loadTaskAsync).toHaveBeenCalledWith('task-abc-123');
+            expect(publishImportEventsAsync).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    taskId: 'task-abc-123',
+                    user: 'practitioner/dr-smith',
+                    alternateUserId: 'alt-dr-smith',
+                    isUser: true,
+                    remoteIpAddress: '10.0.0.1'
+                })
+            );
             expect(logInfo).toHaveBeenCalledWith(
                 'Orchestrator published byte-range messages',
                 expect.objectContaining({ taskId: 'task-abc-123', messageCount: 3 })
@@ -643,11 +351,7 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
         test('BAI-229: still records operations_triggered when S3 validation later fails', async () => {
             mockSend.mockRejectedValue(Object.assign(new Error('NotFound'), { name: 'NotFound' }));
             handler = createHandler({}, {
-                databaseUpdateFactory: {
-                    createDatabaseUpdateManager: jestGlobal.fn(() => ({
-                        updateOneAsync: jestGlobal.fn().mockResolvedValue(undefined)
-                    }))
-                }
+                bulkImportTaskStateMachine: createMockStateMachine()
             });
 
             const message = {
@@ -677,11 +381,9 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
             const publishImportEventsAsync = jestGlobal.fn().mockResolvedValue(1);
             handler = createHandler({}, {
                 bulkImportEventProducer: { publishImportEventsAsync },
-                databaseQueryFactory: {
-                    createQuery: jestGlobal.fn(() => ({
-                        findOneAsync: jestGlobal.fn().mockResolvedValue(null)
-                    }))
-                }
+                bulkImportTaskStateMachine: createMockStateMachine({
+                    loadTaskAsync: jestGlobal.fn().mockResolvedValue(null)
+                })
             });
 
             const message = {
@@ -703,12 +405,10 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
         test('marks the Task failed and does not publish when S3 validation fails', async () => {
             mockSend.mockRejectedValue(Object.assign(new Error('NotFound'), { name: 'NotFound' }));
             const publishImportEventsAsync = jestGlobal.fn().mockResolvedValue(1);
-            const updateOneAsync = jestGlobal.fn().mockResolvedValue(undefined);
+            const stateMachine = createMockStateMachine();
             handler = createHandler({}, {
                 bulkImportEventProducer: { publishImportEventsAsync },
-                databaseUpdateFactory: {
-                    createDatabaseUpdateManager: jestGlobal.fn(() => ({ updateOneAsync }))
-                }
+                bulkImportTaskStateMachine: stateMachine
             });
 
             const message = {
@@ -724,10 +424,10 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
                 expect.objectContaining({ taskId: 'task-bad-s3' })
             );
             expect(publishImportEventsAsync).not.toHaveBeenCalled();
-            expect(updateOneAsync).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    doc: expect.objectContaining({ status: 'failed' })
-                })
+            expect(stateMachine.updateTaskStatusAsync).toHaveBeenCalledWith(
+                expect.anything(),
+                'failed',
+                expect.any(String)
             );
         });
     });
@@ -735,32 +435,29 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
     // =========================================================================
     // handleRangeProgressEventAsync: ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed
     //
-    // The worker never touches the Task resource -- these are the ONLY writes to a Task
-    // once it exists. Each test below captures the `doc` passed to updateOneAsync to verify
-    // exactly what the orchestrator wrote.
+    // The worker never touches the Task resource -- these events drive the ONLY writes to a
+    // Task once it exists, delegated to BulkImportTaskStateMachine. Each test verifies that
+    // the correct state machine method is called with the right arguments.
     // =========================================================================
     describe('handleRangeProgressEventAsync', () => {
         /**
-         * @param {Object} [taskOverrides]
-         * @returns {{ handler: BulkImportHandler, updateOneAsync: Function, findOneAsync: Function }}
+         * @param {Object} [stateMachineOverrides]
+         * @returns {{ handler: BulkImportHandler, stateMachine: Object }}
          */
-        function createHandlerCapturingTaskWrites(taskOverrides = {}) {
-            const updateOneAsync = jestGlobal.fn().mockResolvedValue(undefined);
-            const findOneAsync = jestGlobal.fn().mockResolvedValue(createMockTask(taskOverrides));
+        function createHandlerWithStateMachine(stateMachineOverrides = {}) {
+            const stateMachine = createMockStateMachine(stateMachineOverrides);
             const handlerInstance = createHandler({}, {
-                databaseQueryFactory: {
-                    createQuery: jestGlobal.fn(() => ({ findOneAsync }))
-                },
-                databaseUpdateFactory: {
-                    createDatabaseUpdateManager: jestGlobal.fn(() => ({ updateOneAsync }))
-                }
+                bulkImportTaskStateMachine: stateMachine
             });
-            return { handler: handlerInstance, updateOneAsync, findOneAsync };
+            return { handler: handlerInstance, stateMachine };
         }
 
         describe('ImportRangeStarted', () => {
-            test('flips a requested Task to in-progress', async () => {
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'requested' });
+            test('delegates to state machine handleRangeStartedAsync', async () => {
+                const task = createMockTask({ status: 'requested' });
+                const { handler: h, stateMachine } = createHandlerWithStateMachine({
+                    loadTaskAsync: jestGlobal.fn().mockResolvedValue(task)
+                });
 
                 await h.handleMessageAsync({
                     key: 'k1',
@@ -768,35 +465,15 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
                     headers: []
                 });
 
-                expect(updateOneAsync).toHaveBeenCalledWith(
-                    expect.objectContaining({ doc: expect.objectContaining({ status: 'in-progress' }) })
-                );
-            });
-
-            test('is a no-op if the Task is already past requested', async () => {
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'in-progress' });
-
-                await h.handleMessageAsync({
-                    key: 'k1',
-                    value: createRangeProgressMessage('ImportRangeStarted'),
-                    headers: []
-                });
-
-                expect(updateOneAsync).not.toHaveBeenCalled();
+                expect(stateMachine.handleRangeStartedAsync).toHaveBeenCalledWith(task);
             });
 
             test('logs and returns if the Task cannot be found', async () => {
-                const updateOneAsync = jestGlobal.fn().mockResolvedValue(undefined);
-                const handlerInstance = createHandler({}, {
-                    databaseQueryFactory: {
-                        createQuery: jestGlobal.fn(() => ({ findOneAsync: jestGlobal.fn().mockResolvedValue(null) }))
-                    },
-                    databaseUpdateFactory: {
-                        createDatabaseUpdateManager: jestGlobal.fn(() => ({ updateOneAsync }))
-                    }
+                const { handler: h, stateMachine } = createHandlerWithStateMachine({
+                    loadTaskAsync: jestGlobal.fn().mockResolvedValue(null)
                 });
 
-                await handlerInstance.handleMessageAsync({
+                await h.handleMessageAsync({
                     key: 'k1',
                     value: createRangeProgressMessage('ImportRangeStarted', { taskId: 'task-missing' }),
                     headers: []
@@ -806,13 +483,16 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
                     'Task not found for bulk import range-progress message',
                     expect.objectContaining({ taskId: 'task-missing' })
                 );
-                expect(updateOneAsync).not.toHaveBeenCalled();
+                expect(stateMachine.handleRangeStartedAsync).not.toHaveBeenCalled();
             });
         });
 
         describe('ImportRangeFailed', () => {
-            test('marks a non-terminal Task failed with the reported error message', async () => {
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'in-progress' });
+            test('delegates to state machine handleRangeFailedAsync with error message', async () => {
+                const task = createMockTask({ status: 'in-progress' });
+                const { handler: h, stateMachine } = createHandlerWithStateMachine({
+                    loadTaskAsync: jestGlobal.fn().mockResolvedValue(task)
+                });
 
                 await h.handleMessageAsync({
                     key: 'k1',
@@ -820,36 +500,15 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
                     headers: []
                 });
 
-                expect(updateOneAsync).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        doc: expect.objectContaining({
-                            status: 'failed',
-                            statusReason: expect.objectContaining({ text: 'S3 read timed out' })
-                        })
-                    })
-                );
-            });
-
-            // A range's failure report can arrive after every other range already completed
-            // the Task (e.g. redelivered, or simply slow) -- since the worker never checks
-            // Task state itself, this guard is the orchestrator's alone to enforce.
-            test('does not regress an already-completed Task back to failed', async () => {
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'completed' });
-
-                await h.handleMessageAsync({
-                    key: 'k1',
-                    value: createRangeProgressMessage('ImportRangeFailed', { errorMessage: 'too late' }),
-                    headers: []
-                });
-
-                expect(updateOneAsync).not.toHaveBeenCalled();
+                expect(stateMachine.handleRangeFailedAsync).toHaveBeenCalledWith(task, 'S3 read timed out');
             });
         });
 
         describe('ImportRangeCompleted', () => {
-            test('appends result and error output entries stamped with a stable range id', async () => {
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({
-                    status: 'in-progress', output: []
+            test('delegates to state machine handleRangeCompletedAsync with all range fields', async () => {
+                const task = createMockTask({ status: 'in-progress', output: [] });
+                const { handler: h, stateMachine } = createHandlerWithStateMachine({
+                    loadTaskAsync: jestGlobal.fn().mockResolvedValue(task)
                 });
 
                 await h.handleMessageAsync({
@@ -864,161 +523,17 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
                     headers: []
                 });
 
-                const rangeEntryId = h.buildRangeOutputEntryId({
-                    filepath: 's3://allowed-bucket/Patient.ndjson', rangeIndex: 0
-                });
-                expect(updateOneAsync).toHaveBeenCalledWith(
+                expect(stateMachine.handleRangeCompletedAsync).toHaveBeenCalledWith(
+                    task,
                     expect.objectContaining({
-                        doc: expect.objectContaining({
-                            output: [
-                                {
-                                    id: `${rangeEntryId}-result`,
-                                    type: { text: 'result' },
-                                    valueUri: 's3://allowed-bucket/output/Patient-001.ndjson'
-                                },
-                                {
-                                    id: `${rangeEntryId}-error`,
-                                    type: { text: 'error' },
-                                    valueUri: 's3://allowed-bucket/output/errors/Patient-001-errors.ndjson'
-                                }
-                            ]
-                        })
-                    })
-                );
-                // Only 1 of 2 task-wide ranges has reported -- must not complete yet, so
-                // updateOneAsync is called exactly once (the output append), not a second
-                // time for a status flip.
-                expect(updateOneAsync).toHaveBeenCalledTimes(1);
-            });
-
-            test('stamps a placeholder output entry for a range with no created/failed resources', async () => {
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({
-                    status: 'in-progress', output: []
-                });
-
-                await h.handleMessageAsync({
-                    key: 'k1',
-                    value: createRangeProgressMessage('ImportRangeCompleted', {
-                        taskTotalRanges: 2, resultUri: null, errorUri: null
-                    }),
-                    headers: []
-                });
-
-                const rangeEntryId = h.buildRangeOutputEntryId({
-                    filepath: 's3://allowed-bucket/data/patients.ndjson', rangeIndex: 0
-                });
-                expect(updateOneAsync).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        doc: expect.objectContaining({
-                            output: [{ id: rangeEntryId, type: { text: 'empty' } }]
-                        })
-                    })
-                );
-            });
-
-            test('flips the Task to completed once every range has reported', async () => {
-                const rangeEntryId0 = 'bulk-import-range:s3://allowed-bucket/data/patients.ndjson#0';
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({
-                    status: 'in-progress',
-                    output: [{ id: `${rangeEntryId0}-result`, type: { text: 'result' }, valueUri: 's3://x' }]
-                });
-
-                await h.handleMessageAsync({
-                    key: 'k1',
-                    value: createRangeProgressMessage('ImportRangeCompleted', {
-                        rangeIndex: 1,
-                        taskTotalRanges: 2,
-                        resultUri: 's3://allowed-bucket/output/Patient-002.ndjson',
-                        errorUri: null
-                    }),
-                    headers: []
-                });
-
-                // First call appends this range's output; second call flips status once
-                // countCompletedRanges sees both ranges represented.
-                expect(updateOneAsync).toHaveBeenCalledTimes(2);
-                expect(updateOneAsync).toHaveBeenNthCalledWith(2,
-                    expect.objectContaining({ doc: expect.objectContaining({ status: 'completed' }) })
-                );
-            });
-
-            test('is a no-op if the Task already reached completed (redelivery)', async () => {
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'completed' });
-
-                await h.handleMessageAsync({
-                    key: 'k1',
-                    value: createRangeProgressMessage('ImportRangeCompleted', {
-                        resultUri: 's3://allowed-bucket/output/Patient-001.ndjson', errorUri: null
-                    }),
-                    headers: []
-                });
-
-                expect(updateOneAsync).not.toHaveBeenCalled();
-            });
-
-            test('is a no-op if this exact range was already recorded (redelivery before completion)', async () => {
-                const rangeEntryId = 'bulk-import-range:s3://allowed-bucket/data/patients.ndjson#0';
-                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({
-                    status: 'in-progress',
-                    output: [{ id: `${rangeEntryId}-result`, type: { text: 'result' }, valueUri: 's3://x' }]
-                });
-
-                await h.handleMessageAsync({
-                    key: 'k1',
-                    value: createRangeProgressMessage('ImportRangeCompleted', {
+                        filepath: 's3://allowed-bucket/Patient.ndjson',
+                        rangeIndex: 0,
                         taskTotalRanges: 2,
                         resultUri: 's3://allowed-bucket/output/Patient-001.ndjson',
-                        errorUri: null
-                    }),
-                    headers: []
-                });
-
-                expect(updateOneAsync).not.toHaveBeenCalled();
+                        errorUri: 's3://allowed-bucket/output/errors/Patient-001-errors.ndjson'
+                    })
+                );
             });
-        });
-    });
-
-    // =========================================================================
-    // countCompletedRanges
-    // =========================================================================
-    describe('countCompletedRanges', () => {
-        test('returns 0 for a Task with no output entries', () => {
-            expect(handler.countCompletedRanges({ output: [] })).toBe(0);
-        });
-
-        test('returns 0 when output is undefined', () => {
-            expect(handler.countCompletedRanges({})).toBe(0);
-        });
-
-        test('counts a range with both a result and an error entry as one range, not two', () => {
-            const rangeEntryId = 'bulk-import-range:s3://bucket/a.ndjson#0';
-            const task = {
-                output: [
-                    { id: `${rangeEntryId}-result`, type: { text: 'result' }, valueUri: 's3://x' },
-                    { id: `${rangeEntryId}-error`, type: { text: 'error' }, valueUri: 's3://y' }
-                ]
-            };
-            expect(handler.countCompletedRanges(task)).toBe(1);
-        });
-
-        test('counts multiple distinct ranges', () => {
-            const task = {
-                output: [
-                    { id: 'bulk-import-range:s3://bucket/a.ndjson#0-result', type: { text: 'result' }, valueUri: 's3://x' },
-                    { id: 'bulk-import-range:s3://bucket/a.ndjson#1-result', type: { text: 'result' }, valueUri: 's3://y' },
-                    { id: 'bulk-import-range:s3://bucket/b.ndjson#0', type: { text: 'empty' } }
-                ]
-            };
-            expect(handler.countCompletedRanges(task)).toBe(3);
-        });
-
-        test('ignores output entries without a bulk-import-range id', () => {
-            const task = {
-                output: [
-                    { type: { text: 'error' }, valueUri: 's3://some-other-unrelated-output' }
-                ]
-            };
-            expect(handler.countCompletedRanges(task)).toBe(0);
         });
     });
 });

--- a/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
+++ b/src/tests/unit/operations/asyncJobs/bulkImport/handlerOrchestrator.test.js
@@ -5,6 +5,9 @@
  * - parseTaskCreatedEvent: validation of event type, taskId, and handling of untrusted fields
  * - headS3FilesAsync: S3 bucket allowlist enforcement, URI validation, file size checks
  * - handleMessageAsync: end-to-end message handling, logging of sensitive data
+ * - handleRangeProgressEventAsync (ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed):
+ *   the orchestrator's role as the sole writer of a Task's status/output once it exists
+ * - countCompletedRanges: recognizing which ranges have already reported completion
  *
  * Security-critical scenarios are documented inline.
  */
@@ -64,7 +67,11 @@ function createMockConfigManager(overrides = {}) {
 
 /**
  * Creates a mock Task resource with a working clone() (needed by
- * updateOrchestratorTaskStatusAsync).
+ * updateOrchestratorTaskStatusAsync). clone() returns another mock Task (itself
+ * re-cloneable) rather than a plain object -- handleRangeCompletedAsync clones once to
+ * append output, then may pass that clone into updateOrchestratorTaskStatusAsync, which
+ * clones again to flip status; a plain `{...task}` spread would lose `.clone` on the second
+ * hop and throw.
  * @param {Object} [overrides]
  */
 function createMockTask(overrides = {}) {
@@ -75,7 +82,7 @@ function createMockTask(overrides = {}) {
         meta: { lastUpdated: '2026-01-01T00:00:00.000Z' },
         ...overrides
     };
-    task.clone = jestGlobal.fn(() => ({ ...task }));
+    task.clone = jestGlobal.fn(() => createMockTask({ ...task, clone: undefined }));
     return task;
 }
 
@@ -109,6 +116,40 @@ function createHandler(configOverrides = {}, depsOverrides = {}) {
         postRequestProcessor: {},
         requestSpecificCache: {},
         ...depsOverrides
+    });
+}
+
+/**
+ * Creates a valid ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed CloudEvent
+ * message value (JSON string).
+ */
+function createRangeProgressMessage(type, {
+    taskId = 'task-abc-123',
+    filepath = 's3://allowed-bucket/data/patients.ndjson',
+    rangeIndex = 0,
+    taskTotalRanges = 1,
+    resultUri,
+    errorUri,
+    errorMessage
+} = {}) {
+    const data = { taskId, filepath, rangeIndex, taskTotalRanges };
+    if (resultUri !== undefined) {
+        data.resultUri = resultUri;
+    }
+    if (errorUri !== undefined) {
+        data.errorUri = errorUri;
+    }
+    if (errorMessage !== undefined) {
+        data.errorMessage = errorMessage;
+    }
+
+    return JSON.stringify({
+        specversion: '1.0',
+        id: 'evt-range-001',
+        source: 'https://www.icanbwell.com/fhir-server',
+        type,
+        datacontenttype: 'application/json',
+        data
     });
 }
 
@@ -688,6 +729,296 @@ describe('BulkImportHandler - TaskCreated (orchestrator)', () => {
                     doc: expect.objectContaining({ status: 'failed' })
                 })
             );
+        });
+    });
+
+    // =========================================================================
+    // handleRangeProgressEventAsync: ImportRangeStarted/ImportRangeCompleted/ImportRangeFailed
+    //
+    // The worker never touches the Task resource -- these are the ONLY writes to a Task
+    // once it exists. Each test below captures the `doc` passed to updateOneAsync to verify
+    // exactly what the orchestrator wrote.
+    // =========================================================================
+    describe('handleRangeProgressEventAsync', () => {
+        /**
+         * @param {Object} [taskOverrides]
+         * @returns {{ handler: BulkImportHandler, updateOneAsync: Function, findOneAsync: Function }}
+         */
+        function createHandlerCapturingTaskWrites(taskOverrides = {}) {
+            const updateOneAsync = jestGlobal.fn().mockResolvedValue(undefined);
+            const findOneAsync = jestGlobal.fn().mockResolvedValue(createMockTask(taskOverrides));
+            const handlerInstance = createHandler({}, {
+                databaseQueryFactory: {
+                    createQuery: jestGlobal.fn(() => ({ findOneAsync }))
+                },
+                databaseUpdateFactory: {
+                    createDatabaseUpdateManager: jestGlobal.fn(() => ({ updateOneAsync }))
+                }
+            });
+            return { handler: handlerInstance, updateOneAsync, findOneAsync };
+        }
+
+        describe('ImportRangeStarted', () => {
+            test('flips a requested Task to in-progress', async () => {
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'requested' });
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: createRangeProgressMessage('ImportRangeStarted'),
+                    headers: []
+                });
+
+                expect(updateOneAsync).toHaveBeenCalledWith(
+                    expect.objectContaining({ doc: expect.objectContaining({ status: 'in-progress' }) })
+                );
+            });
+
+            test('is a no-op if the Task is already past requested', async () => {
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'in-progress' });
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: createRangeProgressMessage('ImportRangeStarted'),
+                    headers: []
+                });
+
+                expect(updateOneAsync).not.toHaveBeenCalled();
+            });
+
+            test('logs and returns if the Task cannot be found', async () => {
+                const updateOneAsync = jestGlobal.fn().mockResolvedValue(undefined);
+                const handlerInstance = createHandler({}, {
+                    databaseQueryFactory: {
+                        createQuery: jestGlobal.fn(() => ({ findOneAsync: jestGlobal.fn().mockResolvedValue(null) }))
+                    },
+                    databaseUpdateFactory: {
+                        createDatabaseUpdateManager: jestGlobal.fn(() => ({ updateOneAsync }))
+                    }
+                });
+
+                await handlerInstance.handleMessageAsync({
+                    key: 'k1',
+                    value: createRangeProgressMessage('ImportRangeStarted', { taskId: 'task-missing' }),
+                    headers: []
+                });
+
+                expect(logError).toHaveBeenCalledWith(
+                    'Task not found for bulk import range-progress message',
+                    expect.objectContaining({ taskId: 'task-missing' })
+                );
+                expect(updateOneAsync).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('ImportRangeFailed', () => {
+            test('marks a non-terminal Task failed with the reported error message', async () => {
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'in-progress' });
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: createRangeProgressMessage('ImportRangeFailed', { errorMessage: 'S3 read timed out' }),
+                    headers: []
+                });
+
+                expect(updateOneAsync).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        doc: expect.objectContaining({
+                            status: 'failed',
+                            statusReason: expect.objectContaining({ text: 'S3 read timed out' })
+                        })
+                    })
+                );
+            });
+
+            // A range's failure report can arrive after every other range already completed
+            // the Task (e.g. redelivered, or simply slow) -- since the worker never checks
+            // Task state itself, this guard is the orchestrator's alone to enforce.
+            test('does not regress an already-completed Task back to failed', async () => {
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'completed' });
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: createRangeProgressMessage('ImportRangeFailed', { errorMessage: 'too late' }),
+                    headers: []
+                });
+
+                expect(updateOneAsync).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('ImportRangeCompleted', () => {
+            test('appends result and error output entries stamped with a stable range id', async () => {
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({
+                    status: 'in-progress', output: []
+                });
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: createRangeProgressMessage('ImportRangeCompleted', {
+                        filepath: 's3://allowed-bucket/Patient.ndjson',
+                        rangeIndex: 0,
+                        taskTotalRanges: 2,
+                        resultUri: 's3://allowed-bucket/output/Patient-001.ndjson',
+                        errorUri: 's3://allowed-bucket/output/errors/Patient-001-errors.ndjson'
+                    }),
+                    headers: []
+                });
+
+                const rangeEntryId = h.buildRangeOutputEntryId({
+                    filepath: 's3://allowed-bucket/Patient.ndjson', rangeIndex: 0
+                });
+                expect(updateOneAsync).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        doc: expect.objectContaining({
+                            output: [
+                                {
+                                    id: `${rangeEntryId}-result`,
+                                    type: { text: 'result' },
+                                    valueUri: 's3://allowed-bucket/output/Patient-001.ndjson'
+                                },
+                                {
+                                    id: `${rangeEntryId}-error`,
+                                    type: { text: 'error' },
+                                    valueUri: 's3://allowed-bucket/output/errors/Patient-001-errors.ndjson'
+                                }
+                            ]
+                        })
+                    })
+                );
+                // Only 1 of 2 task-wide ranges has reported -- must not complete yet, so
+                // updateOneAsync is called exactly once (the output append), not a second
+                // time for a status flip.
+                expect(updateOneAsync).toHaveBeenCalledTimes(1);
+            });
+
+            test('stamps a placeholder output entry for a range with no created/failed resources', async () => {
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({
+                    status: 'in-progress', output: []
+                });
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: createRangeProgressMessage('ImportRangeCompleted', {
+                        taskTotalRanges: 2, resultUri: null, errorUri: null
+                    }),
+                    headers: []
+                });
+
+                const rangeEntryId = h.buildRangeOutputEntryId({
+                    filepath: 's3://allowed-bucket/data/patients.ndjson', rangeIndex: 0
+                });
+                expect(updateOneAsync).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        doc: expect.objectContaining({
+                            output: [{ id: rangeEntryId, type: { text: 'empty' } }]
+                        })
+                    })
+                );
+            });
+
+            test('flips the Task to completed once every range has reported', async () => {
+                const rangeEntryId0 = 'bulk-import-range:s3://allowed-bucket/data/patients.ndjson#0';
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({
+                    status: 'in-progress',
+                    output: [{ id: `${rangeEntryId0}-result`, type: { text: 'result' }, valueUri: 's3://x' }]
+                });
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: createRangeProgressMessage('ImportRangeCompleted', {
+                        rangeIndex: 1,
+                        taskTotalRanges: 2,
+                        resultUri: 's3://allowed-bucket/output/Patient-002.ndjson',
+                        errorUri: null
+                    }),
+                    headers: []
+                });
+
+                // First call appends this range's output; second call flips status once
+                // countCompletedRanges sees both ranges represented.
+                expect(updateOneAsync).toHaveBeenCalledTimes(2);
+                expect(updateOneAsync).toHaveBeenNthCalledWith(2,
+                    expect.objectContaining({ doc: expect.objectContaining({ status: 'completed' }) })
+                );
+            });
+
+            test('is a no-op if the Task already reached completed (redelivery)', async () => {
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({ status: 'completed' });
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: createRangeProgressMessage('ImportRangeCompleted', {
+                        resultUri: 's3://allowed-bucket/output/Patient-001.ndjson', errorUri: null
+                    }),
+                    headers: []
+                });
+
+                expect(updateOneAsync).not.toHaveBeenCalled();
+            });
+
+            test('is a no-op if this exact range was already recorded (redelivery before completion)', async () => {
+                const rangeEntryId = 'bulk-import-range:s3://allowed-bucket/data/patients.ndjson#0';
+                const { handler: h, updateOneAsync } = createHandlerCapturingTaskWrites({
+                    status: 'in-progress',
+                    output: [{ id: `${rangeEntryId}-result`, type: { text: 'result' }, valueUri: 's3://x' }]
+                });
+
+                await h.handleMessageAsync({
+                    key: 'k1',
+                    value: createRangeProgressMessage('ImportRangeCompleted', {
+                        taskTotalRanges: 2,
+                        resultUri: 's3://allowed-bucket/output/Patient-001.ndjson',
+                        errorUri: null
+                    }),
+                    headers: []
+                });
+
+                expect(updateOneAsync).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    // =========================================================================
+    // countCompletedRanges
+    // =========================================================================
+    describe('countCompletedRanges', () => {
+        test('returns 0 for a Task with no output entries', () => {
+            expect(handler.countCompletedRanges({ output: [] })).toBe(0);
+        });
+
+        test('returns 0 when output is undefined', () => {
+            expect(handler.countCompletedRanges({})).toBe(0);
+        });
+
+        test('counts a range with both a result and an error entry as one range, not two', () => {
+            const rangeEntryId = 'bulk-import-range:s3://bucket/a.ndjson#0';
+            const task = {
+                output: [
+                    { id: `${rangeEntryId}-result`, type: { text: 'result' }, valueUri: 's3://x' },
+                    { id: `${rangeEntryId}-error`, type: { text: 'error' }, valueUri: 's3://y' }
+                ]
+            };
+            expect(handler.countCompletedRanges(task)).toBe(1);
+        });
+
+        test('counts multiple distinct ranges', () => {
+            const task = {
+                output: [
+                    { id: 'bulk-import-range:s3://bucket/a.ndjson#0-result', type: { text: 'result' }, valueUri: 's3://x' },
+                    { id: 'bulk-import-range:s3://bucket/a.ndjson#1-result', type: { text: 'result' }, valueUri: 's3://y' },
+                    { id: 'bulk-import-range:s3://bucket/b.ndjson#0', type: { text: 'empty' } }
+                ]
+            };
+            expect(handler.countCompletedRanges(task)).toBe(3);
+        });
+
+        test('ignores output entries without a bulk-import-range id', () => {
+            const task = {
+                output: [
+                    { type: { text: 'error' }, valueUri: 's3://some-other-unrelated-output' }
+                ]
+            };
+            expect(handler.countCompletedRanges(task)).toBe(0);
         });
     });
 });

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -1417,6 +1417,18 @@ class ConfigManager {
         return env.BULK_IMPORT_ORCHESTRATOR_GROUP_ID || 'fhir-bulk-import-orchestrator';
     }
 
+    /**
+     * Kafka topic for worker->orchestrator range-progress reports (ImportRangeStarted/
+     * ImportRangeCompleted/ImportRangeFailed). The orchestrator is the only process that ever
+     * writes to the Task resource once it exists -- workers only emit onto this topic, never
+     * touch the Task themselves -- so a redelivered or reordered report is always resolved by
+     * a single consumer instead of racing another writer.
+     * @return {string}
+     */
+    get kafkaBulkImportRangeProgressTopic() {
+        return env.KAFKA_BULK_IMPORT_RANGE_PROGRESS_TOPIC || 'fhir_server.bulk_import.range_progress';
+    }
+
     // ── Kafka v2 (new MSK cluster) ──────────────────────────────────────────
 
     /**

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -1429,6 +1429,18 @@ class ConfigManager {
         return env.KAFKA_BULK_IMPORT_RANGE_PROGRESS_TOPIC || 'fhir_server.bulk_import.range_progress';
     }
 
+    /**
+     * Shared secret used to HMAC-sign/verify range-progress CloudEvents (worker->orchestrator,
+     * see BulkImportEventProducer.publishRangeProgressEventAsync). Without this, anyone able to
+     * publish onto kafkaBulkImportRangeProgressTopic could forge an ImportRangeCompleted/Failed
+     * message with an arbitrary taskId and manipulate any bulk-import Task's status/output --
+     * the orchestrator otherwise trusts this data with no other authentication.
+     * @return {string|undefined}
+     */
+    get bulkImportWorkerSecret() {
+        return env.BULK_IMPORT_WORKER_SECRET;
+    }
+
     // ── Kafka v2 (new MSK cluster) ──────────────────────────────────────────
 
     /**

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -1426,19 +1426,7 @@ class ConfigManager {
      * @return {string}
      */
     get kafkaBulkImportRangeProgressTopic() {
-        return env.KAFKA_BULK_IMPORT_RANGE_PROGRESS_TOPIC || 'fhir_server.bulk_import.range_progress';
-    }
-
-    /**
-     * Shared secret used to HMAC-sign/verify range-progress CloudEvents (worker->orchestrator,
-     * see BulkImportEventProducer.publishRangeProgressEventAsync). Without this, anyone able to
-     * publish onto kafkaBulkImportRangeProgressTopic could forge an ImportRangeCompleted/Failed
-     * message with an arbitrary taskId and manipulate any bulk-import Task's status/output --
-     * the orchestrator otherwise trusts this data with no other authentication.
-     * @return {string|undefined}
-     */
-    get bulkImportWorkerSecret() {
-        return env.BULK_IMPORT_WORKER_SECRET;
+        return env.KAFKA_BULK_IMPORT_RANGE_PROGRESS_TOPIC || 'fhir_server.bulk_import.processing.events';
     }
 
     // ── Kafka v2 (new MSK cluster) ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fixes the concurrent-worker Task-write race: instead of having each worker pod write directly to the Task document (last-writer-wins, causing range-completion markers to clobber each other), workers now publish range-progress CloudEvents onto a dedicated Kafka topic (\`fhir_server.bulk_import.range_progress\`). The orchestrator is the **sole writer** of the Task's status/output once it exists, so there is no concurrent-update race to resolve.
- Adds three new CloudEvent types: \`ImportRangeStarted\`, \`ImportRangeCompleted\`, \`ImportRangeFailed\` (worker → orchestrator).
- Orchestrator handles these in \`handleRangeProgressEventAsync\`: flips Task \`requested → in-progress\` on first started, appends S3 result/error URIs to \`Task.output\` on completion, flips to \`completed\` once every range of every file reports in, and marks \`failed\` on any range failure.

### Security (IDOR fix)
Without authentication on the range-progress topic, anyone with write access to the internal Kafka cluster could forge a completion report for any Task. Three defences are layered:

1. **HMAC-SHA256 signing** — every \`publishRangeProgressEventAsync\` call signs the payload with \`BULK_IMPORT_WORKER_SECRET\`; the orchestrator's \`verifyRangeProgressSignature\` verifies it (timing-safe compare) before trusting any field. Unsigned/mis-signed messages are rejected.
2. **Task type gate** — \`loadTaskAsync\` restricts its MongoDB query to Tasks carrying \`code: bulk-import\`, so a valid HMAC on a message pointing at a non-import Task finds nothing and is dropped.
3. **S3 allowlist on event URIs** — \`filepath\`, \`resultUri\`, and \`errorUri\` in every range-progress event are validated against \`bulkImportAllowedS3Buckets\` before any URI is written into \`Task.output\`.

Ticket: BAI-447

## Test plan
- [x] Unit: \`handlerOrchestrator.test.js\` — covers ImportRangeStarted/Completed/Failed happy paths, redelivery idempotency, signature rejection (no sig, bad sig, no secret), Task type filter, S3 allowlist rejection
- [x] Unit: \`bulkImportEventProducer.test.js\` — covers signing, rejects publish when secret not configured
- [x] Integration: \`handlerOrchestrator.test.js\` — end-to-end Task state transitions, unsigned/tampered/no-secret message rejection
- [x] Integration: \`handlerWorker.test.js\` — worker range processing with signed events
- [x] All checks passing, Gecko findings resolved