### PR TITLE
DCON-5398 Bump ip-address from 10.4.0 to 10.7.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7508,9 +7508,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.1.1":
-  version: 10.4.0
-  resolution: "ip-address@npm:10.4.0"
-  checksum: 10c0/d7b0bd2624fd861afbae6e49036a9b56f9506eaff7ff38592b7b4492dd5c272b53f5356dc8cc019e318acf29a96c90a3d1af1df761960267d23efa96858270fa
+  version: 10.7.0
+  resolution: "ip-address@npm:10.7.0"
+  checksum: 10c0/bb6f514708b84ec75ad4d8156f3d571a5b8e592a15359386100f4f8d7366a4b7723d54b88a30d80b3f51ca5f4dee239e94ef4b53765b9c41a8ea46b421307d14
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps `ip-address` from 10.4.0 to 10.7.0, resolving AIKIDO-2026-154096 and AIKIDO-2026-604326 (tracked in DCON-5398).
- Transitive dependency pulled in by `socks` (`^10.1.1`); bump stays within that declared range.
- No direct usage of `ip-address` or `socks` in `src/`.

## Test plan
- [ ] CI test suite passes