### PR TITLE
DCON-4848 Fix K8sClient namespace for bwell-app 3.x clusters

### DIFF
--- a/src/tests/unit/utils/configManager.test.js
+++ b/src/tests/unit/utils/configManager.test.js
@@ -116,6 +116,24 @@ describe('ConfigManager', () => {
         });
     });
 
+    // ========== useEnvironmentValueForK8sNamespace ==========
+    describe('useEnvironmentValueForK8sNamespace', () => {
+        test('defaults to true when not set', () => {
+            delete process.env.USE_ENVIRONMENT_VALUE_FOR_K8S_NAMESPACE;
+            expect(new ConfigManager().useEnvironmentValueForK8sNamespace).toBe(true);
+        });
+
+        test('returns false when explicitly disabled', () => {
+            process.env.USE_ENVIRONMENT_VALUE_FOR_K8S_NAMESPACE = 'false';
+            expect(new ConfigManager().useEnvironmentValueForK8sNamespace).toBe(false);
+        });
+
+        test('returns true when explicitly enabled', () => {
+            process.env.USE_ENVIRONMENT_VALUE_FOR_K8S_NAMESPACE = 'true';
+            expect(new ConfigManager().useEnvironmentValueForK8sNamespace).toBe(true);
+        });
+    });
+
     // ========== accessTagsIndexed (large method with switch) ==========
     describe('accessTagsIndexed', () => {
         test('returns empty array when no env vars set', () => {

--- a/src/tests/unit/utils/k8sClient.test.js
+++ b/src/tests/unit/utils/k8sClient.test.js
@@ -98,7 +98,8 @@ describe('K8sClient', () => {
 
         mockConfigManager = {
             environmentValue: 'dev',
-            hostnameValue: 'fhir-server-pod-0'
+            hostnameValue: 'fhir-server-pod-0',
+            useEnvironmentValueForK8sNamespace: true
         };
 
         k8sClient = new K8sClient({ configManager: mockConfigManager });
@@ -135,15 +136,16 @@ describe('K8sClient', () => {
             expect(logError).toHaveBeenCalledWith('Error while initializing k8 client:', expect.any(Error));
         });
 
-        test('reads namespace from the current kube config context', () => {
-            expect(mockKubeConfig.getContextObject).toHaveBeenCalledWith('inClusterContext');
-            expect(k8sClient.namespace).toBe('fhir-server');
+        test('derives namespace from environmentValue by default (useEnvironmentValueForK8sNamespace defaults to true)', () => {
+            expect(mockKubeConfig.getContextObject).not.toHaveBeenCalled();
+            expect(k8sClient.namespace).toBe('fhir-server-dev');
         });
 
-        test('resolves namespace independently of environmentValue naming conventions', () => {
+        test('reads namespace from the kube config context when useEnvironmentValueForK8sNamespace is false', () => {
+            mockConfigManager.useEnvironmentValueForK8sNamespace = false;
             mockKubeConfig.getContextObject.mockReturnValueOnce({ namespace: 'fhir-server' });
-            mockConfigManager.environmentValue = 'dev';
             const client = new K8sClient({ configManager: mockConfigManager });
+            expect(mockKubeConfig.getContextObject).toHaveBeenCalledWith('inClusterContext');
             expect(client.namespace).toBe('fhir-server');
         });
     });
@@ -156,7 +158,7 @@ describe('K8sClient', () => {
             const job = await k8sClient.createJobBody({ scriptCommand, context });
             expect(mockCoreV1Api.readNamespacedPod).toHaveBeenCalledWith({
                 name: 'fhir-server-pod-0',
-                namespace: 'fhir-server'
+                namespace: 'fhir-server-dev'
             });
         });
 
@@ -256,7 +258,7 @@ describe('K8sClient', () => {
             expect(result).toBe(true);
             expect(mockBatchV1Api.createNamespacedJob).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    namespace: 'fhir-server'
+                    namespace: 'fhir-server-dev'
                 })
             );
             expect(logInfo).toHaveBeenCalledWith('Job created:', expect.anything());
@@ -302,9 +304,10 @@ describe('K8sClient', () => {
             await expect(k8sClient.createJob({ scriptCommand, context })).rejects.toThrow('Permission denied');
         });
 
-        test('uses the namespace read from the kube config context, not environmentValue', async () => {
+        test('uses the live kube config namespace instead of environmentValue when useEnvironmentValueForK8sNamespace is false', async () => {
             mockBatchV1Api.createNamespacedJob.mockResolvedValue({ body: { metadata: { name: 'test-job' } } });
             mockConfigManager.environmentValue = 'production';
+            mockConfigManager.useEnvironmentValueForK8sNamespace = false;
             mockKubeConfig.getContextObject.mockReturnValueOnce({ namespace: 'fhir-server' });
             k8sClient = new K8sClient({ configManager: mockConfigManager });
 

--- a/src/tests/unit/utils/k8sClient.test.js
+++ b/src/tests/unit/utils/k8sClient.test.js
@@ -6,7 +6,9 @@ const { describe, test, expect, beforeEach, afterEach, jest: jestObj } = require
 // Mock @kubernetes/client-node
 const mockKubeConfig = {
     loadFromCluster: jestObj.fn(),
-    makeApiClient: jestObj.fn()
+    makeApiClient: jestObj.fn(),
+    getCurrentContext: jestObj.fn().mockReturnValue('inClusterContext'),
+    getContextObject: jestObj.fn().mockReturnValue({ namespace: 'fhir-server' })
 };
 
 const mockBatchV1Api = {
@@ -132,6 +134,18 @@ describe('K8sClient', () => {
             const client = new K8sClient({ configManager: mockConfigManager });
             expect(logError).toHaveBeenCalledWith('Error while initializing k8 client:', expect.any(Error));
         });
+
+        test('reads namespace from the current kube config context', () => {
+            expect(mockKubeConfig.getContextObject).toHaveBeenCalledWith('inClusterContext');
+            expect(k8sClient.namespace).toBe('fhir-server');
+        });
+
+        test('resolves namespace independently of environmentValue naming conventions', () => {
+            mockKubeConfig.getContextObject.mockReturnValueOnce({ namespace: 'fhir-server' });
+            mockConfigManager.environmentValue = 'dev';
+            const client = new K8sClient({ configManager: mockConfigManager });
+            expect(client.namespace).toBe('fhir-server');
+        });
     });
 
     describe('createJobBody', () => {
@@ -142,7 +156,7 @@ describe('K8sClient', () => {
             const job = await k8sClient.createJobBody({ scriptCommand, context });
             expect(mockCoreV1Api.readNamespacedPod).toHaveBeenCalledWith({
                 name: 'fhir-server-pod-0',
-                namespace: 'fhir-server-dev'
+                namespace: 'fhir-server'
             });
         });
 
@@ -242,7 +256,7 @@ describe('K8sClient', () => {
             expect(result).toBe(true);
             expect(mockBatchV1Api.createNamespacedJob).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    namespace: 'fhir-server-dev'
+                    namespace: 'fhir-server'
                 })
             );
             expect(logInfo).toHaveBeenCalledWith('Job created:', expect.anything());
@@ -288,15 +302,16 @@ describe('K8sClient', () => {
             await expect(k8sClient.createJob({ scriptCommand, context })).rejects.toThrow('Permission denied');
         });
 
-        test('uses correct namespace derived from environmentValue', async () => {
+        test('uses the namespace read from the kube config context, not environmentValue', async () => {
             mockBatchV1Api.createNamespacedJob.mockResolvedValue({ body: { metadata: { name: 'test-job' } } });
             mockConfigManager.environmentValue = 'production';
+            mockKubeConfig.getContextObject.mockReturnValueOnce({ namespace: 'fhir-server' });
             k8sClient = new K8sClient({ configManager: mockConfigManager });
 
             await k8sClient.createJob({ scriptCommand, context });
             expect(mockBatchV1Api.createNamespacedJob).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    namespace: 'fhir-server-production'
+                    namespace: 'fhir-server'
                 })
             );
         });

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -66,14 +66,8 @@ class ConfigManager {
     }
 
     /**
-     * Whether K8sClient should derive its namespace (for reading the current pod
-     * and creating jobs) from `fhir-server-${environmentValue}` — the legacy
-     * <service>-<env> naming convention used on dev-ue1/staging-ue1/prod-ue1/
-     * client-sandbox-ue1. Defaults to true to preserve existing behavior.
-     * bwell-app 3.x clusters (e.g. dev-use1-eks) use the bare service name as
-     * the namespace instead, so this must be set to false there, at which
-     * point K8sClient reads the namespace live from the in-cluster kube config
-     * context instead.
+     * Whether K8sClient derives its namespace from environmentValue instead of
+     * reading it from the kube config context. Defaults to true.
      * @return {boolean}
      */
     get useEnvironmentValueForK8sNamespace() {

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -66,6 +66,21 @@ class ConfigManager {
     }
 
     /**
+     * Whether K8sClient should derive its namespace (for reading the current pod
+     * and creating jobs) from `fhir-server-${environmentValue}` — the legacy
+     * <service>-<env> naming convention used on dev-ue1/staging-ue1/prod-ue1/
+     * client-sandbox-ue1. Defaults to true to preserve existing behavior.
+     * bwell-app 3.x clusters (e.g. dev-use1-eks) use the bare service name as
+     * the namespace instead, so this must be set to false there, at which
+     * point K8sClient reads the namespace live from the in-cluster kube config
+     * context instead.
+     * @return {boolean}
+     */
+    get useEnvironmentValueForK8sNamespace() {
+        return isTrueWithFallback(env.USE_ENVIRONMENT_VALUE_FOR_K8S_NAMESPACE, true);
+    }
+
+    /**
      * current hostname value
      * @return {string|null}
      */

--- a/src/utils/k8sClient.js
+++ b/src/utils/k8sClient.js
@@ -32,12 +32,7 @@ class K8sClient {
             this.kc.loadFromCluster();
 
             /**
-             * Namespace to use for reading the current pod and creating jobs.
-             * Legacy clusters (dev-ue1/staging-ue1/prod-ue1/client-sandbox-ue1)
-             * follow a `fhir-server-<env>` convention; bwell-app 3.x clusters
-             * (e.g. dev-use1-eks) use the bare service name instead, which is
-             * read live from the service-account namespace file that
-             * loadFromCluster() mounts via the downward API.
+             * Namespace used for reading the current pod and creating jobs.
              */
             this.namespace = this.configManager.useEnvironmentValueForK8sNamespace
                 ? `fhir-server-${this.configManager.environmentValue}`

--- a/src/utils/k8sClient.js
+++ b/src/utils/k8sClient.js
@@ -32,6 +32,15 @@ class K8sClient {
             this.kc.loadFromCluster();
 
             /**
+             * Namespace the current pod is actually running in, read from the
+             * service-account namespace file loadFromCluster() mounts via the
+             * downward API. Namespace naming conventions differ between clusters
+             * (e.g. legacy `fhir-server-<env>` vs bwell-app 3.x `fhir-server`),
+             * so this must be read live rather than derived from environmentValue.
+             */
+            this.namespace = this.kc.getContextObject(this.kc.getCurrentContext())?.namespace;
+
+            /**
              * Create an API client for batch (jobs) operations
              */
             this.k8sBatchV1Api = this.kc.makeApiClient(k8s.BatchV1Api);
@@ -54,7 +63,7 @@ class K8sClient {
      */
     async createJobBody({ scriptCommand, context }) {
         try {
-            const currentNamespace = `fhir-server-${this.configManager.environmentValue}`;
+            const currentNamespace = this.namespace;
 
             // Get the current Pod details
             const readNamespacedPodParam = {
@@ -154,7 +163,7 @@ class K8sClient {
      */
     async createJob({ scriptCommand, context }) {
         try {
-            const namespace = `fhir-server-${this.configManager.environmentValue}`;
+            const namespace = this.namespace;
             const body = await this.createJobBody({ scriptCommand, context });
             const param = {
                 namespace,

--- a/src/utils/k8sClient.js
+++ b/src/utils/k8sClient.js
@@ -32,13 +32,16 @@ class K8sClient {
             this.kc.loadFromCluster();
 
             /**
-             * Namespace the current pod is actually running in, read from the
-             * service-account namespace file loadFromCluster() mounts via the
-             * downward API. Namespace naming conventions differ between clusters
-             * (e.g. legacy `fhir-server-<env>` vs bwell-app 3.x `fhir-server`),
-             * so this must be read live rather than derived from environmentValue.
+             * Namespace to use for reading the current pod and creating jobs.
+             * Legacy clusters (dev-ue1/staging-ue1/prod-ue1/client-sandbox-ue1)
+             * follow a `fhir-server-<env>` convention; bwell-app 3.x clusters
+             * (e.g. dev-use1-eks) use the bare service name instead, which is
+             * read live from the service-account namespace file that
+             * loadFromCluster() mounts via the downward API.
              */
-            this.namespace = this.kc.getContextObject(this.kc.getCurrentContext())?.namespace;
+            this.namespace = this.configManager.useEnvironmentValueForK8sNamespace
+                ? `fhir-server-${this.configManager.environmentValue}`
+                : this.kc.getContextObject(this.kc.getCurrentContext())?.namespace;
 
             /**
              * Create an API client for batch (jobs) operations


### PR DESCRIPTION
## Summary
- Every hourly run of `fhir-server-cron-job` on `dev-use1-eks` was failing to create its export/history-migration Kubernetes Jobs with a 403 (`pods "..." is forbidden ... in the namespace "fhir-server-dev"`), confirmed via GroundCover logs and live entity state.
- Root cause: `K8sClient` hardcoded the namespace as `` fhir-server-${environmentValue} `` — the legacy `<service>-<env>` convention used on `dev-ue1`/`staging-ue1`/`prod-ue1`/`client-sandbox-ue1`. bwell-app 3.x clusters (e.g. `dev-use1-eks`) use the bare service name (`fhir-server`) as the namespace instead, per the ArgoCD app spec in `cie.gha-deploy`'s `argo` branch action.
- `K8sClient` can now resolve the namespace live from the in-cluster kube config context (populated from the mounted service-account namespace file via `@kubernetes/client-node`'s `loadFromCluster()`), which is correct on any cluster regardless of naming convention.
- Rollout is gated behind a new `configManager.useEnvironmentValueForK8sNamespace` flag (env `USE_ENVIRONMENT_VALUE_FOR_K8S_NAMESPACE`), **defaulting to `true`** to preserve the existing `fhir-server-${environmentValue}` behavior everywhere unless explicitly opted out. To actually fix the bug on `dev-use1-eks`, that environment's Helm values (in `icanbwell/bwell-fhir-server`, `.helm/fhir-server/dev-use1-eks.values.yaml`) need `USE_ENVIRONMENT_VALUE_FOR_K8S_NAMESPACE: "false"` set — that's a separate PR in that repo, not included here.

Ref: DCON-4848

## Test plan
- [x] `k8sClient.test.js` — updated existing tests for the default (flag `true`) namespace, added tests for the flag-`false` kube-config-context path.
- [x] `configManager.test.js` — added coverage for the new `useEnvironmentValueForK8sNamespace` getter (default true, explicit true/false).
- [x] `cronJob.test.js` / `cronJobRunner.test.js` — unaffected, still passing.
- [x] `yarn test:jest` on all four affected suites — 108/108 passing.
- [x] `eslint` clean on all changed files.
- [ ] Once `dev-use1-eks`'s Helm values set the flag to `false`, manually verify the next hourly cron run no longer logs the `createNamespacedJob` 403.