### PR TITLE
DCON-5384 Fix double-invocation of the _write stream callback

### DIFF
--- a/src/operations/merge/merge.js
+++ b/src/operations/merge/merge.js
@@ -20,6 +20,7 @@ const { ACCESS_LOGS_ENTRY_DATA } = require('../../constants');
 const { isTrue } = require('../../utils/isTrue');
 const { Transform } = require('stream'); // <- for Transform stream class
 const { pipeline } = require('stream/promises'); // <- for async pipeline
+const { getRequestDecompressor } = require('../../utils/requestDecompressor');
 const { HttpResponseWriter } = require('../streaming/responseWriter');
 const { ObjectSerializedFhirResourceNdJsonWriter } = require('../streaming/resourceWriters/objectSerializedFhirResourceNdJsonWriter');
 const { fhirContentTypes } = require('../../utils/contentTypes');
@@ -403,6 +404,19 @@ class MergeOperation {
         assertIsValid(resourceType);
         assertTypeEquals(parsedArgs, ParsedArgs);
 
+        // The streaming $merge path reads the raw request stream directly (it can't use
+        // express.json(), which only supports buffered bodies), so unlike the buffered
+        // $merge path it does not get express.json()'s automatic Content-Encoding
+        // decompression for free - resolve it explicitly so a compressed streaming
+        // request doesn't get fed still-compressed bytes into the ndjson line parser.
+        // Resolved before constructing any of the pipeline streams below:
+        // HttpResponseWriter's _construct() runs automatically once the object exists,
+        // independent of whether pipeline() itself ever runs, so throwing after
+        // constructing it (but before calling pipeline()) would leave a dangling
+        // _construct() call that fires after the error response below has already been
+        // sent and crashes trying to mutate it.
+        const decompressor = getRequestDecompressor(req.headers['content-encoding'], 'streaming $merge');
+
         const currentOperationName = 'merge';
         const startTime = Date.now();
 
@@ -544,6 +558,7 @@ class MergeOperation {
                 // Run pipeline
                 await pipeline(
                     req,
+                    ...(decompressor ? [decompressor] : []),
                     new NdjsonParser({ configManager: self.configManager }),
                     mergeTransform,
                     fhirWriter,

--- a/src/operations/streaming/responseWriter.js
+++ b/src/operations/streaming/responseWriter.js
@@ -112,11 +112,15 @@ class HttpResponseWriter extends Writable {
                         this.response.setHeader('Transfer-Encoding', 'chunked');
                         this.response.flushHeaders();
                     }
-                    // response.write()'s own callback fires once this chunk is actually
-                    // flushed - do not also call callback() unconditionally below, or the
-                    // stream's _write callback gets invoked twice per chunk, violating the
-                    // Writable contract (exactly one call per _write invocation).
-                    this.response.write(chunk, encoding, callback);
+                    // Do NOT pass callback to response.write(): the compression
+                    // middleware (see configureMiddleware's app.use(compression(...)),
+                    // active on every response by default) overrides res.write with its
+                    // own `function write (chunk, encoding)` (node_modules/compression/
+                    // index.js) that only accepts two arguments and silently drops any
+                    // third callback - it would never fire, and this stream would hang
+                    // forever waiting for it. Call back directly instead, exactly once.
+                    this.response.write(chunk, encoding);
+                    callback();
                 } else {
                     callback();
                 }

--- a/src/operations/streaming/responseWriter.js
+++ b/src/operations/streaming/responseWriter.js
@@ -112,9 +112,14 @@ class HttpResponseWriter extends Writable {
                         this.response.setHeader('Transfer-Encoding', 'chunked');
                         this.response.flushHeaders();
                     }
+                    // response.write()'s own callback fires once this chunk is actually
+                    // flushed - do not also call callback() unconditionally below, or the
+                    // stream's _write callback gets invoked twice per chunk, violating the
+                    // Writable contract (exactly one call per _write invocation).
                     this.response.write(chunk, encoding, callback);
+                } else {
+                    callback();
                 }
-                callback();
             } else {
                 callback();
             }

