### PR TITLE
DCON-5311 surface Mongo query-timeout as FHIR IssueType timeout on /mcp instead of generic internal error

### DIFF
--- a/src/mcp/mcpToolHandler.js
+++ b/src/mcp/mcpToolHandler.js
@@ -17,6 +17,21 @@ const { QueryParameterValue } = require('../operations/query/queryParameterValue
 const { searchParameterQueries } = require('../searchParameters/searchParameters');
 const { logError } = require('../operations/common/logging');
 const { convertErrorToOperationOutcome } = require('../utils/convertErrorToOperationOutcome');
+const OperationOutcome = require('../fhir/classes/4_0_0/resources/operationOutcome');
+const OperationOutcomeIssue = require('../fhir/classes/4_0_0/backbone_elements/operationOutcomeIssue');
+const CodeableConcept = require('../fhir/classes/4_0_0/complex_types/codeableConcept');
+
+/**
+ * Mongo server error code for "operation exceeded time limit" (MaxTimeMSExpired). Walks
+ * RethrownError's `.original_error` (which resolves through any number of wrapping layers --
+ * see src/utils/rethrownError.js -- to the innermost error) so a query timeout deep in
+ * searchManager.js's pipeline() is still recognized here.
+ * @param {Error} err
+ * @returns {boolean}
+ */
+function isMongoTimeoutError (err) {
+    return err?.original_error?.code === 50 || err?.code === 50;
+}
 
 class McpToolHandler {
     /**
@@ -236,6 +251,27 @@ class McpToolHandler {
             // unexpected/internal failure) is masked to a generic message with no stack trace or
             // internal details; a known error with a statusCode < 500 (e.g. ForbiddenError,
             // NotFoundError from src/utils/httpErrors.js) keeps its client-safe FHIR `.issue`.
+            //
+            // A Mongo query-timeout (code 50/MaxTimeMSExpired) carries no PHI or internal detail
+            // worth masking -- unlike a raw stack trace, "the search timed out" is itself safe to
+            // return -- so it gets its own FHIR IssueType('timeout') instead of being bucketed into
+            // the generic 'internal' code. Without this, a caller (or an on-call engineer staring
+            // at "Internal Server Error") has no way to tell a timeout apart from an actual server
+            // fault short of trawling server-side logs (see DCON-5311).
+            if (isMongoTimeoutError(err)) {
+                const operationOutcome = new OperationOutcome({
+                    issue: [
+                        new OperationOutcomeIssue({
+                            severity: 'error',
+                            code: 'timeout',
+                            details: new CodeableConcept({
+                                text: 'The search timed out. Try narrowing your search criteria.'
+                            })
+                        })
+                    ]
+                });
+                return { isError: true, content: [{ type: 'text', text: JSON.stringify(operationOutcome) }] };
+            }
             const status = err.statusCode || 500;
             const operationOutcome = convertErrorToOperationOutcome({ error: err, internalError: status >= 500 });
             return { isError: true, content: [{ type: 'text', text: JSON.stringify(operationOutcome) }] };

--- a/src/tests/unit/mcp/mcpToolHandler.test.js
+++ b/src/tests/unit/mcp/mcpToolHandler.test.js
@@ -17,6 +17,7 @@ const { FilterById } = require('../../../operations/query/filters/id');
 const { FilterParameters } = require('../../../operations/query/filters/filterParameters');
 const { FieldMapper } = require('../../../operations/query/filters/fieldMapper');
 const { fhirBundleOutputSchema } = require('../../../mcp/fhirBundleOutputSchema');
+const { RethrownError } = require('../../../utils/rethrownError');
 
 function createPrototypedMock (RealClass) {
     return Object.create(RealClass.prototype);
@@ -281,6 +282,42 @@ describe('McpToolHandler', () => {
             const operationOutcome = JSON.parse(result.content[0].text);
             expect(operationOutcome.issue[0].details.text).toBe('Internal Server Error');
             expect(result.content[0].text).not.toContain('boom');
+        });
+
+        test('surfaces a Mongo query-timeout (MaxTimeMSExpired) as FHIR IssueType "timeout", not generic "internal"', async () => {
+            const { handler, searchBundleOperation } = createHandler();
+            jestGlobal.spyOn(httpContext, 'get').mockReturnValue({ user: 'test-user' });
+            // Mirrors the real wrapping chain (see DCON-5311): mongoStreamReader.js's
+            // readCursorAsync wraps the raw Mongo error in a RethrownError, and searchManager.js
+            // wraps that again with a query-shaped message. RethrownError.original_error resolves
+            // through both layers to the innermost error, which is what isMongoTimeoutError checks.
+            const rawMongoTimeout = new Error(
+                'Executor error during find command: fhir.Patient_4_0_0 :: caused by :: operation exceeded time limit'
+            );
+            rawMongoTimeout.code = 50;
+            rawMongoTimeout.codeName = 'MaxTimeMSExpired';
+            const innerRethrown = new RethrownError({
+                message: rawMongoTimeout.message,
+                error: rawMongoTimeout,
+                source: 'readAsync'
+            });
+            const outerRethrown = new RethrownError({
+                message: 'Error reading resources for Patient with query: {"telecom.value":"redacted@example.com"}',
+                error: innerRethrown
+            });
+            searchBundleOperation.searchBundleAsync.mockRejectedValue(outerRethrown);
+
+            const result = await handler.handleSearchToolCall({ resourceType: 'Patient', args: {} });
+
+            expect(result.isError).toBe(true);
+            const operationOutcome = JSON.parse(result.content[0].text);
+            expect(operationOutcome.issue[0].code).toBe('timeout');
+            expect(operationOutcome.issue[0].details.text).toBe(
+                'The search timed out. Try narrowing your search criteria.'
+            );
+            // Still must not leak the wrapped error's query/PHI-adjacent details.
+            expect(result.content[0].text).not.toContain('redacted@example.com');
+            expect(result.content[0].text).not.toContain('operation exceeded time limit');
         });
     });
 


### PR DESCRIPTION
## Summary
- `McpToolHandler.handleSearchToolCall`'s catch block (`src/mcp/mcpToolHandler.js`) masks every 500-class error to a generic `OperationOutcome{code: 'internal', details.text: 'Internal Server Error'}` — deliberately, to mirror the HIPAA/HITRUST-safe error shape used by REST/GraphQL (`src/routeHandlers/handleError.js`). That's correct for genuine internal failures, but it also swallows Mongo query-timeouts (`code: 50` / `MaxTimeMSExpired`) into the same opaque bucket, with no way for a caller (or an on-call engineer looking only at the client response) to tell "the search timed out" apart from "something is actually broken" (see DCON-5311).
- `src/operations/streaming/mongoStreamReader.js`'s `readCursorAsync` already special-cases `e.code === 50` for the REST/GraphQL streaming path (distinct message text, still routed through the safe `convertErrorToOperationOutcome` helper). This PR brings the `/mcp` path to the same level of specificity, but goes one step further and uses the standard FHIR `IssueType` code `timeout` (a real value in the FHIR R4 `issue-type` ValueSet) instead of overloading `internal` with different text.
- Adds `isMongoTimeoutError(err)`, which checks `err.original_error?.code === 50` — `RethrownError.original_error` (`src/utils/rethrownError.js`) resolves through any number of wrapping layers to the innermost error, so this still recognizes the timeout even after `searchManager.js` re-wraps `mongoStreamReader.js`'s `RethrownError` a second time (the exact chain seen in the DCON-5311 incident logs).
- A timeout carries no PHI or internal detail worth masking — "the search timed out, narrow your query" is itself safe to return — so this is a narrower, safer response than the generic message, not a new class of information disclosure.

## Test plan
- [x] New unit test in `src/tests/unit/mcp/mcpToolHandler.test.js`: constructs the real two-layer `RethrownError` chain (mirroring `mongoStreamReader.js` → `searchManager.js`) around a mock Mongo `code: 50` error, asserts the response uses `code: 'timeout'` with the safe message, and asserts the raw Mongo message/query string is still not present in the response.
- [x] Existing test `'returns an error result when searchBundleAsync throws, masking internal details'` still passes unchanged — a plain `Error('boom')` with no `.code`/`.original_error` still falls through to the generic `internal` path.
- [x] `yarn run test:jest src/tests/unit/mcp/mcpToolHandler.test.js` — 12/12 passing
- [x] `eslint src/mcp/mcpToolHandler.js src/tests/unit/mcp/mcpToolHandler.test.js` — clean

## Related
- DCON-5311 (search_patient email-search timeout — the incident that surfaced this) — companion index fix in icanbwell/bwell-fhir-server#234
- DCON-5316, DCON-5317 — same underlying Mongo-timeout-masked-as-internal pattern on other resource types/workloads