### PR TITLE
DCON-5365 Fix base64 live-object cleanup race and add S3 operation logging

### DIFF
--- a/src/dataLayer/base64DataManager.js
+++ b/src/dataLayer/base64DataManager.js
@@ -5,7 +5,7 @@ const { PreSaveManager } = require('../preSaveHandlers/preSave');
 const { PreSaveOptions } = require('../preSaveHandlers/preSaveOptions');
 const { RethrownError } = require('../utils/rethrownError');
 const { BLOB_OP, BINARY_DATA_VALUE_PLACEHOLDER } = require('../constants');
-const { logError } = require('../operations/common/logging');
+const { logError, logInfo } = require('../operations/common/logging');
 const base64DataResources = require('./base64DataResources.json');
 const { CloudStorageClient } = require('../utils/cloudStorageClient');
 const { computeContentHashAsync } = require('../utils/contentHash');
@@ -344,20 +344,17 @@ class Base64DataManager {
     /**
      * Best-effort delete of every live-bucket object for `{resourceType, uuid}` at or before
      * `lastUpdated`'s timestamp: lists everything under the uuid's live-folder prefix and deletes
-     * each key whose parsed timestamp is <= the target ms, leaving any strictly newer key (a
-     * concurrent writer's fresh upload) untouched. A live key is never regenerated once superseded,
-     * so anything at-or-below the target is provably safe to delete — either the key the caller asked
-     * for, or an orphan stray left behind by an earlier race or partial failure. Once nothing remains
-     * under the prefix, the folder (a virtual grouping of keys — S3 has no real folder object) stops
-     * appearing in any listing.
+     * each key whose parsed timestamp is <= the target ms. Once nothing remains under the prefix,
+     * the folder (a virtual grouping of keys — S3 has no real folder object) stops appearing in any
+     * listing.
      *
-     * Used by `removeHelper.js` (full resource DELETE), `deleteSupersededLiveObjectsAsync` (PUT/PATCH
-     * supersede), and `cleanupPreviousLiveObjectAsync` ($merge/bulk supersede) — each passes the
-     * timestamp of an OLDER, already-superseded key, so the sweep only reaches backward and never
-     * touches a newer, still-committed key. Do NOT call this from the write-failure rollback path
-     * (`deleteOwnUploadedLiveObjectsAsync`): there the target is THIS request's own (newer) key, so
-     * sweeping backward would also delete a still-committed OLDER version's live object — see
-     * `_deleteExactLiveObjectAsync` for that case. No-op on falsy `lastUpdated`; never throws.
+     * Used only by `removeHelper.js` (full resource DELETE), where sweeping the whole prefix is
+     * unconditionally correct — the resource is gone, so no key under it is ever "still committed".
+     * Do NOT call this for a supersede/rollback cleanup on a resource that still exists: the target
+     * timestamp isn't guaranteed to stay older than whatever key ends up committed (a concurrent
+     * writer's reconciliation can reuse an older key than the one it's superseding), so the <= sweep
+     * can delete a still-referenced object. Those callers use the exact-key
+     * `_deleteExactLiveObjectAsync` instead. No-op on falsy `lastUpdated`; never throws.
      * @param {string} resourceType
      * @param {string} uuid
      * @param {Date|string|number|null|undefined} lastUpdated
@@ -369,6 +366,7 @@ class Base64DataManager {
         if (!ms) { return; }
         const prefix = this._buildLiveFolderKey(resourceType, uuid);
         let keys;
+        logInfo('S3 listObjects', { source: 'Base64DataManager', resourceType, uuid, prefix });
         try {
             keys = await this.base64FieldCloudStorageClient.listObjectsAsync({ prefix });
         } catch (err) {
@@ -384,6 +382,7 @@ class Base64DataManager {
         if (keysToDelete.length === 0) {
             return;
         }
+        logInfo('S3 deleteObjects', { source: 'Base64DataManager', resourceType, uuid, keys: keysToDelete });
         try {
             const { errors } = await this.base64FieldCloudStorageClient.deleteObjectsAsync({
                 filePaths: keysToDelete
@@ -454,6 +453,10 @@ class Base64DataManager {
                     // exists — a stale read can look "unchanged" after another writer superseded it.
                     const priorMs = this._toEpochMs(priorBlobMeta.lastUpdated);
                     const priorKey = this._buildLiveKey(resource.resourceType, resource._uuid, priorMs);
+                    logInfo('S3 exists', {
+                        source: 'Base64DataManager', resourceType: resource.resourceType,
+                        uuid: resource._uuid, key: priorKey
+                    });
                     const stillExists = await this.base64FieldCloudStorageClient.existsAsync(priorKey);
                     if (stillExists) {
                         // True no-op: strip the inline `data` (Mongo keeps only the sidecar) and stash
@@ -510,6 +513,10 @@ class Base64DataManager {
         let uploadResponse;
         const MAX_ATTEMPTS = 5;
         for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+            logInfo('S3 upload', {
+                source: 'Base64DataManager', resourceType: resource.resourceType,
+                uuid: resource._uuid, key: liveKey
+            });
             try {
                 uploadResponse = await this.base64FieldCloudStorageClient.uploadAsync({
                     filePath: liveKey, data: Buffer.from(value, 'utf8'), ifNoneMatch: true
@@ -570,7 +577,7 @@ class Base64DataManager {
                 const previousMs = this._toEpochMs(stashed.previousLastUpdated);
                 const currentMs = currentBlobMeta ? this._toEpochMs(currentBlobMeta.lastUpdated) : null;
                 if (previousMs !== currentMs) {
-                    await this.deleteLiveObjectAsync(resource.resourceType, resource._uuid, stashed.previousLastUpdated);
+                    await this._deleteExactLiveObjectAsync(resource.resourceType, resource._uuid, stashed.previousLastUpdated);
                 }
             });
         }
@@ -607,6 +614,31 @@ class Base64DataManager {
         return refs;
     }
 
+    getLiveObjectRefsOrResourceLastUpdated (resource) {
+        const refs = new Map();
+        if (!resource || !this.enableBase64FieldCloudStorage) {
+            return refs;
+        }
+        const entries = this.resourcePaths[resource.resourceType];
+        if (!entries) {
+            return refs;
+        }
+        const fallback = this._normalizeStamp(resource.meta && resource.meta.lastUpdated);
+        for (const entry of entries) {
+            const dataSegments = this._parseJsonPointer(entry.dataPath);
+            const blobMetaSegments = this._parseJsonPointer(entry.blobMetaPath);
+            const blobMetaLeaf = blobMetaSegments[blobMetaSegments.length - 1];
+            this._processPathsSync(resource, dataSegments, [], ({ parent, indices }) => {
+                const blobMeta = parent[blobMetaLeaf];
+                const lastUpdated = (blobMeta && blobMeta.lastUpdated) || fallback;
+                if (lastUpdated) {
+                    refs.set(this._substituteIndices(dataSegments, indices), lastUpdated);
+                }
+            });
+        }
+        return refs;
+    }
+
     /**
      * Delete the live objects `currentResource` superseded relative to a pre-write snapshot from
      * `getLiveObjectRefs`. For each previously-referenced leaf now absent or pointing at a different
@@ -623,7 +655,7 @@ class Base64DataManager {
         for (const [leafKey, previousLastUpdated] of previousRefs) {
             const currentLastUpdated = currentRefs.get(leafKey);
             if (!currentLastUpdated || this._toEpochMs(currentLastUpdated) !== this._toEpochMs(previousLastUpdated)) {
-                await this.deleteLiveObjectAsync(currentResource.resourceType, currentResource._uuid, previousLastUpdated);
+                await this._deleteExactLiveObjectAsync(currentResource.resourceType, currentResource._uuid, previousLastUpdated);
             }
         }
     }
@@ -660,11 +692,12 @@ class Base64DataManager {
 
     /**
      * Best-effort, unconditional delete of exactly the live object at `{uuid}/{epochMsOf(lastUpdated)}`
-     * — no sweep of neighboring keys. Used only by `deleteOwnUploadedLiveObjectsAsync` (write-failure
-     * rollback), which must remove nothing but the key THIS request itself created: a committed prior
-     * version's live object (if any) is untouched by a failed write and must survive it.
-     * `deleteLiveObjectAsync`'s broader sweep is unsafe here — it would also delete that still-
-     * committed older key, since it is always at-or-below this request's own (newer) timestamp.
+     * — no sweep of neighboring keys, no `listObjectsAsync` call. Used by `deleteOwnUploadedLiveObjectsAsync`
+     * (write-failure rollback), `deleteSupersededLiveObjectsAsync` (PUT/PATCH supersede), and
+     * `cleanupPreviousLiveObjectAsync` ($merge/bulk supersede) — each already knows the one specific
+     * key it wants gone and must never touch any other key under the same uuid prefix, including
+     * whatever key the write just committed: `deleteLiveObjectAsync`'s <= sweep can't guarantee that,
+     * since a concurrent writer's reconciliation may reuse a key older than the one it superseded.
      * No-op on falsy `lastUpdated`; never throws.
      * @param {string} resourceType
      * @param {string} uuid
@@ -677,6 +710,7 @@ class Base64DataManager {
         const ms = this._toEpochMs(lastUpdated);
         if (!ms) { return; }
         const key = this._buildLiveKey(resourceType, uuid, ms);
+        logInfo('S3 delete', { source: 'Base64DataManager', resourceType, uuid, key });
         try {
             await this.base64FieldCloudStorageClient.deleteAsync(key);
         } catch (err) {
@@ -806,6 +840,10 @@ class Base64DataManager {
         if (incomingLastUpdated) {
             const incomingMs = this._toEpochMs(incomingLastUpdated);
             const incomingKey = this._buildLiveKey(docToWrite.resourceType, docToWrite._uuid, incomingMs);
+            logInfo('S3 exists', {
+                source: 'Base64DataManager', resourceType: docToWrite.resourceType,
+                uuid: docToWrite._uuid, key: incomingKey
+            });
             if (await this.base64FieldCloudStorageClient.existsAsync(incomingKey)) {
                 lastUpdatedMs = incomingMs;
             }
@@ -893,6 +931,10 @@ class Base64DataManager {
                         ? this.historyResourceCloudStorageClient
                         : this.base64FieldCloudStorageClient;
                     let downloaded;
+                    logInfo('S3 download', {
+                        source: 'Base64DataManager', resourceType: resource.resourceType,
+                        uuid: resource._uuid, key: s3Key
+                    });
                     try {
                         downloaded = await client.downloadAsync(s3Key);
                     } catch (err) {
@@ -976,6 +1018,10 @@ class Base64DataManager {
                     const liveKey = this._buildLiveKey(
                         resource.resourceType, resource._uuid, this._toEpochMs(blobMeta.lastUpdated)
                     );
+                    logInfo('S3 download', {
+                        source: 'Base64DataManager', resourceType: resource.resourceType,
+                        uuid: resource._uuid, key: liveKey
+                    });
                     return this.base64FieldCloudStorageClient.downloadAsync(liveKey);
                 };
                 await this._ensureHistoryObjectAsync(resource, entry, blobMeta.hash, bytesProvider);
@@ -1016,6 +1062,10 @@ class Base64DataManager {
     async _ensureHistoryObjectAsync (resource, entry, hash, bytesProvider) {
         const historyKey = this._buildHistoryKey(resource.resourceType, resource._uuid, hash);
         try {
+            logInfo('S3 copyObject', {
+                source: 'Base64DataManager', resourceType: resource.resourceType,
+                uuid: resource._uuid, key: historyKey
+            });
             const refreshed = await this.historyResourceCloudStorageClient.copyObjectAsync({
                 sourcePath: historyKey, filePath: historyKey
             });
@@ -1041,6 +1091,10 @@ class Base64DataManager {
                 });
                 return;
             }
+            logInfo('S3 upload', {
+                source: 'Base64DataManager', resourceType: resource.resourceType,
+                uuid: resource._uuid, key: historyKey
+            });
             await this.historyResourceCloudStorageClient.uploadAsync({
                 filePath: historyKey, data: Buffer.from(bytes, 'utf8')
             });
@@ -1242,6 +1296,10 @@ class Base64DataManager {
                     if (!content) {
                         return;
                     }
+                    logInfo('S3 upload', {
+                        source: 'Base64DataManager', resourceType: snapshot.resourceType,
+                        uuid: snapshot._uuid, key: historyKey
+                    });
                     await this.historyResourceCloudStorageClient.uploadAsync({
                         filePath: historyKey,
                         data: Buffer.from(content, 'utf8')
@@ -1249,11 +1307,19 @@ class Base64DataManager {
                 } else {
                     // Unchanged content: refresh the existing object's TTL. If it has
                     // already expired (copy reports the source missing), re-upload it.
+                    logInfo('S3 copyObject', {
+                        source: 'Base64DataManager', resourceType: snapshot.resourceType,
+                        uuid: snapshot._uuid, key: historyKey
+                    });
                     const refreshed = await this.historyResourceCloudStorageClient.copyObjectAsync({
                         sourcePath: historyKey,
                         filePath: historyKey
                     });
                     if (!refreshed && content) {
+                        logInfo('S3 upload', {
+                            source: 'Base64DataManager', resourceType: snapshot.resourceType,
+                            uuid: snapshot._uuid, key: historyKey
+                        });
                         await this.historyResourceCloudStorageClient.uploadAsync({
                             filePath: historyKey,
                             data: Buffer.from(content, 'utf8')

--- a/src/operations/remove/removeHelper.js
+++ b/src/operations/remove/removeHelper.js
@@ -112,13 +112,16 @@ class RemoveHelper {
                 resource.meta.lastUpdated = new Date(
                     moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ')
                 );
-                // Snapshot which live-bucket objects this resource still references, for cleanup
-                // AFTER the Mongo delete commits (not here — deleting the live object before the
-                // Mongo write commits would orphan it if that write then failed). Captured BEFORE
+                // Snapshot the live-bucket cleanup boundary per configured leaf, for cleanup AFTER
+                // the Mongo delete commits (not here — deleting the live object before the Mongo
+                // write commits would orphan it if that write then failed). Captured BEFORE
                 // transformAsync below, not after: a leaf that gets newly externalized at delete
                 // time (never externalized, over threshold) gets a brand-new `_blobMeta` with no
-                // corresponding live object, so capturing first correctly excludes it here.
-                const liveRefs = this.base64DataManager.getLiveObjectRefs(resource);
+                // corresponding live object, so capturing first correctly excludes it here. A leaf
+                // with no `_blobMeta` at all still gets a boundary (`resource.meta.lastUpdated`, set
+                // above) so a stray object from an earlier externalized version whose own supersede
+                // cleanup never ran still gets swept.
+                const liveRefs = this.base64DataManager.getLiveObjectRefsOrResourceLastUpdated(resource);
                 // Ensure this version's base64 data (if any) is durably in the history bucket, and
                 // strip it from `resource` to `_blobMeta`-only, BEFORE it's snapshotted into history
                 // below — a no-op for a resource type with no configured base64 paths.

--- a/src/tests/integration/binary/blobStorage/binaryDelete.test.js
+++ b/src/tests/integration/binary/blobStorage/binaryDelete.test.js
@@ -171,6 +171,28 @@ describe('Binary delete — S3 history persistence', () => {
         expect(deleteHistoryEntry.resource.data).toBe(SMALL_DATA);
     });
 
+    test('REST DELETE of a never-externalized Binary also sweeps a stray older live object left under the uuid prefix, but never a newer one', async () => {
+        const request = await createTestRequest(registerMockClients);
+        const container = getTestContainer();
+        const liveClient = container.base64FieldCloudStorageClient;
+        const id = 'binary-delete-stray-sweep';
+
+        await request.put(`/4_0_0/Binary/${id}`).send(buildBinary(id, SMALL_DATA)).set(getHeaders()).expect(201);
+        await drainPostRequest(container);
+        const doc = await readBinaryFromMongo(container, id);
+        expect(doc._blobMeta).toBeUndefined();
+
+        const staleStrayKey = `Binary_4_0_0/${doc._uuid}/${Date.now() - 60_000}`;
+        const futureKey = `Binary_4_0_0/${doc._uuid}/${Date.now() + 60_000}`;
+        liveClient.uploadedData[staleStrayKey] = 'orphaned-by-an-earlier-partial-failure';
+        liveClient.uploadedData[futureKey] = 'a-concurrent-writers-fresh-upload';
+
+        await request.delete(`/4_0_0/Binary/${id}`).set(getHeaders()).expect(204);
+
+        expect(liveClient.uploadedData[staleStrayKey]).toBeUndefined();
+        expect(liveClient.uploadedData[futureKey]).toBe('a-concurrent-writers-fresh-upload');
+    });
+
     test('$graph DELETE on Binary as the root resource strips pre-hydrated data before writing history, and cleans up the live object after commit', async () => {
         const request = await createTestRequest(registerMockClients);
         const container = getTestContainer();

--- a/src/tests/unit/dataLayer/blobStorage/base64DataManager.unit.test.js
+++ b/src/tests/unit/dataLayer/blobStorage/base64DataManager.unit.test.js
@@ -117,6 +117,30 @@ describe('Base64DataManager — path-aware live-object helpers (nested/array con
         expect(refs.get('content/1/attachment/data').getTime()).toBe(lu1.getTime());
     });
 
+    test('getLiveObjectRefsOrResourceLastUpdated falls back to resource.meta.lastUpdated for a leaf with no _blobMeta, but keeps the sidecar timestamp where one exists', () => {
+        const metaLu = new Date('2026-07-10T00:00:10.000Z');
+        const blobLu = new Date('2026-07-10T00:00:01.000Z');
+        const resource = {
+            resourceType: 'DocRefFake', id: 'd1', _uuid: 'uuid-fallback', meta: { lastUpdated: metaLu },
+            content: [
+                { attachment: { _blobMeta: { hash: 'h', rawSize: 1, lastUpdated: blobLu } } },
+                { attachment: {} }
+            ]
+        };
+        const refs = ctx.mgr.getLiveObjectRefsOrResourceLastUpdated(resource);
+        expect(refs.get('content/0/attachment/data').getTime()).toBe(blobLu.getTime());
+        expect(refs.get('content/1/attachment/data').getTime()).toBe(metaLu.getTime());
+    });
+
+    test('getLiveObjectRefsOrResourceLastUpdated returns nothing for a leaf when both _blobMeta and resource.meta.lastUpdated are missing', () => {
+        const resource = {
+            resourceType: 'DocRefFake', id: 'd2', _uuid: 'uuid-fallback-2', meta: {},
+            content: [{ attachment: {} }]
+        };
+        const refs = ctx.mgr.getLiveObjectRefsOrResourceLastUpdated(resource);
+        expect(refs.size).toBe(0);
+    });
+
     test('deleteSupersededLiveObjectsAsync deletes only the leaves whose ref changed', async () => {
         const lu0 = new Date('2026-07-10T00:00:00.000Z');
         const lu1 = new Date('2026-07-10T00:00:01.000Z');
@@ -131,6 +155,21 @@ describe('Base64DataManager — path-aware live-object helpers (nested/array con
         await ctx.mgr.deleteSupersededLiveObjectsAsync(current, previousRefs);
         expect(ctx.client.uploadedData[key0]).toBeUndefined(); // superseded → deleted
         expect(ctx.client.uploadedData[key1]).toBe('old1'); // unchanged → kept
+    });
+
+    test('deleteSupersededLiveObjectsAsync must NOT sweep away the currently-committed live object when the previous ref is numerically NEWER (concurrent-write key reuse)', async () => {
+        const uuid = 'uuid-supersede-guard';
+        const ownReusedLu = new Date('2026-07-10T00:00:00.000Z'); // this write's own, reused (older) key — now committed
+        const raceLostLu = new Date('2026-07-10T00:00:05.000Z'); // a concurrent writer's key seen mid-retry — actually superseded
+        const ownReusedKey = `DocRefFake_4_0_0/${uuid}/${ownReusedLu.getTime()}`;
+        const raceLostKey = `DocRefFake_4_0_0/${uuid}/${raceLostLu.getTime()}`;
+        ctx.client.uploadedData[ownReusedKey] = 'just-committed';
+        ctx.client.uploadedData[raceLostKey] = 'superseded-by-this-write';
+        const previousRefs = ctx.mgr.getLiveObjectRefs(makeDoc(uuid, { lastUpdated: raceLostLu }, undefined));
+        const current = makeDoc(uuid, { lastUpdated: ownReusedLu }, undefined);
+        await ctx.mgr.deleteSupersededLiveObjectsAsync(current, previousRefs);
+        expect(ctx.client.uploadedData[ownReusedKey]).toBe('just-committed'); // just-committed → MUST survive
+        expect(ctx.client.uploadedData[raceLostKey]).toBeUndefined(); // superseded → deleted
     });
 
     test('resolveWriteForExternalizedDataChange (nested): a diverged leaf re-uploads R\'s bytes and wins; a matching leaf is left alone', async () => {
@@ -208,6 +247,25 @@ describe('Base64DataManager — path-aware live-object helpers (nested/array con
         await ctx.mgr.deleteOwnUploadedLiveObjectsAsync(doc, requestInfo);
         expect(ctx.client.uploadedData[ownUploadedKey]).toBeUndefined(); // this request's own orphan → deleted
         expect(ctx.client.uploadedData[committedKey]).toBe('still-committed-v1'); // still-committed prior → MUST survive
+    });
+
+    test('cleanupPreviousLiveObjectAsync must NOT sweep away the currently-committed live object when the stashed previousLastUpdated is numerically NEWER (concurrent-write key reuse)', async () => {
+        const requestInfo = { requestId: 'r-cleanup-sweep-guard' };
+        const uuid = 'uuid-cleanup-guard';
+        const dataSegments = ['content', '[]', 'attachment', 'data'];
+        const ownReusedLu = new Date('2026-07-10T00:00:00.000Z');
+        const raceLostLu = new Date('2026-07-10T00:00:05.000Z');
+        const ownReusedKey = `DocRefFake_4_0_0/${uuid}/${ownReusedLu.getTime()}`;
+        const raceLostKey = `DocRefFake_4_0_0/${uuid}/${raceLostLu.getTime()}`;
+        ctx.client.uploadedData[ownReusedKey] = 'just-committed';
+        ctx.client.uploadedData[raceLostKey] = 'superseded-by-this-write';
+        ctx.mgr._stashOriginalData(requestInfo, uuid, dataSegments, [0], {
+            changed: true, previousLastUpdated: raceLostLu
+        });
+        const resource = makeDoc(uuid, { lastUpdated: ownReusedLu }, undefined);
+        await ctx.mgr.cleanupPreviousLiveObjectAsync(resource, requestInfo);
+        expect(ctx.client.uploadedData[ownReusedKey]).toBe('just-committed'); // just-committed → MUST survive
+        expect(ctx.client.uploadedData[raceLostKey]).toBeUndefined(); // superseded → deleted
     });
 });
 


### PR DESCRIPTION
## Summary

Two related fixes in `Base64DataManager` (blob-storage offload for base64 fields), plus S3-call logging for observability.

### 1. Fix wrongful S3 deletion under concurrent writes

`deleteSupersededLiveObjectsAsync` (PUT/PATCH/$merge supersede) and `cleanupPreviousLiveObjectAsync` ($merge/bulk supersede) deleted via a **sweep** (`deleteLiveObjectAsync`: list the uuid's live-folder prefix, delete every key `<=` a target timestamp). That sweep assumed the target timestamp is always older than whatever key ends up committed — an assumption broken by `_reconcileDivergedLeafAsync`'s "reuse my own live object if it still exists" branch: under a concurrent-write race, a retry can recommit an **older** live key than the one it's superseding, so the sweep ends up deleting the object the write just committed.

Both call sites now delete via the existing exact-key `_deleteExactLiveObjectAsync` instead (same pattern already used for the write-failure rollback path). Since both already guard `previous !== current` before deleting, an exact-key delete can never touch the just-committed key. This also eliminates the redundant `listObjectsAsync` calls from this flow (down to 0, from up to 1 per racing writer).

`deleteLiveObjectAsync`'s sweep is unchanged and still used by `removeHelper.js`'s full-resource DELETE, where sweeping the whole prefix is correct (nothing should remain after a delete).

### 2. Full-resource DELETE now cleans up orphans even when not currently externalized

`removeHelper.js`'s post-delete cleanup only attempted anything for leaves with a live `_blobMeta` (i.e. currently externalized). A resource that had been externalized in an earlier version, then later patched back inline/below-threshold (whose own supersede-cleanup didn't run, or failed), left its stray S3 object untouched forever on a subsequent full DELETE.

Added `getLiveObjectRefsOrResourceLastUpdated`: for every configured leaf, uses `_blobMeta.lastUpdated` when present, else falls back to `resource.meta.lastUpdated` (already stamped to "now" at delete time). Since `deleteLiveObjectAsync`'s sweep only ever deletes keys `<=` the given boundary, this guarantees nothing newer than the resource's own timestamp is ever touched.

### 3. S3 operation logging

Added `logInfo('S3 <op>', { resourceType, uuid, key/prefix })` immediately before every S3 client call in `Base64DataManager` (upload, delete, list, download, exists, copyObject) for observability into future incidents.

## Testing

TDD (red → green) for both fixes:
- 2 new unit tests reproducing the exact race in `deleteSupersededLiveObjectsAsync`/`cleanupPreviousLiveObjectAsync` — confirmed failing pre-fix (deleted the just-committed key), passing post-fix.
- 2 new unit tests for `getLiveObjectRefsOrResourceLastUpdated`.
- 1 new integration test in `binaryDelete.test.js` — plants a stray older live object and a future-dated one under a never-externalized Binary's uuid prefix, REST-DELETEs it, confirms the stray is swept pre-existing-key while the future one survives. Confirmed failing pre-fix, passing post-fix.

Full suite results:
- `base64DataManager.unit.test.js`: 40/40 pass
- Full blob-storage integration suite (`blobStorage`, `binaryDelete`, `blobStorageContract(Disabled)`, `danglingReferenceRace`, `mixedFieldRetryReconciliation`, `putPatchCleanup`): 57/57 pass
- `fastDatabaseUpdateManager`/`databaseUpdateManager` unit tests (incl. nullPatches): 66/66 pass
- `eslint`: 0 errors on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)