### PR TITLE
DCON-5272 Fix cms-partner mcp routes access via delegated access claim

### DIFF
--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -330,8 +330,8 @@ class AuthService {
                     context.userType = AUTH_USER_TYPES.delegatedUser;
 
                     if (Array.isArray(jwt_payload.entitlements)) {
-                    context.purposeOfUse = jwt_payload.entitlements;
-                }
+                        context.purposeOfUse = jwt_payload.entitlements;
+                    }
                 }
             }
         }

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -306,36 +306,32 @@ class AuthService {
             context.subject = jwt_payload['sub'];
             context.username = context.personIdFromJwtToken;
             const isAllowedUserType = this.allowedJWTUserTypes.includes(jwt_payload.user_type);
-            if (this.configManager.enableDelegatedAccessDetection && jwt_payload.act) {
-                if (isAllowedUserType) {
-                    // cms-partner takes precedence over delegation; act claim is ignored.
-                    logInfo('Ignoring act claim on a token with an allowed (cms-partner) user_type', {
-                        reason: 'cms_partner_token_with_act_claim',
-                        userType: jwt_payload.user_type
-                    });
-                } else {
-                    const result = this.processForDelegatedActor({ jwt_payload });
-                    if (result.failure) {
-                        done(null, false, { reason: 'delegated_actor_failure' });
-                        return;
-                    } else if (result.actor) {
-                        context.actor = result.actor;
-                        context.userType = AUTH_USER_TYPES.delegatedUser;
-
-                        if (Array.isArray(jwt_payload.entitlements)) {
-                            context.purposeOfUse = jwt_payload.entitlements;
-                        }
-                    }
-                }
-            }
-            // if userType is not already set through delegated access detection,
-            // accept user_type claim only when it is one of the allowed values
-            if (!context.userType && isAllowedUserType) {
+            if (isAllowedUserType) {
                 context.userType = jwt_payload.user_type;
                 // Initialized empty object to attach the consent policy
                 context.actor = {};
                 if (Array.isArray(jwt_payload.entitlements)) {
                     context.purposeOfUse = jwt_payload.entitlements;
+                }
+                if (jwt_payload.act) {
+                    logInfo('cms-partner token also carries an act claim; act claim is not used', {
+                        reason: 'cms_partner_token_with_act_claim',
+                        userType: jwt_payload.user_type
+                    });
+                }
+            }
+            if (this.configManager.enableDelegatedAccessDetection && jwt_payload.act && !context.userType) {
+                const result = this.processForDelegatedActor({ jwt_payload });
+                if (result.failure) {
+                    done(null, false, { reason: 'delegated_actor_failure' });
+                    return;
+                } else if (result.actor) {
+                    context.actor = result.actor;
+                    context.userType = AUTH_USER_TYPES.delegatedUser;
+
+                    if (Array.isArray(jwt_payload.entitlements)) {
+                    context.purposeOfUse = jwt_payload.entitlements;
+                }
                 }
             }
         }

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -305,23 +305,32 @@ class AuthService {
 
             context.subject = jwt_payload['sub'];
             context.username = context.personIdFromJwtToken;
+            const isAllowedUserType = this.allowedJWTUserTypes.includes(jwt_payload.user_type);
             if (this.configManager.enableDelegatedAccessDetection && jwt_payload.act) {
-                const result = this.processForDelegatedActor({ jwt_payload });
-                if (result.failure) {
-                    done(null, false, { reason: 'delegated_actor_failure' });
-                    return;
-                } else if (result.actor) {
-                    context.actor = result.actor;
-                    context.userType = AUTH_USER_TYPES.delegatedUser;
+                if (isAllowedUserType) {
+                    // cms-partner takes precedence over delegation; act claim is ignored.
+                    logInfo('Ignoring act claim on a token with an allowed (cms-partner) user_type', {
+                        reason: 'cms_partner_token_with_act_claim',
+                        userType: jwt_payload.user_type
+                    });
+                } else {
+                    const result = this.processForDelegatedActor({ jwt_payload });
+                    if (result.failure) {
+                        done(null, false, { reason: 'delegated_actor_failure' });
+                        return;
+                    } else if (result.actor) {
+                        context.actor = result.actor;
+                        context.userType = AUTH_USER_TYPES.delegatedUser;
 
-                    if (Array.isArray(jwt_payload.entitlements)) {
-                        context.purposeOfUse = jwt_payload.entitlements;
+                        if (Array.isArray(jwt_payload.entitlements)) {
+                            context.purposeOfUse = jwt_payload.entitlements;
+                        }
                     }
                 }
             }
             // if userType is not already set through delegated access detection,
             // accept user_type claim only when it is one of the allowed values
-            if (!context.userType && this.allowedJWTUserTypes.includes(jwt_payload.user_type)) {
+            if (!context.userType && isAllowedUserType) {
                 context.userType = jwt_payload.user_type;
                 // Initialized empty object to attach the consent policy
                 context.actor = {};

--- a/src/tests/integration/mcp/mcpEndpoint.integration.test.js
+++ b/src/tests/integration/mcp/mcpEndpoint.integration.test.js
@@ -336,6 +336,54 @@ describe('/mcp endpoint', () => {
         expect(resp.body.resourceType).toBe('OperationOutcome');
     });
 
+    test('a token with both cms-partner user_type and a delegated act claim is still blocked from /mcp as cms-partner (act claim ignored)', async () => {
+        // cms-partner user_type takes precedence over a delegated act claim (act is ignored),
+        // so this is still blocked as cms-partner -- same 403 as the plain cms-partner test above.
+        const ENABLE_DELEGATED_ACCESS_DETECTION = process.env.ENABLE_DELEGATED_ACCESS_DETECTION;
+        process.env.ENABLE_DELEGATED_ACCESS_DETECTION = '1';
+        try {
+            const request = await createTestRequest(registerRealAuditLogger);
+
+            const conflictingToken = getHeadersWithCustomPayload({
+                scope: 'patient/*.read user/*.* access/*.*',
+                username: 'cms-partner@example.com',
+                clientFhirPersonId: 'mcp-t7b-cms-person',
+                clientFhirPatientId: 'clientFhirPatient',
+                bwellFhirPersonId: 'mcp-t7b-cms-person',
+                bwellFhirPatientId: 'bwellFhirPatient',
+                user_type: AUTH_USER_TYPES.cmsPartnerUser,
+                act: { reference: 'RelatedPerson/mcp-t7b-rp', sub: 'delegate-sub' },
+                token_use: 'access'
+            }).Authorization.replace(/^Bearer /, '');
+
+            const resp = await request
+                .post('/mcp')
+                .set({
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json, text/event-stream',
+                    Authorization: `Bearer ${conflictingToken}`
+                })
+                .send({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'tools/call',
+                    params: { name: 'search_patient', arguments: {} }
+                });
+
+            expect(resp.status).toBe(403);
+            expect(resp.body).toEqual({
+                resourceType: 'OperationOutcome',
+                issue: [{
+                    severity: 'error',
+                    code: 'forbidden',
+                    details: { text: 'cms-partner does not have access to this endpoint' }
+                }]
+            });
+        } finally {
+            process.env.ENABLE_DELEGATED_ACCESS_DETECTION = ENABLE_DELEGATED_ACCESS_DETECTION;
+        }
+    });
+
     test('a patient-scoped caller does not see a resource hidden via data-connection-view-control consent', async () => {
         const CLIENTS_WITH_DATA_CONNECTION_VIEW_CONTROL = process.env.CLIENTS_WITH_DATA_CONNECTION_VIEW_CONTROL;
         process.env.CLIENTS_WITH_DATA_CONNECTION_VIEW_CONTROL = 'client';

--- a/src/tests/unit/strategies/authService.test.js
+++ b/src/tests/unit/strategies/authService.test.js
@@ -828,7 +828,43 @@ describe('AuthService', () => {
                 })
             );
             expect(logInfo).toHaveBeenCalledWith(
-                'Ignoring act claim on a token with an allowed (cms-partner) user_type',
+                'cms-partner token also carries an act claim; act claim is not used',
+                expect.objectContaining({ reason: 'cms_partner_token_with_act_claim', userType: 'cms-partner' })
+            );
+        });
+
+        test('logs a cms-partner token carrying an act claim even when delegated access detection is disabled', () => {
+            // enableDelegatedAccessDetection defaults to false via the outer beforeEach
+            const done = jest.fn();
+            authService.processUserInfo({
+                username: 'testuser',
+                subject: 'sub1',
+                isUser: true,
+                jwt_payload: {
+                    clientFhirPersonId: 'person-1',
+                    clientFhirPatientId: 'patient-1',
+                    bwellFhirPersonId: 'bwell-person-1',
+                    bwellFhirPatientId: 'bwell-patient-1',
+                    sub: 'subject-1',
+                    user_type: 'cms-partner',
+                    act: { reference: 'RelatedPerson/rp-1', sub: 'delegate-sub' }
+                },
+                done,
+                client_id: 'client1',
+                scope: 'patient/Patient.read'
+            });
+            expect(done).toHaveBeenCalledWith(
+                null,
+                expect.any(Object),
+                expect.objectContaining({
+                    context: expect.objectContaining({
+                        userType: 'cms-partner',
+                        actor: {}
+                    })
+                })
+            );
+            expect(logInfo).toHaveBeenCalledWith(
+                'cms-partner token also carries an act claim; act claim is not used',
                 expect.objectContaining({ reason: 'cms_partner_token_with_act_claim', userType: 'cms-partner' })
             );
         });

--- a/src/tests/unit/strategies/authService.test.js
+++ b/src/tests/unit/strategies/authService.test.js
@@ -790,6 +790,49 @@ describe('AuthService', () => {
             );
         });
 
+        test('cms-partner user_type takes precedence over a delegated act claim, and logs it', () => {
+            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => true, configurable: true });
+            AuthService.jwksCache = undefined;
+            AuthService.userInfoCache = undefined;
+            authService = new AuthService({
+                configManager: mockConfigManager,
+                wellKnownConfigurationManager: mockWellKnownConfigManager
+            });
+
+            const done = jest.fn();
+            authService.processUserInfo({
+                username: 'testuser',
+                subject: 'sub1',
+                isUser: true,
+                jwt_payload: {
+                    clientFhirPersonId: 'person-1',
+                    clientFhirPatientId: 'patient-1',
+                    bwellFhirPersonId: 'bwell-person-1',
+                    bwellFhirPatientId: 'bwell-patient-1',
+                    sub: 'subject-1',
+                    user_type: 'cms-partner',
+                    act: { reference: 'RelatedPerson/rp-1', sub: 'delegate-sub' }
+                },
+                done,
+                client_id: 'client1',
+                scope: 'patient/Patient.read'
+            });
+            expect(done).toHaveBeenCalledWith(
+                null,
+                expect.any(Object),
+                expect.objectContaining({
+                    context: expect.objectContaining({
+                        userType: 'cms-partner',
+                        actor: {}
+                    })
+                })
+            );
+            expect(logInfo).toHaveBeenCalledWith(
+                'Ignoring act claim on a token with an allowed (cms-partner) user_type',
+                expect.objectContaining({ reason: 'cms_partner_token_with_act_claim', userType: 'cms-partner' })
+            );
+        });
+
         test('ignores non-allowed user_type values', () => {
             const done = jest.fn();
             authService.processUserInfo({


### PR DESCRIPTION
## Summary
- cms-partner tokens now take precedence over a delegated `act` claim in `AuthService.processUserInfo` -- previously the delegated-actor branch unconditionally overwrote `context.userType`, which could let access `forbidForUserTypes([cmsPartnerUser])` on `/mcp` and GraphQL routes if it also carried an `act` claim.
- The ignored act claim is logged (`cms_partner_token_with_act_claim`) so it's visible if this combination ever actually occurs.

## Test plan
- [x] Unit test: cms-partner token + act claim -> userType stays `cms-partner`, act ignored, logged
- [x] Integration test: same combined token still gets a 403 on `/mcp`, same as a plain cms-partner token
- [ ] Full suite (`make tests`)