### PR TITLE
DCON-5384 Fix double-invocation of the _write stream callback (rebased)

### DIFF
--- a/src/operations/streaming/responseWriter.js
+++ b/src/operations/streaming/responseWriter.js
@@ -112,11 +112,15 @@ class HttpResponseWriter extends Writable {
                         this.response.setHeader('Transfer-Encoding', 'chunked');
                         this.response.flushHeaders();
                     }
-                    // response.write()'s own callback fires once this chunk is actually
-                    // flushed - do not also call callback() unconditionally below, or the
-                    // stream's _write callback gets invoked twice per chunk, violating the
-                    // Writable contract (exactly one call per _write invocation).
-                    this.response.write(chunk, encoding, callback);
+                    // Do NOT pass callback to response.write(): the compression
+                    // middleware (see configureMiddleware's app.use(compression(...)),
+                    // active on every response by default) overrides res.write with its
+                    // own `function write (chunk, encoding)` (node_modules/compression/
+                    // index.js) that only accepts two arguments and silently drops any
+                    // third callback - it would never fire, and this stream would hang
+                    // forever waiting for it. Call back directly instead, exactly once.
+                    this.response.write(chunk, encoding);
+                    callback();
                 } else {
                     callback();
                 }

--- a/src/operations/streaming/responseWriter.js
+++ b/src/operations/streaming/responseWriter.js
@@ -112,9 +112,14 @@ class HttpResponseWriter extends Writable {
                         this.response.setHeader('Transfer-Encoding', 'chunked');
                         this.response.flushHeaders();
                     }
+                    // response.write()'s own callback fires once this chunk is actually
+                    // flushed - do not also call callback() unconditionally below, or the
+                    // stream's _write callback gets invoked twice per chunk, violating the
+                    // Writable contract (exactly one call per _write invocation).
                     this.response.write(chunk, encoding, callback);
+                } else {
+                    callback();
                 }
-                callback();
             } else {
                 callback();
             }

