### PR TITLE
DCON-4810 Add _History suffix to base64 field history bucket S3 key

### DIFF
--- a/src/dataLayer/base64DataManager.js
+++ b/src/dataLayer/base64DataManager.js
@@ -40,7 +40,7 @@ const UNCHANGED_LEAF_CACHE_NAME = 'base64DataManager.unchangedLeaf';
  *              via `If-None-Match` and never regenerated once superseded, so a stale key can be
  *              deleted with no cross-check.
  *            - history (`historyResourceCloudStorageClient`): every version, keyed by content hash
- *              `{Type}_4_0_0/{uuid}/{hash}` (`_buildHistoryKey`).
+ *              `{Type}_4_0_0_History/{uuid}/{hash}` (`_buildHistoryKey`).
  *
  *            Flows (detailed on each method): INSERT (`transformAsync` + `BLOB_OP.INSERT`) uploads
  *            over-threshold leaves and writes the sidecar; RETRIEVE downloads bytes back onto `data`
@@ -1450,7 +1450,7 @@ class Base64DataManager {
      * @private
      */
     _buildHistoryKey (resourceType, uuid, hash) {
-        return `${resourceType}_4_0_0/${uuid}/${hash}`;
+        return `${resourceType}_4_0_0_History/${uuid}/${hash}`;
     }
 
     /**

--- a/src/tests/binary/blobStorage/base64DataManager.unit.test.js
+++ b/src/tests/binary/blobStorage/base64DataManager.unit.test.js
@@ -467,7 +467,7 @@ describe('Base64DataManager — BLOB_OP.DELETE (unit-only)', () => {
             _blobMeta: { hash, rawSize: 1, lastUpdated }
         };
         await mgr.transformAsync(resource, BLOB_OP.DELETE);
-        expect(historyClient.uploadedData[`Binary_4_0_0/uuid-d1/${hash}`]).toBe(data);
+        expect(historyClient.uploadedData[`Binary_4_0_0_History/uuid-d1/${hash}`]).toBe(data);
         expect(resource.data).toBeUndefined();
         expect(resource._blobMeta).toEqual({ hash, rawSize: 1, lastUpdated });
     });
@@ -484,7 +484,7 @@ describe('Base64DataManager — BLOB_OP.DELETE (unit-only)', () => {
         };
         await mgr.transformAsync(resource, BLOB_OP.DELETE);
         expect(downloadSpy).not.toHaveBeenCalled();
-        expect(historyClient.uploadedData[`Binary_4_0_0/uuid-d2/${hash}`]).toBe(data);
+        expect(historyClient.uploadedData[`Binary_4_0_0_History/uuid-d2/${hash}`]).toBe(data);
         expect(resource.data).toBeUndefined();
     });
 
@@ -493,7 +493,7 @@ describe('Base64DataManager — BLOB_OP.DELETE (unit-only)', () => {
         const data = 'QQ==';
         const hash = await computeContentHashAsync(data);
         const lastUpdated = new Date('2026-07-10T00:00:00.000Z');
-        const historyKey = `Binary_4_0_0/uuid-d3/${hash}`;
+        const historyKey = `Binary_4_0_0_History/uuid-d3/${hash}`;
         // Seeded — simulates an earlier version with identical content already persisted to history.
         historyClient.uploadedData[historyKey] = data;
         const downloadSpy = jest.spyOn(liveClient, 'downloadAsync');
@@ -515,7 +515,7 @@ describe('Base64DataManager — BLOB_OP.DELETE (unit-only)', () => {
         const resource = { resourceType: 'Binary', id: 'd4', _uuid: 'uuid-d4', meta: { lastUpdated }, data };
         await mgr.transformAsync(resource, BLOB_OP.DELETE);
         const hash = await computeContentHashAsync(data);
-        expect(historyClient.uploadedData[`Binary_4_0_0/uuid-d4/${hash}`]).toBe(data);
+        expect(historyClient.uploadedData[`Binary_4_0_0_History/uuid-d4/${hash}`]).toBe(data);
         expect(resource.data).toBeUndefined();
         expect(resource._blobMeta).toEqual({ hash, rawSize: 2, lastUpdated });
     });

--- a/src/tests/binary/blobStorage/binaryDelete.test.js
+++ b/src/tests/binary/blobStorage/binaryDelete.test.js
@@ -98,7 +98,7 @@ describe('Binary delete — S3 history persistence', () => {
     };
 
     const liveKeyOf = (doc) => `Binary_4_0_0/${doc._uuid}/${doc._blobMeta.lastUpdated.getTime()}`;
-    const historyKeyOf = (doc) => `Binary_4_0_0/${doc._uuid}/${doc._blobMeta.hash}`;
+    const historyKeyOf = (doc) => `Binary_4_0_0_History/${doc._uuid}/${doc._blobMeta.hash}`;
     const liveFolderPrefixOf = (doc) => `Binary_4_0_0/${doc._uuid}/`;
     const keysUnderLiveFolder = (liveClient, doc) => Object.keys(liveClient.uploadedData)
         .filter((key) => key.startsWith(liveFolderPrefixOf(doc)));

--- a/src/tests/binary/blobStorage/blobStorage.test.js
+++ b/src/tests/binary/blobStorage/blobStorage.test.js
@@ -274,13 +274,14 @@ describe('Binary base64 S3 offload — write paths', () => {
         expect(liveClient.uploadedData[keyV2]).toBe(ALT_LARGE_DATA);
         expect(liveClient.uploadedData[keyV1]).toBeUndefined();
 
-        // History bucket is content-addressed: `Binary_4_0_0/{uuid}/{hash}`. Two distinct payloads
-        // (LARGE + ALT) => two distinct history objects; the suffix is a base64url hash, not an epoch.
+        // History bucket is content-addressed: `Binary_4_0_0_History/{uuid}/{hash}`. Two distinct
+        // payloads (LARGE + ALT) => two distinct history objects; the suffix is a base64url hash,
+        // not an epoch.
         const versionedKeys = Object.keys(historyClient.uploadedData)
-            .filter(k => k.startsWith(`Binary_4_0_0/${docV1._uuid}/`));
+            .filter(k => k.startsWith(`Binary_4_0_0_History/${docV1._uuid}/`));
         expect(versionedKeys.length).toBe(2);
         for (const key of versionedKeys) {
-            const suffix = key.replace(`Binary_4_0_0/${docV1._uuid}/`, '');
+            const suffix = key.replace(`Binary_4_0_0_History/${docV1._uuid}/`, '');
             expect(suffix).toMatch(/^[A-Za-z0-9_-]+$/);
         }
 
@@ -643,7 +644,7 @@ describe('Binary base64 S3 offload — write paths', () => {
     });
 
     const historyKeysFor = (historyClient, uuid) =>
-        Object.keys(historyClient.uploadedData).filter(k => k.startsWith(`Binary_4_0_0/${uuid}/`));
+        Object.keys(historyClient.uploadedData).filter(k => k.startsWith(`Binary_4_0_0_History/${uuid}/`));
 
     // History-collection snapshots for a uuid, sorted ascending by versionId.
     const historySnapshotsFor = async (container, uuid) => {
@@ -1326,7 +1327,7 @@ describe('Binary base64 S3 offload — write paths', () => {
     // `{Type}/{uuid}/{hash}`), never the live bucket, and bypass the per-request stash so distinct
     // versions in one response don't cross-contaminate.
     describe('history reads — each version hydrates from the history bucket', () => {
-        const historyKeyOf = (uuid, snapshot) => `Binary_4_0_0/${uuid}/${snapshot.resource._blobMeta.hash}`;
+        const historyKeyOf = (uuid, snapshot) => `Binary_4_0_0_History/${uuid}/${snapshot.resource._blobMeta.hash}`;
         // toHaveResponse walks `data` char-by-char and FHIR-validates the body — pathologically slow
         // on an 80 KB payload. Swap the real payloads for short, distinct placeholders on BOTH the
         // response and the fixture before the whole-response compare (the real bytes are asserted
@@ -1621,7 +1622,7 @@ describe('Binary base64 S3 offload — write paths', () => {
         await drainPostRequest(container);
         const seeded = await readBinaryFromMongo(container, id);
         const liveKey = liveKeyOf(seeded);
-        const historyKey = `Binary_4_0_0/${seeded._uuid}/${seeded._blobMeta.hash}`;
+        const historyKey = `Binary_4_0_0_History/${seeded._uuid}/${seeded._blobMeta.hash}`;
 
         const downloadSpy = jest.spyOn(liveClient, 'downloadAsync');
         const copySpy = jest.spyOn(historyClient, 'copyObjectAsync');


### PR DESCRIPTION
## Summary
- Update `_buildHistoryKey` in `base64DataManager.js` to include the `_History` suffix on the collection-name segment of the history-bucket S3 key, matching the convention already enforced by the whole-history migration scripts (`Binary_4_0_0_History/...`) that share the same bucket.
- Update the class-doc comment describing the key format.
- Update 4 hardcoded history-key assertions in `base64DataManager.unit.test.js` to match.

No data migration needed — this is a new, unreleased flow with no existing history objects at the old key format.

## Test plan
- `yarn jest --runInBand --forceExit src/tests/binary/blobStorage/base64DataManager.unit.test.js` → 36/36 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)