### PR TITLE
DCON-000 Gate ConsentCacheInvalidationHandler on everything-cache write flag

### DIFF
--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -1203,7 +1203,8 @@ const createContainer = function () {
             c.patientPersonDataChangeEventProducer,
             new ConsentCacheInvalidationHandler({
                 redisManager: c.redisManager,
-                bwellPersonFinder: c.bwellPersonFinder
+                bwellPersonFinder: c.bwellPersonFinder,
+                configManager: c.configManager
             })
         ];
 

--- a/src/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.js
+++ b/src/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.js
@@ -1,6 +1,7 @@
 const { BasePostSaveHandler } = require('../../../utils/basePostSaveHandler');
 const { assertTypeEquals } = require('../../../utils/assertType');
 const { RedisManager } = require('../../../utils/redisManager');
+const { ConfigManager } = require('../../../utils/configManager');
 const { BwellPersonFinder } = require('../../../utils/bwellPersonFinder');
 const { ReferenceParser } = require('../../../utils/referenceParser');
 const { isUuid } = require('../../../utils/uid.util');
@@ -10,6 +11,11 @@ const { logDebug, logError } = require('../../../operations/common/logging');
 /**
  * Post-save handler that invalidates the Patient/$everything Redis cache whenever a
  * Consent resource is created, updated, or removed.
+ *
+ * No-ops entirely unless configManager.writeToCacheForEverythingOperation is true (i.e.
+ * ENABLE_REDIS && ENABLE_REDIS_CACHE_WRITE_FOR_EVERYTHING_OPERATION) - the same gate
+ * everythingHelper.js itself uses before writing to the $everything cache. If that cache is
+ * never written to, there is nothing for this handler to invalidate.
  *
  * The $everything cache (see PatientEverythingCacheKeyGenerator) is keyed in part on a
  * "generation" counter stored in Redis (Patient:<uuid>:Everything:Generation or
@@ -39,8 +45,9 @@ class ConsentCacheInvalidationHandler extends BasePostSaveHandler {
      * @param {Object} params
      * @param {RedisManager} params.redisManager
      * @param {BwellPersonFinder} params.bwellPersonFinder
+     * @param {ConfigManager} params.configManager
      */
