### PR TITLE
DCON-4809 Scope trust proxy to a configurable hop count

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -538,7 +538,7 @@ function createApp({fnGetContainer}) {
 
     // enables access to reverse proxy information
     // https://expressjs.com/en/guide/behind-proxies.html
-    app.enable('trust proxy');
+    app.set('trust proxy', configManager.trustProxyHopCount);
 
     return app;
 }

--- a/src/middleware/fhir/base/base.service.js
+++ b/src/middleware/fhir/base/base.service.js
@@ -54,10 +54,11 @@ const createRequestPromises = (entries, req, baseVersion) => {
     // This is a same-process loopback call: the batch/transaction handler re-dispatches each
     // bundle entry back through this server's own single-resource endpoints. The destination
     // must never be derived from anything caller-controlled - not even req.hostname, which
-    // resolves to an attacker-suppliable value here (this app enables "trust proxy"
-    // unconditionally in src/app.js, so req.hostname/req.host prefer X-Forwarded-Host from any
-    // client, not only from a verified upstream proxy). Always target our own configured
-    // listening port on loopback instead, over plain HTTP (this app never terminates TLS itself).
+    // resolves to an attacker-suppliable value here (src/app.js sets a non-zero "trust proxy"
+    // hop count by default, and any non-zero value makes req.hostname/req.host prefer
+    // X-Forwarded-Host from any client, not only from a verified upstream proxy). Always target
+    // our own configured listening port on loopback instead, over plain HTTP (this app never
+    // terminates TLS itself).
     const serverHost = `127.0.0.1:${fhirServerConfig.server.port}`;
     const requestPromises = [];
     const results = [];

--- a/src/tests/trustProxy/fixtures/observation.json
+++ b/src/tests/trustProxy/fixtures/observation.json
@@ -1,0 +1,75 @@
+{
+  "resourceType": "Observation",
+  "id": "1",
+  "meta": {
+    "source": "https://www.icanbwell.com",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "bwell"
+      }
+    ]
+  },
+  "status": "final",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>Carbon dioxide in blood</p></div>"
+  },
+  "code": {
+    "coding": [
+      {
+        "system": "URN:OID:2.16.840.1.113883.6.96",
+        "code": "11557-6",
+        "display": "Carbon dioxide in blood"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/1",
+    "display": "P. van de Heuvel"
+  },
+  "encounter": {
+    "reference": "Encounter/1"
+  },
+  "effectiveDateTime": "2013-04-02T10:30:10+01:00",
+  "issued": "2013-04-03T15:30:10+01:00",
+  "performer": [
+    {
+      "reference": "Practitioner/f005",
+      "display": "A. Langeveld"
+    }
+  ],
+  "valueQuantity": {
+    "value": 6.2,
+    "unit": "kPa",
+    "system": "http://unitsofmeasure.org",
+    "code": "kPa"
+  },
+  "interpretation": [
+    {
+      "coding": [
+        {
+          "system": "urn:oid:2.16.840.1.113883.6.96",
+          "code": "H",
+          "display": "High"
+        }
+      ]
+    }
+  ],
+  "referenceRange": [
+    {
+      "low": {
+        "value": 4.8,
+        "unit": "kPa",
+        "system": "http://unitsofmeasure.org",
+        "code": "kPa"
+      },
+      "high": {
+        "value": 6,
+        "unit": "kPa",
+        "system": "http://unitsofmeasure.org",
+        "code": "kPa"
+      }
+    }
+  ]
+}

--- a/src/tests/trustProxy/trustProxy.test.js
+++ b/src/tests/trustProxy/trustProxy.test.js
@@ -1,0 +1,209 @@
+const supertest = require('supertest');
+const observationResource = require('./fixtures/observation.json');
+
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    createTestApp
+} = require('../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+
+const FORWARDED_HEADERS = {
+    'X-Forwarded-Host': 'attacker.example.com',
+    'X-Forwarded-Proto': 'https',
+    'X-Forwarded-For': '1.2.3.4, 5.6.7.8, 9.10.11.12'
+};
+
+describe('trust proxy Tests', () => {
+    const originalHopCount = process.env.TRUST_PROXY_HOP_COUNT;
+
+    beforeEach(async () => {
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        await commonAfterEach();
+        if (originalHopCount === undefined) {
+            delete process.env.TRUST_PROXY_HOP_COUNT;
+        } else {
+            process.env.TRUST_PROXY_HOP_COUNT = originalHopCount;
+        }
+    });
+
+    /**
+     * @param {string|undefined} hopCount value for TRUST_PROXY_HOP_COUNT, or undefined to leave it unset
+     * @return {import('supertest').SuperTest<import('supertest').Test>}
+     */
+    function createRequestWithHopCount(hopCount) {
+        if (hopCount === undefined) {
+            delete process.env.TRUST_PROXY_HOP_COUNT;
+        } else {
+            process.env.TRUST_PROXY_HOP_COUNT = hopCount;
+        }
+        return supertest(createTestApp());
+    }
+
+    /**
+     * @param {import('supertest').SuperTest<import('supertest').Test>} request
+     * @return {Promise<string>} the self link of a search bundle built from the forwarded headers
+     */
+    async function getSelfLinkForForwardedRequest(request) {
+        await request
+            .post('/4_0_0/Observation/$merge')
+            .send(observationResource)
+            .set(getHeaders())
+            .expect(200);
+
+        const response = await request
+            .get('/4_0_0/Observation?_bundle=1')
+            .set({ ...getHeaders(), ...FORWARDED_HEADERS })
+            .expect(200);
+
+        return response.body.link.find((link) => link.relation === 'self').url;
+    }
+
+    describe('bundle link urls honor X-Forwarded-Host/Proto only per the configured hop count', () => {
+        test('a hop count of 0 ignores forwarded headers and uses the real Host header', async () => {
+            const selfLink = await getSelfLinkForForwardedRequest(createRequestWithHopCount('0'));
+
+            expect(selfLink).toBe('http://localhost:3000/4_0_0/Observation?_bundle=1');
+            expect(selfLink).not.toContain('attacker.example.com');
+        });
+
+        test('a hop count of 1 trusts the forwarded headers of the connecting peer', async () => {
+            const selfLink = await getSelfLinkForForwardedRequest(createRequestWithHopCount('1'));
+
+            expect(selfLink).toBe('https://attacker.example.com/4_0_0/Observation?_bundle=1');
+        });
+
+        test('the default hop count trusts the forwarded headers of the connecting peer', async () => {
+            const selfLink = await getSelfLinkForForwardedRequest(createRequestWithHopCount(undefined));
+
+            expect(selfLink).toBe('https://attacker.example.com/4_0_0/Observation?_bundle=1');
+        });
+
+        test('a non-integer hop count falls back to the default instead of disabling proxy trust', async () => {
+            const selfLink = await getSelfLinkForForwardedRequest(
+                createRequestWithHopCount('not-an-integer')
+            );
+
+            expect(selfLink).toBe('https://attacker.example.com/4_0_0/Observation?_bundle=1');
+        });
+
+        test('a fractional hop count falls back to the default instead of disabling proxy trust', async () => {
+            const selfLink = await getSelfLinkForForwardedRequest(createRequestWithHopCount('2.5'));
+
+            expect(selfLink).toBe('https://attacker.example.com/4_0_0/Observation?_bundle=1');
+        });
+
+        test('an empty hop count falls back to the default instead of disabling proxy trust', async () => {
+            const selfLink = await getSelfLinkForForwardedRequest(createRequestWithHopCount(''));
+
+            expect(selfLink).toBe('https://attacker.example.com/4_0_0/Observation?_bundle=1');
+        });
+
+        test('every link in the bundle is built from the same host, not just the self link', async () => {
+            const request = createRequestWithHopCount('0');
+            await request
+                .post('/4_0_0/Observation/$merge')
+                .send(observationResource)
+                .set(getHeaders())
+                .expect(200);
+
+            const response = await request
+                .get('/4_0_0/Observation?_bundle=1')
+                .set({ ...getHeaders(), ...FORWARDED_HEADERS })
+                .expect(200);
+
+            expect(response.body.link.length).toBeGreaterThan(0);
+            for (const link of response.body.link) {
+                expect(link.url).toMatch(/^http:\/\/localhost:3000\//);
+            }
+        });
+    });
+
+    describe('a multi-value X-Forwarded-Host resolves to the left-most host', () => {
+        const MULTI_HOST_HEADERS = {
+            'X-Forwarded-Host': 'first.example.com, second.example.com, third.example.com',
+            'X-Forwarded-Proto': 'https',
+            'X-Forwarded-For': '1.1.1.1, 2.2.2.2, 3.3.3.3'
+        };
+
+        /**
+         * @param {string|undefined} hopCount
+         * @return {Promise<string>}
+         */
+        async function getSelfLinkForMultiHostRequest(hopCount) {
+            const request = createRequestWithHopCount(hopCount);
+            await request
+                .post('/4_0_0/Observation/$merge')
+                .send(observationResource)
+                .set(getHeaders())
+                .expect(200);
+
+            const response = await request
+                .get('/4_0_0/Observation?_bundle=1')
+                .set({ ...getHeaders(), ...MULTI_HOST_HEADERS })
+                .expect(200);
+
+            return response.body.link.find((link) => link.relation === 'self').url;
+        }
+
+        test('a hop count of 1 uses the left-most host and ignores the rest', async () => {
+            const selfLink = await getSelfLinkForMultiHostRequest('1');
+
+            expect(selfLink).toBe('https://first.example.com/4_0_0/Observation?_bundle=1');
+            expect(selfLink).not.toContain('second.example.com');
+            expect(selfLink).not.toContain('third.example.com');
+        });
+
+        test('a hop count of 2 still uses the left-most host, so the count gates but does not select', async () => {
+            const selfLink = await getSelfLinkForMultiHostRequest('2');
+
+            expect(selfLink).toBe('https://first.example.com/4_0_0/Observation?_bundle=1');
+        });
+
+        test('the default hop count still uses the left-most host', async () => {
+            const selfLink = await getSelfLinkForMultiHostRequest(undefined);
+
+            expect(selfLink).toBe('https://first.example.com/4_0_0/Observation?_bundle=1');
+        });
+
+        test('a hop count of 0 ignores every forwarded host', async () => {
+            const selfLink = await getSelfLinkForMultiHostRequest('0');
+
+            expect(selfLink).toBe('http://localhost:3000/4_0_0/Observation?_bundle=1');
+            expect(selfLink).not.toContain('example.com');
+        });
+    });
+
+    describe('Content-Location honors X-Forwarded-Proto only per the configured hop count', () => {
+        /**
+         * @param {string|undefined} hopCount
+         * @return {Promise<string>}
+         */
+        async function getContentLocationForForwardedCreate(hopCount) {
+            const request = createRequestWithHopCount(hopCount);
+            const response = await request
+                .post('/4_0_0/Observation/')
+                .send(observationResource)
+                .set({ ...getHeaders(), ...FORWARDED_HEADERS })
+                .expect(201);
+
+            return response.headers['content-location'];
+        }
+
+        test('a hop count of 0 ignores X-Forwarded-Proto', async () => {
+            const contentLocation = await getContentLocationForForwardedCreate('0');
+
+            expect(contentLocation).toMatch(/^http:\/\//);
+        });
+
+        test('a hop count of 1 trusts X-Forwarded-Proto', async () => {
+            const contentLocation = await getContentLocationForForwardedCreate('1');
+
+            expect(contentLocation).toMatch(/^https:\/\//);
+        });
+    });
+});

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -475,6 +475,18 @@ class ConfigManager {
     }
 
     /**
+     * number of reverse proxy hops to trust for express's 'trust proxy' setting
+     * @returns {number}
+     */
+    get trustProxyHopCount() {
+        const value = env.TRUST_PROXY_HOP_COUNT?.trim();
+        const hopCount = Number(value);
+        return value && Number.isInteger(hopCount) && hopCount >= 0
+            ? hopCount
+            : 20;
+    }
+
+    /**
      * whether to enable stats endpoint
      * @returns {boolean}
      */


### PR DESCRIPTION
## Summary

`src/app.js` called `app.enable('trust proxy')` — the boolean-`true` form, which Express's own docs flag as insecure: it trusts `X-Forwarded-Host`/`X-Forwarded-For` from *any* connecting client, not only from a verified upstream proxy.

This replaces it with an env-controlled hop count so each deployment environment can be set to its real reverse-proxy topology.

## Changes

- **`src/app.js`** — `app.enable('trust proxy')` → `app.set('trust proxy', configManager.trustProxyHopCount)`. `configManager` was already in scope in `createApp`.
- **`src/utils/configManager.js`** — new `trustProxyHopCount` getter reading `TRUST_PROXY_HOP_COUNT`, default `20`.
- **`src/middleware/fhir/base/base.service.js`** — the SSRF comment there described `trust proxy` as enabled unconditionally; updated to match.

## Env var

| | |
|---|---|
| `TRUST_PROXY_HOP_COUNT` | number of reverse-proxy hops to trust |
| default | `20` |

The value is validated as a non-negative integer. This matters beyond tidiness: had a malformed value been passed through as a string, Express would compile it as an IP/CIDR trust list — a different trust model entirely. So `2.5`, `-1`, `abc`, and `10.0.0.0/8` all fall back to the default. An explicit `0` is honored (trust nothing), and a declared-but-blank var (`TRUST_PROXY_HOP_COUNT: ''` in a manifest) falls back to the default rather than silently turning proxy trust off.

## Tests

`src/tests/trustProxy/trustProxy.test.js` — 13 integration tests driving real HTTP requests through supertest with `X-Forwarded-Host` / `X-Forwarded-Proto` / `X-Forwarded-For`, asserting on client-observable output rather than on framework internals.

Observable surfaces covered:
- search Bundle `link[].url` (built from `req.hostname` / `req.protocol`)
- `Content-Location` response header on create

| `TRUST_PROXY_HOP_COUNT` | Bundle self link, given `X-Forwarded-Host: attacker.example.com` + `Proto: https` |
|---|---|
| unset (default) | `https://attacker.example.com/4_0_0/Observation?_bundle=1` |
| `1` | `https://attacker.example.com/4_0_0/Observation?_bundle=1` |
| `0` | `http://localhost:3000/4_0_0/Observation?_bundle=1` |
| `not-an-integer` / `2.5` / `''` | falls back to default |

A second block covers a multi-value `X-Forwarded-Host` (`first.example.com, second.example.com, third.example.com`), pinning down that Express resolves it to the left-most host and that the hop count gates the header rather than selecting among its values — so a future Express upgrade that changed this would fail the suite.

The tests call `createTestApp()` + `supertest()` directly rather than `createTestRequest()`, because `commonAfterEach` clears the cached tester but not the cached app — the latter would pin the first test's `trust proxy` value for the whole file.

```bash
yarn jest --runInBand --forceExit src/tests/trustProxy/trustProxy.test.js
```

13/13 passing; `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)