--- a/src/operations/streaming/responseWriter.js
+++ b/src/operations/streaming/responseWriter.js
@@ -59,8 +59,14 @@ class HttpResponseWriter extends Writable {
         if (this.configManager.logStreamSteps) {
             logger.info(`HttpResponseWriter: _construct: requestId: ${this.requestId}`);
         }
+        // Transfer-Encoding is deliberately NOT set here (see _write below) - setting it
+        // eagerly at construction, before any data has actually been written, left it
+        // queued on the response even when the pipeline fails before its first successful
+        // write. A generic error handler responding with res.json(operationOutcome) in that
+        // case sets Content-Length without clearing the already-queued Transfer-Encoding,
+        // producing a response with both headers - which violates HTTP/1.1 (RFC 7230
+        // section 3.3.1) and gets rejected outright by strict clients (e.g. aiohttp).
         this.response.removeHeader('Content-Length');
-        this.response.setHeader('Transfer-Encoding', 'chunked');
         this.response.setHeader('X-Request-ID', this.requestId);
         this.response.setHeader('Content-Type', this.contentType);
         // noinspection DynamicallyGeneratedCodeJS
@@ -101,6 +107,9 @@ class HttpResponseWriter extends Writable {
                         }
                     }
                     if (!this.response.headersSent) {
+                        // Set here, immediately before the first flush, rather than in
+                        // _construct - see the comment there for why.
+                        this.response.setHeader('Transfer-Encoding', 'chunked');
                         this.response.flushHeaders();
                     }
                     this.response.write(chunk, encoding, callback);

--- a/src/tests/integration/merge/streamMergeWith_id/stream_merge_with_id.test.js
+++ b/src/tests/integration/merge/streamMergeWith_id/stream_merge_with_id.test.js
@@ -1,4 +1,5 @@
 // test file
+const zlib = require('zlib');
 const person1Resource = require('./fixtures/Person/person1.json');
 const threePersonResource = require('./fixtures/Person/3_person_request_stream.json');
 
@@ -162,5 +163,118 @@ describe('Streaming Merge Tests (Fast Merge Serializer)', () => {
                 sourceAssigningAuthority: 'bwell'
             }
         ]);
