### PR TITLE
DCON-5223 Generalize _sort period-boundary handling

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,7 @@ module.exports = {
     AUDIT_EVENT_CLIENT_DB: 'auditEventClient_db',
     DB_SEARCH_LIMIT: 100,
     DB_SEARCH_LIMIT_FOR_IDS: 1000,
+    UNSUPPORTED_SORT_FIELDS: ['id'],
     COLLECTION: {
         ACCOUNT: 'Account',
         ACTIVITYDEFINITION: 'ActivityDefinition',

--- a/src/operations/search/searchManager.js
+++ b/src/operations/search/searchManager.js
@@ -733,7 +733,7 @@ class SearchManager {
      * @return {Set<string>}
      */
     getAllowedSortFields ({ resourceType }) {
-        const allowedFields = new Set(this.searchParametersManager.getAllowedFieldsForResource({ resourceType }));
+        const allowedFields = new Set(this.searchParametersManager.getAllowedFieldsForResource({ resourceType }).keys());
         allowedFields.add(this.configManager.defaultSortId);
         return allowedFields;
     }

--- a/src/operations/search/searchManager.js
+++ b/src/operations/search/searchManager.js
@@ -40,7 +40,8 @@ const {
     OPERATIONS: { READ },
     GRIDFS: { RETRIEVE },
     BLOB_OP,
-    AUTH_USER_TYPES
+    AUTH_USER_TYPES,
+    UNSUPPORTED_SORT_FIELDS
 } = require('../../constants');
 
 class SearchManager {
@@ -768,8 +769,9 @@ class SearchManager {
                 /**
                  * @type {string}
                  */
-                const sortField = descending ? sortProperty.substring(1) : sortProperty;
-                if (!allowedSortFields.has(sortField)) {
+                const sortCode = descending ? sortProperty.substring(1) : sortProperty;
+                const sortField = this.resolveSortField({ resourceType, sortCode, allowedSortFields });
+                if (!sortField || UNSUPPORTED_SORT_FIELDS.includes(sortField)) {
                     logWarn(`Ignoring _sort value '${sortProperty}' for ${resourceType}: not a recognized sortable field`);
                     continue;
                 }
@@ -779,6 +781,53 @@ class SearchManager {
             options.sort = sort;
         }
         return { columns, options };
+    }
+
+    /**
+     * Resolves a single _sort code (the sort value with any leading '-' already stripped) to the
+     * Mongo field to sort by, trying each recognition rule in order until one matches:
+     *  1. a search-parameter code that resolves to a field, e.g. 'date' -> 'effectiveDateTime'
+     *  2. a field already declared verbatim on some search parameter for this resourceType
+     *  3. a `<field>.start`/`<field>.end` boundary on a field declared as a Period type -- lets
+     *     e.g. _sort=effectivePeriod.end work for any resource whose 'effectivePeriod' field is
+     * @param {string} resourceType
+     * @param {string} sortCode
+     * @param {Set<string>} allowedSortFields
+     * @return {string | null}
+     */
+    resolveSortField ({ resourceType, sortCode, allowedSortFields }) {
+        const resolvedField = this.searchParametersManager.getFieldNameForSearchParameter(resourceType, sortCode);
+        if (resolvedField) {
+            return resolvedField;
+        }
+        if (allowedSortFields.has(sortCode)) {
+            return sortCode;
+        }
+        return this.resolvePeriodBoundarySortField({ resourceType, sortCode });
+    }
+
+    /**
+     * Recognizes `<field>.start`/`<field>.end` as a valid _sort target for any FHIR Period-typed
+     * field (fieldType 'period') declared on this resourceType, without requiring a dedicated
+     * search parameter for that exact dotted path -- e.g. _sort=effectivePeriod.end works for any
+     * resource whose 'effectivePeriod' field is declared as type 'period' by some search
+     * parameter, not just resources with a hand-added `_xPeriodEnd` parameter.
+     * @param {string} resourceType
+     * @param {string} sortCode
+     * @return {string | null}
+     */
+    resolvePeriodBoundarySortField ({ resourceType, sortCode }) {
+        const lastDotIndex = sortCode.lastIndexOf('.');
+        if (lastDotIndex === -1) {
+            return null;
+        }
+        const boundary = sortCode.substring(lastDotIndex + 1);
+        if (boundary !== 'start' && boundary !== 'end') {
+            return null;
+        }
+        const baseField = sortCode.substring(0, lastDotIndex);
+        const fieldType = this.searchParametersManager.getFieldType({ resourceType, field: baseField });
+        return fieldType === 'period' ? sortCode : null;
     }
 
     // noinspection FunctionWithInconsistentReturnsJS

--- a/src/searchParameters/searchParametersManager.js
+++ b/src/searchParameters/searchParametersManager.js
@@ -49,19 +49,12 @@ class SearchParametersManager {
         }
 
         /**
-         * memoized result of getAllowedFieldsForResource(), keyed by resourceType, search
-         * parameter definitions never change at runtime, so this is safe to cache for the
-         * lifetime of this (singleton) instance
-         * @type {Map<string, Set<string>>}
+         * memoized result of getResourceFieldMetadata(), keyed by resourceType, search parameter
+         * definitions never change at runtime, so this is safe to cache for the lifetime of this
+         * (singleton) instance
+         * @type {Map<string, {allowedFields: Set<string>, fieldTypes: Map<string, string>}>}
          */
-        this.allowedFieldsForResourceByType = new Map();
-        /**
-         * memoized result of getFieldType(), keyed by resourceType then by field path, search
-         * parameter definitions never change at runtime, so this is safe to cache for the
-         * lifetime of this (singleton) instance
-         * @type {Map<string, Map<string, string>>}
-         */
-        this.fieldTypesByResourceType = new Map();
+        this.resourceFieldMetadataByType = new Map();
     }
 
     /**
@@ -118,20 +111,22 @@ class SearchParametersManager {
     }
 
     /**
-     * Returns every Mongo field path declared on this resource's own search-parameter
-     * definitions, plus the generic `Resource` bucket's (the same resourceType-then-Resource
-     * fallback rule as getPropertyObject/getFieldNameForSearchParameter, but returning the full
-     * set of field paths for a resource instead of looking up one search parameter by name).
-     * Memoized per resourceType since these definitions never change at runtime.
+     * Walks every search parameter declared for a resourceType, plus the generic `Resource`
+     * bucket (same resourceType-then-Resource fallback rule as getPropertyObject/
+     * getFieldNameForSearchParameter), collecting both the full set of Mongo field paths
+     * (getAllowedFieldsForResource) and each field's declared FHIR type from fieldTypesObj
+     * (getFieldType) in a single pass. Memoized per resourceType since these definitions never
+     * change at runtime.
      * @param {string} resourceType
-     * @return {Set<string>}
+     * @return {{allowedFields: Set<string>, fieldTypes: Map<string, string>}}
      */
-    getAllowedFieldsForResource ({ resourceType }) {
-        const cached = this.allowedFieldsForResourceByType.get(resourceType);
+    getResourceFieldMetadata ({ resourceType }) {
+        const cached = this.resourceFieldMetadataByType.get(resourceType);
         if (cached) {
             return cached;
         }
         const allowedFields = new Set();
+        const fieldTypes = new Map();
         for (const searchResourceType of [resourceType, 'Resource']) {
             const searchParametersForResource = this.getSearchParametersForResource({ resourceType: searchResourceType });
             if (searchParametersForResource) {
@@ -139,44 +134,40 @@ class SearchParametersManager {
                     for (const field of propertyObj.fields) {
                         allowedFields.add(field);
                     }
+                    for (const [fieldName, fieldType] of Object.entries(propertyObj.fieldTypesObj || {})) {
+                        if (!fieldTypes.has(fieldName)) {
+                            fieldTypes.set(fieldName, fieldType);
+                        }
+                    }
                 }
             }
         }
-        this.allowedFieldsForResourceByType.set(resourceType, allowedFields);
-        return allowedFields;
+        const metadata = { allowedFields, fieldTypes };
+        this.resourceFieldMetadataByType.set(resourceType, metadata);
+        return metadata;
+    }
+
+    /**
+     * Returns every Mongo field path declared on this resource's own search-parameter
+     * definitions, plus the generic `Resource` bucket's.
+     * @param {string} resourceType
+     * @return {Set<string>}
+     */
+    getAllowedFieldsForResource ({ resourceType }) {
+        return this.getResourceFieldMetadata({ resourceType }).allowedFields;
     }
 
     /**
      * Returns the FHIR field type (e.g. 'period', 'datetime', 'instant') declared for a Mongo
-     * field path on a resourceType, by scanning every search parameter's fieldTypesObj for that
-     * resourceType plus the generic Resource bucket (same resourceType-then-Resource fallback
-     * rule as getAllowedFieldsForResource). This lets callers recognize e.g. any Period-typed
-     * field generically (a `<field>.start`/`<field>.end` _sort target) without needing a
-     * dedicated search parameter declared per field. Memoized per resourceType since these
-     * definitions never change at runtime.
+     * field path on a resourceType. This lets callers recognize e.g. any Period-typed field
+     * generically (a `<field>.start`/`<field>.end` _sort target) without needing a dedicated
+     * search parameter declared per field.
      * @param {string} resourceType
      * @param {string} field
      * @return {string | null}
      */
     getFieldType ({ resourceType, field }) {
-        let fieldTypes = this.fieldTypesByResourceType.get(resourceType);
-        if (!fieldTypes) {
-            fieldTypes = new Map();
-            for (const searchResourceType of [resourceType, 'Resource']) {
-                const searchParametersForResource = this.getSearchParametersForResource({ resourceType: searchResourceType });
-                if (searchParametersForResource) {
-                    for (const propertyObj of Object.values(searchParametersForResource)) {
-                        for (const [fieldName, fieldType] of Object.entries(propertyObj.fieldTypesObj || {})) {
-                            if (!fieldTypes.has(fieldName)) {
-                                fieldTypes.set(fieldName, fieldType);
-                            }
-                        }
-                    }
-                }
-            }
-            this.fieldTypesByResourceType.set(resourceType, fieldTypes);
-        }
-        return fieldTypes.get(field) || null;
+        return this.getResourceFieldMetadata({ resourceType }).fieldTypes.get(field) || null;
     }
 
     /**

--- a/src/searchParameters/searchParametersManager.js
+++ b/src/searchParameters/searchParametersManager.js
@@ -55,6 +55,13 @@ class SearchParametersManager {
          * @type {Map<string, Set<string>>}
          */
         this.allowedFieldsForResourceByType = new Map();
+        /**
+         * memoized result of getFieldType(), keyed by resourceType then by field path, search
+         * parameter definitions never change at runtime, so this is safe to cache for the
+         * lifetime of this (singleton) instance
+         * @type {Map<string, Map<string, string>>}
+         */
+        this.fieldTypesByResourceType = new Map();
     }
 
     /**
@@ -137,6 +144,39 @@ class SearchParametersManager {
         }
         this.allowedFieldsForResourceByType.set(resourceType, allowedFields);
         return allowedFields;
+    }
+
+    /**
+     * Returns the FHIR field type (e.g. 'period', 'datetime', 'instant') declared for a Mongo
+     * field path on a resourceType, by scanning every search parameter's fieldTypesObj for that
+     * resourceType plus the generic Resource bucket (same resourceType-then-Resource fallback
+     * rule as getAllowedFieldsForResource). This lets callers recognize e.g. any Period-typed
+     * field generically (a `<field>.start`/`<field>.end` _sort target) without needing a
+     * dedicated search parameter declared per field. Memoized per resourceType since these
+     * definitions never change at runtime.
+     * @param {string} resourceType
+     * @param {string} field
+     * @return {string | null}
+     */
+    getFieldType ({ resourceType, field }) {
+        let fieldTypes = this.fieldTypesByResourceType.get(resourceType);
+        if (!fieldTypes) {
+            fieldTypes = new Map();
+            for (const searchResourceType of [resourceType, 'Resource']) {
+                const searchParametersForResource = this.getSearchParametersForResource({ resourceType: searchResourceType });
+                if (searchParametersForResource) {
+                    for (const propertyObj of Object.values(searchParametersForResource)) {
+                        for (const [fieldName, fieldType] of Object.entries(propertyObj.fieldTypesObj || {})) {
+                            if (!fieldTypes.has(fieldName)) {
+                                fieldTypes.set(fieldName, fieldType);
+                            }
+                        }
+                    }
+                }
+            }
+            this.fieldTypesByResourceType.set(resourceType, fieldTypes);
+        }
+        return fieldTypes.get(field) || null;
     }
 
     /**

--- a/src/searchParameters/searchParametersManager.js
+++ b/src/searchParameters/searchParametersManager.js
@@ -49,12 +49,12 @@ class SearchParametersManager {
         }
 
         /**
-         * memoized result of getResourceFieldMetadata(), keyed by resourceType, search parameter
-         * definitions never change at runtime, so this is safe to cache for the lifetime of this
-         * (singleton) instance
-         * @type {Map<string, {allowedFields: Set<string>, fieldTypes: Map<string, string>}>}
+         * memoized result of getAllowedFieldsForResource(), keyed by resourceType, search
+         * parameter definitions never change at runtime, so this is safe to cache for the
+         * lifetime of this (singleton) instance
+         * @type {Map<string, Map<string, string | null>>}
          */
-        this.resourceFieldMetadataByType = new Map();
+        this.allowedFieldsByResourceType = new Map();
     }
 
     /**
@@ -113,48 +113,39 @@ class SearchParametersManager {
     /**
      * Walks every search parameter declared for a resourceType, plus the generic `Resource`
      * bucket (same resourceType-then-Resource fallback rule as getPropertyObject/
-     * getFieldNameForSearchParameter), collecting both the full set of Mongo field paths
-     * (getAllowedFieldsForResource) and each field's declared FHIR type from fieldTypesObj
-     * (getFieldType) in a single pass. Memoized per resourceType since these definitions never
-     * change at runtime.
+     * getFieldNameForSearchParameter), building a single Map keyed by every allowed Mongo field
+     * path for that resourceType. A key's mere presence (checked via .has()) is what makes that
+     * field an allowed sort field, independent of its value; the value (read via .get()) is that
+     * field's declared FHIR type (e.g. 'period', 'datetime'), or null when no type was declared.
+     * This is the one source both callers wanting the allowed field names (via .keys(), e.g.
+     * SearchManager.getAllowedSortFields) and getFieldType (via .get()) read from, so the walk
+     * happens once per resourceType. A field already resolved to a real type is never
+     * overwritten by a later untyped occurrence of the same field name, regardless of which
+     * bucket/search-parameter is walked first. Memoized per resourceType since these definitions
+     * never change at runtime.
      * @param {string} resourceType
-     * @return {{allowedFields: Set<string>, fieldTypes: Map<string, string>}}
+     * @return {Map<string, string | null>}
      */
-    getResourceFieldMetadata ({ resourceType }) {
-        const cached = this.resourceFieldMetadataByType.get(resourceType);
+    getAllowedFieldsForResource ({ resourceType }) {
+        const cached = this.allowedFieldsByResourceType.get(resourceType);
         if (cached) {
             return cached;
         }
-        const allowedFields = new Set();
-        const fieldTypes = new Map();
-        for (const searchResourceType of [resourceType, 'Resource']) {
-            const searchParametersForResource = this.getSearchParametersForResource({ resourceType: searchResourceType });
+        const allowedFields = new Map();
+        for (const resourceTypeBucket of [resourceType, 'Resource']) {
+            const searchParametersForResource = this.getSearchParametersForResource({ resourceType: resourceTypeBucket });
             if (searchParametersForResource) {
                 for (const propertyObj of Object.values(searchParametersForResource)) {
                     for (const field of propertyObj.fields) {
-                        allowedFields.add(field);
-                    }
-                    for (const [fieldName, fieldType] of Object.entries(propertyObj.fieldTypesObj || {})) {
-                        if (!fieldTypes.has(fieldName)) {
-                            fieldTypes.set(fieldName, fieldType);
+                        if (!allowedFields.get(field)) {
+                            allowedFields.set(field, (propertyObj.fieldTypesObj && propertyObj.fieldTypesObj[field]) || null);
                         }
                     }
                 }
             }
         }
-        const metadata = { allowedFields, fieldTypes };
-        this.resourceFieldMetadataByType.set(resourceType, metadata);
-        return metadata;
-    }
-
-    /**
-     * Returns every Mongo field path declared on this resource's own search-parameter
-     * definitions, plus the generic `Resource` bucket's.
-     * @param {string} resourceType
-     * @return {Set<string>}
-     */
-    getAllowedFieldsForResource ({ resourceType }) {
-        return this.getResourceFieldMetadata({ resourceType }).allowedFields;
+        this.allowedFieldsByResourceType.set(resourceType, allowedFields);
+        return allowedFields;
     }
 
     /**
@@ -167,7 +158,7 @@ class SearchParametersManager {
      * @return {string | null}
      */
     getFieldType ({ resourceType, field }) {
-        return this.getResourceFieldMetadata({ resourceType }).fieldTypes.get(field) || null;
+        return this.getAllowedFieldsForResource({ resourceType }).get(field) || null;
     }
 
     /**

--- a/src/tests/graphql/explanationOfBenefit/fixtures/expected_graphql_response_with_explain.json
+++ b/src/tests/graphql/explanationOfBenefit/fixtures/expected_graphql_response_with_explain.json
@@ -3,7 +3,7 @@
   "meta": {
     "tag": [
       {
-        "display": "[db.ExplanationOfBenefit_4_0_0.find({'_sourceId':{'$in':['WPS-Claim-230916613369','WPS-Claim-429017018331']}}, {'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'identifier':1,'meta':1,'careTeam':1,'diagnosis':1,'insurance':1,'insurer':1,'item':1,'outcome':1,'payee':1,'procedure':1,'provider':1,'status':1,'supportingInfo':1,'type':1,'use':1,'patient':1,'_id':0}).sort({'id':1,'_uuid':1}).limit(2)]",
+        "display": "[db.ExplanationOfBenefit_4_0_0.find({'_sourceId':{'$in':['WPS-Claim-230916613369','WPS-Claim-429017018331']}}, {'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'identifier':1,'meta':1,'careTeam':1,'diagnosis':1,'insurance':1,'insurer':1,'item':1,'outcome':1,'payee':1,'procedure':1,'provider':1,'status':1,'supportingInfo':1,'type':1,'use':1,'patient':1,'_id':0}).sort({'_uuid':1}).limit(2)]",
         "system": "https://www.icanbwell.com/query"
       },
       {
@@ -11,11 +11,11 @@
         "system": "https://www.icanbwell.com/queryCollection"
       },
       {
-        "display": "[{'projection':{'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'identifier':1,'meta':1,'careTeam':1,'diagnosis':1,'insurance':1,'insurer':1,'item':1,'outcome':1,'payee':1,'procedure':1,'provider':1,'status':1,'supportingInfo':1,'type':1,'use':1,'patient':1,'_id':0},'sort':{'id':1,'_uuid':1},'limit':2}]",
+        "display": "[{'projection':{'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'identifier':1,'meta':1,'careTeam':1,'diagnosis':1,'insurance':1,'insurer':1,'item':1,'outcome':1,'payee':1,'procedure':1,'provider':1,'status':1,'supportingInfo':1,'type':1,'use':1,'patient':1,'_id':0},'sort':{'_uuid':1},'limit':2}]",
         "system": "https://www.icanbwell.com/queryOptions"
       },
       {
-        "display": "[['_sourceId','id','_uuid']]",
+        "display": "[['_sourceId','_uuid']]",
         "system": "https://www.icanbwell.com/queryFields"
       },
       {

--- a/src/tests/graphqlv2/explanationOfBenefit/fixtures/expected_graphql_response_with_explain.json
+++ b/src/tests/graphqlv2/explanationOfBenefit/fixtures/expected_graphql_response_with_explain.json
@@ -6,7 +6,7 @@
         "tag": [
           {
             "system": "https://www.icanbwell.com/query",
-            "display": "[db.ExplanationOfBenefit_4_0_0.find({'_sourceId':{'$in':['WPS-Claim-230916613369','WPS-Claim-429017018331']}}, {'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'identifier':1,'meta':1,'careTeam':1,'diagnosis':1,'insurance':1,'insurer':1,'item':1,'outcome':1,'payee':1,'procedure':1,'provider':1,'status':1,'supportingInfo':1,'type':1,'use':1,'patient':1,'_id':0}).sort({'id':1,'_uuid':1}).limit(2)]"
+            "display": "[db.ExplanationOfBenefit_4_0_0.find({'_sourceId':{'$in':['WPS-Claim-230916613369','WPS-Claim-429017018331']}}, {'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'identifier':1,'meta':1,'careTeam':1,'diagnosis':1,'insurance':1,'insurer':1,'item':1,'outcome':1,'payee':1,'procedure':1,'provider':1,'status':1,'supportingInfo':1,'type':1,'use':1,'patient':1,'_id':0}).sort({'_uuid':1}).limit(2)]"
           },
           {
             "system": "https://www.icanbwell.com/queryCollection",
@@ -14,11 +14,11 @@
           },
           {
             "system": "https://www.icanbwell.com/queryOptions",
-            "display": "[{'projection':{'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'identifier':1,'meta':1,'careTeam':1,'diagnosis':1,'insurance':1,'insurer':1,'item':1,'outcome':1,'payee':1,'procedure':1,'provider':1,'status':1,'supportingInfo':1,'type':1,'use':1,'patient':1,'_id':0},'sort':{'id':1,'_uuid':1},'limit':2}]"
+            "display": "[{'projection':{'_uuid':1,'_sourceId':1,'_sourceAssigningAuthority':1,'resourceType':1,'id':1,'identifier':1,'meta':1,'careTeam':1,'diagnosis':1,'insurance':1,'insurer':1,'item':1,'outcome':1,'payee':1,'procedure':1,'provider':1,'status':1,'supportingInfo':1,'type':1,'use':1,'patient':1,'_id':0},'sort':{'_uuid':1},'limit':2}]"
           },
           {
             "system": "https://www.icanbwell.com/queryFields",
-            "display": "[['_sourceId','id','_uuid']]"
+            "display": "[['_sourceId','_uuid']]"
           },
           {
             "system": "https://www.icanbwell.com/queryTime",

--- a/src/tests/query/periodFilter/pertiodFilter.test.js
+++ b/src/tests/query/periodFilter/pertiodFilter.test.js
@@ -93,3 +93,4 @@ describe('Period start/end field search tests', () => {
         expect(resp).toHaveResponse(expectedObservationPeriodStartEq2026);
     });
 });
+

--- a/src/tests/query/sortFieldHardening/fixtures/CarePlan/careplan1.json
+++ b/src/tests/query/sortFieldHardening/fixtures/CarePlan/careplan1.json
@@ -1,0 +1,42 @@
+{
+  "resourceType": "CarePlan",
+  "id": "careplan-2015",
+  "meta": {
+    "source": "mps",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "status": "active",
+  "intent": "plan",
+  "subject": {
+    "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727",
+    "display": "Mr. Max124 Larry532 Gibson10"
+  },
+  "period": {
+    "start": "2015-06-19T01:15:45+00:00",
+    "end": "2015-06-19T01:30:45+00:00"
+  },
+  "activity": [
+    {
+      "detail": {
+        "status": "not-started",
+        "scheduledPeriod": {
+          "start": "2025-06-19T01:15:45+00:00",
+          "end": "2025-06-19T01:30:45+00:00"
+        }
+      }
+    }
+  ]
+}

--- a/src/tests/query/sortFieldHardening/fixtures/CarePlan/careplan2.json
+++ b/src/tests/query/sortFieldHardening/fixtures/CarePlan/careplan2.json
@@ -1,0 +1,42 @@
+{
+  "resourceType": "CarePlan",
+  "id": "careplan-2027",
+  "meta": {
+    "source": "mps",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "status": "active",
+  "intent": "plan",
+  "subject": {
+    "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727",
+    "display": "Mr. Max124 Larry532 Gibson10"
+  },
+  "period": {
+    "start": "2027-06-19T01:15:45+00:00",
+    "end": "2027-06-19T01:30:45+00:00"
+  },
+  "activity": [
+    {
+      "detail": {
+        "status": "not-started",
+        "scheduledPeriod": {
+          "start": "2020-06-19T01:15:45+00:00",
+          "end": "2020-06-19T01:30:45+00:00"
+        }
+      }
+    }
+  ]
+}

--- a/src/tests/query/sortFieldHardening/fixtures/Encounter/encounter1.json
+++ b/src/tests/query/sortFieldHardening/fixtures/Encounter/encounter1.json
@@ -1,0 +1,60 @@
+{
+  "resourceType": "Encounter",
+  "id": "encounter-2014",
+  "meta": {
+    "source": "mps",
+    "profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"],
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "AMB"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "162673000",
+          "display": "General examination of patient (procedure)"
+        }
+      ],
+      "text": "General examination of patient (procedure)"
+    }
+  ],
+  "subject": {
+    "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727",
+    "display": "Mr. Max124 Larry532 Gibson10"
+  },
+  "period": {
+    "start": "2014-06-19T01:15:45+00:00",
+    "end": "2014-06-19T01:30:45+00:00"
+  },
+  "location": [
+    {
+      "id": "-1000003632",
+      "location": {
+        "reference": "Location/-1000003632",
+        "display": "PCP193904"
+      }
+    }
+  ],
+  "serviceProvider": {
+    "reference": "Organization/00ab3fbd-6157-3f4a-a58c-178d16b9e3f1",
+    "display": "PCP193904"
+  }
+}

--- a/src/tests/query/sortFieldHardening/fixtures/Encounter/encounter2.json
+++ b/src/tests/query/sortFieldHardening/fixtures/Encounter/encounter2.json
@@ -1,0 +1,60 @@
+{
+  "resourceType": "Encounter",
+  "id": "encounter-2026",
+  "meta": {
+    "source": "mps",
+    "profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"],
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "AMB"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "162673000",
+          "display": "General examination of patient (procedure)"
+        }
+      ],
+      "text": "General examination of patient (procedure)"
+    }
+  ],
+  "subject": {
+    "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727",
+    "display": "Mr. Max124 Larry532 Gibson10"
+  },
+  "period": {
+    "start": "2026-06-19T01:15:45+00:00",
+    "end": "2026-06-19T01:30:45+00:00"
+  },
+  "location": [
+    {
+      "id": "-1000003632",
+      "location": {
+        "reference": "Location/-1000003632",
+        "display": "PCP193904"
+      }
+    }
+  ],
+  "serviceProvider": {
+    "reference": "Organization/00ab3fbd-6157-3f4a-a58c-178d16b9e3f1",
+    "display": "PCP193904"
+  }
+}

--- a/src/tests/query/sortFieldHardening/fixtures/MedicationStatement/medicationstatement1.json
+++ b/src/tests/query/sortFieldHardening/fixtures/MedicationStatement/medicationstatement1.json
@@ -1,0 +1,33 @@
+{
+  "resourceType": "MedicationStatement",
+  "id": "medicationstatement-2016",
+  "meta": {
+    "source": "mps",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "status": "active",
+  "medicationCodeableConcept": {
+    "text": "Test medication 2016"
+  },
+  "subject": {
+    "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727",
+    "display": "Mr. Max124 Larry532 Gibson10"
+  },
+  "effectivePeriod": {
+    "start": "2016-06-19T01:15:45+00:00",
+    "end": "2016-06-19T01:30:45+00:00"
+  }
+}

--- a/src/tests/query/sortFieldHardening/fixtures/MedicationStatement/medicationstatement2.json
+++ b/src/tests/query/sortFieldHardening/fixtures/MedicationStatement/medicationstatement2.json
@@ -1,0 +1,33 @@
+{
+  "resourceType": "MedicationStatement",
+  "id": "medicationstatement-2028",
+  "meta": {
+    "source": "mps",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "status": "active",
+  "medicationCodeableConcept": {
+    "text": "Test medication 2028"
+  },
+  "subject": {
+    "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727",
+    "display": "Mr. Max124 Larry532 Gibson10"
+  },
+  "effectivePeriod": {
+    "start": "2028-06-19T01:15:45+00:00",
+    "end": "2028-06-19T01:30:45+00:00"
+  }
+}

--- a/src/tests/query/sortFieldHardening/fixtures/Observation/observation1.json
+++ b/src/tests/query/sortFieldHardening/fixtures/Observation/observation1.json
@@ -1,0 +1,36 @@
+{
+  "resourceType": "Observation",
+  "id": "observation-2017",
+  "meta": {
+    "source": "mps",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "8310-5",
+        "display": "Body temperature"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727",
+    "display": "Mr. Max124 Larry532 Gibson10"
+  },
+  "effectiveDateTime": "2017-06-19T01:15:45+00:00"
+}

--- a/src/tests/query/sortFieldHardening/fixtures/Observation/observation2.json
+++ b/src/tests/query/sortFieldHardening/fixtures/Observation/observation2.json
@@ -1,0 +1,36 @@
+{
+  "resourceType": "Observation",
+  "id": "observation-2029",
+  "meta": {
+    "source": "mps",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "8310-5",
+        "display": "Body temperature"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727",
+    "display": "Mr. Max124 Larry532 Gibson10"
+  },
+  "effectiveDateTime": "2029-06-19T01:15:45+00:00"
+}

--- a/src/tests/query/sortFieldHardening/fixtures/Person/person1.json
+++ b/src/tests/query/sortFieldHardening/fixtures/Person/person1.json
@@ -1,0 +1,29 @@
+{
+  "resourceType": "Person",
+  "id": "person-active-true",
+  "meta": {
+    "source": "mps",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "active": true,
+  "link": [
+    {
+      "target": {
+        "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727"
+      }
+    }
+  ]
+}

--- a/src/tests/query/sortFieldHardening/fixtures/Person/person2.json
+++ b/src/tests/query/sortFieldHardening/fixtures/Person/person2.json
@@ -1,0 +1,29 @@
+{
+  "resourceType": "Person",
+  "id": "person-active-false",
+  "meta": {
+    "source": "mps",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "active": false,
+  "link": [
+    {
+      "target": {
+        "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727"
+      }
+    }
+  ]
+}

--- a/src/tests/query/sortFieldHardening/fixtures/Task/task1.json
+++ b/src/tests/query/sortFieldHardening/fixtures/Task/task1.json
@@ -1,0 +1,27 @@
+{
+  "resourceType": "Task",
+  "id": "task-first",
+  "meta": {
+    "source": "mps",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "status": "requested",
+  "intent": "order",
+  "for": {
+    "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727",
+    "display": "Mr. Max124 Larry532 Gibson10"
+  }
+}

--- a/src/tests/query/sortFieldHardening/fixtures/Task/task2.json
+++ b/src/tests/query/sortFieldHardening/fixtures/Task/task2.json
@@ -1,0 +1,27 @@
+{
+  "resourceType": "Task",
+  "id": "task-second",
+  "meta": {
+    "source": "mps",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "status": "requested",
+  "intent": "order",
+  "for": {
+    "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727",
+    "display": "Mr. Max124 Larry532 Gibson10"
+  }
+}

--- a/src/tests/query/sortFieldHardening/fixtures/VerificationResult/verificationresult1.json
+++ b/src/tests/query/sortFieldHardening/fixtures/VerificationResult/verificationresult1.json
@@ -1,0 +1,28 @@
+{
+  "resourceType": "VerificationResult",
+  "id": "verificationresult-1",
+  "meta": {
+    "source": "mps",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "status": "validated",
+  "statusDate": "2021-06-19T01:15:45+00:00",
+  "target": [
+    {
+      "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727"
+    }
+  ]
+}

--- a/src/tests/query/sortFieldHardening/fixtures/VerificationResult/verificationresult2.json
+++ b/src/tests/query/sortFieldHardening/fixtures/VerificationResult/verificationresult2.json
@@ -1,0 +1,28 @@
+{
+  "resourceType": "VerificationResult",
+  "id": "verificationresult-2",
+  "meta": {
+    "source": "mps",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "mps-api"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "client"
+      },
+      {
+        "system": "https://www.icanbwell.com/sourceAssigningAuthority",
+        "code": "client"
+      }
+    ]
+  },
+  "status": "validated",
+  "statusDate": "2023-06-19T01:15:45+00:00",
+  "target": [
+    {
+      "reference": "Patient/5902c735-072c-5df3-b3b9-8b10bd3df727"
+    }
+  ]
+}

--- a/src/tests/query/sortFieldHardening/sortFieldHardening.test.js
+++ b/src/tests/query/sortFieldHardening/sortFieldHardening.test.js
@@ -1,0 +1,220 @@
+// test file
+const enounter1 = require('./fixtures/Encounter/encounter1.json');
+const enounter2 = require('./fixtures/Encounter/encounter2.json');
+const careplan1 = require('./fixtures/CarePlan/careplan1.json');
+const careplan2 = require('./fixtures/CarePlan/careplan2.json');
+const medicationStatement1 = require('./fixtures/MedicationStatement/medicationstatement1.json');
+const medicationStatement2 = require('./fixtures/MedicationStatement/medicationstatement2.json');
+const task1 = require('./fixtures/Task/task1.json');
+const task2 = require('./fixtures/Task/task2.json');
+const observation1 = require('./fixtures/Observation/observation1.json');
+const observation2 = require('./fixtures/Observation/observation2.json');
+const verificationResult1 = require('./fixtures/VerificationResult/verificationresult1.json');
+const verificationResult2 = require('./fixtures/VerificationResult/verificationresult2.json');
+const person1 = require('./fixtures/Person/person1.json');
+const person2 = require('./fixtures/Person/person2.json');
+
+const { commonBeforeEach, commonAfterEach, createTestRequest, getHeaders, getHeadersWithAdmin } = require('../../common');
+const { describe, beforeEach, afterEach, test, expect, jest } = require('@jest/globals');
+
+const FAKE_TIMER_OPTIONS = {
+    doNotFake: [
+        'hrtime',
+        'nextTick',
+        'performance',
+        'queueMicrotask',
+        'requestAnimationFrame',
+        'cancelAnimationFrame',
+        'requestIdleCallback',
+        'cancelIdleCallback',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+        'setTimeout',
+        'clearTimeout'
+    ]
+};
+
+describe('_sort field hardening tests', () => {
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+    });
+
+    test('_sort recognizes raw period.start/period.end values without needing _periodStart/_periodEnd (Encounter)', async () => {
+        const request = await createTestRequest();
+
+        let resp = await request.post('/4_0_0/Encounter/$merge').send([enounter1, enounter2]).set(getHeaders());
+        expect(resp).toHaveMergeResponse([{ created: true }, { created: true }]);
+
+        // enounter1.period is 2014, enounter2.period is 2026 (see fixtures)
+        resp = await request.get('/4_0_0/Encounter?_sort=period.start&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['encounter-2014', 'encounter-2026']);
+
+        resp = await request.get('/4_0_0/Encounter?_sort=-period.end&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['encounter-2026', 'encounter-2014']);
+    });
+
+    test('_sort recognizes CarePlan period.start/period.end via the generic period-type fallback', async () => {
+        const request = await createTestRequest();
+
+        let resp = await request.post('/4_0_0/CarePlan/$merge').send([careplan1, careplan2]).set(getHeaders());
+        expect(resp).toHaveMergeResponse([{ created: true }, { created: true }]);
+
+        // careplan1.period is 2015, careplan2.period is 2027 (see fixtures)
+        resp = await request.get('/4_0_0/CarePlan?_sort=period.start&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['careplan-2015', 'careplan-2027']);
+
+        resp = await request.get('/4_0_0/CarePlan?_sort=-period.start&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['careplan-2027', 'careplan-2015']);
+    });
+
+    // CarePlan has two independently-declared Period-typed fields: the top-level 'period' (from
+    // the 'date' search parameter) and the nested 'activity.detail.scheduledPeriod' (from the
+    // 'activity-date' search parameter). The fixtures deliberately set these in reverse order of
+    // each other (careplan-2015's nested period is later than careplan-2027's) so that sorting by
+    // each field independently produces opposite orderings -- proving resolvePeriodBoundarySortField
+    // resolves each dotted path on its own declared field, not by coincidence.
+    test("_sort recognizes CarePlan's nested activity.detail.scheduledPeriod.start/.end independently from the top-level period field", async () => {
+        const request = await createTestRequest();
+
+        let resp = await request.post('/4_0_0/CarePlan/$merge').send([careplan1, careplan2]).set(getHeaders());
+        expect(resp).toHaveMergeResponse([{ created: true }, { created: true }]);
+
+        // top-level period: careplan-2015 (2015) before careplan-2027 (2027)
+        resp = await request.get('/4_0_0/CarePlan?_sort=period.start&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['careplan-2015', 'careplan-2027']);
+
+        // nested activity.detail.scheduledPeriod: careplan-2027 (2020) before careplan-2015 (2025) -- reversed
+        resp = await request.get('/4_0_0/CarePlan?_sort=activity.detail.scheduledPeriod.start&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['careplan-2027', 'careplan-2015']);
+
+        resp = await request.get('/4_0_0/CarePlan?_sort=-activity.detail.scheduledPeriod.end&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['careplan-2015', 'careplan-2027']);
+    });
+
+    test('_sort recognizes MedicationStatement effectivePeriod.start/effectivePeriod.end via the generic period-type fallback', async () => {
+        const request = await createTestRequest();
+
+        let resp = await request.post('/4_0_0/MedicationStatement/$merge')
+            .send([medicationStatement1, medicationStatement2]).set(getHeaders());
+        expect(resp).toHaveMergeResponse([{ created: true }, { created: true }]);
+
+        // medicationStatement1.effectivePeriod is 2016, medicationStatement2.effectivePeriod is 2028 (see fixtures)
+        resp = await request.get('/4_0_0/MedicationStatement?_sort=effectivePeriod.start&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['medicationstatement-2016', 'medicationstatement-2028']);
+
+        resp = await request.get('/4_0_0/MedicationStatement?_sort=-effectivePeriod.end&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['medicationstatement-2028', 'medicationstatement-2016']);
+    });
+
+    test('_sort silently ignores fields that are not real search parameters instead of erroring', async () => {
+        const request = await createTestRequest();
+
+        let resp = await request.post('/4_0_0/CarePlan/$merge').send([careplan1, careplan2]).set(getHeaders());
+        expect(resp).toHaveMergeResponse([{ created: true }, { created: true }]);
+
+        // a lone unrecognized field: request succeeds, no data is lost, order falls back to the default tie-breaker
+        resp = await request.get('/4_0_0/CarePlan?_sort=totally.bogus.field&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp).toHaveStatusCode(200);
+        expect(resp.body.entry.map(e => e.resource.id).sort()).toEqual(['careplan-2015', 'careplan-2027']);
+
+        // an injection-shaped nested path probe: also dropped, not treated as a valid sort target
+        resp = await request.get('/4_0_0/CarePlan?_sort=meta.extension.url.nested.field.that.does.not.exist&_bundle=1')
+            .set(getHeadersWithAdmin());
+        expect(resp).toHaveStatusCode(200);
+        expect(resp.body.entry.map(e => e.resource.id).sort()).toEqual(['careplan-2015', 'careplan-2027']);
+
+        // mixed with a real field: the unrecognized field is dropped, the real field still decides order
+        resp = await request.get('/4_0_0/CarePlan?_sort=garbage.nested.nonexistent.field,period.start&_bundle=1')
+            .set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['careplan-2015', 'careplan-2027']);
+    });
+
+    test('_sort ignores the _id search-parameter code and the raw id field', async () => {
+        const request = await createTestRequest();
+
+        let resp = await request.post('/4_0_0/CarePlan/$merge').send([careplan1, careplan2]).set(getHeaders());
+        expect(resp).toHaveMergeResponse([{ created: true }, { created: true }]);
+
+        resp = await request.get('/4_0_0/CarePlan?_sort=_id&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp).toHaveStatusCode(200);
+        expect(resp.body.entry.map(e => e.resource.id).sort()).toEqual(['careplan-2015', 'careplan-2027']);
+
+        // the raw 'id' field resolves to the same ambiguous field as '_id' and must also be dropped
+        resp = await request.get('/4_0_0/CarePlan?_sort=id&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp).toHaveStatusCode(200);
+        expect(resp.body.entry.map(e => e.resource.id).sort()).toEqual(['careplan-2015', 'careplan-2027']);
+
+        // mixed with a real field: _id is dropped, the real field still decides order
+        resp = await request.get('/4_0_0/CarePlan?_sort=_id,-period.start&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['careplan-2027', 'careplan-2015']);
+    });
+
+    test("_sort resolves Task's _lastUpdated search-parameter code to meta.lastUpdated, but still ignores _id", async () => {
+        const request = await createTestRequest();
+
+        jest.useFakeTimers(FAKE_TIMER_OPTIONS);
+
+        jest.setSystemTime(new Date('2020-01-01T00:00:00Z'));
+        let resp = await request.post('/4_0_0/Task/$merge').send(task1).set(getHeaders());
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        jest.setSystemTime(new Date('2022-01-01T00:00:00Z'));
+        resp = await request.post('/4_0_0/Task/$merge').send(task2).set(getHeaders());
+        expect(resp).toHaveMergeResponse({ created: true });
+
+        jest.useRealTimers();
+
+        resp = await request.get('/4_0_0/Task?_sort=_lastUpdated&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['task-first', 'task-second']);
+
+        resp = await request.get('/4_0_0/Task?_sort=-_lastUpdated&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['task-second', 'task-first']);
+
+        resp = await request.get('/4_0_0/Task?_sort=_id&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp).toHaveStatusCode(200);
+        expect(resp.body.entry.map(e => e.resource.id).sort()).toEqual(['task-first', 'task-second']);
+    });
+
+    test("_sort resolves Observation's date search-parameter code to effectiveDateTime", async () => {
+        const request = await createTestRequest();
+
+        let resp = await request.post('/4_0_0/Observation/$merge').send([observation1, observation2]).set(getHeaders());
+        expect(resp).toHaveMergeResponse([{ created: true }, { created: true }]);
+
+        // observation1.effectiveDateTime is 2017, observation2.effectiveDateTime is 2029 (see fixtures)
+        resp = await request.get('/4_0_0/Observation?_sort=date&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['observation-2017', 'observation-2029']);
+
+        resp = await request.get('/4_0_0/Observation?_sort=-date&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp.body.entry.map(e => e.resource.id)).toEqual(['observation-2029', 'observation-2017']);
+    });
+
+    test("_sort still ignores VerificationResult's statusDate since no search parameter declares that field", async () => {
+        const request = await createTestRequest();
+
+        let resp = await request.post('/4_0_0/VerificationResult/$merge')
+            .send([verificationResult1, verificationResult2]).set(getHeaders());
+        expect(resp).toHaveMergeResponse([{ created: true }, { created: true }]);
+
+        resp = await request.get('/4_0_0/VerificationResult?_sort=-statusDate&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp).toHaveStatusCode(200);
+        expect(resp.body.entry.map(e => e.resource.id).sort()).toEqual(['verificationresult-1', 'verificationresult-2']);
+    });
+
+    test("_sort still ignores Person's active since no search parameter declares that field", async () => {
+        const request = await createTestRequest();
+
+        let resp = await request.post('/4_0_0/Person/$merge').send([person1, person2]).set(getHeaders());
+        expect(resp).toHaveMergeResponse([{ created: true }, { created: true }]);
+
+        resp = await request.get('/4_0_0/Person?_sort=-active&_bundle=1').set(getHeadersWithAdmin());
+        expect(resp).toHaveStatusCode(200);
+        expect(resp.body.entry.map(e => e.resource.id).sort()).toEqual(['person-active-false', 'person-active-true']);
+    });
+});

--- a/src/tests/unit/operations/search/searchManager.test.js
+++ b/src/tests/unit/operations/search/searchManager.test.js
@@ -90,6 +90,7 @@ describe('SearchManager', () => {
         mockPatientQueryCreator = Object.create(PatientQueryCreator.prototype);
         mockSearchParametersManager = Object.create(SearchParametersManager.prototype);
         mockSearchParametersManager.allowedFieldsForResourceByType = new Map();
+        mockSearchParametersManager.fieldTypesByResourceType = new Map();
 
         searchManager = new SearchManager({
             databaseQueryFactory: mockDatabaseQueryFactory,
@@ -206,15 +207,40 @@ describe('SearchManager', () => {
                 if (resourceType === 'Observation') {
                     return {
                         status: new SearchParameterDefinition({ type: 'token', field: 'status' }),
-                        category: new SearchParameterDefinition({ type: 'token', field: 'category' })
+                        category: new SearchParameterDefinition({ type: 'token', field: 'category' }),
+                        date: new SearchParameterDefinition({
+                            type: 'date',
+                            fields: ['effectiveDateTime', 'effectivePeriod', 'effectiveTiming', 'effectiveInstant']
+                        }),
+                        patient: new SearchParameterDefinition({ type: 'reference', field: 'subject' })
+                    };
+                }
+                if (resourceType === 'MedicationStatement') {
+                    return {
+                        effective: new SearchParameterDefinition({
+                            type: 'date',
+                            fields: ['effectiveDateTime', 'effectivePeriod'],
+                            fieldTypesObj: { effectiveDateTime: 'datetime', effectivePeriod: 'period' }
+                        })
                     };
                 }
                 if (resourceType === 'Resource') {
                     return {
+                        _id: new SearchParameterDefinition({ type: 'token', field: 'id' }),
                         _lastUpdated: new SearchParameterDefinition({ type: 'date', field: 'meta.lastUpdated' })
                     };
                 }
                 return undefined;
+            });
+            mockSearchParametersManager.getFieldNameForSearchParameter = jest.fn((searchResourceType, searchParameterName) => {
+                const byResourceType = {
+                    Observation: { status: 'status', category: 'category', date: 'effectiveDateTime', patient: 'subject' },
+                    MedicationStatement: { effective: 'effectiveDateTime' },
+                    Resource: { _id: 'id', _lastUpdated: 'meta.lastUpdated' }
+                };
+                return byResourceType[searchResourceType]?.[searchParameterName] ??
+                    byResourceType.Resource[searchParameterName] ??
+                    null;
             });
         });
 
@@ -259,6 +285,78 @@ describe('SearchManager', () => {
             const parsedArgs = { get: () => ({ queryParameterValue: { values: ['_uuid'] } }), _sort: '_uuid' };
             const result = searchManager.handleSortQuery({ parsedArgs, columns: new Set(), options: {}, resourceType: 'Observation' });
             expect(result.options.sort._uuid).toBe(1);
+        });
+
+        it('resolves a search-parameter code to its underlying field when they differ (_sort=-date on Observation)', () => {
+            const parsedArgs = { get: () => ({ queryParameterValue: { values: ['-date'] } }), _sort: '-date' };
+            const result = searchManager.handleSortQuery({ parsedArgs, columns: new Set(), options: {}, resourceType: 'Observation' });
+            expect(result.options.sort.effectiveDateTime).toBe(-1);
+            expect(result.options.sort.date).toBeUndefined();
+            expect(result.columns.has('effectiveDateTime')).toBe(true);
+        });
+
+        it('resolves the _lastUpdated search-parameter code (Resource bucket) to meta.lastUpdated', () => {
+            const parsedArgs = { get: () => ({ queryParameterValue: { values: ['_lastUpdated'] } }), _sort: '_lastUpdated' };
+            const result = searchManager.handleSortQuery({ parsedArgs, columns: new Set(), options: {}, resourceType: 'Observation' });
+            expect(result.options.sort['meta.lastUpdated']).toBe(1);
+            expect(result.options.sort._lastUpdated).toBeUndefined();
+        });
+
+        it('resolves a reference-type search-parameter code to its field (patient -> subject)', () => {
+            const parsedArgs = { get: () => ({ queryParameterValue: { values: ['patient'] } }), _sort: 'patient' };
+            const result = searchManager.handleSortQuery({ parsedArgs, columns: new Set(), options: {}, resourceType: 'Observation' });
+            expect(result.options.sort.subject).toBe(1);
+            expect(result.options.sort.patient).toBeUndefined();
+        });
+
+        it('resolves effectivePeriod.end via the generic period-type fallback, with no dedicated search parameter declaring that dotted path (matches real client traffic)', () => {
+            const parsedArgs = { get: () => ({ queryParameterValue: { values: ['-effectivePeriod.end'] } }), _sort: '-effectivePeriod.end' };
+            const result = searchManager.handleSortQuery({ parsedArgs, columns: new Set(), options: {}, resourceType: 'MedicationStatement' });
+            expect(result.options.sort['effectivePeriod.end']).toBe(-1);
+            expect(result.columns.has('effectivePeriod.end')).toBe(true);
+        });
+
+        it('resolves effectivePeriod.start via the generic period-type fallback the same way', () => {
+            const parsedArgs = { get: () => ({ queryParameterValue: { values: ['effectivePeriod.start'] } }), _sort: 'effectivePeriod.start' };
+            const result = searchManager.handleSortQuery({ parsedArgs, columns: new Set(), options: {}, resourceType: 'MedicationStatement' });
+            expect(result.options.sort['effectivePeriod.start']).toBe(1);
+        });
+
+        it('drops a boundary other than start/end on a period-typed field (effectivePeriod.middle is not a real boundary)', () => {
+            const parsedArgs = { get: () => ({ queryParameterValue: { values: ['effectivePeriod.middle'] } }), _sort: 'effectivePeriod.middle' };
+            const result = searchManager.handleSortQuery({ parsedArgs, columns: new Set(), options: {}, resourceType: 'MedicationStatement' });
+            expect(result.options.sort).toStrictEqual({});
+        });
+
+        it('drops a .start/.end suffix on a field that is declared but not typed as a period (Observation.effectivePeriod has no fieldTypesObj in this fixture, unlike MedicationStatement)', () => {
+            const parsedArgs = { get: () => ({ queryParameterValue: { values: ['effectivePeriod.end'] } }), _sort: 'effectivePeriod.end' };
+            const result = searchManager.handleSortQuery({ parsedArgs, columns: new Set(), options: {}, resourceType: 'Observation' });
+            expect(result.options.sort).toStrictEqual({});
+        });
+
+        it('drops a dotted value whose base field was never declared by any search parameter', () => {
+            const parsedArgs = { get: () => ({ queryParameterValue: { values: ['bogus.field'] } }), _sort: 'bogus.field' };
+            const result = searchManager.handleSortQuery({ parsedArgs, columns: new Set(), options: {}, resourceType: 'MedicationStatement' });
+            expect(result.options.sort).toStrictEqual({});
+        });
+
+        it('drops an injection-shaped value ($-prefixed) since it was never declared as an allowed field', () => {
+            const parsedArgs = { get: () => ({ queryParameterValue: { values: ['effectivePeriod.$where'] } }), _sort: 'effectivePeriod.$where' };
+            const result = searchManager.handleSortQuery({ parsedArgs, columns: new Set(), options: {}, resourceType: 'MedicationStatement' });
+            expect(result.options.sort).toStrictEqual({});
+        });
+
+        it('drops the _id search-parameter code since id resolution to sourceId/uuid is not yet decided', () => {
+            const parsedArgs = { get: () => ({ queryParameterValue: { values: ['_id'] } }), _sort: '_id' };
+            const result = searchManager.handleSortQuery({ parsedArgs, columns: new Set(), options: {}, resourceType: 'Observation' });
+            expect(result.options.sort).toStrictEqual({});
+            expect(result.columns.has('id')).toBe(false);
+        });
+
+        it('drops the raw id field too, since it resolves to the same ambiguous field as _id', () => {
+            const parsedArgs = { get: () => ({ queryParameterValue: { values: ['-id'] } }), _sort: '-id' };
+            const result = searchManager.handleSortQuery({ parsedArgs, columns: new Set(), options: {}, resourceType: 'Observation' });
+            expect(result.options.sort).toStrictEqual({});
         });
     });
 

--- a/src/tests/unit/operations/search/searchManager.test.js
+++ b/src/tests/unit/operations/search/searchManager.test.js
@@ -89,8 +89,7 @@ describe('SearchManager', () => {
         mockPatientScopeManager = Object.create(PatientScopeManager.prototype);
         mockPatientQueryCreator = Object.create(PatientQueryCreator.prototype);
         mockSearchParametersManager = Object.create(SearchParametersManager.prototype);
-        mockSearchParametersManager.allowedFieldsForResourceByType = new Map();
-        mockSearchParametersManager.fieldTypesByResourceType = new Map();
+        mockSearchParametersManager.resourceFieldMetadataByType = new Map();
 
         searchManager = new SearchManager({
             databaseQueryFactory: mockDatabaseQueryFactory,

--- a/src/tests/unit/operations/search/searchManager.test.js
+++ b/src/tests/unit/operations/search/searchManager.test.js
@@ -89,7 +89,7 @@ describe('SearchManager', () => {
         mockPatientScopeManager = Object.create(PatientScopeManager.prototype);
         mockPatientQueryCreator = Object.create(PatientQueryCreator.prototype);
         mockSearchParametersManager = Object.create(SearchParametersManager.prototype);
-        mockSearchParametersManager.resourceFieldMetadataByType = new Map();
+        mockSearchParametersManager.allowedFieldsByResourceType = new Map();
 
         searchManager = new SearchManager({
             databaseQueryFactory: mockDatabaseQueryFactory,


### PR DESCRIPTION
## Summary
- Replace CarePlan/MedicationStatement custom `_periodStart`/`_periodEnd`/`_effectivePeriodStart`/`_effectivePeriodEnd` search parameters with a generic period-boundary fallback in `SearchManager.handleSortQuery`: any `<field>.start`/`<field>.end` is recognized when the base field is declared as FHIR type `period` by any search parameter.
- Add `SearchParametersManager.getFieldType` to resolve a field's declared FHIR type across search parameters.
- Move `UNSUPPORTED_SORT_FIELDS` into `src/constants.js` as a list constant.
- Add `sortFieldHardening` test suite covering period-typed fields, nested CarePlan periods, `_id`/unsupported field handling, Task `_lastUpdated`, Observation `date`, and VerificationResult/Person fields.

## Test plan
- [ ] `node node_modules/.bin/jest src/tests/query/sortFieldHardening/sortFieldHardening.test.js --no-coverage`
- [ ] `node node_modules/.bin/jest src/tests/query/periodFilter/pertiodFilter.test.js --no-coverage`
- [ ] `node node_modules/.bin/jest src/tests/unit/operations/search/searchManager.test.js --no-coverage`
- [ ] `make lint`