### PR TITLE
DCON-5452 Fix search-value escaping for $, comma, and pipe search parameters

### DIFF
--- a/docs/superpowers/plans/2026-09-06-search-value-escaping-plan.md
+++ b/docs/superpowers/plans/2026-09-06-search-value-escaping-plan.md
@@ -1,0 +1,873 @@
+# Search Value Escaping (`\$`, `\,`, `\|`, `\\`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every place this codebase splits a search value on `,`, `|`, or `$` respect
+backslash-escaping (`\,`, `\|`, `\$`, `\\`) per the FHIR search spec
+(https://hl7.org/fhir/R4B/search.html#escaping), instead of naively splitting on every literal
+occurrence of the character.
+
+**Architecture:** One new pure-function utility (`splitUnescaped` / `unescapeSearchValue`)
+replaces every existing naive `.split(',')` / `.split('|')` / `.split('$')` call site across
+`queryParameterValue.js`, `parsedArgsItem.js`, `querybuilder.util.js`, and
+`filters/composite.js`. Splitting never unescapes (so a later stage's escape marker survives);
+only the true leaf value (about to become a literal Mongo match/regex value) calls the unescape
+function, exactly once.
+
+**Tech Stack:** Node.js / CommonJS, Jest, MongoDB filter documents (no schema/index changes).
+
+**Spec:** `docs/superpowers/specs/2026-09-06-search-value-escaping-design.md`
+
+## Global Constraints
+
+- No unescaping happens until a string has finished all delimiter-splitting it will ever go
+  through — composite's `$`-split must NOT unescape `\|`/`\,`, since the token/quantity filters it
+  hands each component to still need those escape markers intact.
+- A lone trailing backslash, or a backslash followed by a character that isn't `$`/`,`/`|`/`\`, is
+  passed through literally — never throw for this.
+- Every new/modified function must have a docstring-level comment only where the *why* isn't
+  obvious from the code (per this repo's comment convention) — no restating what the code does.
+- Follow existing test file conventions exactly (see each task) — extend the existing test file
+  for a module, don't create a parallel one.
+
+---
+
+## Task 1: `searchValueEscaping.js` utility
+
+**Files:**
+- Create: `src/utils/searchValueEscaping.js`
+- Test: `src/tests/unit/utils/searchValueEscaping.test.js` (new)
+
+**Interfaces:**
+- Produces: `splitUnescaped(value: string, delimiter: string): string[]` and
+  `unescapeSearchValue(value: string): string`, both exported from
+  `src/utils/searchValueEscaping.js`. Every later task imports one or both of these.
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+const { describe, test, expect } = require('@jest/globals');
+const { splitUnescaped, unescapeSearchValue } = require('../../../utils/searchValueEscaping');
+
+describe('searchValueEscaping', () => {
+    describe('splitUnescaped', () => {
+        test('splits on an unescaped delimiter', () => {
+            expect(splitUnescaped('a,b', ',')).toEqual(['a', 'b']);
+        });
+
+        test('does not split on an escaped delimiter', () => {
+            expect(splitUnescaped('a\\,b', ',')).toEqual(['a\\,b']);
+        });
+
+        test('splits on a real delimiter after an escaped one', () => {
+            expect(splitUnescaped('a\\,b,c', ',')).toEqual(['a\\,b', 'c']);
+        });
+
+        test('treats an even run of backslashes before the delimiter as not escaping it', () => {
+            expect(splitUnescaped('a\\\\,b', ',')).toEqual(['a\\\\', 'b']);
+        });
+
+        test('treats an odd run of backslashes before the delimiter as escaping it', () => {
+            expect(splitUnescaped('a\\\\\\,b', ',')).toEqual(['a\\\\\\,b']);
+        });
+
+        test('only splits on the given delimiter, leaving other separator characters alone', () => {
+            expect(splitUnescaped('a|b,c', ',')).toEqual(['a|b', 'c']);
+        });
+
+        test('returns the original single-element array when there is no delimiter', () => {
+            expect(splitUnescaped('abc', ',')).toEqual(['abc']);
+        });
+
+        test('returns [value] unchanged for non-string input', () => {
+            expect(splitUnescaped(undefined, ',')).toEqual([undefined]);
+        });
+
+        test('handles an empty string', () => {
+            expect(splitUnescaped('', ',')).toEqual(['']);
+        });
+    });
+
+    describe('unescapeSearchValue', () => {
+        test('unescapes an escaped comma', () => {
+            expect(unescapeSearchValue('a\\,b')).toBe('a,b');
+        });
+
+        test('unescapes an escaped pipe', () => {
+            expect(unescapeSearchValue('a\\|b')).toBe('a|b');
+        });
+
+        test('unescapes an escaped dollar sign', () => {
+            expect(unescapeSearchValue('a\\$b')).toBe('a$b');
+        });
+
+        test('unescapes an escaped backslash', () => {
+            expect(unescapeSearchValue('a\\\\b')).toBe('a\\b');
+        });
+
+        test('collapses two consecutive escaped backslashes to two literal backslashes', () => {
+            expect(unescapeSearchValue('a\\\\\\\\b')).toBe('a\\\\b');
+        });
+
+        test('passes a trailing lone backslash through literally', () => {
+            expect(unescapeSearchValue('abc\\')).toBe('abc\\');
+        });
+
+        test('passes a backslash followed by a non-escapable character through literally', () => {
+            expect(unescapeSearchValue('a\\nb')).toBe('a\\nb');
+        });
+
+        test('returns non-string input unchanged', () => {
+            expect(unescapeSearchValue(undefined)).toBe(undefined);
+        });
+
+        test('handles an empty string', () => {
+            expect(unescapeSearchValue('')).toBe('');
+        });
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/unit/utils/searchValueEscaping.test.js`
+Expected: FAIL — `Cannot find module '../../../utils/searchValueEscaping'`
+
+- [ ] **Step 3: Write the implementation**
+
+```js
+/**
+ * Escape-aware splitting/unescaping for FHIR search values, per
+ * https://hl7.org/fhir/R4B/search.html#escaping — ',', '|', '$', and '\' are separator/escape
+ * characters; a literal occurrence of the first three must be backslash-escaped by the caller,
+ * and a literal '\' must be escaped as '\\'.
+ *
+ * A search value can pass through more than one delimiter-splitting stage before reaching a
+ * leaf use (e.g. a composite component: split on '$', then handed to a token filter that splits
+ * on '|'). splitUnescaped() never unescapes -- doing so early would destroy an escape marker a
+ * later stage still needs. Only unescapeSearchValue() actually converts escape sequences to
+ * literal characters, and it must be called exactly once, at the true leaf (the point where a
+ * string is about to become a literal Mongo match/regex value, with no further delimiter
+ * splitting ahead of it).
+ */
+
+const ESCAPABLE_CHARS = new Set(['$', ',', '|', '\\']);
+
+/**
+ * Splits `value` on every occurrence of `delimiter` that is not escaped -- a delimiter is
+ * escaped if it's preceded by an odd number of consecutive backslashes. Backslash sequences are
+ * left untouched in the returned parts (no unescaping here).
+ * @param {string} value
+ * @param {string} delimiter a single character
+ * @return {string[]}
+ */
+function splitUnescaped (value, delimiter) {
+    if (typeof value !== 'string') {
+        return [value];
+    }
+    const parts = [];
+    let current = '';
+    let backslashRun = 0;
+    for (let i = 0; i < value.length; i++) {
+        const ch = value[i];
+        if (ch === '\\') {
+            backslashRun++;
+            current += ch;
+            continue;
+        }
+        if (ch === delimiter && backslashRun % 2 === 0) {
+            parts.push(current);
+            current = '';
+        } else {
+            current += ch;
+        }
+        backslashRun = 0;
+    }
+    parts.push(current);
+    return parts;
+}
+
+/**
+ * Converts '\$', '\,', '\|', '\\' to their literal characters. A lone trailing backslash, or a
+ * backslash followed by a character that isn't one of the four escapable characters, is passed
+ * through literally rather than treated as an error -- rejecting it risks breaking a free-text
+ * value that happens to contain a backslash for unrelated reasons.
+ * @param {string} value
+ * @return {string}
+ */
+function unescapeSearchValue (value) {
+    if (typeof value !== 'string') {
+        return value;
+    }
+    let result = '';
+    for (let i = 0; i < value.length; i++) {
+        const ch = value[i];
+        if (ch === '\\' && i + 1 < value.length && ESCAPABLE_CHARS.has(value[i + 1])) {
+            result += value[i + 1];
+            i++;
+        } else {
+            result += ch;
+        }
+    }
+    return result;
+}
+
+module.exports = {
+    splitUnescaped,
+    unescapeSearchValue
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/unit/utils/searchValueEscaping.test.js`
+Expected: PASS (all 19 tests)
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+yarn run fix_lint
+git add src/utils/searchValueEscaping.js src/tests/unit/utils/searchValueEscaping.test.js
+git commit -m "Add escape-aware split/unescape utility for FHIR search values"
+```
+
+---
+
+## Task 2: `QueryParameterValue` — escape-aware comma handling
+
+**Files:**
+- Modify: `src/operations/query/queryParameterValue.js:30` and `:52`
+- Test: `src/tests/unit/operations/query/queryParameterValue.test.js` (extend)
+
+**Interfaces:**
+- Consumes: `splitUnescaped(value, ',')` from Task 1.
+- Produces: no interface change — `QueryParameterValue.values`/`.operator` now correctly treat an
+  escaped comma as non-splitting. Later tasks that call into `QueryParameterValue` are unaffected.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/tests/unit/operations/query/queryParameterValue.test.js`, inside the existing
+`describe('constructor', ...)` block:
+
+```js
+        test('does not set operator to $or when the only comma is escaped', () => {
+            const qpv = new QueryParameterValue({ value: 'Smith\\, John' });
+            expect(qpv.operator).toBe('$and');
+        });
+
+        test('still sets operator to $or when an unescaped comma follows an escaped one', () => {
+            const qpv = new QueryParameterValue({ value: 'Smith\\, John,Patient/2' });
+            expect(qpv.operator).toBe('$or');
+        });
+```
+
+Add a new top-level `describe('values (escaping)', ...)` block:
+
+```js
+    describe('values (escaping)', () => {
+        test('keeps an escaped comma inside a single value', () => {
+            const qpv = new QueryParameterValue({ value: 'Smith\\, John' });
+            expect(qpv.values).toEqual(['Smith\\, John']);
+        });
+
+        test('splits on an unescaped comma after an escaped one', () => {
+            const qpv = new QueryParameterValue({ value: 'Smith\\, John,Patient/2' });
+            expect(qpv.values).toEqual(['Smith\\, John', 'Patient/2']);
+        });
+    });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/unit/operations/query/queryParameterValue.test.js`
+Expected: FAIL — the two new constructor tests and the two new `values` tests report `$or` /
+extra-split results instead of the expected escape-aware ones.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/operations/query/queryParameterValue.js`, add the import at the top:
+
+```js
+const { splitUnescaped } = require('../../utils/searchValueEscaping');
+```
+
+Replace the constructor's operator-detection (currently line 30):
+
+```js
+        if (typeof value === 'string' && value.includes(',')) {
+            this.operator = '$or';
+        }
+```
+
+with:
+
+```js
+        if (typeof value === 'string' && splitUnescaped(value, ',').length > 1) {
+            this.operator = '$or';
+        }
+```
+
+Replace `parseQueryParameterValueIntoArrayIfNeeded`'s split (currently line 52):
+
+```js
+            const parts = queryParameterValue.split(',');
+```
+
+with:
+
+```js
+            const parts = splitUnescaped(queryParameterValue, ',');
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/unit/operations/query/queryParameterValue.test.js`
+Expected: PASS (all tests, including the 4 new ones)
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+yarn run fix_lint
+git add src/operations/query/queryParameterValue.js src/tests/unit/operations/query/queryParameterValue.test.js
+git commit -m "Make QueryParameterValue's comma-OR-split escape-aware"
+```
+
+---
+
+## Task 3: `ParsedArgsItem.applyModifierToQueryParameterValue` — escape-aware comma split
+
+**Files:**
+- Modify: `src/operations/query/parsedArgsItem.js:88`
+- Test: `src/tests/unit/operations/query/parsedArgsItem.test.js` (extend)
+
+**Interfaces:**
+- Consumes: `splitUnescaped(value, ',')` from Task 1.
+
+This function only runs when `this.propertyObj.target` includes one of the current `modifiers`
+(i.e. a reference-type search parameter with a `ResourceType:` modifier, e.g.
+`subject:Patient=Smith\, John`) — find the existing test(s) exercising
+`applyModifierToQueryParameterValue` to match the exact `propertyObj`/`modifiers` shape already
+used there before adding the new case.
+
+- [ ] **Step 1: Write the failing test**
+
+First, locate how the existing suite constructs a `ParsedArgsItem` that exercises
+`applyModifierToQueryParameterValue` (search the test file for `target:` in a `propertyObj`).
+Add a new test alongside it:
+
+```js
+    test('does not split an escaped comma when applying a target modifier', () => {
+        const item = new ParsedArgsItem({
+            queryParameter: 'subject',
+            queryParameterValue: new QueryParameterValue({ value: 'Smith\\, John' }),
+            propertyObj: new SearchParameterDefinition({
+                target: ['Patient'],
+                type: 'reference',
+                fields: ['subject'],
+                field: 'subject'
+            }),
+            modifiers: ['Patient']
+        });
+        expect(item.queryParameterValue.value).toEqual(['Patient/Smith\\, John']);
+    });
+```
+
+(Adjust the `SearchParameterDefinition` constructor args to match whatever shape the existing
+`target`-modifier test in this file already uses — reuse that exact pattern rather than
+inventing a new one.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/unit/operations/query/parsedArgsItem.test.js -t "does not split an escaped comma"`
+Expected: FAIL — value is split into `['Patient/Smith\\', 'Patient/ John']` (two elements) instead
+of one.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/operations/query/parsedArgsItem.js`, add the import at the top:
+
+```js
+const { splitUnescaped } = require('../../utils/searchValueEscaping');
+```
+
+Replace the split inside `applyModifierToQueryParameterValue` (currently):
+
+```js
+                const queryParameterValues = this.queryParameterValue.value.split(',');
+```
+
+with:
+
+```js
+                const queryParameterValues = splitUnescaped(this.queryParameterValue.value, ',');
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/unit/operations/query/parsedArgsItem.test.js`
+Expected: PASS (all tests, including the new one)
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+yarn run fix_lint
+git add src/operations/query/parsedArgsItem.js src/tests/unit/operations/query/parsedArgsItem.test.js
+git commit -m "Make ParsedArgsItem's target-modifier comma-split escape-aware"
+```
+
+---
+
+## Task 4: `querybuilder.util.js` — `tokenQueryBuilder` and `tokenQueryContainsBuilder`
+
+**Files:**
+- Modify: `src/utils/querybuilder.util.js` (`tokenQueryBuilder` ~line 147,
+  `tokenQueryContainsBuilder` ~line 225)
+- Test: `src/tests/unit/utils/querybuilder.util.test.js` (extend)
+
+**Interfaces:**
+- Consumes: `splitUnescaped`, `unescapeSearchValue` from Task 1.
+- Produces: no signature change to either function.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing `describe('tokenQueryBuilder', ...)` block:
+
+```js
+        test('unescapes an escaped pipe within the system portion', () => {
+            const result = tokenQueryBuilder({
+                target: 'http://x\\|y|actual-code',
+                type: 'code',
+                field: 'code.coding',
+                resourceType: 'Observation'
+            });
+            expect(result).toEqual({
+                'code.coding.system': 'http://x|y',
+                'code.coding.code': 'actual-code'
+            });
+        });
+
+        test('unescapes an escaped comma within the value portion (single value, not split)', () => {
+            const result = tokenQueryBuilder({
+                target: 'sys|a\\,b',
+                type: 'code',
+                field: 'code.coding',
+                resourceType: 'Observation'
+            });
+            expect(result).toEqual({
+                'code.coding.system': 'sys',
+                'code.coding.code': 'a,b'
+            });
+        });
+```
+
+Add to the existing `describe('tokenQueryContainsBuilder', ...)` block:
+
+```js
+        test('unescapes an escaped pipe within the system portion', () => {
+            const result = tokenQueryContainsBuilder({
+                target: 'http://x\\|y|actual',
+                type: 'code',
+                field: 'code.coding'
+            });
+            expect(result['code.coding.system'].$regex).toBe('http\\:\\/\\/x\\|y');
+        });
+
+        test('does not split an escaped comma within the value portion', () => {
+            const result = tokenQueryContainsBuilder({
+                target: 'a\\,b',
+                type: 'code',
+                field: 'code.coding'
+            });
+            expect(result['code.coding.code'].$regex).toBe('a\\,b');
+        });
+```
+
+(The exact expected `$regex` strings above must match whatever `escapeRegExp` produces for those
+inputs on this branch — run the test once, read the actual failure output, and correct the
+literal expected strings to match if they differ; the *behavior* under test — one unescaped
+value, not two — is what matters, not the exact regex-escaping output.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/unit/utils/querybuilder.util.test.js -t "unescapes an escaped"`
+Expected: FAIL — `system`/`code` end up split into extra pieces or still contain the backslash.
+
+- [ ] **Step 3: Write the implementation**
+
+Add the import near the top of `src/utils/querybuilder.util.js`:
+
+```js
+const { splitUnescaped, unescapeSearchValue } = require('./searchValueEscaping');
+```
+
+In `tokenQueryBuilder`, replace:
+
+```js
+    if (typeof target === 'string' && target.includes('|')) {
+        [system, value] = target.split('|');
+    } else {
+        value = target;
+    }
+```
+
+with:
+
+```js
+    if (typeof target === 'string' && target.includes('|')) {
+        [system, value] = splitUnescaped(target, '|').map(unescapeSearchValue);
+    } else {
+        value = typeof target === 'string' ? unescapeSearchValue(target) : target;
+    }
+```
+
+Leave the rest of `tokenQueryBuilder` unchanged (including its own `value.includes(',')` /
+`value.split(',')` for the `$in` case) — `value` is now already unescaped, so a literal comma
+that survived (because it was never escaped) still correctly means "multiple values" per FHIR's
+own token-list convention, and an escaped comma (`\,`) is already gone by this point, so it can
+no longer trigger that split at all. No further change needed there.
+
+Apply the identical pattern to `tokenQueryContainsBuilder` — replace:
+
+```js
+    if (typeof target === 'string' && target.includes('|')) {
+        [system, value] = target.split('|');
+    } else {
+        value = target;
+    }
+```
+
+with:
+
+```js
+    if (typeof target === 'string' && target.includes('|')) {
+        [system, value] = splitUnescaped(target, '|').map(unescapeSearchValue);
+    } else {
+        value = typeof target === 'string' ? unescapeSearchValue(target) : target;
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/unit/utils/querybuilder.util.test.js`
+Expected: PASS (full file, no regressions in the other ~15 describe blocks)
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+yarn run fix_lint
+git add src/utils/querybuilder.util.js src/tests/unit/utils/querybuilder.util.test.js
+git commit -m "Make tokenQueryBuilder/tokenQueryContainsBuilder's pipe-split escape-aware"
+```
+
+---
+
+## Task 5: `querybuilder.util.js` — `tokenIdentifierOfTypeQueryBuilder`, `extensionQueryBuilder`, `quantityQueryBuilder`
+
+**Files:**
+- Modify: `src/utils/querybuilder.util.js` (`tokenIdentifierOfTypeQueryBuilder` ~line 292,
+  `extensionQueryBuilder` ~line 1271, `quantityQueryBuilder` ~line 455)
+- Test: `src/tests/unit/utils/querybuilder.util.test.js` (extend)
+
+**Interfaces:**
+- Consumes: `splitUnescaped`, `unescapeSearchValue` from Task 1 (already imported in this file by
+  Task 4).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `describe('tokenIdentifierOfTypeQueryBuilder', ...)`:
+
+```js
+        test('unescapes an escaped pipe within one of the three parts', () => {
+            const result = tokenIdentifierOfTypeQueryBuilder({
+                target: 'http://x\\|y|SB|123456',
+                field: 'identifier'
+            });
+            expect(result.$and[0].identifier.$elemMatch['type.coding.system']).toBe('http://x|y');
+            expect(result.$and[0].identifier.$elemMatch['type.coding.code']).toBe('SB');
+            expect(result.$and[1]['identifier.value']).toBe('123456');
+        });
+```
+
+Add to `describe('extensionQueryBuilder', ...)`:
+
+```js
+        test('unescapes an escaped pipe within the url portion', () => {
+            const result = extensionQueryBuilder({
+                target: 'http://x\\|y|value',
+                type: 'valueString',
+                field: 'extension',
+                resourceType: 'Patient'
+            });
+            const elemMatch = result.extension.$elemMatch || result.extension;
+            expect(JSON.stringify(result)).toContain('http://x|y');
+            expect(JSON.stringify(result)).not.toContain('http://x\\\\|y');
+        });
+```
+
+Add to `describe('quantityQueryBuilder', ...)`:
+
+```js
+        test('unescapes an escaped pipe within the system portion', () => {
+            const result = quantityQueryBuilder({
+                target: '5.4|http://unitsofmeasure\\|org|mg',
+                field: 'valueQuantity'
+            });
+            expect(result['valueQuantity.system']).toBe('http://unitsofmeasure|org');
+            expect(result['valueQuantity.code']).toBe('mg');
+        });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/unit/utils/querybuilder.util.test.js -t "unescapes an escaped pipe"`
+Expected: FAIL for all three new tests — each currently mis-splits on the escaped pipe.
+
+- [ ] **Step 3: Write the implementation**
+
+In `tokenIdentifierOfTypeQueryBuilder`, replace:
+
+```js
+    let targetArray = target.split('|').filter((t) => t !== '');
+```
+
+with:
+
+```js
+    let targetArray = splitUnescaped(target, '|').map(unescapeSearchValue).filter((t) => t !== '');
+```
+
+In `extensionQueryBuilder`, replace:
+
+```js
+    if (typeof target === 'string' && target.includes('|')) {
+        [url, value] = target.split('|');
+    } else {
+        value = target;
+    }
+```
+
+with:
+
+```js
+    if (typeof target === 'string' && target.includes('|')) {
+        [url, value] = splitUnescaped(target, '|').map(unescapeSearchValue);
+    } else {
+        value = typeof target === 'string' ? unescapeSearchValue(target) : target;
+    }
+```
+
+In `quantityQueryBuilder`, replace:
+
+```js
+    // split by the two pipes
+    let [num, system, code] = target.split('|');
+```
+
+with:
+
+```js
+    // split by the two pipes
+    let [num, system, code] = splitUnescaped(target, '|');
+    if (system) {
+        system = unescapeSearchValue(system);
+    }
+    if (code) {
+        code = unescapeSearchValue(code);
+    }
+```
+
+(`num` is deliberately left un-unescaped — it's parsed as a number a few lines below via
+`Number(strNum)`/`isNaN(num)`, so it never legitimately contains an escape sequence, and running
+it through `unescapeSearchValue` would be a no-op for any valid numeric-with-prefix value anyway.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/unit/utils/querybuilder.util.test.js`
+Expected: PASS (full file)
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+yarn run fix_lint
+git add src/utils/querybuilder.util.js src/tests/unit/utils/querybuilder.util.test.js
+git commit -m "Make remaining querybuilder.util pipe-splits escape-aware"
+```
+
+---
+
+## Task 6: `FilterByComposite.filterOneValue` — escape-aware `$`-split
+
+**Files:**
+- Modify: `src/operations/query/filters/composite.js`
+- Test: `src/tests/unit/operations/query/filters/composite.test.js` (extend)
+
+**Interfaces:**
+- Consumes: `splitUnescaped` from Task 1. Deliberately does **not** call `unescapeSearchValue` —
+  each resulting component string is handed to `FilterByToken`/`FilterByQuantity`/etc. (via
+  `filterOneComponent`), which apply their own splitting/unescaping from Tasks 4-5.
+
+- [ ] **Step 1: Write the failing test**
+
+First read `src/tests/unit/operations/query/filters/composite.test.js` to find how it mocks
+`FilterByToken`/`FilterByString`/etc. and constructs a `propertyObj.scopes` fixture for a
+2-component, root-scope-only composite (mirrors the existing "root-only AND" test in that file).
+Add a new test using the same fixture shape:
+
+```js
+    test('does not split an escaped $ within a component value', () => {
+        // Using the same 2-component root-scope fixture as the "root-only AND" test above, but
+        // with a component value containing an escaped '$'.
+        const filter = createCompositeFilter({
+            /* same propertyObj.scopes fixture as the existing root-only test */
+        });
+        filter.parsedArg.queryParameterValue = new QueryParameterValue({
+            value: 'a\\$b$1234-5',
+            operator: '$and'
+        });
+
+        const result = filter.filter();
+
+        // The mocked first-component filter class must have been called with the single,
+        // unsplit value 'a\$b' (still escaped -- FilterByComposite must not unescape it itself),
+        // not two separate values from an incorrect 3-way split.
+        expect(mockFilterByStringInstanceFilter).toHaveBeenCalledTimes(1);
+    });
+```
+
+(Adapt variable/mock names — `createCompositeFilter`, `mockFilterByStringInstanceFilter` — to
+whatever the existing test file's helpers/mocks are actually named; reuse them exactly rather
+than inventing new ones.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/unit/operations/query/filters/composite.test.js -t "does not split an escaped"`
+Expected: FAIL — `filterOneValue` currently splits `'a\\$b$1234-5'` into three parts
+(`['a\\', 'b', '1234-5']`), so the mismatched-part-count check throws a `BadRequestError` instead
+of reaching the component filters at all.
+
+- [ ] **Step 3: Write the implementation**
+
+Add the import near the top of `src/operations/query/filters/composite.js`:
+
+```js
+const { splitUnescaped } = require('../../../utils/searchValueEscaping');
+```
+
+Replace, in `filterOneValue`:
+
+```js
+        const parts = value.split('$');
+```
+
+with:
+
+```js
+        const parts = splitUnescaped(value, '$');
+```
+
+No other change in this file — `filterOneComponent` already passes each part straight to the
+relevant `FilterClass`, which (as of Tasks 4-5) now unescapes `|`/`,` itself at its own leaf.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/unit/operations/query/filters/composite.test.js`
+Expected: PASS (full file, no regressions in the existing root/array/OR-of-scopes/genomics tests)
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+yarn run fix_lint
+git add src/operations/query/filters/composite.js src/tests/unit/operations/query/filters/composite.test.js
+git commit -m "Make FilterByComposite's \$-split escape-aware"
+```
+
+---
+
+## Task 7: End-to-end integration test
+
+**Files:**
+- Modify: `src/tests/integration/searchParameters/search_by_composite/search_by_composite.test.js`
+  (extend with one new test case — read the existing file first to match its fixture-loading and
+  assertion conventions exactly, e.g. how it loads `Observation` fixtures and issues the search
+  request)
+
+**Interfaces:**
+- Consumes: nothing new — this is a black-box HTTP/DB-backed test confirming Tasks 1-6 work
+  together.
+
+- [ ] **Step 1: Write the failing test**
+
+Add one new test to the existing suite: two `Observation` fixtures differing only in that one has
+a `code.coding.system` containing a literal pipe character (e.g. `http://example.org/sys|extra`)
+and the other doesn't. Search with
+`code-value-quantity=http://example.org/sys\|extra|8480-6$ge140` (the `\|` escaped so it's part
+of the system, not the system/code separator) and assert only the matching Observation is
+returned. Follow the exact request-building/assertion helpers the existing tests in this file
+already use (e.g. however they call the search endpoint and read `response.body.entry`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/integration/searchParameters/search_by_composite/search_by_composite.test.js -t "escaped"`
+Expected: FAIL before Tasks 1-6 land; since this task runs *after* them, expected: this new test
+should already PASS once written (it's a confirmation test, not a TDD-red step for new
+production code) — if it fails, one of Tasks 1-6 has a bug; stop and fix that task before
+proceeding.
+
+- [ ] **Step 3: Run the full test to confirm it passes**
+
+Run: `nvm use && node node_modules/.bin/jest src/tests/integration/searchParameters/search_by_composite/search_by_composite.test.js`
+Expected: PASS (full file)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tests/integration/searchParameters/search_by_composite/search_by_composite.test.js
+git commit -m "Add end-to-end test for escaped pipe within a composite token component"
+```
+
+---
+
+## Task 8: Documentation
+
+**Files:**
+- Modify: `readme/cheatsheet.md` (add a short escaping section near the existing
+  [1.9 Composite Search Parameters](#19-composite-search-parameters) section, which already
+  documents the `$`-joined composite syntax this escaping applies to)
+
+- [ ] **Step 1: Write the doc addition**
+
+Immediately after the existing "1.9 Composite Search Parameters" section's modifier-restrictions
+bullet list (the one ending "...return a 400 rather than silently producing an incorrect
+filter."), add:
+
+```markdown
+- If a component's own value needs to contain a literal `,`, `|`, or `$`, escape it with a
+  backslash (`\,`, `\|`, `\$`) per the FHIR spec's
+  [escaping rules](https://www.hl7.org/fhir/R4B/search.html#escaping) — e.g.
+  `code-value-quantity=http://example.org/sys\|extra|8480-6$ge140` searches for a token whose
+  system is literally `http://example.org/sys|extra`. This applies to every search parameter
+  type that uses `,`/`|` as a separator (token `system|code`, quantity `num|system|code`,
+  comma-separated OR values), not just composite parameters.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add readme/cheatsheet.md
+git commit -m "Document search value escaping in cheatsheet"
+```
+
+---
+
+## Self-Review Notes (for the plan author, not a task to execute)
+
+- **Spec coverage:** Task 1 covers the spec's "Key ordering insight" + utility design. Tasks 2-3
+  cover the `,` touch points. Tasks 4-5 cover all five `|` touch points identified in the spec
+  (note: the spec's Background section calls one of these a "canonical/reference builder" at
+  `querybuilder.util.js:1286` — that line is actually inside `extensionQueryBuilder`, used by
+  `FilterByToken` for `field === 'extension'`, not a separate canonical/reference function;
+  `FilterByCanonical` does no pipe-splitting at all. Task 5 uses the corrected function name).
+  Task 6 covers the `$` touch point. Task 7 covers the spec's Testing Plan's integration-test
+  item. Task 8 covers the spec's cheatsheet documentation item.
+- **Type consistency:** `splitUnescaped`/`unescapeSearchValue` signatures are identical across
+  every task that imports them.

--- a/docs/superpowers/specs/2026-09-06-search-value-escaping-design.md
+++ b/docs/superpowers/specs/2026-09-06-search-value-escaping-design.md
@@ -1,0 +1,150 @@
+# Search Value Escaping (`\$`, `\,`, `\|`, `\\`) — Design
+
+## Background
+
+Per the FHIR search spec (https://hl7.org/fhir/R4B/search.html#escaping), `,`, `|`, `$`, and `\`
+are all separator/escape characters. Any literal occurrence of one of the first three in a search
+value must be backslash-escaped (`\,`, `\|`, `\$`), and a literal backslash must be escaped as
+`\\`. Escaping must be undone before the value is matched.
+
+This server currently has three independent call sites that split on one of these characters with
+no escaping awareness at all:
+
+- **`,` (OR values)** — `QueryParameterValue.parseQueryParameterValueIntoArrayIfNeeded`
+  (`src/operations/query/queryParameterValue.js:52`) and
+  `ParsedArgsItem.applyModifierToQueryParameterValue`
+  (`src/operations/query/parsedArgsItem.js:88`) both do a plain `.split(',')`. This affects every
+  search parameter type — a `string` value containing a literal comma, e.g. `name=Smith, John`, is
+  silently split into two OR'd values today.
+- **`|` (token `system|code`, quantity `num|system|code`, canonical `url|version`)** —
+  `src/utils/querybuilder.util.js` does a plain `.split('|')` in five places:
+  `tokenQueryBuilder` (:162), `tokenQueryContainsBuilder` (:240, plus a nested `.split(',')` on the
+  value portion at :295), `tokenIdentifierOfTypeQueryBuilder` (:crossed via the `:295` shared split),
+  `quantityQueryBuilder` (:461), and a canonical/reference builder (:1286).
+- **`$` (composite components)** — `FilterByComposite.filterOneValue`
+  (`src/operations/query/filters/composite.js`, added by #2483) does `value.split('$')` with no
+  escaping either. #2483's own design doc dismissed this ("no component type ... legitimately
+  produces a literal `$` in its own value syntax today"), but that only considered `$` in
+  isolation — it didn't account for the fact that a composite component's value is itself a
+  token/string/quantity value that flows through the `,`/`|`-splitting call sites above, which
+  *do* have realistic literal-value collisions (a token code containing a pipe, a string value
+  containing a comma).
+
+Net effect: any search value containing a literal `,`, `|`, or (post-#2483) `$` that the caller
+correctly escaped per spec gets silently mis-split into the wrong number of parts, either
+producing a wrong/narrower result set or (for composite) a `BadRequestError` from the component
+count check.
+
+## Scope
+
+Fix all three separators generically, in the shared splitting/leaf-value layer, so every current
+and future caller of these functions benefits with no caller-specific code. This necessarily
+touches `queryParameterValue.js`, `parsedArgsItem.js`, `querybuilder.util.js`, and
+`FilterByComposite` together — fixing `$` alone (composite's own gap) isn't possible in isolation,
+since a composite component's value is handed to the exact same token/quantity functions that also
+need the `|`/`,` fix.
+
+Out of scope: stemming/fuzzy/thesaurus matching, and any Mongo query-shape change beyond correct
+escaping of the value itself (that's `_text`/`_content`, a separate stacked PR).
+
+## Key ordering insight
+
+A value can pass through *multiple* splitting stages before reaching a leaf use (e.g. a composite
+component: `$`-split, then handed to `tokenQueryBuilder`, which `|`-splits it, whose value part may
+then be `,`-split again for `:contains`). Unescaping too early destroys an escape marker a later
+stage still needs — e.g. unescaping `\|` to a literal `|` right after the `$`-split would cause the
+subsequent `|`-split to wrongly break the token value.
+
+The fix: every split becomes **escape-aware but non-unescaping** (skip delimiter occurrences
+preceded by an odd number of backslashes; leave all backslash sequences in the output parts
+untouched). Only the true leaf — the point where a string is about to become a literal
+`$regex`/exact-match value with no further delimiter-splitting ahead of it — calls a single
+**unescape** pass that converts `\$`, `\,`, `\|`, `\\` to their literal characters.
+
+## Approach
+
+**Chosen:** one shared utility module, `src/utils/searchValueEscaping.js`, with two functions:
+
+- `splitUnescaped(value, delimiter)` — escape-aware split, as described above. Replaces every
+  `.split(',')` / `.split('|')` / `.split('$')` call site in scope.
+- `unescapeSearchValue(value)` — single final unescape pass. Called once per leaf string, at each
+  call site's terminal value(s) only.
+
+**Alternatives considered:**
+- *Unescape immediately after each split* — rejected: breaks multi-stage values (composite
+  components, token `:contains` sub-values) as described above.
+- *Single global find-replace on the raw query string before any parsing* — rejected: can't
+  distinguish which separator's escape belongs to which stage without already knowing the parse
+  structure, and would break composite's reuse of the same string through multiple independent
+  modules.
+
+## Architecture & Components
+
+1. **`src/utils/searchValueEscaping.js`** (new) — `splitUnescaped`, `unescapeSearchValue`.
+2. **`src/operations/query/queryParameterValue.js`** — `parseQueryParameterValueIntoArrayIfNeeded`
+   uses `splitUnescaped(value, ',')` instead of `.split(',')`. Values are still raw (unescaped) at
+   this point — each one may need further `|`/`$` splitting downstream.
+3. **`src/operations/query/parsedArgsItem.js`** — `applyModifierToQueryParameterValue`'s
+   `.split(',')` gets the same treatment.
+4. **`src/utils/querybuilder.util.js`** — all five `.split('|')` sites switch to
+   `splitUnescaped(target, '|')`; `tokenQueryContainsBuilder`'s nested `.split(',')` on the value
+   portion switches to `splitUnescaped(value, ',')`. Every terminal `system`/`value`/`code`/`url`
+   string gets `unescapeSearchValue(...)` applied once, immediately before use in a
+   `$regex`/exact-match condition (this is the leaf for these functions — nothing splits on these
+   strings again after this point).
+5. **`src/operations/query/filters/composite.js`** — `filterOneValue`'s `value.split('$')` becomes
+   `splitUnescaped(value, '$')`. No `unescapeSearchValue` call here — each resulting component
+   string is handed to `FilterByToken`/`FilterByQuantity`/etc., which apply their own splitting and
+   unescaping per point 4.
+6. **`readme/cheatsheet.md`** — add a short section documenting escaping support (mirrors #2483
+   adding composite-value-syntax documentation there).
+
+## Data Flow
+
+**Token search with an escaped pipe in the code:** `code=http://x\|y|actual-code`
+```
+QueryParameterValue: splitUnescaped(..., ',') -> single value, no comma -> unchanged
+tokenQueryBuilder: splitUnescaped(target, '|') -> ['http://x\|y', 'actual-code']
+  unescapeSearchValue('http://x\|y') -> 'http://x|y'   (system)
+  unescapeSearchValue('actual-code') -> 'actual-code'  (value)
+```
+
+**Composite component with an escaped comma in a string value:**
+`name-and-code=Smith\, John$1234-5`
+```
+QueryParameterValue: splitUnescaped(..., ',') -> single value (the internal \, is not a bare ',')
+FilterByComposite.filterOneValue: splitUnescaped(value, '$') -> ['Smith\, John', '1234-5']
+  component 1 (string) -> FilterByString -> stringQueryBuilder receives 'Smith\, John' raw;
+    (string values don't split on ',' today, so no change needed there — just confirm
+    unescapeSearchValue is applied before the $regex is built)
+  component 2 (token) -> FilterByToken -> as above
+```
+
+## Error Handling
+
+- A lone trailing backslash, or a backslash followed by a character that isn't `$`, `,`, `|`, or
+  `\`, is passed through literally (lenient) rather than throwing — treating it as a `BadRequestError`
+  risks rejecting free-text values that happen to contain a backslash for unrelated reasons.
+- No behavior change to existing `BadRequestError` cases (e.g. composite's mismatched part count) —
+  those still fire, just on the correctly-split part count now.
+
+## Testing Plan
+
+1. **Unit tests** — `src/tests/unit/utils/searchValueEscaping.test.js` (new): escaped delimiter,
+   unescaped delimiter, consecutive escapes (`\\$`), trailing lone backslash, multiple delimiters
+   in one value, empty string.
+2. **`querybuilder.util.js` tests** — extend existing unit tests for `tokenQueryBuilder`,
+   `tokenQueryContainsBuilder`, `quantityQueryBuilder`, and the canonical builder with
+   escaped-separator cases.
+3. **`FilterByComposite` tests** — extend `src/tests/unit/operations/query/filters/composite.test.js`
+   with a component value containing an escaped `$`, and (via a string/token component) an escaped
+   `,`/`|`.
+4. **Integration tests** — one end-to-end case per affected search parameter type (token, quantity,
+   composite) using a real escaped value against Mongo Memory Server, confirming it now narrows
+   correctly instead of mis-splitting.
+
+## Out of Scope
+
+- `_text`/`_content` full-text search — separate stacked PR.
+- Any new query capability beyond correct escaping (no fuzzy matching, no relevance scoring).
+- ClickHouse analytics query path — not touched by this design.

--- a/readme/cheatsheet.md
+++ b/readme/cheatsheet.md
@@ -208,6 +208,13 @@ A composite search parameter combines two or more related component values into 
 - Each part must be non-empty (a trailing or missing `$` part, e.g. `code-value-quantity=55284-4$`, returns a 400).
 - The `missing`, `contains`, `above`, `below`, `text`, `of-type`, and `exact` modifiers are not supported on composite parameters and return a 400 rather than silently producing an incorrect filter.
 - The same composite parameters are also available via [GraphQL](graphql.md) (e.g. `code_value_quantity: { value: "55284-4$ge140" }`) and via MCP tool calls (same `'$'`-joined string), with identical semantics.
+- If a component's own value needs to contain a literal `,`, `|`, or `$`, escape it with a
+  backslash (`\,`, `\|`, `\$`) per the FHIR spec's
+  [escaping rules](https://www.hl7.org/fhir/R4B/search.html#escaping) — e.g.
+  `code-value-quantity=http://example.org/sys\|extra|8480-6$ge140` searches for a token whose
+  system is literally `http://example.org/sys|extra`. This applies to every search parameter
+  type that uses `,`/`|` as a separator (token `system|code`, quantity `num|system|code`,
+  comma-separated OR values), not just composite parameters.
 
 FHIR specification: https://www.hl7.org/fhir/R4B/search.html#composite
 

--- a/src/operations/query/filters/composite.js
+++ b/src/operations/query/filters/composite.js
@@ -1,4 +1,5 @@
 const { BadRequestError } = require('../../../utils/httpErrors');
+const { splitUnescaped } = require('../../../utils/searchValueEscaping');
 const { BaseFilter } = require('./baseFilter');
 const { FilterParameters } = require('./filterParameters');
 const { FieldMapper } = require('./fieldMapper');
@@ -73,7 +74,7 @@ class FilterByComposite extends BaseFilter {
      * @return {import('mongodb').Filter<import('mongodb').DefaultSchema>}
      */
     filterOneValue(value) {
-        const parts = value.split('$');
+        const parts = splitUnescaped(value, '$');
         if (parts.some((p) => !p || !p.trim())) {
             throw new BadRequestError(
                 new Error(

--- a/src/operations/query/filters/string.js
+++ b/src/operations/query/filters/string.js
@@ -1,4 +1,5 @@
 const { nameQueryBuilder, addressQueryBuilder, stringQueryBuilder } = require('../../../utils/querybuilder.util');
+const { unescapeSearchValue } = require('../../../utils/searchValueEscaping');
 const { BaseFilter } = require('./baseFilter');
 
 /**
@@ -22,7 +23,7 @@ class FilterByString extends BaseFilter {
             const ors = addressQueryBuilder({ target: value, useExactSearch: useExactSearch });
             return { $or: ors };
         } else {
-            return useExactSearch ? { [this.fieldMapper.getFieldName(field)]: value } : { [`${this.fieldMapper.getFieldName(field)}`]: stringQueryBuilder({ target: value }) };
+            return useExactSearch ? { [this.fieldMapper.getFieldName(field)]: unescapeSearchValue(value) } : { [`${this.fieldMapper.getFieldName(field)}`]: stringQueryBuilder({ target: value }) };
         }
     }
 }

--- a/src/operations/query/parsedArgsItem.js
+++ b/src/operations/query/parsedArgsItem.js
@@ -98,6 +98,12 @@ class ParsedArgsItem {
         });
 
         if (modifiedQueryParameterValues.length) {
+            // .join() (plain ',') is not a true inverse of the escape-aware splitUnescaped()
+            // used above: if a value ended in an odd number of trailing backslashes, the comma
+            // this inserts would misread as escaped on the next split. Not fixed with proper
+            // escaping here because these values are always `${modifier}/${id}` or a bare id,
+            // and real FHIR ids can only contain [A-Za-z0-9-.] (REGEX.ID_FIELD, constants.js) --
+            // never a backslash -- so no real query can trigger this asymmetry.
             this.queryParameterValue = new QueryParameterValue({
                 value: modifiedQueryParameterValues.join(), operator: this.queryParameterValue.operator
             });

--- a/src/operations/query/parsedArgsItem.js
+++ b/src/operations/query/parsedArgsItem.js
@@ -4,6 +4,7 @@ const { QueryParameterValue } = require('./queryParameterValue');
 const { SearchParameterDefinition } = require('../../searchParameters/searchParameterTypes');
 const { ReferenceParser } = require('../../utils/referenceParser');
 const { removeNull } = require('../../utils/nullRemover');
+const { splitUnescaped } = require('../../utils/searchValueEscaping');
 
 /**
  * @classdesc This class holds the parsed structure for an arg on the url
@@ -85,7 +86,7 @@ class ParsedArgsItem {
         const modifiedQueryParameterValues = [];
         this.modifiers.forEach(modifier => {
             if (this.propertyObj.target && this.propertyObj.target.includes(modifier) && this.queryParameterValue.value) {
-                const queryParameterValues = this.queryParameterValue.value.split(',');
+                const queryParameterValues = splitUnescaped(this.queryParameterValue.value, ',');
                 queryParameterValues.forEach(value => {
                     if (value && value.includes('/')) {
                         modifiedQueryParameterValues.push(`${value}`);

--- a/src/operations/query/queryParameterValue.js
+++ b/src/operations/query/queryParameterValue.js
@@ -6,6 +6,7 @@
  **/
 const { assertIsValid } = require('../../utils/assertType');
 const { removeNull } = require('../../utils/nullRemover');
+const { splitUnescaped } = require('../../utils/searchValueEscaping');
 
 class QueryParameterValue {
     /**
@@ -27,7 +28,7 @@ class QueryParameterValue {
          * @type {QueryParameterType}
          */
         this.operator = operator;
-        if (typeof value === 'string' && value.includes(',')) {
+        if (typeof value === 'string' && splitUnescaped(value, ',').length > 1) {
             this.operator = '$or';
         }
         assertIsValid(['$or', '$and'].includes(operator), `operator ${operator} is not in $or, $and`);
@@ -49,7 +50,7 @@ class QueryParameterValue {
         if (
             typeof queryParameterValue === 'string'
         ) {
-            const parts = queryParameterValue.split(',');
+            const parts = splitUnescaped(queryParameterValue, ',');
             if (parts.length > 1) {
                 return parts;
             }

--- a/src/tests/unit/operations/query/filters/composite.test.js
+++ b/src/tests/unit/operations/query/filters/composite.test.js
@@ -160,6 +160,31 @@ describe('FilterByComposite', () => {
         expect(variantCondition.variant.$elemMatch.$and).toHaveLength(2);
     });
 
+    test('does not split an escaped $ within a component value', () => {
+        const component1 = new SearchParameterDefinition({
+            type: 'token',
+            field: 'code',
+            fieldType: 'CodeableConcept'
+        });
+        const component2 = new SearchParameterDefinition({
+            type: 'quantity',
+            field: 'valueQuantity'
+        });
+        const composite = makeComposite([{ components: [component1, component2] }]);
+        // 'a\$b' must stay one $-delimited part (unescaped to 'a$b' by tokenQueryBuilder), not
+        // get mis-split into ['a\\', 'b', 'ge140'] (3 parts against a 2-component composite,
+        // which would throw a mismatched-part-count BadRequestError instead).
+        const result = makeFilter(composite, { value: 'a\\$b$ge140' }).filter();
+        expect(result).toHaveLength(1);
+        const [
+            {
+                $and: [andSegments]
+            }
+        ] = result;
+        expect(JSON.stringify(andSegments)).toContain('a$b');
+        expect(JSON.stringify(andSegments)).not.toContain('a\\\\$b');
+    });
+
     test('mismatched $-part count throws BadRequestError', () => {
         const component1 = new SearchParameterDefinition({ type: 'token', field: 'code' });
         const component2 = new SearchParameterDefinition({

--- a/src/tests/unit/operations/query/filters/string.test.js
+++ b/src/tests/unit/operations/query/filters/string.test.js
@@ -46,6 +46,12 @@ describe('FilterByString', () => {
         expect(result.name).toBe('Smith');
     });
 
+    test('exact modifier unescapes an escaped comma so it matches the literal value', () => {
+        const filter = createFilter(null, ['exact']);
+        const result = filter.filterByItem('name', 'Smith\\, Jones');
+        expect(result.name).toBe('Smith, Jones');
+    });
+
     test('HumanName field uses nameQueryBuilder with $or', () => {
         const filter = createFilter('HumanName');
         const result = filter.filterByItem('name', 'Smith');

--- a/src/tests/unit/operations/query/parsedArgsItem.test.js
+++ b/src/tests/unit/operations/query/parsedArgsItem.test.js
@@ -151,6 +151,16 @@ describe('ParsedArgsItem', () => {
             expect(item.queryParameterValue.value).toContain('Patient/456');
         });
 
+        test('does not split an escaped comma when applying a target modifier', () => {
+            const item = createParsedArgsItem({
+                value: 'Smith\\, John',
+                target: ['Patient'],
+                modifiers: ['Patient']
+            });
+
+            expect(item.queryParameterValue.value).toBe('Patient/Smith\\, John');
+        });
+
         test('does NOT prepend resourceType to values already containing a slash', () => {
             const item = createParsedArgsItem({
                 value: 'Practitioner/789,123',

--- a/src/tests/unit/operations/query/queryParameterValue.test.js
+++ b/src/tests/unit/operations/query/queryParameterValue.test.js
@@ -38,6 +38,28 @@ describe('QueryParameterValue', () => {
             const qpv = new QueryParameterValue({ value: 'a,b', operator: '$and' });
             expect(qpv.operator).toBe('$or');
         });
+
+        test('does not set operator to $or when the only comma is escaped', () => {
+            const qpv = new QueryParameterValue({ value: 'Smith\\, John' });
+            expect(qpv.operator).toBe('$and');
+        });
+
+        test('still sets operator to $or when an unescaped comma follows an escaped one', () => {
+            const qpv = new QueryParameterValue({ value: 'Smith\\, John,Patient/2' });
+            expect(qpv.operator).toBe('$or');
+        });
+    });
+
+    describe('values (escaping)', () => {
+        test('keeps an escaped comma inside a single value', () => {
+            const qpv = new QueryParameterValue({ value: 'Smith\\, John' });
+            expect(qpv.values).toEqual(['Smith\\, John']);
+        });
+
+        test('splits on an unescaped comma after an escaped one', () => {
+            const qpv = new QueryParameterValue({ value: 'Smith\\, John,Patient/2' });
+            expect(qpv.values).toEqual(['Smith\\, John', 'Patient/2']);
+        });
     });
 
     describe('values getter', () => {

--- a/src/tests/unit/utils/querybuilder.util.test.js
+++ b/src/tests/unit/utils/querybuilder.util.test.js
@@ -366,6 +366,12 @@ describe('querybuilder.util', () => {
             expect(result['vQ.value']).toHaveProperty('$exists', true);
             expect(result['vQ.value'].$not).toHaveProperty('$gte');
         });
+
+        test('unescapes an escaped pipe within the system portion', () => {
+            const result = quantityQueryBuilder({ target: '5.4|http://unitsofmeasure\\|org|mg', field: 'vQ' });
+            expect(result['vQ.system']).toBe('http://unitsofmeasure|org');
+            expect(result['vQ.code']).toBe('mg');
+        });
     });
 
     // ========== dateQueryBuilder (largest method) ==========
@@ -595,6 +601,12 @@ describe('querybuilder.util', () => {
         test('required overrides url', () => {
             const result = extensionQueryBuilder({ target: 'http://x|val', type: 'valueString', field: 'extension', required: 'http://override', resourceType: 'Patient' });
             expect(result.extension.$elemMatch.url).toBe('http://override');
+        });
+
+        test('unescapes an escaped pipe within the url portion', () => {
+            const result = extensionQueryBuilder({ target: 'http://x\\|y|val', type: 'valueString', field: 'extension', resourceType: 'Patient' });
+            expect(result.extension.$elemMatch.url).toBe('http://x|y');
+            expect(result.extension.$elemMatch.valueString).toBe('val');
         });
     });
 });

--- a/src/tests/unit/utils/querybuilder.util.test.js
+++ b/src/tests/unit/utils/querybuilder.util.test.js
@@ -183,6 +183,14 @@ describe('querybuilder.util', () => {
             expect(result.coding.$elemMatch.system).toBe('sys');
             expect(result.coding.$elemMatch.code).toBe('a,b');
         });
+
+        test('a value-only target whose only pipe is escaped is not mistaken for system|value', () => {
+            // 'a\|b' means the literal value 'a|b' with no system -- must NOT be split into
+            // system='a|b'/value=undefined just because the raw string contains a '|' character.
+            const result = tokenQueryBuilder({ target: 'a\\|b', type: 'code', field: 'coding', resourceType: 'Observation' });
+            expect(result['coding.code']).toBe('a|b');
+            expect(result['coding.system']).toBeUndefined();
+        });
     });
 
     // ========== tokenQueryContainsBuilder ==========
@@ -213,6 +221,12 @@ describe('querybuilder.util', () => {
         test('does not split an escaped comma within the value portion', () => {
             const result = tokenQueryContainsBuilder({ target: 'a\\,b', type: 'value', field: 'identifier' });
             expect(result['identifier.value'].$regex).toBe('a,b');
+        });
+
+        test('a value-only target whose only pipe is escaped is not mistaken for system|value', () => {
+            const result = tokenQueryContainsBuilder({ target: 'a\\|b', type: 'value', field: 'identifier' });
+            expect(result['identifier.value'].$regex).toBe('a\\|b');
+            expect(result['identifier.system']).toBeUndefined();
         });
     });
 
@@ -622,6 +636,12 @@ describe('querybuilder.util', () => {
             const result = extensionQueryBuilder({ target: 'http://x\\|y|val', type: 'valueString', field: 'extension', resourceType: 'Patient' });
             expect(result.extension.$elemMatch.url).toBe('http://x|y');
             expect(result.extension.$elemMatch.valueString).toBe('val');
+        });
+
+        test('a value-only target whose only pipe is escaped is not mistaken for url|value', () => {
+            const result = extensionQueryBuilder({ target: 'a\\|b', type: 'valueString', field: 'extension', resourceType: 'Patient' });
+            expect(result['extension.valueString']).toBe('a|b');
+            expect(result['extension.url']).toBeUndefined();
         });
     });
 });

--- a/src/tests/unit/utils/querybuilder.util.test.js
+++ b/src/tests/unit/utils/querybuilder.util.test.js
@@ -58,6 +58,11 @@ describe('querybuilder.util', () => {
             const result = stringQueryBuilder({ target: 'ABC' });
             expect(result.$regex.flags).toContain('i');
         });
+
+        test('unescapes an escaped comma so a literal comma in the value actually matches', () => {
+            const result = stringQueryBuilder({ target: 'Foo\\, Bar' });
+            expect(result.$regex.test('Foo, Bar')).toBe(true);
+        });
     });
 
     // ========== addressQueryBuilder ==========
@@ -260,6 +265,16 @@ describe('querybuilder.util', () => {
         test('boolean target is set directly', () => {
             const result = exactMatchQueryBuilder({ target: true, field: 'active' });
             expect(result).toEqual({ active: true });
+        });
+
+        test('does not split an escaped comma, and unescapes it in the single-value result', () => {
+            const result = exactMatchQueryBuilder({ target: 'Foo\\, Bar', field: 'title' });
+            expect(result).toEqual({ title: 'Foo, Bar' });
+        });
+
+        test('unescapes each value of a real comma-separated $in list', () => {
+            const result = exactMatchQueryBuilder({ target: 'a\\,b,c', field: 'title' });
+            expect(result.title).toEqual({ $in: ['a,b', 'c'] });
         });
     });
 

--- a/src/tests/unit/utils/querybuilder.util.test.js
+++ b/src/tests/unit/utils/querybuilder.util.test.js
@@ -166,6 +166,18 @@ describe('querybuilder.util', () => {
             expect(result.coding.$elemMatch.system).toBe('sys');
             expect(result.coding.$elemMatch.value).toBe('val');
         });
+
+        test('unescapes an escaped pipe within the system portion', () => {
+            const result = tokenQueryBuilder({ target: 'http://x\\|y|actual-code', type: 'code', field: 'coding', resourceType: 'Observation' });
+            expect(result.coding.$elemMatch.system).toBe('http://x|y');
+            expect(result.coding.$elemMatch.code).toBe('actual-code');
+        });
+
+        test('unescapes an escaped comma within the value portion (single value, not split)', () => {
+            const result = tokenQueryBuilder({ target: 'sys|a\\,b', type: 'code', field: 'coding', resourceType: 'Observation' });
+            expect(result.coding.$elemMatch.system).toBe('sys');
+            expect(result.coding.$elemMatch.code).toBe('a,b');
+        });
     });
 
     // ========== tokenQueryContainsBuilder ==========
@@ -186,6 +198,17 @@ describe('querybuilder.util', () => {
             expect(result.identifier.$elemMatch.system).toHaveProperty('$regex');
             expect(result.identifier.$elemMatch.value).toHaveProperty('$regex');
         });
+
+        test('unescapes an escaped pipe within the system portion, not splitting on it', () => {
+            const result = tokenQueryContainsBuilder({ target: 'http://x\\|y|actual', type: 'value', field: 'identifier' });
+            expect(result.identifier.$elemMatch.system.$regex).toBe('http://x\\|y');
+            expect(result.identifier.$elemMatch.value.$regex).toBe('actual');
+        });
+
+        test('does not split an escaped comma within the value portion', () => {
+            const result = tokenQueryContainsBuilder({ target: 'a\\,b', type: 'value', field: 'identifier' });
+            expect(result['identifier.value'].$regex).toBe('a,b');
+        });
     });
 
     // ========== tokenIdentifierOfTypeQueryBuilder ==========
@@ -202,6 +225,13 @@ describe('querybuilder.util', () => {
             expect(result.$and[0].identifier.$elemMatch['type.coding.system']).toBe('sys');
             expect(result.$and[0].identifier.$elemMatch['type.coding.code']).toBe('code');
             expect(result.$and[1]['identifier.value']).toBe('val');
+        });
+
+        test('unescapes an escaped pipe within one of the three parts', () => {
+            const result = tokenIdentifierOfTypeQueryBuilder({ target: 'http://x\\|y|SB|123456', field: 'identifier' });
+            expect(result.$and[0].identifier.$elemMatch['type.coding.system']).toBe('http://x|y');
+            expect(result.$and[0].identifier.$elemMatch['type.coding.code']).toBe('SB');
+            expect(result.$and[1]['identifier.value']).toBe('123456');
         });
     });
 

--- a/src/tests/unit/utils/searchValueEscaping.test.js
+++ b/src/tests/unit/utils/searchValueEscaping.test.js
@@ -1,0 +1,80 @@
+const { describe, test, expect } = require('@jest/globals');
+const { splitUnescaped, unescapeSearchValue } = require('../../../utils/searchValueEscaping');
+
+describe('searchValueEscaping', () => {
+    describe('splitUnescaped', () => {
+        test('splits on an unescaped delimiter', () => {
+            expect(splitUnescaped('a,b', ',')).toEqual(['a', 'b']);
+        });
+
+        test('does not split on an escaped delimiter', () => {
+            expect(splitUnescaped('a\\,b', ',')).toEqual(['a\\,b']);
+        });
+
+        test('splits on a real delimiter after an escaped one', () => {
+            expect(splitUnescaped('a\\,b,c', ',')).toEqual(['a\\,b', 'c']);
+        });
+
+        test('treats an even run of backslashes before the delimiter as not escaping it', () => {
+            expect(splitUnescaped('a\\\\,b', ',')).toEqual(['a\\\\', 'b']);
+        });
+
+        test('treats an odd run of backslashes before the delimiter as escaping it', () => {
+            expect(splitUnescaped('a\\\\\\,b', ',')).toEqual(['a\\\\\\,b']);
+        });
+
+        test('only splits on the given delimiter, leaving other separator characters alone', () => {
+            expect(splitUnescaped('a|b,c', ',')).toEqual(['a|b', 'c']);
+        });
+
+        test('returns the original single-element array when there is no delimiter', () => {
+            expect(splitUnescaped('abc', ',')).toEqual(['abc']);
+        });
+
+        test('returns [value] unchanged for non-string input', () => {
+            expect(splitUnescaped(undefined, ',')).toEqual([undefined]);
+        });
+
+        test('handles an empty string', () => {
+            expect(splitUnescaped('', ',')).toEqual(['']);
+        });
+    });
+
+    describe('unescapeSearchValue', () => {
+        test('unescapes an escaped comma', () => {
+            expect(unescapeSearchValue('a\\,b')).toBe('a,b');
+        });
+
+        test('unescapes an escaped pipe', () => {
+            expect(unescapeSearchValue('a\\|b')).toBe('a|b');
+        });
+
+        test('unescapes an escaped dollar sign', () => {
+            expect(unescapeSearchValue('a\\$b')).toBe('a$b');
+        });
+
+        test('unescapes an escaped backslash', () => {
+            expect(unescapeSearchValue('a\\\\b')).toBe('a\\b');
+        });
+
+        test('collapses two consecutive escaped backslashes to two literal backslashes', () => {
+            expect(unescapeSearchValue('a\\\\\\\\b')).toBe('a\\\\b');
+        });
+
+        test('passes a trailing lone backslash through literally', () => {
+            expect(unescapeSearchValue('abc\\')).toBe('abc\\');
+        });
+
+        test('passes a backslash followed by a non-escapable character through literally', () => {
+            expect(unescapeSearchValue('a\\nb')).toBe('a\\nb');
+        });
+
+        test('returns non-string input unchanged', () => {
+            expect(unescapeSearchValue(undefined)).toBe(undefined);
+        });
+
+        test('handles an empty string', () => {
+            expect(unescapeSearchValue('')).toBe('');
+        });
+    });
+});

--- a/src/utils/querybuilder.util.js
+++ b/src/utils/querybuilder.util.js
@@ -4,6 +4,7 @@
 
 const moment = require('moment-timezone');
 const { escapeRegExp } = require('./regexEscaper');
+const { splitUnescaped, unescapeSearchValue } = require('./searchValueEscaping');
 const { BadRequestError } = require('./httpErrors');
 const { FhirTypesManager } = require('../fhir/fhirTypesManager');
 /**
@@ -159,7 +160,9 @@ const tokenQueryBuilder = function ({ target, type, field, required, exists_flag
     }
 
     if (typeof target === 'string' && target.includes('|')) {
-        [system, value] = target.split('|');
+        // splitUnescaped only, never unescapeSearchValue here -- `value` may still need its own
+        // comma-split below, which must see any escaped comma still escaped.
+        [system, value] = splitUnescaped(target, '|');
     } else {
         value = target;
     }
@@ -170,13 +173,14 @@ const tokenQueryBuilder = function ({ target, type, field, required, exists_flag
 
     const queryBuilderElementMatch = {};
     if (system) {
+        system = unescapeSearchValue(system);
         queryBuilder[`${field}.system`] = system;
         queryBuilderElementMatch.system = system;
     }
 
     if (value) {
-        if (typeof value === 'string' && value.includes(',')) {
-            const values = value.split(',');
+        if (typeof value === 'string' && splitUnescaped(value, ',').length > 1) {
+            const values = splitUnescaped(value, ',').map(unescapeSearchValue);
             queryBuilder[`${field}.${type}`] = {
                 $in: values
             };
@@ -184,6 +188,7 @@ const tokenQueryBuilder = function ({ target, type, field, required, exists_flag
                 $in: values
             };
         } else {
+            value = typeof value === 'string' ? unescapeSearchValue(value) : value;
             queryBuilder[`${field}.${type}`] = value;
             queryBuilderElementMatch[`${type}`] = value;
         }
@@ -237,7 +242,9 @@ const tokenQueryContainsBuilder = function ({ target, type, field, required, exi
     }
 
     if (typeof target === 'string' && target.includes('|')) {
-        [system, value] = target.split('|');
+        // splitUnescaped only, never unescapeSearchValue here -- `value` may still need its own
+        // comma-split below, which must see any escaped comma still escaped.
+        [system, value] = splitUnescaped(target, '|');
     } else {
         value = target;
     }
@@ -248,6 +255,7 @@ const tokenQueryContainsBuilder = function ({ target, type, field, required, exi
 
     const queryBuilderElementMatch = {};
     if (system) {
+        system = unescapeSearchValue(system);
         queryBuilder[`${field}.system`] = {
             $regex: escapeRegExp(system),
             $options: 'i'
@@ -259,8 +267,8 @@ const tokenQueryContainsBuilder = function ({ target, type, field, required, exi
     }
 
     if (value) {
-        if (typeof value === 'string' && value.includes(',')) {
-            const values = value.split(',');
+        if (typeof value === 'string' && splitUnescaped(value, ',').length > 1) {
+            const values = splitUnescaped(value, ',').map(unescapeSearchValue);
             queryBuilder[`${field}.${type}`] = {
                 $regex: values.map(v => escapeRegExp(v)).join('|'),
                 $options: 'i'
@@ -270,6 +278,7 @@ const tokenQueryContainsBuilder = function ({ target, type, field, required, exi
                 $options: 'i'
             };
         } else {
+            value = typeof value === 'string' ? unescapeSearchValue(value) : value;
             queryBuilder[`${field}.${type}`] = {
                 $regex: escapeRegExp(value),
                 $options: 'i'
@@ -292,7 +301,7 @@ const tokenQueryContainsBuilder = function ({ target, type, field, required, exi
 const tokenIdentifierOfTypeQueryBuilder = function ({ target, field }) {
     let queryBuilder = {};
 
-    let targetArray = target.split('|').filter((t) => t !== '');
+    let targetArray = splitUnescaped(target, '|').map(unescapeSearchValue).filter((t) => t !== '');
     if (targetArray.length !== 3) {
         return queryBuilder;
     }

--- a/src/utils/querybuilder.util.js
+++ b/src/utils/querybuilder.util.js
@@ -160,10 +160,14 @@ const tokenQueryBuilder = function ({ target, type, field, required, exists_flag
         return queryBuilder;
     }
 
-    if (typeof target === 'string' && target.includes('|')) {
+    const targetPipeParts = typeof target === 'string' ? splitUnescaped(target, '|') : null;
+    if (targetPipeParts && targetPipeParts.length > 1) {
         // splitUnescaped only, never unescapeSearchValue here -- `value` may still need its own
-        // comma-split below, which must see any escaped comma still escaped.
-        [system, value] = splitUnescaped(target, '|');
+        // comma-split below, which must see any escaped comma still escaped. Gating on the
+        // split's own length (not the escape-oblivious target.includes('|')) matters: a
+        // value-only target whose only '|' is escaped (e.g. 'a\|b', meaning literal value
+        // 'a|b') must fall into the value-only branch below, not be mistaken for system|value.
+        [system, value] = targetPipeParts;
     } else {
         value = target;
     }
@@ -242,10 +246,14 @@ const tokenQueryContainsBuilder = function ({ target, type, field, required, exi
         return queryBuilder;
     }
 
-    if (typeof target === 'string' && target.includes('|')) {
+    const targetPipeParts = typeof target === 'string' ? splitUnescaped(target, '|') : null;
+    if (targetPipeParts && targetPipeParts.length > 1) {
         // splitUnescaped only, never unescapeSearchValue here -- `value` may still need its own
-        // comma-split below, which must see any escaped comma still escaped.
-        [system, value] = splitUnescaped(target, '|');
+        // comma-split below, which must see any escaped comma still escaped. Gating on the
+        // split's own length (not the escape-oblivious target.includes('|')) matters: a
+        // value-only target whose only '|' is escaped (e.g. 'a\|b', meaning literal value
+        // 'a|b') must fall into the value-only branch below, not be mistaken for system|value.
+        [system, value] = targetPipeParts;
     } else {
         value = target;
     }
@@ -1297,10 +1305,14 @@ const extensionQueryBuilder = function ({ target, type, field, required, exists_
         return queryBuilder;
     }
 
-    if (typeof target === 'string' && target.includes('|')) {
+    const targetPipeParts = typeof target === 'string' ? splitUnescaped(target, '|') : null;
+    if (targetPipeParts && targetPipeParts.length > 1) {
         // splitUnescaped only, never unescapeSearchValue here -- `value` may still need its own
-        // comma-split below, which must see any escaped comma still escaped.
-        [url, value] = splitUnescaped(target, '|');
+        // comma-split below, which must see any escaped comma still escaped. Gating on the
+        // split's own length (not the escape-oblivious target.includes('|')) matters: a
+        // value-only target whose only '|' is escaped (e.g. 'a\|b', meaning literal value
+        // 'a|b') must fall into the value-only branch below, not be mistaken for url|value.
+        [url, value] = targetPipeParts;
     } else {
         value = target;
     }

--- a/src/utils/querybuilder.util.js
+++ b/src/utils/querybuilder.util.js
@@ -467,12 +467,16 @@ const quantityQueryBuilder = function ({ target, field }) {
         return qB;
     }
     // split by the two pipes
-    let [num, system, code] = target.split('|');
+    let [num, system, code] = splitUnescaped(target, '|');
 
     if (system) {
+        // num is parsed as a number below (Number(strNum)/isNaN(num)) and never legitimately
+        // contains an escape sequence, so it's deliberately left un-unescaped.
+        system = unescapeSearchValue(system);
         qB[`${field}.system`] = system;
     }
     if (code) {
+        code = unescapeSearchValue(code);
         qB[`${field}.code`] = code;
     }
 
@@ -1292,7 +1296,9 @@ const extensionQueryBuilder = function ({ target, type, field, required, exists_
     }
 
     if (typeof target === 'string' && target.includes('|')) {
-        [url, value] = target.split('|');
+        // splitUnescaped only, never unescapeSearchValue here -- `value` may still need its own
+        // comma-split below, which must see any escaped comma still escaped.
+        [url, value] = splitUnescaped(target, '|');
     } else {
         value = target;
     }
@@ -1303,13 +1309,14 @@ const extensionQueryBuilder = function ({ target, type, field, required, exists_
 
     const queryBuilderElementMatch = {};
     if (url) {
+        url = unescapeSearchValue(url);
         queryBuilder[`${field}.url`] = url;
         queryBuilderElementMatch.url = url;
     }
 
     if (value) {
-        if (typeof value === 'string' && value.includes(',')) {
-            const values = value.split(',');
+        if (typeof value === 'string' && splitUnescaped(value, ',').length > 1) {
+            const values = splitUnescaped(value, ',').map(unescapeSearchValue);
             queryBuilder[`${field}.${type}`] = {
                 $in: values
             };
@@ -1317,6 +1324,7 @@ const extensionQueryBuilder = function ({ target, type, field, required, exists_
                 $in: values
             };
         } else {
+            value = typeof value === 'string' ? unescapeSearchValue(value) : value;
             queryBuilder[`${field}.${type}`] = value;
             queryBuilderElementMatch[`${type}`] = value;
         }

--- a/src/utils/querybuilder.util.js
+++ b/src/utils/querybuilder.util.js
@@ -18,6 +18,7 @@ const stringQueryBuilder = function ({ target }) {
     if (typeof target !== 'string') {
         return {};
     }
+    target = unescapeSearchValue(target);
     let t2 = target.replace(/[\\(\\)\\-\\_\\+\\=\\/\\.]/g, '\\$&');
     return { $regex: new RegExp('^' + escapeRegExp(t2), 'i') };
 };
@@ -351,15 +352,16 @@ const exactMatchQueryBuilder = function ({ target, field, exists_flag }) {
         return queryBuilder;
     }
 
-    const value = target;
+    let value = target;
 
     if (value !== undefined) {
-        if (typeof value === 'string' && value.includes(',')) {
-            const values = value.split(',');
+        if (typeof value === 'string' && splitUnescaped(value, ',').length > 1) {
+            const values = splitUnescaped(value, ',').map(unescapeSearchValue);
             queryBuilder[`${field}`] = {
                 $in: values
             };
         } else {
+            value = typeof value === 'string' ? unescapeSearchValue(value) : value;
             queryBuilder[`${field}`] = value;
         }
     }

--- a/src/utils/searchValueEscaping.js
+++ b/src/utils/searchValueEscaping.js
@@ -1,0 +1,80 @@
+/**
+ * Escape-aware splitting/unescaping for FHIR search values, per
+ * https://hl7.org/fhir/R4B/search.html#escaping — ',', '|', '$', and '\' are separator/escape
+ * characters; a literal occurrence of the first three must be backslash-escaped by the caller,
+ * and a literal '\' must be escaped as '\\'.
+ *
+ * A search value can pass through more than one delimiter-splitting stage before reaching a
+ * leaf use (e.g. a composite component: split on '$', then handed to a token filter that splits
+ * on '|'). splitUnescaped() never unescapes -- doing so early would destroy an escape marker a
+ * later stage still needs. Only unescapeSearchValue() actually converts escape sequences to
+ * literal characters, and it must be called exactly once, at the true leaf (the point where a
+ * string is about to become a literal Mongo match/regex value, with no further delimiter
+ * splitting ahead of it).
+ */
+
+const ESCAPABLE_CHARS = new Set(['$', ',', '|', '\\']);
+
+/**
+ * Splits `value` on every occurrence of `delimiter` that is not escaped -- a delimiter is
+ * escaped if it's preceded by an odd number of consecutive backslashes. Backslash sequences are
+ * left untouched in the returned parts (no unescaping here).
+ * @param {string} value
+ * @param {string} delimiter a single character
+ * @return {string[]}
+ */
+function splitUnescaped (value, delimiter) {
+    if (typeof value !== 'string') {
+        return [value];
+    }
+    const parts = [];
+    let current = '';
+    let backslashRun = 0;
+    for (let i = 0; i < value.length; i++) {
+        const ch = value[i];
+        if (ch === '\\') {
+            backslashRun++;
+            current += ch;
+            continue;
+        }
+        if (ch === delimiter && backslashRun % 2 === 0) {
+            parts.push(current);
+            current = '';
+        } else {
+            current += ch;
+        }
+        backslashRun = 0;
+    }
+    parts.push(current);
+    return parts;
+}
+
+/**
+ * Converts '\$', '\,', '\|', '\\' to their literal characters. A lone trailing backslash, or a
+ * backslash followed by a character that isn't one of the four escapable characters, is passed
+ * through literally rather than treated as an error -- rejecting it risks breaking a free-text
+ * value that happens to contain a backslash for unrelated reasons.
+ * @param {string} value
+ * @return {string}
+ */
+function unescapeSearchValue (value) {
+    if (typeof value !== 'string') {
+        return value;
+    }
+    let result = '';
+    for (let i = 0; i < value.length; i++) {
+        const ch = value[i];
+        if (ch === '\\' && i + 1 < value.length && ESCAPABLE_CHARS.has(value[i + 1])) {
+            result += value[i + 1];
+            i++;
+        } else {
+            result += ch;
+        }
+    }
+    return result;
+}
+
+module.exports = {
+    splitUnescaped,
+    unescapeSearchValue
+};


### PR DESCRIPTION
## Summary

Per the FHIR search spec (https://hl7.org/fhir/R4B/search.html#escaping), `,`, `|`, `$`, and `\`
are separator/escape characters — a literal occurrence of the first three in a search value must
be backslash-escaped (`\,`, `\|`, `\$`). This server had three independent call sites that split
on one of these characters with no escaping awareness at all:

- **`,` (OR values)** — `QueryParameterValue`/`ParsedArgsItem` naive `.split(',')`. Affects every
  search parameter type — `name=Smith, John` was silently split into two OR'd values.
- **`|` (token `system|code`, quantity `num|system|code`, extension `url|value`)** —
  `querybuilder.util.js`'s `tokenQueryBuilder`, `tokenQueryContainsBuilder`,
  `tokenIdentifierOfTypeQueryBuilder`, `extensionQueryBuilder`, `quantityQueryBuilder`.
- **`$` (composite components)** — `FilterByComposite.filterOneValue` (added by #2483), same gap,
  extended to the new composite separator.

Fixing `$` alone wasn't actually possible in isolation: a composite component's value is handed
straight to the same token/quantity functions above, which needed the `,`/`|` fix too.

## Approach

One shared utility, `src/utils/searchValueEscaping.js`:
- `splitUnescaped(value, delimiter)` — escape-aware split (skips delimiters preceded by an odd
  backslash run), never unescapes.
- `unescapeSearchValue(value)` — converts `\$`/`\,`/`\|`/`\\` to literal characters. Called
  exactly once, at the true leaf, after all delimiter-splitting for that value is done.

The ordering matters: a value can pass through more than one splitting stage (e.g. composite's
`$`-split, then a token's `|`-split, then that token's own nested `,`-split for `:contains`).
Unescaping too early destroys an escape marker a later stage still needs — caught this mid-
implementation when an escaped comma inside a token's value portion got prematurely unescaped
before the value's own comma-split ran, then wrongly re-split on the now-literal comma.

## Scope boundary

Stacked on #2483 (`composite-search-params`). Deliberately independent of the sibling PR
implementing `_text`/`_content` (#2566) — separate concern, separate branch.

## Test plan

- [x] 179 unit tests across the 5 touched modules (`searchValueEscaping`, `queryParameterValue`,
      `parsedArgsItem`, `querybuilder.util`, `FilterByComposite`), including escaped-separator
      cases for every fixed call site.
- [x] Lint clean.
- [ ] End-to-end integration test — attempted but backed out; blocked by a local Testcontainers/
      Colima Docker-socket mismatch unrelated to this change (`clickHouseTestRunner.js` hardcodes
      `/var/run/docker.sock`, which is a stale symlink on this dev machine). The composite unit
      test already exercises the real `FilterByToken`/`FilterByQuantity` classes end-to-end at
      the filter level (not mocked), so coverage is solid without it, but a CI run or a
      Colima-aware override would be worth adding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)