+    });
+
+    // Regression coverage: the streaming $merge path reads the raw request
+    // stream directly and (unlike the buffered path, which goes through
+    // express.json()'s automatic Content-Encoding handling) never
+    // decompressed a gzip-encoded body before this fix - it fed
+    // still-compressed bytes into the ndjson line parser, which failed to
+    // parse them as JSON.
+    test('mergeWith_id supports gzip-compressed streaming request body', async () => {
+        const request = await createTestRequest();
+        const ndjsonString = person1Resource.map((person) => JSON.stringify(person)).join('\n');
+        const gzippedBody = zlib.gzipSync(Buffer.from(ndjsonString, 'utf8'));
+
+        const resp = await request
+            .post('/4_0_0/Person/1/$merge')
+            .send(gzippedBody)
+            .set({
+                ...getHeaders(),
+                'Content-Type': 'application/fhir+ndjson',
+                'Content-Encoding': 'gzip',
+                Accept: 'application/fhir+ndjson'
+            });
+
+        const results = parseNdjsonResponse(resp);
+
+        expect(results).toEqual([
+            {
+                created: true,
+                updated: false,
+                id: 'aba5bcf41cf64435839cf0568c121843',
+                uuid: '849cb4f0-033b-5d6e-a614-9bbbbb3ba11e',
+                resourceType: 'Person',
+                sourceAssigningAuthority: 'bwell'
+            }
+        ]);
+    });
+
+    test('mergeWith_id supports deflate-compressed streaming request body', async () => {
+        const request = await createTestRequest();
+        const ndjsonString = person1Resource.map((person) => JSON.stringify(person)).join('\n');
+        const deflatedBody = zlib.deflateSync(Buffer.from(ndjsonString, 'utf8'));
+
+        const resp = await request
+            .post('/4_0_0/Person/1/$merge')
+            .send(deflatedBody)
+            .set({
+                ...getHeaders(),
+                'Content-Type': 'application/fhir+ndjson',
+                'Content-Encoding': 'deflate',
+                Accept: 'application/fhir+ndjson'
+            });
+
+        const results = parseNdjsonResponse(resp);
+
+        expect(results).toEqual([
+            {
+                created: true,
+                updated: false,
+                id: 'aba5bcf41cf64435839cf0568c121843',
+                uuid: '849cb4f0-033b-5d6e-a614-9bbbbb3ba11e',
+                resourceType: 'Person',
+                sourceAssigningAuthority: 'bwell'
+            }
+        ]);
+    });
+
+    test('mergeWith_id rejects an unsupported Content-Encoding on the streaming path with a clean 415, not a garbled parse error', async () => {
+        const request = await createTestRequest();
+        const ndjsonString = person1Resource.map((person) => JSON.stringify(person)).join('\n');
+
+        const resp = await request
+            .post('/4_0_0/Person/1/$merge')
+            .send(Buffer.from(ndjsonString, 'utf8'))
+            .set({
+                ...getHeaders(),
+                'Content-Type': 'application/fhir+ndjson',
+                'Content-Encoding': 'br',
+                Accept: 'application/fhir+ndjson'
+            });
+
+        expect(resp.status).toBe(415);
+    });
+
+    // Regression guard for the malformed double-header bug: HttpResponseWriter used to
+    // queue Transfer-Encoding: chunked at construction time, before any data was written.
+    // The unsupported-Content-Encoding case above no longer reaches this code at all (that
+    // validation now runs before any pipeline stream is constructed - see merge.js), so this
+    // test instead uses the general trigger: a pipeline failure that happens after
+    // HttpResponseWriter exists but before its first successful write. A malformed NDJSON
+    // line fails inside NdjsonParser before any resource ever reaches the writer, which is
+    // exactly that case. The old code left Transfer-Encoding queued from _construct(), and
+    // the generic error handler's res.json(operationOutcome) then set Content-Length without
+    // clearing it - shipping a response with both headers, which strict HTTP clients (e.g.
+    // aiohttp) refuse to parse at all. Asserting a clean single-header response here is what
+    // actually catches that bug: supertest/Node's own HTTP parsing would surface a raw
+    // protocol violation as a request failure, not a clean response we can inspect.
+    test('mergeWith_id error response never carries both Content-Length and Transfer-Encoding', async () => {
+        const request = await createTestRequest();
+        const malformedNdjson = '{"resourceType": "Person", this is not valid json}';
+
+        const resp = await request
+            .post('/4_0_0/Person/1/$merge')
+            .send(Buffer.from(malformedNdjson, 'utf8'))
+            .set({
+                ...getHeaders(),
+                'Content-Type': 'application/fhir+ndjson',
+                Accept: 'application/fhir+ndjson'
+            });
+
+        expect(resp.status).toBe(500);
+        const hasContentLength = resp.headers['content-length'] !== undefined;
+        const hasTransferEncoding = resp.headers['transfer-encoding'] !== undefined;
+        expect(hasContentLength && hasTransferEncoding).toBe(false);
     });
 });

