### PR TITLE
DCON-5380 Address review nits on streaming $merge decompressor

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
     "@graphql-eslint/eslint-plugin": "^4.4.0",
     "@jest/globals": "^30.4.1",
     "@testcontainers/clickhouse": "^12.0.0",
-    "@types/bytes": "^3",
     "csv42": "^5.0.3",
     "dotenv": "^17.4.2",
     "eslint": "^10.4.0",

--- a/src/tests/unit/operations/streaming/responseWriter.test.js
+++ b/src/tests/unit/operations/streaming/responseWriter.test.js
@@ -173,6 +173,19 @@ describe('HttpResponseWriter', () => {
 
             writer._write('data', 'utf8', (err) => {
                 expect(mockResponse.setHeader).toHaveBeenCalledWith('Transfer-Encoding', 'chunked');
+
+                // Ordering is the whole point of the fix: setting the header *after*
+                // flushHeaders() would be a no-op, and asserting only that setHeader was called
+                // would pass either way. Compare invocation order to pin it down.
+                const transferEncodingCallIndex = mockResponse.setHeader.mock.calls
+                    .findIndex(([name]) => name === 'Transfer-Encoding');
+                expect(transferEncodingCallIndex).toBeGreaterThanOrEqual(0);
+                const setHeaderOrder =
+                    mockResponse.setHeader.mock.invocationCallOrder[transferEncodingCallIndex];
+                const flushOrder = mockResponse.flushHeaders.mock.invocationCallOrder[0];
+
+                expect(flushOrder).toBeDefined();
+                expect(setHeaderOrder).toBeLessThan(flushOrder);
                 done();
             });
         });

--- a/src/tests/unit/utils/requestDecompressor.test.js
+++ b/src/tests/unit/utils/requestDecompressor.test.js
@@ -3,9 +3,14 @@
 const zlib = require('zlib');
 const { pipeline } = require('stream/promises');
 const { PassThrough } = require('stream');
-const { describe, test, expect } = require('@jest/globals');
+const { describe, test, expect, jest: jestObj } = require('@jest/globals');
 
-const { getRequestDecompressor } = require('../../../utils/requestDecompressor');
+jestObj.mock('../../../operations/common/logging', () => ({
+    logWarn: jestObj.fn()
+}));
+
+const { getRequestDecompressor, DecompressedSizeLimitTransform } = require('../../../utils/requestDecompressor');
+const { logWarn } = require('../../../operations/common/logging');
 
 /**
  * Runs a compressed buffer through the full decompressor chain (as merge.js's pipeline()
@@ -118,5 +123,79 @@ describe('getRequestDecompressor', () => {
         const result = await runThroughDecompressor(compressed, 'gzip');
 
         expect(result.toString('utf8')).toBe(original.toString('utf8'));
+    });
+
+    test('falls back to the default limit (not an unlimited or always-413 one) when PAYLOAD_LIMIT is unparseable', async () => {
+        // bytes() returns null for an unparseable value. Passing that straight through as
+        // maxBytes would make `bytesSeen > null` true from the very first chunk, failing every
+        // compressed streaming request with a 413 - so a config typo has to fall back instead.
+        const original = Buffer.from('a'.repeat(1000));
+        const compressed = zlib.gzipSync(original);
+
+        const result = await runThroughDecompressor(compressed, 'gzip', 'not-a-size');
+
+        expect(result.length).toBe(1000);
+        expect(logWarn).toHaveBeenCalledWith(
+            expect.stringContaining('PAYLOAD_LIMIT'),
+            expect.anything()
+        );
+    });
+
+    test('the fallback limit is still enforced, not disabled', async () => {
+        // Guards the other half of the fallback: dropping to the default must not mean
+        // "no limit" (which is how body-parser treats an unparseable limit).
+        const original = Buffer.alloc(60 * 1024 * 1024, 0);
+
+        await expect(
+            runThroughDecompressor(zlib.gzipSync(original), 'gzip', 'not-a-size')
+        ).rejects.toMatchObject({ statusCode: 413 });
+    });
+});
+
+describe('DecompressedSizeLimitTransform', () => {
+    /**
+     * Feeds fixed-size chunks through the transform on its own (no decompression stage) so the
+     * exact byte at which it trips is observable.
+     */
+    async function runChunks (maxBytes, chunks) {
+        const transform = new DecompressedSizeLimitTransform({ maxBytes, operationName: 'test op' });
+        const source = new PassThrough();
+        const sink = new PassThrough();
+        const collected = [];
+        sink.on('data', (chunk) => collected.push(chunk));
+
+        for (const chunk of chunks) {
+            source.write(chunk);
+        }
+        source.end();
+        await pipeline(source, transform, sink);
+
+        return Buffer.concat(collected);
+    }
+
+    test('passes through a body exactly at the limit', async () => {
+        const result = await runChunks(100, [Buffer.alloc(100, 0x61)]);
+
+        expect(result.length).toBe(100);
+    });
+
+    test('rejects a body one byte over the limit', async () => {
+        await expect(runChunks(100, [Buffer.alloc(101, 0x61)]))
+            .rejects.toMatchObject({ statusCode: 413 });
+    });
+
+    test('counts bytes cumulatively across chunks, not per chunk', async () => {
+        // Each chunk on its own is under the limit; only the running total exceeds it.
+        await expect(runChunks(100, [Buffer.alloc(60, 0x61), Buffer.alloc(60, 0x61)]))
+            .rejects.toMatchObject({ statusCode: 413 });
+    });
+
+    test('names the operation and the limit in the error message', async () => {
+        await expect(runChunks(100, [Buffer.alloc(101, 0x61)])).rejects.toMatchObject({
+            message: expect.stringContaining('test op')
+        });
+        await expect(runChunks(100, [Buffer.alloc(101, 0x61)])).rejects.toMatchObject({
+            message: expect.stringContaining('100 bytes')
+        });
     });
 });

