### PR TITLE
DCON-5506 Fix $export _elements silently dropping Binary/DocumentReference blob data

### DIFF
--- a/src/operations/export/script/bulkDataExportRunner.js
+++ b/src/operations/export/script/bulkDataExportRunner.js
@@ -594,12 +594,9 @@ class BulkDataExportRunner {
         let resource = FhirResourceCreator.createByResourceType(doc, resourceType);
         if (!isProjected) {
             await this.enrichmentManager.enrichAsync({ resources: [resource], parsedArgs });
-            await this.databaseAttachmentManager.transformAttachments({
-                resource,
-                operation: GRIDFS.RETRIEVE
-            });
-            resource = await this.base64DataManager.transformAsync(resource, BLOB_OP.RETRIEVE);
         }
+        resource = await this.databaseAttachmentManager.transformAttachments(resource, GRIDFS.RETRIEVE);
+        resource = await this.base64DataManager.transformAsync(resource, BLOB_OP.RETRIEVE);
         return FhirResourceSerializer.serialize(resource.toJSONInternal());
     }
 

--- a/src/operations/export/script/bulkDataExportRunner.js
+++ b/src/operations/export/script/bulkDataExportRunner.js
@@ -571,9 +571,10 @@ class BulkDataExportRunner {
 
     /**
      * Turns a raw Mongo export doc into a serialized NDJSON-ready object.
-     * Full export (no projection) hydrates + enriches + attachment-transforms as before.
-     * The projected (_elements) path skips those re-expansions and serializes the doc
-     * as fetched; the resource serializer drops Mongo-internal fields (_uuid, _sourceId, ...).
+     * Full export (no projection) enriches the resource; the projected (_elements) path
+     * skips enrichment only - attachment (GridFS) and base64 (S3) rehydration always run,
+     * since both are no-ops when their sidecar field isn't present on the doc.
+     * The resource serializer then drops Mongo-internal fields (_uuid, _sourceId, ...).
      *
      * Raw-elements contract: with enrichment skipped, reference-valued elements are emitted
      * in their raw stored (uuid) form, not the enrichment-rewritten form a full export gives.

--- a/src/tests/integration/export/export.binary.test.js
+++ b/src/tests/integration/export/export.binary.test.js
@@ -173,4 +173,155 @@ describe('Export Binary S3 Hydration Tests', () => {
         expect(exportedBinary.data).toBe(LARGE_DATA);
         expect(exportedBinary._blobMeta).toBeUndefined();
     });
+
+    test('Export with _elements=id,data still rehydrates S3-offloaded data for a projected Binary', async () => {
+        const request = await createTestRequest(registerMockClients);
+        const postRequestProcessor = getTestContainer().postRequestProcessor;
+        const postSaveProcessor = getTestContainer().postSaveProcessor;
+
+        const largeBinaryId = 'export-elements-large-binary';
+        await request
+            .put(`/4_0_0/Binary/${largeBinaryId}`)
+            .send(buildBinary({ id: largeBinaryId, data: LARGE_DATA }))
+            .set(getHeaders())
+            .expect(201);
+
+        const smallBinaryId = 'export-elements-small-binary';
+        const smallData = 'c21hbGwtYmluYXJ5LWRhdGE=';
+        await request
+            .put(`/4_0_0/Binary/${smallBinaryId}`)
+            .send(buildBinary({ id: smallBinaryId, data: smallData }))
+            .set(getHeaders())
+            .expect(201);
+
+        let resp = await request
+            .post('/4_0_0/$export?_type=Binary&_elements=id,data')
+            .set(getHeaders())
+            .expect(202);
+
+        expect(resp.headers['content-location']).toBeDefined();
+        const exportStatusId = resp.headers['content-location'].split('/').pop();
+
+        const container = getTestContainer();
+        const requestId = generateUUID();
+        const exportS3Client = new MockS3Client({ bucketName: 'test', region: 'test' });
+
+        container.register('bulkDataExportRunner', (c) => new BulkDataExportRunner({
+            databaseQueryFactory: c.databaseQueryFactory,
+            databaseExportManager: c.databaseExportManager,
+            patientFilterManager: c.patientFilterManager,
+            databaseAttachmentManager: c.databaseAttachmentManager,
+            base64DataManager: c.base64DataManager,
+            r4SearchQueryCreator: c.r4SearchQueryCreator,
+            patientQueryCreator: c.patientQueryCreator,
+            enrichmentManager: c.enrichmentManager,
+            resourceLocatorFactory: c.resourceLocatorFactory,
+            r4ArgsParser: c.r4ArgsParser,
+            searchManager: c.searchManager,
+            postSaveProcessor: c.postSaveProcessor,
+            bulkExportEventProducer: c.bulkExportEventProducer,
+            storageProviderFactory: c.storageProviderFactory,
+            exportStatusId,
+            patientReferenceBatchSize: 1000,
+            uploadPartSize: 1024 * 1024,
+            s3Client: exportS3Client,
+            requestId
+        }));
+
+        const bulkDataExportRunner = container.bulkDataExportRunner;
+        await bulkDataExportRunner.processAsync();
+        await postRequestProcessor.executeAsync({ requestId });
+        await postSaveProcessor.flushAsync();
+
+        resp = await request
+            .get(`/4_0_0/$export/${exportStatusId}`)
+            .set(getHeaders())
+            .expect(200);
+
+        expect(resp.body.output).toHaveLength(1);
+        expect(resp.body.errors).toHaveLength(0);
+
+        const exportedFilePath = `${bulkDataExportRunner.baseS3Folder}/Binary.ndjson`;
+        const exportedNdjson = exportS3Client.uploadedData[exportedFilePath];
+        expect(exportedNdjson).toBeDefined();
+
+        const exportedBinaries = exportedNdjson
+            .trim()
+            .split('\n')
+            .map((line) => JSON.parse(line));
+        const exportedLarge = exportedBinaries.find((b) => b.id === largeBinaryId);
+        const exportedSmall = exportedBinaries.find((b) => b.id === smallBinaryId);
+
+        expect(exportedLarge.data).toBe(LARGE_DATA);
+        expect(exportedLarge._blobMeta).toBeUndefined();
+        expect(exportedSmall.data).toBe(smallData);
+    });
+
+    test('Export with _elements=id omits data entirely and does not leak _blobMeta', async () => {
+        const request = await createTestRequest(registerMockClients);
+        const postRequestProcessor = getTestContainer().postRequestProcessor;
+        const postSaveProcessor = getTestContainer().postSaveProcessor;
+
+        const binaryId = 'export-elements-id-only-binary';
+        await request
+            .put(`/4_0_0/Binary/${binaryId}`)
+            .send(buildBinary({ id: binaryId, data: LARGE_DATA }))
+            .set(getHeaders())
+            .expect(201);
+
+        let resp = await request
+            .post('/4_0_0/$export?_type=Binary&_elements=id')
+            .set(getHeaders())
+            .expect(202);
+
+        expect(resp.headers['content-location']).toBeDefined();
+        const exportStatusId = resp.headers['content-location'].split('/').pop();
+
+        const container = getTestContainer();
+        const requestId = generateUUID();
+        const exportS3Client = new MockS3Client({ bucketName: 'test', region: 'test' });
+
+        container.register('bulkDataExportRunner', (c) => new BulkDataExportRunner({
+            databaseQueryFactory: c.databaseQueryFactory,
+            databaseExportManager: c.databaseExportManager,
+            patientFilterManager: c.patientFilterManager,
+            databaseAttachmentManager: c.databaseAttachmentManager,
+            base64DataManager: c.base64DataManager,
+            r4SearchQueryCreator: c.r4SearchQueryCreator,
+            patientQueryCreator: c.patientQueryCreator,
+            enrichmentManager: c.enrichmentManager,
+            resourceLocatorFactory: c.resourceLocatorFactory,
+            r4ArgsParser: c.r4ArgsParser,
+            searchManager: c.searchManager,
+            postSaveProcessor: c.postSaveProcessor,
+            bulkExportEventProducer: c.bulkExportEventProducer,
+            storageProviderFactory: c.storageProviderFactory,
+            exportStatusId,
+            patientReferenceBatchSize: 1000,
+            uploadPartSize: 1024 * 1024,
+            s3Client: exportS3Client,
+            requestId
+        }));
+
+        const bulkDataExportRunner = container.bulkDataExportRunner;
+        await bulkDataExportRunner.processAsync();
+        await postRequestProcessor.executeAsync({ requestId });
+        await postSaveProcessor.flushAsync();
+
+        resp = await request
+            .get(`/4_0_0/$export/${exportStatusId}`)
+            .set(getHeaders())
+            .expect(200);
+
+        expect(resp.body.errors).toHaveLength(0);
+
+        const exportedFilePath = `${bulkDataExportRunner.baseS3Folder}/Binary.ndjson`;
+        const exportedNdjson = exportS3Client.uploadedData[exportedFilePath];
+        expect(exportedNdjson).toBeDefined();
+
+        const exportedBinary = JSON.parse(exportedNdjson.trim());
+        expect(exportedBinary.data).toBeUndefined();
+        expect(exportedBinary._blobMeta).toBeUndefined();
+        expect(exportedBinary.id).toBe(binaryId);
+    });
 });

--- a/src/tests/integration/export/export.documentReference.test.js
+++ b/src/tests/integration/export/export.documentReference.test.js
@@ -1,0 +1,172 @@
+// test file
+const {
+    commonBeforeEach,
+    commonAfterEach,
+    getHeaders,
+    createTestRequest,
+    getTestContainer
+} = require('../common');
+const { describe, beforeEach, afterEach, test, expect } = require('@jest/globals');
+const { BulkDataExportRunner } = require('../../../operations/export/script/bulkDataExportRunner');
+const { MockK8sClient } = require('./mocks/k8sClient');
+const { MockS3Client } = require('./mocks/s3Client');
+const { generateUUID } = require('../../../utils/uid.util');
+
+const buildDocumentReference = ({ id, data }) => ({
+    resourceType: 'DocumentReference',
+    id,
+    meta: {
+        source: 'https://test.example.com/source',
+        security: [
+            { system: 'https://www.icanbwell.com/owner', code: 'test' },
+            { system: 'https://www.icanbwell.com/access', code: 'test' },
+            { system: 'https://www.icanbwell.com/sourceAssigningAuthority', code: 'test' }
+        ]
+    },
+    status: 'current',
+    content: [
+        {
+            attachment: {
+                contentType: 'application/pdf',
+                data
+            }
+        }
+    ]
+});
+
+describe('Export DocumentReference GridFS Hydration Tests', () => {
+    const registerMockClients = (c) => {
+        c.register('k8sClient', (cc) => new MockK8sClient({ configManager: cc.configManager }));
+        return c;
+    };
+
+    beforeEach(async () => {
+        process.env.ENABLE_BULK_EXPORT = '1';
+        const container = getTestContainer();
+        if (container) {
+            delete container.services.bulkDataExportRunner;
+        }
+        await commonBeforeEach();
+    });
+
+    afterEach(async () => {
+        process.env.ENABLE_BULK_EXPORT = '0';
+        await commonAfterEach();
+    });
+
+    const runExport = async ({ request, query }) => {
+        const postRequestProcessor = getTestContainer().postRequestProcessor;
+        const postSaveProcessor = getTestContainer().postSaveProcessor;
+
+        let resp = await request
+            .post(`/4_0_0/$export?_type=DocumentReference${query}`)
+            .set(getHeaders())
+            .expect(202);
+
+        expect(resp.headers['content-location']).toBeDefined();
+        const exportStatusId = resp.headers['content-location'].split('/').pop();
+
+        const container = getTestContainer();
+        const requestId = generateUUID();
+        const exportS3Client = new MockS3Client({ bucketName: 'test', region: 'test' });
+
+        container.register('bulkDataExportRunner', (c) => new BulkDataExportRunner({
+            databaseQueryFactory: c.databaseQueryFactory,
+            databaseExportManager: c.databaseExportManager,
+            patientFilterManager: c.patientFilterManager,
+            databaseAttachmentManager: c.databaseAttachmentManager,
+            base64DataManager: c.base64DataManager,
+            r4SearchQueryCreator: c.r4SearchQueryCreator,
+            patientQueryCreator: c.patientQueryCreator,
+            enrichmentManager: c.enrichmentManager,
+            resourceLocatorFactory: c.resourceLocatorFactory,
+            r4ArgsParser: c.r4ArgsParser,
+            searchManager: c.searchManager,
+            postSaveProcessor: c.postSaveProcessor,
+            bulkExportEventProducer: c.bulkExportEventProducer,
+            storageProviderFactory: c.storageProviderFactory,
+            exportStatusId,
+            patientReferenceBatchSize: 1000,
+            uploadPartSize: 1024 * 1024,
+            s3Client: exportS3Client,
+            requestId
+        }));
+
+        const bulkDataExportRunner = container.bulkDataExportRunner;
+        await bulkDataExportRunner.processAsync();
+        await postRequestProcessor.executeAsync({ requestId });
+        await postSaveProcessor.flushAsync();
+
+        resp = await request
+            .get(`/4_0_0/$export/${exportStatusId}`)
+            .set(getHeaders())
+            .expect(200);
+
+        expect(resp.body.errors).toHaveLength(0);
+
+        const exportedFilePath = `${bulkDataExportRunner.baseS3Folder}/DocumentReference.ndjson`;
+        const exportedNdjson = exportS3Client.uploadedData[exportedFilePath];
+        expect(exportedNdjson).toBeDefined();
+
+        return exportedNdjson
+            .trim()
+            .split('\n')
+            .filter((line) => line.length > 0)
+            .map((line) => JSON.parse(line));
+    };
+
+    test('Export includes GridFS-offloaded data for a DocumentReference resource', async () => {
+        const request = await createTestRequest(registerMockClients);
+
+        const docId = 'export-docref-full';
+        const data = 'ZnVsbC1leHBvcnQtZG9jcmVmLWRhdGE=';
+        await request
+            .put(`/4_0_0/DocumentReference/${docId}`)
+            .send(buildDocumentReference({ id: docId, data }))
+            .set(getHeaders())
+            .expect(201);
+
+        const exportedDocs = await runExport({ request, query: '' });
+
+        expect(exportedDocs).toHaveLength(1);
+        expect(exportedDocs[0].content[0].attachment.data).toBe(data);
+        expect(exportedDocs[0].content[0].attachment._file_id).toBeUndefined();
+    });
+
+    test('Export with _elements=id,content still rehydrates GridFS data for a projected DocumentReference', async () => {
+        const request = await createTestRequest(registerMockClients);
+
+        const docId = 'export-docref-elements';
+        const data = 'cHJvamVjdGVkLWRvY3JlZi1kYXRh';
+        await request
+            .put(`/4_0_0/DocumentReference/${docId}`)
+            .send(buildDocumentReference({ id: docId, data }))
+            .set(getHeaders())
+            .expect(201);
+
+        const exportedDocs = await runExport({ request, query: '&_elements=id,content' });
+
+        expect(exportedDocs).toHaveLength(1);
+        expect(exportedDocs[0].content[0].attachment.data).toBe(data);
+        expect(exportedDocs[0].content[0].attachment._file_id).toBeUndefined();
+    });
+
+    test('Export with _elements=id omits content entirely and does not leak _file_id', async () => {
+        const request = await createTestRequest(registerMockClients);
+
+        const docId = 'export-docref-id-only';
+        const data = 'aWQtb25seS1kb2NyZWYtZGF0YQ==';
+        await request
+            .put(`/4_0_0/DocumentReference/${docId}`)
+            .send(buildDocumentReference({ id: docId, data }))
+            .set(getHeaders())
+            .expect(201);
+
+        const exportedDocs = await runExport({ request, query: '&_elements=id' });
+
+        expect(exportedDocs).toHaveLength(1);
+        expect(exportedDocs[0].content).toBeUndefined();
+        expect(exportedDocs[0]._file_id).toBeUndefined();
+        expect(exportedDocs[0].id).toBe(docId);
+    });
+});

--- a/src/tests/unit/operations/export/bulkDataExportRunner.nullSafety.test.js
+++ b/src/tests/unit/operations/export/bulkDataExportRunner.nullSafety.test.js
@@ -116,7 +116,7 @@ describe('BulkDataExportRunner - null safety bugs', () => {
             mocks.resourceLocatorFactory.createResourceLocator = jest.fn().mockReturnValue(mockResourceLocator);
 
             mocks.enrichmentManager.enrichAsync = jest.fn().mockResolvedValue(undefined);
-            mocks.databaseAttachmentManager.transformAttachments = jest.fn().mockResolvedValue(undefined);
+            mocks.databaseAttachmentManager.transformAttachments = jest.fn().mockImplementation((doc) => doc);
             mocks.base64DataManager.transformAsync = jest.fn().mockImplementation((doc) => doc);
 
             // Math.floor(uploadPartSize / 0) would be Infinity, and `new Array(Infinity)`
@@ -166,7 +166,7 @@ describe('BulkDataExportRunner - null safety bugs', () => {
             mocks.resourceLocatorFactory.createResourceLocator = jest.fn().mockReturnValue(mockResourceLocator);
 
             mocks.enrichmentManager.enrichAsync = jest.fn().mockResolvedValue(undefined);
-            mocks.databaseAttachmentManager.transformAttachments = jest.fn().mockResolvedValue(undefined);
+            mocks.databaseAttachmentManager.transformAttachments = jest.fn().mockImplementation((doc) => doc);
             mocks.base64DataManager.transformAsync = jest.fn().mockImplementation((doc) => doc);
 
             // Set up multipartContext with existing previousBuffer
@@ -286,7 +286,7 @@ describe('BulkDataExportRunner - null safety bugs', () => {
             // Make enrichmentManager throw after multipart upload is started
             mocks.enrichmentManager.enrichAsync = jest.fn().mockRejectedValue(new Error('Enrichment failed'));
 
-            mocks.databaseAttachmentManager.transformAttachments = jest.fn().mockResolvedValue(undefined);
+            mocks.databaseAttachmentManager.transformAttachments = jest.fn().mockImplementation((doc) => doc);
             mocks.base64DataManager.transformAsync = jest.fn().mockImplementation((doc) => doc);
 
             // handlePatientExportAsync must abort the in-progress multipart upload when an

--- a/src/tests/unit/operations/export/bulkDataExportRunner.test.js
+++ b/src/tests/unit/operations/export/bulkDataExportRunner.test.js
@@ -60,6 +60,7 @@ describe('BulkDataExportRunner', () => {
         };
 
         // Setup mocks
+        mocks.databaseAttachmentManager.configManager = { enabledGridFsResources: [] };
         mocks.databaseExportManager.getExportStatusResourceWithId = jest.fn();
         mocks.databaseExportManager.updateExportStatusAsync = jest.fn().mockResolvedValue(undefined);
         mocks.postSaveProcessor.afterSaveAsync = jest.fn().mockResolvedValue(undefined);
@@ -385,8 +386,7 @@ describe('BulkDataExportRunner', () => {
                 patientReferences: ['Patient/1'],
                 multipartContext,
                 // Truthy projection -> isProjected=true -> serializeExportDoc skips
-                // enrichment/attachment/base64 entirely, matching the actual _elements
-                // path this fix targets (and avoiding the need to mock those out).
+                // enrichment only, matching the actual _elements path this fix targets.
                 elementsProjection: { resourceType: 1, id: 1 }
             });
 


### PR DESCRIPTION
## Summary

[DCON-5506](https://icanbwell.atlassian.net/browse/DCON-5506): `$export` with an `_elements` projection silently dropped rehydrated blob data for both storage backends:

- **Binary.data offloaded to S3** (the reported bug): `serializeExportDoc` gated `Base64DataManager.transformAsync(RETRIEVE)` behind `!isProjected`, so a projected export (`_elements=id,data`) never rehydrated `data` from S3 even though it was explicitly requested. No error, no `_blobMeta`, just a missing field.
- **DocumentReference attachments in GridFS** (found while fixing the above, not in the original ticket): same `isProjected` gate skipped `DatabaseAttachmentManager.transformAttachments(RETRIEVE)`. Additionally, that call used the signature `transformAttachments({ resource, operation })` (an object literal) instead of the positional `transformAttachments(resource, operation)` every other caller in the codebase uses — so GridFS rehydration on export never worked at all, projected or not.

## Fix

`serializeExportDoc` now always runs both rehydration steps (only enrichment stays projection-gated), and the GridFS call uses the correct positional signature. Both rehydration calls are self-gating no-ops when their sidecar field (`_blobMeta` / `_file_id`) isn't present on the doc, so this is safe for full exports, `_elements` that omit the data field, and small/inline resources that were never externalized.

## Testing

- `export.binary.test.js`: added a projected-export regression test (S3-offloaded + inline Binary, `_elements=id,data`) and an `_elements=id`-only edge case proving no `_blobMeta` leaks when data isn't requested.
- `export.documentReference.test.js` (new): full export, `_elements=id,content` projected export, and `_elements=id`-only edge case for GridFS-backed DocumentReference attachments.
- Updated two unit-test mocks in `bulkDataExportRunner.test.js` / `.nullSafety.test.js` that were written against the old (buggy) call shape.

All of `src/tests/integration/export/` (50 tests) and `src/tests/unit/operations/export/` (129 tests) pass. `npx eslint` on all changed files: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DCON-5506]: https://icanbwell.atlassian.net/browse/DCON-5506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