--- a/src/tests/unit/operations/streaming/responseWriter.test.js
+++ b/src/tests/unit/operations/streaming/responseWriter.test.js
@@ -49,7 +49,15 @@ describe('HttpResponseWriter', () => {
             removeHeader: jestObj.fn(),
             setHeader: jestObj.fn(),
             setTimeout: jestObj.fn(),
-            write: jestObj.fn(),
+            // Mirrors real http.ServerResponse.write(): invokes its callback once the
+            // chunk is "flushed". _write must rely on this rather than also calling
+            // its own callback unconditionally (that double-invokes the stream's
+            // _write callback - see the dedicated test below).
+            write: jestObj.fn((chunk, encoding, cb) => {
+                if (cb) {
+                    cb();
+                }
+            }),
             writable: true,
             headersSent: false,
             flushHeaders: jestObj.fn(),
@@ -215,6 +223,34 @@ describe('HttpResponseWriter', () => {
                 expect(mockResponse.write).not.toHaveBeenCalled();
                 done();
             });
+        });
+
+        test('invokes the _write callback exactly once when writable', () => {
+            // Regression guard: _write used to call response.write(chunk, encoding,
+            // callback) - which itself invokes callback once the chunk is flushed -
+            // and then call callback() again unconditionally right after, double-
+            // invoking the stream's _write callback and violating the Writable
+            // contract (exactly one call per _write invocation).
+            let callCount = 0;
+
+            writer._write('data', 'utf8', (err) => {
+                callCount += 1;
+                expect(err).toBeUndefined();
+            });
+
+            expect(callCount).toBe(1);
+        });
+
+        test('invokes the _write callback exactly once when not writable', () => {
+            mockResponse.writable = false;
+            let callCount = 0;
+
+            writer._write('data', 'utf8', (err) => {
+                callCount += 1;
+                expect(err).toBeUndefined();
+            });
+
+            expect(callCount).toBe(1);
         });
 
         test('logs verbose when logStreamSteps is enabled and content is ndjson', (done) => {

--- a/src/tests/unit/operations/streaming/responseWriter.test.js
+++ b/src/tests/unit/operations/streaming/responseWriter.test.js
@@ -49,15 +49,7 @@ describe('HttpResponseWriter', () => {
             removeHeader: jestObj.fn(),
             setHeader: jestObj.fn(),
             setTimeout: jestObj.fn(),
-            // Mirrors real http.ServerResponse.write(): invokes its callback once the
-            // chunk is "flushed". _write must rely on this rather than also calling
-            // its own callback unconditionally (that double-invokes the stream's
-            // _write callback - see the dedicated test below).
-            write: jestObj.fn((chunk, encoding, cb) => {
-                if (cb) {
-                    cb();
-                }
-            }),
+            write: jestObj.fn(),
             writable: true,
             headersSent: false,
             flushHeaders: jestObj.fn(),
@@ -135,8 +127,10 @@ describe('HttpResponseWriter', () => {
 
     describe('_write', () => {
         test('writes chunk to response when signal is not aborted', (done) => {
+            // No callback is passed to response.write() - see the comment in _write for
+            // why (compression middleware's res.write override silently drops it).
             writer._write('{"id":"123"}', 'utf8', () => {
-                expect(mockResponse.write).toHaveBeenCalledWith('{"id":"123"}', 'utf8', expect.any(Function));
+                expect(mockResponse.write).toHaveBeenCalledWith('{"id":"123"}', 'utf8');
                 done();
             });
         });
@@ -226,11 +220,29 @@ describe('HttpResponseWriter', () => {
         });
 
         test('invokes the _write callback exactly once when writable', () => {
-            // Regression guard: _write used to call response.write(chunk, encoding,
-            // callback) - which itself invokes callback once the chunk is flushed -
-            // and then call callback() again unconditionally right after, double-
-            // invoking the stream's _write callback and violating the Writable
-            // contract (exactly one call per _write invocation).
+            // Regression guard: _write must call its callback exactly once per
+            // invocation (the Writable contract), whether or not response.write()
+            // itself honors a callback argument (it doesn't, when compression
+            // middleware is active - see the comment in _write).
+            let callCount = 0;
+
+            writer._write('data', 'utf8', (err) => {
+                callCount += 1;
+                expect(err).toBeUndefined();
+            });
+
+            expect(callCount).toBe(1);
+        });
+
+        test('completes even when response.write ignores a callback argument (compression middleware)', () => {
+            // Regression guard for the real bug: node_modules/compression overrides
+            // res.write with `function write (chunk, encoding)` - two arguments only -
+            // and is active on every response by default (configureMiddleware's
+            // app.use(compression(...))). Passing a callback to response.write() and
+            // relying on it to fire would hang this stream forever in production,
+            // since compression's override silently drops any third argument. Model
+            // that here: a write() that takes no callback parameter at all.
+            mockResponse.write = jestObj.fn((chunk, encoding) => true);
             let callCount = 0;
 
             writer._write('data', 'utf8', (err) => {


### PR DESCRIPTION
## Summary

Supersedes #2552, which is currently `CONFLICTING` and cannot merge. Same two commits by @imranq2, unchanged — only the base moved.

**Why #2552 conflicts:** it was stacked on #2550's branch and carries a copy of that PR's first commit, `6f1a2be1c`. #2550 has since been squash-merged to `main` as `a44a767c4`, so that content now exists twice with different SHAs, and git can't reconcile the two.

**Fix:** `git rebase --onto origin/main 6f1a2be1c`, dropping the now-redundant `6f1a2be1c` and replaying only the two DCON-5384 commits onto current `main`. Applied with zero conflicts.

Merging `main` into the branch instead was tried and rejected — it produces four conflicted files (`merge.js`, `requestDecompressor.js`, and two test files), all of them the same duplicated squash content, plus a merge commit. The rebase is strictly cleaner.

## Verification

- [x] `git range-diff 6f1a2be1c..<old> a44a767c4..<new>` reports `=` for both commits — Imran's patches are byte-identical, only the base changed. Original authorship is preserved on both commits.
- [x] Rebase applied with **zero conflicts**.
- [x] Full unit suite on the rebased branch: **500 suites, 8678 passed, 3 skipped, 0 failed.**
- [x] `eslint` clean on both changed files.
- [x] Net diff vs `main` is only what DCON-5384 intends: `responseWriter.js` (+13) and `responseWriter.test.js` (+50). None of #2550's content reappears.

## Note for reviewers

The end state of `_write` calls `callback()` synchronously right after `response.write(chunk, encoding)`, so the Writable never waits for the socket to drain — backpressure is not honored on this path. That is not a regression from this PR: as the second commit documents, `compression` overrides `res.write` with a two-argument `function write (chunk, encoding)` (verified at `node_modules/compression/index.js:99`) that silently drops the third argument, so the callback passed to `response.write()` never fired in production anyway and only the unconditional second call ever ran. This PR preserves that behavior while removing the genuine double-invocation that occurred when compression was bypassed. Worth a separate ticket rather than widening this one.

JIRA: [DCON-5384](https://icanbwell.atlassian.net/browse/DCON-5384)


[DCON-5384]: https://icanbwell.atlassian.net/browse/DCON-5384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