--- a/src/utils/requestDecompressor.js
+++ b/src/utils/requestDecompressor.js
@@ -2,6 +2,14 @@ const zlib = require('zlib');
 const { Transform } = require('stream');
 const bytesParse = require('bytes');
 const { UnsupportedMediaTypeError, PayloadTooLargeError } = require('./httpErrors');
+const { logWarn } = require('../operations/common/logging');
+
+/**
+ * Fallback cap on decompressed request bodies, used when no limit is passed in or the one that
+ * was passed in can't be parsed. Matches ConfigManager.payloadLimit's own default.
+ * @type {string}
+ */
+const DEFAULT_MAX_DECOMPRESSED_SIZE = '50mb';
 
 /**
  * Guards against decompression-bomb DoS: the buffered $merge path gets a body-size cap for
@@ -35,6 +43,30 @@ class DecompressedSizeLimitTransform extends Transform {
 }
 
 /**
+ * Parses a payload-limit string (e.g. '50mb') into a byte count, falling back to the default if
+ * it can't be parsed. `bytes()` returns null for an unparseable value, and a null maxBytes would
+ * make every size comparison below true - failing every compressed request with a 413 - so an
+ * unparseable PAYLOAD_LIMIT must not be passed through silently. Falling back keeps the limit
+ * enforced (unlike body-parser, which treats an unparseable limit as no limit at all) while the
+ * warning surfaces the misconfiguration.
+ *
+ * @param {string|number} maxDecompressedSize
+ * @returns {number} the cap in bytes
+ */
+function resolveMaxBytes (maxDecompressedSize) {
+    const maxBytes = bytesParse(maxDecompressedSize);
+    if (maxBytes !== null && maxBytes !== undefined) {
+        return maxBytes;
+    }
+    logWarn(
+        `requestDecompressor: could not parse "${maxDecompressedSize}" as a size ` +
+        `(check the PAYLOAD_LIMIT env var); falling back to ${DEFAULT_MAX_DECOMPRESSED_SIZE}`,
+        {}
+    );
+    return bytesParse(DEFAULT_MAX_DECOMPRESSED_SIZE);
+}
+
+/**
  * Returns the decompression Transform stream(s) for the given Content-Encoding header value,
  * as an array suitable for spreading directly into a stream.pipeline() call - empty if the
  * body is not compressed (identity encoding). Mirrors body-parser's own supported encodings
@@ -50,7 +82,7 @@ class DecompressedSizeLimitTransform extends Transform {
  * @returns {import('stream').Transform[]}
  * @throws {UnsupportedMediaTypeError} if the encoding is not identity/gzip/deflate
  */
