### PR TITLE
DCON-5457 Add MongoDB connection-pool (CMAP) metrics

### DIFF
--- a/src/tests/unit/utils/mongoDatabaseManager.test.js
+++ b/src/tests/unit/utils/mongoDatabaseManager.test.js
@@ -99,6 +99,33 @@ describe('MongoDatabaseManager', () => {
             expect(client.db).toBeDefined();
         });
 
+        test('subscribes the client to CMAP pool events so checkout waits are measured', async () => {
+            const { isTrue } = require('../../../utils/isTrue');
+            isTrue.mockReturnValue(false);
+            const metrics = require('../../../utils/metrics');
+            const recordSpy = jest
+                .spyOn(metrics.mongoPoolCheckoutDurationHistogram, 'record')
+                .mockImplementation(() => {});
+
+            await manager.createClientAsync({
+                connection: 'mongodb://user:pass@localhost:27017',
+                db_name: 'testdb',
+                options: { maxPoolSize: 10 }
+            });
+
+            // Drive the handler the manager actually registered, rather than asserting that
+            // registerMongoPoolMonitoring was called -- this exercises the real recording path.
+            const checkedOutHandler = mockOn.mock.calls.find(
+                ([event]) => event === 'connectionCheckedOut'
+            )?.[1];
+            expect(checkedOutHandler).toBeDefined();
+
+            checkedOutHandler({ durationMS: 13000 });
+
+            expect(recordSpy).toHaveBeenCalledWith(13, { pool: 'testdb' });
+            recordSpy.mockRestore();
+        });
+
         test('BUG: throws TypeError when connection is undefined', async () => {
             const config = {
                 connection: undefined,

--- a/src/tests/unit/utils/mongoPoolMonitor.test.js
+++ b/src/tests/unit/utils/mongoPoolMonitor.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const { EventEmitter } = require('events');
+const { describe, test, expect, beforeEach, jest } = require('@jest/globals');
+
+// The OTel meter is process-wide ambient (see metrics.js docstring), so the only honest
+// seam is the @opentelemetry/api boundary. Unlike metrics.test.js's shared-instrument
+// mock, this keys instruments by name so a test can assert WHICH instrument was hit.
+jest.mock('@opentelemetry/api', () => {
+    const counters = {};
+    const histograms = {};
+    return {
+        metrics: {
+            getMeter: () => ({
+                createCounter: (name) => {
+                    counters[name] = counters[name] || { add: jest.fn() };
+                    return counters[name];
+                },
+                createHistogram: (name) => {
+                    histograms[name] = histograms[name] || { record: jest.fn() };
+                    return histograms[name];
+                }
+            })
+        },
+        __counters: counters,
+        __histograms: histograms
+    };
+});
+
+const { __counters, __histograms } = require('@opentelemetry/api');
+const { registerMongoPoolMonitoring } = require('../../../utils/mongoPoolMonitor');
+
+const CHECKOUT_DURATION = 'fhir_mongo_pool_checkout_duration_seconds';
+const CHECKOUT_FAILED = 'fhir_mongo_pool_checkout_failed_total';
+const POOL_CLEARED = 'fhir_mongo_pool_cleared_total';
+const CONNECTION_CREATED = 'fhir_mongo_pool_connection_created_total';
+
+describe('registerMongoPoolMonitoring', () => {
+    let client;
+
+    beforeEach(() => {
+        for (const counter of Object.values(__counters)) {
+            counter.add.mockClear();
+        }
+        for (const histogram of Object.values(__histograms)) {
+            histogram.record.mockClear();
+        }
+        // A real EventEmitter stands in for MongoClient: the driver emits CMAP events
+        // through EventEmitter, so this exercises the real subscription path.
+        client = new EventEmitter();
+        registerMongoPoolMonitoring({ client, poolName: 'fhir' });
+    });
+
+    test('records connection checkout wait time in seconds', () => {
+        client.emit('connectionCheckedOut', { durationMS: 13000 });
+
+        expect(__histograms[CHECKOUT_DURATION].record).toHaveBeenCalledWith(13, { pool: 'fhir' });
+    });
+
+    test('records a fast checkout as sub-second, not rounded away', () => {
+        client.emit('connectionCheckedOut', { durationMS: 250 });
+
+        expect(__histograms[CHECKOUT_DURATION].record).toHaveBeenCalledWith(0.25, { pool: 'fhir' });
+    });
+
+    test('counts a failed checkout labelled with the driver reason', () => {
+        client.emit('connectionCheckOutFailed', { reason: 'timeout', durationMS: 30000 });
+
+        expect(__counters[CHECKOUT_FAILED].add).toHaveBeenCalledWith(1, {
+            pool: 'fhir',
+            reason: 'timeout'
+        });
+    });
+
+    test('maps an unrecognized failure reason to unknown to bound label cardinality', () => {
+        client.emit('connectionCheckOutFailed', { reason: 'something-new-from-the-driver' });
+
+        expect(__counters[CHECKOUT_FAILED].add).toHaveBeenCalledWith(1, {
+            pool: 'fhir',
+            reason: 'unknown'
+        });
+    });
+
+    test('records the wait time of a failed checkout, which is otherwise invisible', () => {
+        client.emit('connectionCheckOutFailed', { reason: 'timeout', durationMS: 30000 });
+
+        expect(__histograms[CHECKOUT_DURATION].record).toHaveBeenCalledWith(30, { pool: 'fhir' });
+    });
+
+    test('counts pool clears, which signal the server was marked unknown', () => {
+        client.emit('connectionPoolCleared', {});
+
+        expect(__counters[POOL_CLEARED].add).toHaveBeenCalledWith(1, { pool: 'fhir' });
+    });
+
+    test('counts connections created, exposing pool churn', () => {
+        client.emit('connectionCreated', {});
+
+        expect(__counters[CONNECTION_CREATED].add).toHaveBeenCalledWith(1, { pool: 'fhir' });
+    });
+
+    test('does not record a checkout duration when the driver omits durationMS', () => {
+        client.emit('connectionCheckedOut', {});
+
+        expect(__histograms[CHECKOUT_DURATION].record).not.toHaveBeenCalled();
+    });
+});

--- a/src/utils/metrics.js
+++ b/src/utils/metrics.js
@@ -69,7 +69,9 @@ const LABEL = Object.freeze({
     TOPIC: 'topic',
     ERROR_CODE: 'error_code',
     SUBSYSTEM: 'subsystem',
-    PATH: 'path'
+    PATH: 'path',
+    POOL: 'pool',
+    REASON: 'reason'
 });
 
 const OUTCOME = Object.freeze({
@@ -97,6 +99,16 @@ const OPERATION = Object.freeze({
 
 const SUBSYSTEM = Object.freeze({
     KAFKA: 'kafka'
+});
+
+// The MongoDB driver's ConnectionCheckOutFailedEvent.reason values (mongodb 7.3.0,
+// cmap/connection_pool.js). Bounded here rather than passed through, so a future driver
+// version introducing a new reason string cannot silently widen label cardinality --
+// anything unrecognized collapses to UNKNOWN.
+const POOL_CHECKOUT_FAILURE_REASON = Object.freeze({
+    TIMEOUT: 'timeout',
+    POOL_CLOSED: 'poolClosed',
+    CONNECTION_ERROR: 'connectionError'
 });
 
 // Distinguishes save-time validation (POST/PUT/$merge) from validate-time
@@ -248,6 +260,29 @@ const importFileSizeHistogram = meter.createHistogram('fhir_import_file_size_byt
     advice: {
         explicitBucketBoundaries: [1000, 10000, 100000, 1000000, 5000000, 10000000, 50000000, 100000000, 500000000]
     }
+});
+
+const mongoPoolCheckoutDurationHistogram = meter.createHistogram('fhir_mongo_pool_checkout_duration_seconds', {
+    description: 'Time a request waited to check a connection out of a MongoDB pool, by pool. Recorded for successful and failed checkouts alike. This wait is invisible to the OTel mongodb instrumentation, which spans only the wire command -- a starved pool shows up there as a fast query preceded by nothing.',
+    unit: 's',
+    // A healthy checkout is sub-millisecond, so the low buckets are tight. The high buckets
+    // exist because real incidents land there: a staging $merge burst produced a 13s pool
+    // wait, and a checkout that hits waitQueueTimeoutMS would land at that timeout's value.
+    advice: {
+        explicitBucketBoundaries: [0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30]
+    }
+});
+
+const mongoPoolCheckoutFailedCounter = meter.createCounter('fhir_mongo_pool_checkout_failed_total', {
+    description: 'MongoDB connection checkout failures by pool and reason (timeout|poolClosed|connectionError|unknown).'
+});
+
+const mongoPoolClearedCounter = meter.createCounter('fhir_mongo_pool_cleared_total', {
+    description: 'MongoDB connection pool clears by pool. The driver clears a pool when it marks a server Unknown, so this rising alongside latency means SDAM churn rather than slow queries.'
+});
+
+const mongoPoolConnectionCreatedCounter = meter.createCounter('fhir_mongo_pool_connection_created_total', {
+    description: 'MongoDB connections created by pool. On a warm pool this should sit near zero; a sustained rate means churn, which puts the SCRAM auth handshake on the request hot path.'
 });
 
 /**
@@ -447,6 +482,51 @@ function recordImportFileSize (fileSizeBytes) {
     importFileSizeHistogram.record(fileSizeBytes);
 }
 
+/**
+ * Emit fhir_mongo_pool_checkout_duration_seconds. The driver reports the wait in
+ * milliseconds; the instrument is in seconds to match the other duration histograms here.
+ * @param {string} pool
+ * @param {number} durationMS
+ */
+function recordMongoPoolCheckoutDuration (pool, durationMS) {
+    if (typeof durationMS !== 'number' || !Number.isFinite(durationMS)) {
+        return;
+    }
+    mongoPoolCheckoutDurationHistogram.record(durationMS / 1000, {
+        [LABEL.POOL]: pool || UNKNOWN
+    });
+}
+
+/**
+ * Emit fhir_mongo_pool_checkout_failed_total, collapsing any reason outside the driver's
+ * known set to UNKNOWN so label cardinality stays bounded.
+ * @param {string} pool
+ * @param {string} reason
+ */
+function recordMongoPoolCheckoutFailed (pool, reason) {
+    const isKnownReason = Object.values(POOL_CHECKOUT_FAILURE_REASON).includes(reason);
+    mongoPoolCheckoutFailedCounter.add(1, {
+        [LABEL.POOL]: pool || UNKNOWN,
+        [LABEL.REASON]: isKnownReason ? reason : UNKNOWN
+    });
+}
+
+/**
+ * Emit fhir_mongo_pool_cleared_total.
+ * @param {string} pool
+ */
+function recordMongoPoolCleared (pool) {
+    mongoPoolClearedCounter.add(1, { [LABEL.POOL]: pool || UNKNOWN });
+}
+
+/**
+ * Emit fhir_mongo_pool_connection_created_total.
+ * @param {string} pool
+ */
+function recordMongoPoolConnectionCreated (pool) {
+    mongoPoolConnectionCreatedCounter.add(1, { [LABEL.POOL]: pool || UNKNOWN });
+}
+
 module.exports = {
     // Instruments — exported so integration tests can spy on `.add` / `.record`.
     mergeOutcomeCounter,
@@ -460,6 +540,10 @@ module.exports = {
     importRangeDurationHistogram,
     importS3ReadThroughputHistogram,
     importFileSizeHistogram,
+    mongoPoolCheckoutDurationHistogram,
+    mongoPoolCheckoutFailedCounter,
+    mongoPoolClearedCounter,
+    mongoPoolConnectionCreatedCounter,
 
     // Recording functions — production code calls these.
     recordMergeOutcomes,
@@ -472,6 +556,10 @@ module.exports = {
     recordImportRangeDuration,
     recordImportS3ReadThroughput,
     recordImportFileSize,
+    recordMongoPoolCheckoutDuration,
+    recordMongoPoolCheckoutFailed,
+    recordMongoPoolCleared,
+    recordMongoPoolConnectionCreated,
 
     // Pure helpers — exported for direct unit testing.
     tallyMergeOutcomes,
@@ -485,5 +573,6 @@ module.exports = {
     OPERATION,
     SUBSYSTEM,
     PATH,
+    POOL_CHECKOUT_FAILURE_REASON,
     UNKNOWN
 };

--- a/src/utils/mongoDatabaseManager.js
+++ b/src/utils/mongoDatabaseManager.js
@@ -5,6 +5,7 @@ const { logSystemEventAsync } = require('../operations/common/systemEventLogging
 const { MongoClient, GridFSBucket } = require('mongodb');
 const { ConfigManager } = require('./configManager');
 const { assertTypeEquals } = require('./assertType');
+const { registerMongoPoolMonitoring } = require('./mongoPoolMonitor');
 
 /**
  * client connection
@@ -194,6 +195,12 @@ class MongoDatabaseManager {
          * @type {import('mongodb').MongoClient}
          */
         const client = new MongoClient(clientConfig.connection, clientConfig.options);
+
+        // Subscribe before connect() so the connections the driver opens to satisfy
+        // minPoolSize are counted too. Always on -- this is a fixed set of four
+        // instruments, unlike the per-command logging gated behind LOG_ALL_MONGO_CALLS
+        // below, which is far too chatty to leave enabled.
+        registerMongoPoolMonitoring({ client, poolName: clientConfig.db_name });
 
         try {
             await client.connect();

--- a/src/utils/mongoPoolMonitor.js
+++ b/src/utils/mongoPoolMonitor.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/**
+ * Subscribes a MongoClient to the driver's CMAP (Connection Monitoring and Pooling)
+ * events and translates them into the OTel instruments in ./metrics.
+ *
+ * # Why this exists
+ *
+ * `@opentelemetry/instrumentation-mongodb` spans only the wire command. The time a
+ * request spends queued waiting for a pooled connection happens before that span opens,
+ * so pool starvation is invisible in traces: the waterfall shows a gap with no span in
+ * it, then a fast query. A staging $merge burst produced a 13s gap of exactly this shape,
+ * terminating in a `saslContinue` -- the driver had opened a brand-new connection
+ * mid-request rather than reusing one, and nothing in the trace said so.
+ *
+ * # Why no started -> checkedOut correlation
+ *
+ * The driver already reports the wait: ConnectionCheckedOutEvent and
+ * ConnectionCheckOutFailedEvent both carry `durationMS`, measured from the matching
+ * ConnectionCheckOutStartedEvent. Pairing the events ourselves would mean holding
+ * per-checkout state in a map keyed by an id that ConnectionCheckOutStartedEvent does not
+ * carry, and would leak entries for every checkout that never completes. We read
+ * durationMS instead and hold no state.
+ */
+
+const {
+    recordMongoPoolCheckoutDuration,
+    recordMongoPoolCheckoutFailed,
+    recordMongoPoolCleared,
+    recordMongoPoolConnectionCreated
+} = require('./metrics');
+
+/**
+ * Attach CMAP metric emission to a MongoClient.
+ *
+ * Safe to call on any client: emission is fire-and-forget and never touches the
+ * command path, so a throwing instrument cannot fail a query.
+ *
+ * @param {Object} params
+ * @param {import('mongodb').MongoClient} params.client
+ * @param {string} params.poolName Logical pool label. Bounded by deployment (one per
+ *   configured database), never derived from resource ids or user input.
+ * @returns {void}
+ */
+function registerMongoPoolMonitoring ({ client, poolName }) {
+    if (!client || typeof client.on !== 'function') {
+        return;
+    }
+
+    client.on('connectionCheckedOut', (event) => {
+        recordMongoPoolCheckoutDuration(poolName, event?.durationMS);
+    });
+
+    client.on('connectionCheckOutFailed', (event) => {
+        recordMongoPoolCheckoutFailed(poolName, event?.reason);
+        // A failed checkout still consumed wait time, and that wait is the whole point of
+        // the histogram -- excluding it would hide the worst cases.
+        recordMongoPoolCheckoutDuration(poolName, event?.durationMS);
+    });
+
+    client.on('connectionPoolCleared', () => {
+        recordMongoPoolCleared(poolName);
+    });
+
+    client.on('connectionCreated', () => {
+        recordMongoPoolConnectionCreated(poolName);
+    });
+}
+
+module.exports = {
+    registerMongoPoolMonitoring
+};


### PR DESCRIPTION
Jira: [DCON-5457](https://icanbwell.atlassian.net/browse/DCON-5457)

## Why

`@opentelemetry/instrumentation-mongodb` spans only the wire command. The time a request spends queued waiting for a pooled connection happens *before* that span opens, so pool starvation is invisible in traces.

A staging `Binary/$merge` burst made this concrete. Inside a 27.5s request, `MergeResourceValidator.loadResourcesAsync` took 14.4s, of which **13.1s was a gap containing no span at all**, terminating in `mongodb.saslContinue` — the driver had opened a brand-new connection mid-request instead of reusing a pooled one, and nothing in the trace said so. The `mongodb.find` that followed took 470ms.

## What

Subscribes each `MongoClient` to the driver's CMAP (Connection Monitoring and Pooling) events and emits four instruments:

| Instrument | Type | Labels | Answers |
|---|---|---|---|
| `fhir_mongo_pool_checkout_duration_seconds` | histogram | `pool` | how long did we wait for a connection |
| `fhir_mongo_pool_checkout_failed_total` | counter | `pool`, `reason` | did we give up waiting, and why |
| `fhir_mongo_pool_cleared_total` | counter | `pool` | was the server marked Unknown (SDAM churn) |
| `fhir_mongo_pool_connection_created_total` | counter | `pool` | is the pool churning instead of reusing |

## Design notes

- **No `checkOutStarted` → `checkedOut` correlation.** The driver already reports the wait: both `ConnectionCheckedOutEvent` and `ConnectionCheckOutFailedEvent` carry `durationMS` (verified against the pinned mongodb 7.3.0). Pairing the events ourselves would mean holding per-checkout state keyed by an id that `ConnectionCheckOutStartedEvent` does not carry, and leaking an entry for every checkout that never completes. This holds no state.
- **Failed checkouts also record duration.** A checkout that timed out still consumed wait time, and those are the worst cases — excluding them would hide exactly what we want to see.
- **Bounded label cardinality.** Failure reasons are collapsed against a frozen vocabulary (`timeout`, `poolClosed`, `connectionError`, else `unknown`), so a future driver version introducing a new reason string cannot silently widen cardinality. The `pool` label is the configured `db_name` — bounded per deployment, never derived from resource ids or user input, per the PHI label discipline in `metrics.js`.
- **Histogram buckets** span 0.5ms to 30s. A healthy checkout is sub-millisecond; the high buckets exist because real incidents land there (the 13s above, and a `waitQueueTimeoutMS` hit would land at that timeout).
- **Subscribed before `connect()`** so connections opened to satisfy `minPoolSize` are counted.
- **Always on** — four fixed instruments, unlike the per-command logging behind `LOG_ALL_MONGO_CALLS`, which is far too chatty to leave enabled.

## Deliberately not included

`waitQueueTimeoutMS` is still commented out in `config.js`. That unbounded wait queue is *why* the 13s wait was silent rather than an error, but setting it changes behavior (silent waits become failures), so it belongs in its own change rather than an observability PR.

## Testing

- `src/tests/unit/utils/mongoPoolMonitor.test.js` — 8 new tests. A real `EventEmitter` stands in for `MongoClient` (the driver emits CMAP events through `EventEmitter`), so the real subscription and recording path is exercised; only the ambient `@opentelemetry/api` boundary is mocked. Unlike `metrics.test.js`'s shared-instrument mock, instruments are keyed by name so a test can assert *which* instrument was hit.
- `src/tests/unit/utils/mongoDatabaseManager.test.js` — 1 new test that drives the handler `createClientAsync` actually registered, rather than asserting `registerMongoPoolMonitoring` was called, so it fails if the wiring or the recording path breaks.
- Full unit suite: 504 suites, 8,750 passed, 0 failures. Lint clean.
- Integration tests were not run locally (`jestGlobalSetup` needs a container runtime for ClickHouse testcontainers, no Docker daemon available). This change is additive and does not touch the request path, but CI's integration shards will confirm.

No behavior change to the request path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DCON-5457]: https://icanbwell.atlassian.net/browse/DCON-5457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