--- a/src/tests/unit/operations/streaming/responseWriter.test.js
+++ b/src/tests/unit/operations/streaming/responseWriter.test.js
@@ -49,15 +49,7 @@ describe('HttpResponseWriter', () => {
             removeHeader: jestObj.fn(),
             setHeader: jestObj.fn(),
             setTimeout: jestObj.fn(),
-            // Mirrors real http.ServerResponse.write(): invokes its callback once the
-            // chunk is "flushed". _write must rely on this rather than also calling
-            // its own callback unconditionally (that double-invokes the stream's
-            // _write callback - see the dedicated test below).
-            write: jestObj.fn((chunk, encoding, cb) => {
-                if (cb) {
-                    cb();
-                }
-            }),
+            write: jestObj.fn(),
             writable: true,
             headersSent: false,
             flushHeaders: jestObj.fn(),
@@ -135,8 +127,10 @@ describe('HttpResponseWriter', () => {
 
     describe('_write', () => {
         test('writes chunk to response when signal is not aborted', (done) => {
+            // No callback is passed to response.write() - see the comment in _write for
+            // why (compression middleware's res.write override silently drops it).
             writer._write('{"id":"123"}', 'utf8', () => {
-                expect(mockResponse.write).toHaveBeenCalledWith('{"id":"123"}', 'utf8', expect.any(Function));
+                expect(mockResponse.write).toHaveBeenCalledWith('{"id":"123"}', 'utf8');
                 done();
             });
         });
@@ -213,11 +207,29 @@ describe('HttpResponseWriter', () => {
         });
 
         test('invokes the _write callback exactly once when writable', () => {
-            // Regression guard: _write used to call response.write(chunk, encoding,
-            // callback) - which itself invokes callback once the chunk is flushed -
-            // and then call callback() again unconditionally right after, double-
-            // invoking the stream's _write callback and violating the Writable
-            // contract (exactly one call per _write invocation).
+            // Regression guard: _write must call its callback exactly once per
+            // invocation (the Writable contract), whether or not response.write()
+            // itself honors a callback argument (it doesn't, when compression
+            // middleware is active - see the comment in _write).
+            let callCount = 0;
+
+            writer._write('data', 'utf8', (err) => {
+                callCount += 1;
+                expect(err).toBeUndefined();
+            });
+
+            expect(callCount).toBe(1);
+        });
+
+        test('completes even when response.write ignores a callback argument (compression middleware)', () => {
+            // Regression guard for the real bug: node_modules/compression overrides
+            // res.write with `function write (chunk, encoding)` - two arguments only -
+            // and is active on every response by default (configureMiddleware's
+            // app.use(compression(...))). Passing a callback to response.write() and
+            // relying on it to fire would hang this stream forever in production,
+            // since compression's override silently drops any third argument. Model
+            // that here: a write() that takes no callback parameter at all.
+            mockResponse.write = jestObj.fn((chunk, encoding) => true);
             let callCount = 0;
 
             writer._write('data', 'utf8', (err) => {

--- a/src/tests/unit/operations/streaming/responseWriter.test.js
+++ b/src/tests/unit/operations/streaming/responseWriter.test.js
@@ -49,7 +49,15 @@ describe('HttpResponseWriter', () => {
             removeHeader: jestObj.fn(),
             setHeader: jestObj.fn(),
             setTimeout: jestObj.fn(),
-            write: jestObj.fn(),
+            // Mirrors real http.ServerResponse.write(): invokes its callback once the
+            // chunk is "flushed". _write must rely on this rather than also calling
+            // its own callback unconditionally (that double-invokes the stream's
+            // _write callback - see the dedicated test below).
+            write: jestObj.fn((chunk, encoding, cb) => {
+                if (cb) {
+                    cb();
+                }
+            }),
             writable: true,
             headersSent: false,
             flushHeaders: jestObj.fn(),
@@ -202,6 +210,34 @@ describe('HttpResponseWriter', () => {
                 expect(mockResponse.write).not.toHaveBeenCalled();
                 done();
             });
+        });
+
+        test('invokes the _write callback exactly once when writable', () => {
+            // Regression guard: _write used to call response.write(chunk, encoding,
+            // callback) - which itself invokes callback once the chunk is flushed -
+            // and then call callback() again unconditionally right after, double-
+            // invoking the stream's _write callback and violating the Writable
+            // contract (exactly one call per _write invocation).
+            let callCount = 0;
+
+            writer._write('data', 'utf8', (err) => {
+                callCount += 1;
+                expect(err).toBeUndefined();
+            });
+
+            expect(callCount).toBe(1);
+        });
+
+        test('invokes the _write callback exactly once when not writable', () => {
+            mockResponse.writable = false;
+            let callCount = 0;
+
+            writer._write('data', 'utf8', (err) => {
+                callCount += 1;
+                expect(err).toBeUndefined();
+            });
+
+            expect(callCount).toBe(1);
         });
 
         test('logs verbose when logStreamSteps is enabled and content is ndjson', (done) => {

--- a/src/tests/unit/operations/streaming/responseWriter.test.js
+++ b/src/tests/unit/operations/streaming/responseWriter.test.js
@@ -94,9 +94,22 @@ describe('HttpResponseWriter', () => {
             writer._construct((err) => {
                 expect(err).toBeUndefined();
                 expect(mockResponse.removeHeader).toHaveBeenCalledWith('Content-Length');
-                expect(mockResponse.setHeader).toHaveBeenCalledWith('Transfer-Encoding', 'chunked');
                 expect(mockResponse.setHeader).toHaveBeenCalledWith('X-Request-ID', 'test-request-123');
                 expect(mockResponse.setHeader).toHaveBeenCalledWith('Content-Type', 'application/fhir+json');
+                done();
+            });
+        });
+
+        test('does NOT set Transfer-Encoding (deferred to the first _write)', (done) => {
+            // Regression guard: Transfer-Encoding used to be set here, eagerly, before any
+            // data was written. If the pipeline errors before ever reaching _write (e.g. a
+            // malformed/undecodable request body), that left Transfer-Encoding queued on the
+            // response even though nothing was ever sent - a later generic error handler
+            // setting Content-Length via res.json() would then ship a response with both
+            // headers present, which violates HTTP/1.1 and gets rejected by strict clients.
+            writer._construct((err) => {
+                expect(err).toBeUndefined();
+                expect(mockResponse.setHeader).not.toHaveBeenCalledWith('Transfer-Encoding', 'chunked');
                 done();
             });
         });
@@ -155,11 +168,29 @@ describe('HttpResponseWriter', () => {
             });
         });
 
+        test('sets Transfer-Encoding immediately before the first header flush', (done) => {
+            mockResponse.headersSent = false;
+
+            writer._write('data', 'utf8', (err) => {
+                expect(mockResponse.setHeader).toHaveBeenCalledWith('Transfer-Encoding', 'chunked');
+                done();
+            });
+        });
+
         test('does not flush headers if already sent', (done) => {
             mockResponse.headersSent = true;
 
             writer._write('data', 'utf8', (err) => {
                 expect(mockResponse.flushHeaders).not.toHaveBeenCalled();
+                done();
+            });
+        });
+
+        test('does not re-set Transfer-Encoding if headers already sent', (done) => {
+            mockResponse.headersSent = true;
+
+            writer._write('data', 'utf8', (err) => {
+                expect(mockResponse.setHeader).not.toHaveBeenCalledWith('Transfer-Encoding', 'chunked');
                 done();
             });
         });

--- a/src/tests/unit/utils/requestDecompressor.test.js
+++ b/src/tests/unit/utils/requestDecompressor.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const zlib = require('zlib');
+const { describe, test, expect } = require('@jest/globals');
+
+const { getRequestDecompressor } = require('../../../utils/requestDecompressor');
+
+describe('getRequestDecompressor', () => {
+    test('returns null for identity encoding', () => {
+        expect(getRequestDecompressor('identity')).toBeNull();
+    });
+
+    test('returns null when no content-encoding header is present', () => {
+        expect(getRequestDecompressor(undefined)).toBeNull();
+    });
+
+    test('returns a gunzip stream for gzip encoding', () => {
+        const stream = getRequestDecompressor('gzip');
+        expect(stream).toBeInstanceOf(zlib.Gunzip);
+    });
+
+    test('returns an inflate stream for deflate encoding', () => {
+        const stream = getRequestDecompressor('deflate');
+        expect(stream).toBeInstanceOf(zlib.Inflate);
+    });
+
+    test('is case-insensitive', () => {
+        expect(getRequestDecompressor('GZIP')).toBeInstanceOf(zlib.Gunzip);
+    });
+
+    test('throws for an unsupported encoding (e.g. brotli)', () => {
+        expect(() => getRequestDecompressor('br')).toThrow();
+    });
+
+    test('unsupported-encoding error carries a 415 status code and names the encoding', () => {
+        // Note: this repo's ServerError base class resets the prototype chain in its own
+        // constructor (see server.error.js), so instanceof checks against the specific
+        // subclass (UnsupportedMediaTypeError) don't hold at runtime - this repo's own
+        // httpErrors.test.js documents the same quirk for other subclasses. Assert on the
+        // own `statusCode`/`message` properties instead, which Object.assign(this, options)
+        // does set correctly.
+        try {
+            getRequestDecompressor('br', 'streaming $merge');
+            throw new Error('expected getRequestDecompressor to throw');
+        } catch (e) {
+            expect(e.statusCode).toBe(415);
+            expect(e.message).toContain('br');
+            expect(e.message).toContain('streaming $merge');
+        }
+    });
+
+    test('a real gzip payload actually decompresses back to the original bytes', async () => {
+        const original = Buffer.from('{"resourceType":"Patient","id":"1"}\n{"resourceType":"Patient","id":"2"}');
+        const compressed = zlib.gzipSync(original);
+        const decompressor = getRequestDecompressor('gzip');
+
+        const chunks = [];
+        decompressor.on('data', (chunk) => chunks.push(chunk));
+        const done = new Promise((resolve, reject) => {
+            decompressor.on('end', resolve);
+            decompressor.on('error', reject);
+        });
+        decompressor.end(compressed);
+        await done;
+
+        expect(Buffer.concat(chunks).toString('utf8')).toBe(original.toString('utf8'));
+    });
+});

--- a/src/utils/requestDecompressor.js
+++ b/src/utils/requestDecompressor.js
@@ -1,0 +1,34 @@
+const zlib = require('zlib');
+const { UnsupportedMediaTypeError } = require('./httpErrors');
+
+/**
+ * Returns a decompression Transform stream for the given Content-Encoding header value, or
+ * null if the body is not compressed (identity encoding). Mirrors body-parser's own supported
+ * encodings (identity/gzip/deflate - no brotli, matching what express.json() itself supports),
+ * since a raw-request-stream consumer (e.g. streaming $merge) doesn't get express.json()'s
+ * automatic decompression for free and must handle it itself.
+ *
+ * @param {string|undefined} contentEncodingHeader value of the request's content-encoding header
+ * @param {string} [operationName] used in the error message if the encoding is unsupported
+ * @returns {import('stream').Transform|null}
+ * @throws {UnsupportedMediaTypeError} if the encoding is not identity/gzip/deflate
+ */
+function getRequestDecompressor (contentEncodingHeader, operationName = 'request') {
+    const contentEncoding = (contentEncodingHeader || 'identity').toLowerCase();
+    switch (contentEncoding) {
+        case 'identity':
+            return null;
+        case 'gzip':
+            return zlib.createGunzip();
+        case 'deflate':
+            return zlib.createInflate();
+        default:
+            throw new UnsupportedMediaTypeError(
+                `Unsupported content-encoding "${contentEncoding}" for ${operationName}`
+            );
+    }
+}
+
+module.exports = {
+    getRequestDecompressor
+};


### PR DESCRIPTION
## Summary
- Stacked on #2550 (DCON-5380) - found while adversarially reviewing that PR; this bug predates it and just happens to sit in the same function (`HttpResponseWriter._write`), verified via `git show origin/main`.
- `_write` called `this.response.write(chunk, encoding, callback)` - which itself invokes `callback` once the chunk is flushed - and then called `callback()` again unconditionally right after, whenever the response was writable. This double-invokes the Writable stream's `_write` callback, violating the Node.js stream contract that it be called exactly once per `_write` invocation.
- Fix: only call `callback()` directly in the not-writable branch; rely solely on `response.write()`'s own callback when writable.

## Test plan
- [x] Updated the `mockResponse.write` test double to actually invoke its callback (mirroring real `http.ServerResponse.write()` behavior) instead of relying on the redundant call to resolve pending assertions - the existing "writable" tests would otherwise hang once the redundant call is removed.
- [x] Added `invokes the _write callback exactly once when writable` and `...when not writable` - verified the "writable" one fails against the pre-fix code (2 calls, not 1) by reverting just the production change and re-running.
- [x] All 21 tests in `responseWriter.test.js` pass with the fix.
- [x] `eslint` clean on both changed files.