-function getRequestDecompressor (contentEncodingHeader, operationName = 'request', maxDecompressedSize = '50mb') {
+function getRequestDecompressor (contentEncodingHeader, operationName = 'request', maxDecompressedSize = DEFAULT_MAX_DECOMPRESSED_SIZE) {
     const contentEncoding = (contentEncodingHeader || 'identity').toLowerCase();
     switch (contentEncoding) {
         case 'identity':
@@ -59,7 +91,7 @@ function getRequestDecompressor (contentEncodingHeader, operationName = 'request
         case 'deflate': {
             const decompressStream = contentEncoding === 'gzip' ? zlib.createGunzip() : zlib.createInflate();
             const sizeLimitTransform = new DecompressedSizeLimitTransform({
-                maxBytes: bytesParse(maxDecompressedSize),
+                maxBytes: resolveMaxBytes(maxDecompressedSize),
                 operationName
             });
             return [decompressStream, sizeLimitTransform];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4085,13 +4085,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/bytes@npm:^3":
-  version: 3.1.6
-  resolution: "@types/bytes@npm:3.1.6"
-  checksum: 10c0/2d9fff3d0aa5487f71a94a719b04336f03832211353927b9e1b3dc02a566f38c96b7a5ccb260af3893b4900f5bc5ee1b5adc3074a061b7a0522787ed57a8a5be
-  languageName: node
-  linkType: hard
-
 "@types/connect@npm:3.4.38":
   version: 3.4.38
   resolution: "@types/connect@npm:3.4.38"
@@ -5363,7 +5356,6 @@ __metadata:
     "@opentelemetry/sdk-node": "npm:0.220.0"
     "@sentry/node": "npm:10.54.0"
     "@testcontainers/clickhouse": "npm:^12.0.0"
-    "@types/bytes": "npm:^3"
     accepts: "npm:^1.3.8"
     ajv: "npm:^6.15.0"
     async: "npm:^3.2.6"


### PR DESCRIPTION
## Summary

Review follow-ups on #2550, targeted at that PR's branch so it can be merged in before #2550 lands. Four small items — no behavior change to the decompression fix or the double-header fix themselves.

## Changes

**1. Remove the unused `@types/bytes` devDependency.** Nothing in this repo runs `tsc` — there's no typecheck script in `package.json` and no typecheck job in `.github/workflows/`; `tsconfig.json` is `noEmit` and IDE-only. It was also the only `@types/*` entry in a package.json with ~100 dependencies. The `bytes` runtime dependency itself is unchanged.

**2. Fall back to the default limit when `PAYLOAD_LIMIT` is unparseable.** `bytes()` returns `null` for an unparseable value, and `bytesSeen > null` is `true` from the very first chunk — so a config typo would have failed *every* compressed streaming merge with a 413. Now falls back to `50mb` and logs a warning.

This deliberately diverges from body-parser, which treats an unparseable limit as *no* limit. That's fine for a convenience parser but wrong for a DoS control: silently disabling the guard because of a typo is the worse of the two failure modes, so this fails closed to the documented default instead.

**3. Add direct coverage for `DecompressedSizeLimitTransform`.** It was exported but never imported anywhere, including by its own test file. Rather than dropping the export, this gives it the coverage that was missing — the existing tests only exercised well-under and way-over the limit, with nothing pinning the boundary. New tests cover exactly-at-limit, one-byte-over, cumulative-across-chunks (each chunk under, running total over), and the error message contents.

**4. Assert ordering in the `Transfer-Encoding` test.** It checked that `setHeader` had been called, but not that it ran *before* `flushHeaders()` — which is the entire point of the fix, since setting a header after the flush is a no-op. The test would have passed with the two calls reversed. Now compares `mock.invocationCallOrder`.

## Test plan

- [x] Full unit suite: 499 suites, 8665 passed, 3 skipped, 0 failed.
- [x] `eslint` on all touched files — clean.
- [x] Mutation-tested both new behavioral guards: reverted each fix and confirmed the corresponding test fails, then restored.
  - reverting `resolveMaxBytes` → `bytesParse` fails `falls back to the default limit ... when PAYLOAD_LIMIT is unparseable`
  - moving `setHeader` after `flushHeaders()` fails `sets Transfer-Encoding immediately before the first header flush`
- [x] Verified the real (unmocked) `logWarn` path — the unit test mocks it, so the fallback was otherwise only exercised against a mock. Unparseable limit + 1KB body passes without throwing; unparseable limit + 60MB body still gets a 413, confirming the fallback stays *enforced* rather than becoming unlimited.
- [x] `responseWriter.js` is byte-identical to #2550's head — only its test file changed here.

Integration tests were not run locally (they need Docker for the ClickHouse testcontainer); CI covers them.

## Not included

Two larger findings from the same review are deliberately left out, since they change behavior in #2550's code rather than just tidying it — happy to open these separately or fold them in, whichever @imranq2 prefers:

1. **The size cap only applies to compressed bodies.** `getRequestDecompressor` returns `[]` for identity encoding, so no cap is inserted. Measured against the default 50mb limit: a 120MB single-line uncompressed body was fully accepted and grew server heap by 474MB (`NdjsonParser._buffer` accumulates a newline-free line into one unbounded string). An attacker skipping compression gets the easier path, not the harder one. Pre-existing, but the mechanism to close it now exists.

2. **`Content-Type` leaks from `_construct()` the same way `Transfer-Encoding` did.** Express's `res.json()` only sets `application/json` if Content-Type isn't already set, so the error path ships a JSON OperationOutcome labelled `application/fhir+ndjson`. Confirmed: `500` with `content-type: application/fhir+ndjson; charset=utf-8`. aiohttp — the client named in #2550 — raises `ContentTypeError` from `.json()` on an unexpected mimetype, so the error path may still not parse cleanly for the SDK.

JIRA: [DCON-5380](https://icanbwell.atlassian.net/browse/DCON-5380)


[DCON-5380]: https://icanbwell.atlassian.net/browse/DCON-5380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