### PR TITLE
DCON-4263 Fix RethrownError.stack corruption and $everything stack overflow on large Patients

### DIFF
--- a/src/operations/everything/everythingHelper.js
+++ b/src/operations/everything/everythingHelper.js
@@ -103,6 +103,19 @@ async function settleAllOrThrow(promises) {
 }
 
 /**
+ * @param {*[]} target
+ * @param {*[]|undefined} [source]
+ */
+function pushAll(target, source) {
+    if (!source) {
+        return;
+    }
+    for (const item of source) {
+        target.push(item);
+    }
+}
+
+/**
  * This class is for $everything operation
  */
 class EverythingHelper {
@@ -973,7 +986,7 @@ class EverythingHelper {
                 });
 
                 if (!responseStreamer) {
-                    entries.push(...(relatedEntities || []))
+                    pushAll(entries, relatedEntities);
                 }
 
                 for (const q of queryItems) {
@@ -1029,7 +1042,7 @@ class EverythingHelper {
                 });
 
                 if (!responseStreamer) {
-                    entries.push(...(subscriptionEntities || []))
+                    pushAll(entries, subscriptionEntities);
                 }
 
                 for (const q of subscriptionQueryItems) {
@@ -1123,11 +1136,11 @@ class EverythingHelper {
                             if (depthParallelProcess.length >= this.configManager.everythingMaxParallelProcess) {
                                 const depthResults = await settleAllOrThrow(depthParallelProcess);
                                 depthResults.forEach((result) => {
-                                    queries.push(...(result.queryItems || []));
-                                    explanations.push(...(result.explanations || []));
-                                    optionsForQueries.push(...(result.options || []));
+                                    pushAll(queries, result.queryItems);
+                                    pushAll(explanations, result.explanations);
+                                    pushAll(optionsForQueries, result.options);
                                     if (!responseStreamer) {
-                                        entries.push(...(result.entries || []));
+                                        pushAll(entries, result.entries);
                                     }
                                 });
                                 depthParallelProcess = [];
@@ -1138,11 +1151,11 @@ class EverythingHelper {
                     if (depthParallelProcess.length > 0) {
                         const depthResults = await settleAllOrThrow(depthParallelProcess);
                         depthResults.forEach((result) => {
-                            queries.push(...(result.queryItems || []));
-                            explanations.push(...(result.explanations || []));
-                            optionsForQueries.push(...(result.options || []));
+                            pushAll(queries, result.queryItems);
+                            pushAll(explanations, result.explanations);
+                            pushAll(optionsForQueries, result.options);
                             if (!responseStreamer) {
-                                entries.push(...(result.entries || []));
+                                pushAll(entries, result.entries);
                             }
                         });
                     }
@@ -1371,7 +1384,7 @@ class EverythingHelper {
                 streamedResources
             });
 
-            entries.push(...(bundleEntries || []));
+            pushAll(entries, bundleEntries);
         }
 
         return new ProcessMultipleIdsAsyncResult({
@@ -1755,7 +1768,7 @@ class EverythingHelper {
 
         const result = await settleAllOrThrow(parallelProcess);
         result.forEach(entry => {
-            bundleEntries.push(...(entry.bundleEntries || []));
+            pushAll(bundleEntries, entry.bundleEntries);
         })
 
 
@@ -2090,5 +2103,6 @@ class EverythingHelper {
 
 module.exports = {
     EverythingHelper,
-    escapeForJsonTemplate
+    escapeForJsonTemplate,
+    pushAll
 };

--- a/src/tests/unit/operations/everything/everythingHelperPushAll.test.js
+++ b/src/tests/unit/operations/everything/everythingHelperPushAll.test.js
@@ -1,0 +1,52 @@
+const { describe, test, expect, jest } = require('@jest/globals');
+
+jest.mock('../../../../config', () => ({}));
+jest.mock('../../../../utils/mongoDatabaseManager', () => ({}));
+jest.mock('@sentry/node', () => ({ init: jest.fn(), captureException: jest.fn() }));
+jest.mock('express-http-context', () => ({ get: jest.fn(), set: jest.fn() }));
+jest.mock('../../../../operations/common/logging', () => ({
+    logInfo: jest.fn(),
+    logDebug: jest.fn(),
+    logError: jest.fn(),
+    logWarn: jest.fn()
+}));
+jest.mock('../../../../utils/metrics', () => ({ recordOutboundEverything: jest.fn() }));
+jest.mock('../../../../utils/assertType', () => ({
+    assertTypeEquals: jest.fn(),
+    assertIsValid: jest.fn()
+}));
+
+const { pushAll } = require('../../../../operations/everything/everythingHelper');
+
+describe('pushAll', () => {
+    test('appends every element of source onto target, preserving order', () => {
+        const target = [1, 2];
+        pushAll(target, [3, 4, 5]);
+        expect(target).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test('leaves target unchanged when source is undefined', () => {
+        const target = [1, 2];
+        pushAll(target, undefined);
+        expect(target).toEqual([1, 2]);
+    });
+
+    test('leaves target unchanged when source is an empty array', () => {
+        const target = [1, 2];
+        pushAll(target, []);
+        expect(target).toEqual([1, 2]);
+    });
+
+    test('does not throw RangeError for arrays larger than the JS engine call-argument limit', () => {
+        const target = [];
+        const huge = new Array(200000).fill(0);
+        expect(() => pushAll(target, huge)).not.toThrow();
+        expect(target.length).toBe(200000);
+    });
+
+    test('a naive spread push throws for the same size that pushAll handles safely', () => {
+        const target = [];
+        const huge = new Array(200000).fill(0);
+        expect(() => target.push(...huge)).toThrow(RangeError);
+    });
+});

--- a/src/tests/unit/utils/rethrownError.test.js
+++ b/src/tests/unit/utils/rethrownError.test.js
@@ -79,6 +79,27 @@ describe('RethrownError', () => {
             const result = rethrown.buildCombinedStacks('just a stack', null);
             expect(result).toBe('just a stack');
         });
+
+        test('stack is a combined string, not undefined', () => {
+            const inner = new Error('inner failure');
+            const rethrown = new RethrownError({ message: 'outer context', error: inner });
+
+            expect(typeof rethrown.stack).toBe('string');
+            expect(rethrown.stack).toContain('inner failure');
+            expect(rethrown.stack).toContain('Causes:');
+            expect(rethrown.stack).toContain('RethrownError: outer context');
+        });
+
+        test('stack remains a combined string through multiple rethrows', () => {
+            const rootCause = new Error('root cause');
+            const firstRethrow = new RethrownError({ message: 'first wrap', error: rootCause });
+            const secondRethrow = new RethrownError({ message: 'second wrap', error: firstRethrow });
+
+            expect(typeof secondRethrow.stack).toBe('string');
+            expect(secondRethrow.stack).toContain('root cause');
+            expect(secondRethrow.stack).toContain('first wrap');
+            expect(secondRethrow.stack).toContain('second wrap');
+        });
     });
 
     describe('original_error unwrapping', () => {

--- a/src/utils/rethrownError.js
+++ b/src/utils/rethrownError.js
@@ -50,7 +50,7 @@ class RethrownError extends Error {
         Error.captureStackTrace(this, this.constructor);
         const oldStackDescriptor = Object.getOwnPropertyDescriptor(this, 'stack');
         const stackDescriptor = this.buildStackDescriptor(oldStackDescriptor, error);
-        this.stack = typeof stackDescriptor === 'function' ? stackDescriptor.get() : stackDescriptor.value;
+        Object.defineProperty(this, 'stack', stackDescriptor);
     }
 
     /**
@@ -95,12 +95,18 @@ class RethrownError extends Error {
                 get: function () {
                     const stack = oldStackDescriptor.get.call(this);
                     return self.buildCombinedStacks(stack, this.nested);
-                }
+                },
+                set: oldStackDescriptor.set,
+                enumerable: false,
+                configurable: true
             };
         } else {
             const stack = oldStackDescriptor.value;
             return {
-                value: this.buildCombinedStacks(stack, nested)
+                value: this.buildCombinedStacks(stack, nested),
+                writable: true,
+                enumerable: false,
+                configurable: true
             };
         }
     }


### PR DESCRIPTION
## Summary

Two independent root causes found via systematic debugging + live Groundcover production log evidence (repo has full detail from the investigation; short version below).

### 1. `RethrownError.stack` was always `undefined`

In `src/utils/rethrownError.js`, the constructor's final stack-assignment line checked `typeof stackDescriptor === 'function'` — but `buildStackDescriptor()` always returns a descriptor-shaped **object** (`{get: fn}` or `{value: str}`), never a bare function, so that check is never true. It always fell through to `stackDescriptor.value`, which is `undefined` whenever the original stack was still a lazy getter (the normal V8 case right after `Error.captureStackTrace`). Net effect: **every `RethrownError`'s `.stack` was silently lost**, producing `RethrownError: undefined` in `fhirLoggingManager`'s failure logs instead of the real cause.

Confirmed against real prod logs — `stack_before_rethrow` (captured *before* the buggy line runs) held a correctly-combined stack trace, while `.stack` itself was gone by the time it reached the log.

Fix: install the descriptor properly via `Object.defineProperty(this, 'stack', stackDescriptor)` so the getter runs with correct `this` binding, with `set`/`configurable`/`writable` added so `.stack` stays reassignable like a normal Error's.

### 2. Patient `$everything` stack overflow on large resource sets

Queried Groundcover directly: 148 occurrences of `RangeError: Maximum call stack size exceeded` inside `retrieveEverythingMulipleIdsAsync` over the last 14 days, all `Patient $everything`. This is the dominant real-world failure mode right now (the original ticket's "obj is null or undefined" example predates available log retention and hasn't recurred).

`everythingHelper.js` has no unbounded recursion — the one recursive-shaped traversal is depth-capped by `EVERYTHING_OP_NON_CLINICAL_RESOURCE_DEPTH`. The actual cause is a classic V8 pitfall: `array.push(...bigArray)` throws once the spread array exceeds V8's per-call argument limit (empirically confirmed to fail between 100,000–131,072 elements). Six sites in `everythingHelper.js` accumulate resource-count-scaled arrays this way; for a Patient with a large enough result set, any of them can blow the stack.

Fix: added a `pushAll()` helper that appends via a loop (no argument-count limit) and replaced the unbounded spread-push accumulation of resource-entry arrays with it. Left the small, resource-*type*-bounded metadata array pushes untouched (no realistic overflow risk there).

## Testing

- Added regression tests in `rethrownError.test.js` asserting `.stack` is an actual combined string — verified they fail against the pre-fix code and pass against the fix.
- Added `everythingHelperPushAll.test.js`, including a test that a naive spread-push throws `RangeError` at 200k elements while `pushAll` doesn't.
- All existing `rethrownError` (30) and `everything` (178) unit tests pass.
- Broader sweep across `dataLayer`/`fhir`/`utils` unit tests (3910 tests) passes clean.
- Lint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)