-    constructor({ redisManager, bwellPersonFinder }) {
+    constructor({ redisManager, bwellPersonFinder, configManager }) {
         super();
 
         /**
@@ -54,6 +61,12 @@ class ConsentCacheInvalidationHandler extends BasePostSaveHandler {
          */
         this.bwellPersonFinder = bwellPersonFinder;
         assertTypeEquals(bwellPersonFinder, BwellPersonFinder);
+
+        /**
+         * @type {ConfigManager}
+         */
+        this.configManager = configManager;
+        assertTypeEquals(configManager, ConfigManager);
     }
 
     /**
@@ -66,6 +79,10 @@ class ConsentCacheInvalidationHandler extends BasePostSaveHandler {
      */
     async afterSaveAsync({ requestId, eventType, resourceType, doc }) {
         if (resourceType !== 'Consent' || !doc) {
+            return;
+        }
+
+        if (!this.configManager.writeToCacheForEverythingOperation) {
             return;
         }
 

--- a/src/tests/unit/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.test.js
+++ b/src/tests/unit/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.test.js
@@ -14,6 +14,7 @@ const { describe, beforeEach, afterEach, it, expect, jest } = require('@jest/glo
 const { ConsentCacheInvalidationHandler } = require('../../../../../dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler');
 const { RedisManager } = require('../../../../../utils/redisManager');
 const { BwellPersonFinder } = require('../../../../../utils/bwellPersonFinder');
+const { ConfigManager } = require('../../../../../utils/configManager');
 
 jest.mock('../../../../../operations/common/logging', () => ({
     logError: jest.fn(),
@@ -31,6 +32,7 @@ describe('ConsentCacheInvalidationHandler', () => {
     let handler;
     let mockRedisManager;
     let mockBwellPersonFinder;
+    let mockConfigManager;
     let bumpedKeys;
 
     beforeEach(() => {
@@ -48,9 +50,15 @@ describe('ConsentCacheInvalidationHandler', () => {
             CLIENT_PERSON_UUID, MASTER_PERSON_UUID
         ]);
 
+        mockConfigManager = Object.create(ConfigManager.prototype);
+        Object.defineProperty(mockConfigManager, 'writeToCacheForEverythingOperation', {
+            value: true, writable: true, configurable: true
+        });
+
         handler = new ConsentCacheInvalidationHandler({
             redisManager: mockRedisManager,
-            bwellPersonFinder: mockBwellPersonFinder
+            bwellPersonFinder: mockBwellPersonFinder,
+            configManager: mockConfigManager
         });
     });
 
@@ -68,6 +76,15 @@ describe('ConsentCacheInvalidationHandler', () => {
     it('is a no-op for non-Consent resources', async () => {
         await handler.afterSaveAsync({ requestId: 'r1', eventType: 'U', resourceType: 'Observation', doc: { id: 'o1' } });
         expect(mockRedisManager.incrementGenerationAsync).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when the everything cache write flag (ENABLE_REDIS && ENABLE_REDIS_CACHE_WRITE_FOR_EVERYTHING_OPERATION) is off', async () => {
+        mockConfigManager.writeToCacheForEverythingOperation = false;
+
+        await handler.afterSaveAsync({ requestId: 'r1', eventType: 'U', resourceType: 'Consent', doc: directPatientConsent() });
+
+        expect(mockRedisManager.incrementGenerationAsync).not.toHaveBeenCalled();
+        expect(mockBwellPersonFinder.getImmediatePersonIdsOfPatientsAsync).not.toHaveBeenCalled();
     });
 
     it('on a direct-Patient Consent bumps the Patient key, the immediate client Person, AND the bwell master Person', async () => {

--- a/src/tests/unit/operations/search/proaConsentVulnerabilities.test.js
+++ b/src/tests/unit/operations/search/proaConsentVulnerabilities.test.js
@@ -507,11 +507,23 @@ describe('VULNERABILITY 5: No automatic cache invalidation when Consent status c
         return finder;
     }
 
+    /**
+     * @returns {ConfigManager}
+     */
+    function createFakeConfigManager() {
+        const configManager = Object.create(ConfigManager.prototype);
+        Object.defineProperty(configManager, 'writeToCacheForEverythingOperation', {
+            value: true, writable: true, configurable: true
+        });
+        return configManager;
+    }
+
     it('ConsentCacheInvalidationHandler MUST bump the Everything-cache generation for the consent patient on a Consent write', async () => {
         const redisManager = createFakeRedisManager();
         const handler = new ConsentCacheInvalidationHandler({
             redisManager,
-            bwellPersonFinder: createFakeBwellPersonFinder()
+            bwellPersonFinder: createFakeBwellPersonFinder(),
+            configManager: createFakeConfigManager()
         });
 
         // A revoked consent resource, as it would appear post-save (patient reference
@@ -541,7 +553,8 @@ describe('VULNERABILITY 5: No automatic cache invalidation when Consent status c
         const redisManager = createFakeRedisManager();
         const handler = new ConsentCacheInvalidationHandler({
             redisManager,
-            bwellPersonFinder: createFakeBwellPersonFinder()
+            bwellPersonFinder: createFakeBwellPersonFinder(),
+            configManager: createFakeConfigManager()
         });
         const keyGenerator = new PatientEverythingCacheKeyGenerator({ redisManager });
         const mockParsedArgs = { getRawArgs: () => ({}), _format: undefined };


### PR DESCRIPTION
## Summary
- `ConsentCacheInvalidationHandler` was unconditionally bumping the `Patient:<uuid>:Everything:Generation` / `ClientPerson:<uuid>:Everything:Generation` Redis keys on every Consent create/update/delete, even in environments where the $everything cache is never written to.
- The actual cache-write path (`everythingHelper.js`) only runs when `configManager.writeToCacheForEverythingOperation` is true (`ENABLE_REDIS && ENABLE_REDIS_CACHE_WRITE_FOR_EVERYTHING_OPERATION`). This PR adds the same gate to the invalidation handler so it no-ops (no Redis calls, no Person-graph traversal) when that flag is off.

## Changes
- Inject `configManager` into `ConsentCacheInvalidationHandler` and check `writeToCacheForEverythingOperation` before doing any work.
- Wire `configManager` into the handler's registration in `createContainer.js`.
- Add a unit test asserting the no-op behavior when the flag is off; update existing tests to supply a mock `configManager`.

## Testing
- `yarn jest --runInBand --forceExit src/tests/unit/dataLayer/postSaveHandlers/handlers/consentCacheInvalidationHandler.test.js` — 8/8 passing
- `yarn eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)