### PR TITLE
Bump zod from 4.4.3 to 4.5.4 (AIKIDO-2026-500926, AIKIDO-2026-161437)

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "xss": "^1.0.15",
     "yargs": "^18.1.0",
-    "zod": "^4.4.3"
+    "zod": "^4.5.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.29.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5418,7 +5418,7 @@ __metadata:
     xlsx: "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
     xss: "npm:^1.0.15"
     yargs: "npm:^18.1.0"
-    zod: "npm:^4.4.3"
+    zod: "npm:^4.5.0"
   languageName: unknown
   linkType: soft
 
@@ -11516,9 +11516,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4.2.0, zod@npm:^4.4.3":
-  version: 4.4.3
-  resolution: "zod@npm:4.4.3"
-  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
+"zod@npm:^4.2.0, zod@npm:^4.5.0":
+  version: 4.5.4
+  resolution: "zod@npm:4.5.4"
+  checksum: 10c0/511a2a4d1a6f875dfdd70a1586989a8b14ef126776cd6218a2c760b9f65f14ef389ec20d92ee1aa4fcb4566d4ff3fa012956044f9dc503510d82e4c756a8ba92
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Source finding
- [AIKIDO-2026-500926](https://app.aikido.dev/issues/single/617099357?groupId=628) — medium (severity 48), issue `617099357`
- [AIKIDO-2026-161437](https://app.aikido.dev/issues/single/617099367?groupId=628) — low (severity 23), issue `617099367`

Both share Aikido group `28555734`; one bump closes both.

## Verdict
CONFIRMED-FIXABLE — `zod` is a direct dependency whose existing `^4.4.3` range already permits the patched line, no version conflicts (`@modelcontextprotocol/sdk` only requires `^4.2.0`), and none of the five zod 4.5.0 breaking changes touch the constructs this repo actually uses.

## Fix
- `package.json`: `zod` `^4.4.3` → `^4.5.0`, raising the declared floor. The old range already permitted 4.5.x, so refreshing only the lockfile would leave the manifest free to re-resolve back to the vulnerable 4.4.3 on a future fresh install.
- `yarn.lock`: regenerated via `yarn install`, then **`yarn dedupe zod`**.

The dedupe is load-bearing. `yarn install` alone left two resolutions — `zod@npm:^4.5.0` → 4.5.4 for the direct dep, but `zod@npm:^4.2.0` → **still 4.4.3** for `@modelcontextprotocol/sdk`, because Yarn preserves lock entries that its range already satisfies. The vulnerable copy would have shipped and Aikido would still flag it. Post-dedupe both ranges collapse to a single `zod@npm:4.5.4` and zero copies of 4.4.3 remain in the tree.

### Why this matters here
zod 4.5.0 hardens reserved keys against prototype pollution via `__proto__` / `toString` / `constructor` paths, and removes exponential backtracking in `z.emoji()`. The schemas in `src/mcp/` parse MCP tool arguments supplied by the client, so the prototype-pollution path is genuinely reachable — notably `filters: z.record(z.string(), z.string())` in `src/mcp/genericFhirSearchTool.js`, which feeds a FHIR search query.

### Breaking-change audit
zod 4.5.0 ships five breaking changes; none apply. `src/mcp/` uses only `z.string()` (617×), `z.object()` (35×), `z.record(z.string(), …)` (2×), `z.array()` (2×), `z.number()`, `z.literal()`, `z.any()`.

| 4.5.0 breaking change | Applies? |
|---|---|
| `z.iso.datetime()` now requires seconds | No — not used |
| String `.min`/`.max`/`.length` count code points | No — no length constraints anywhere in `src/mcp` |
| Record keys follow TypeScript semantics | Only 2 open `z.record(z.string(), …)`; no pattern-keyed/intersection use |
| `__proto__` always stripped | This is the security fix; desired hardening |
| Stricter `z.ipv6`/`ulid`/`httpUrl`/`emoji`/`.includes()` | No — none used |

## Testing
- `jest --config jest.unit.config.js src/tests/unit/mcp src/tests/unit/routeHandlers/mcpServer.test.js` — **3 suites / 22 tests passed**
- `jest --config jest.config.js --runInBand src/tests/integration/mcp` — **5 suites / 55 tests passed** (`mcpEndpoint`, `mcpResourceAuthorization`, `mcpFeatureFlag`, `dedicatedTools`, `subscriptionFamilyPatientScope`)
- `eslint "src/**/*.js"` — clean
- Verified `grep -c "resolution: \"zod@npm:4.4.3\"" yarn.lock` → `0`

Full suite not run (targeted checks only, per the sweep routine). `prettier --write` was deliberately **not** run on `package.json`: the file already fails `prettier --check` on `main` (2-space indent vs `.prettierrc` `tabWidth: 4`), so writing it would have added a large unrelated reformat.