### PR TITLE
DCON-5395 Support Organization-actor delegated tokens and Consent-ref…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,6 +212,22 @@ services:
       DELEGATED_ACT_SUB: 46265db4-0da2-4436-b4e8-85bf7e52a426
       DELEGATED_MANAGING_ORGANIZATION: 8a7cbd9c-5b1e-5c3d-9c4f-0b2e5f1a7c6d
       DELEGATED_ACCESS_USER_ENTITLEMENT: FAMRQT
+      # Delegated access user with an Organization actor (BIG's token-exchange grant for
+      # client-initiated access -- RFC: Delegated Token Generation for Client-Initiated Access,
+      # DCON-5236/DCON-5395). entitlements carries a Consent/<id> reference here instead of a
+      # bare v3-ActReason code -- see readme/delegatedActorAccess.md "Organization Actors".
+      MY_DELEGATED_ORG_ACCESS_USER_NAME: delegated-org-client
+      MY_DELEGATED_ORG_ACCESS_USER_PASSWORD: password
+      MY_DELEGATED_ORG_ACCESS_USER_SCOPE: patient/*.read user/*.read access/*.read
+      MY_DELEGATED_ORG_ACCESS_USER_TOKEN_USERNAME: delegated-org-client@example.com
+      MY_DELEGATED_ORG_ACCESS_USER_CLIENT_PERSON_ID: 0b2ad38a-20bc-5cf5-9739-13f242b05892
+      MY_DELEGATED_ORG_ACCESS_USER_CLIENT_PATIENT_ID: 22aa18af-af51-5799-bc55-367c22c85407
+      MY_DELEGATED_ORG_ACCESS_USER_MASTER_PERSON_ID: 0eb80391-0f61-5ce6-b221-a5428f2f38a7
+      MY_DELEGATED_ORG_ACCESS_USER_MASTER_PATIENT_ID: 668d0748-1484-4bba-9cbe-0faf0de8965c
+      DELEGATED_ORG_ACT_REFERENCE: Organization/50d67a31-af1f-4f30-8d41-51e90a5054fa
+      DELEGATED_ORG_ACT_SUB: client-abc
+      DELEGATED_ORG_MANAGING_ORGANIZATION: 50d67a31-af1f-4f30-8d41-51e90a5054fa
+      DELEGATED_ORG_ACCESS_USER_ENTITLEMENT: Consent/8e4a1f26-3c9d-4b7e-9a02-6f1d5c8b2e90
       # This is the user and password that will be created in the realm for admin scope token
       MY_ADMIN_USER_NAME: admin
       MY_ADMIN_USER_PASSWORD: password@#$%^&873

--- a/docs/superpowers/plans/2026-09-11-dcon-5395-delegated-organization-actor.md
+++ b/docs/superpowers/plans/2026-09-11-dcon-5395-delegated-organization-actor.md
@@ -1,0 +1,121 @@
+# DCON-5395: Delegated Organization-Actor Access (Consent-Reference Entitlements)
+
+> **Status:** Implemented. This document is a retrospective record of the design and the
+> work done — checkboxes are marked complete rather than used for tracking in-progress work.
+
+**Ticket:** [DCON-5395](https://icanbwell.atlassian.net/browse/DCON-5395)
+**RFC:** [RFC: Delegated Token Generation for Client-Initiated Access](https://icanbwell.atlassian.net/wiki/spaces/ENTARCH/pages/6652493827)
+**Related:** DCON-5236 (BIG's token-exchange grant), [CIE-8632](https://icanbwell.atlassian.net/browse/CIE-8632) (FHIR app scopes for CRS/BIG)
+**PR:** [icanbwell/fhir-server#2576](https://github.com/icanbwell/fhir-server/pull/2576) (branch `SC-DCON-5395`)
+
+**Goal:** Support a second delegated-actor shape alongside the existing human `RelatedPerson`
+flow — a backend/service-integration client (`Organization`) acting on a Person it has itself
+onboarded, with no human grantee. BIG's token-exchange grant for this flow mints an
+`entitlements` claim carrying a `Consent/<id>` reference instead of a bare `v3-ActReason`
+code, and an `act.reference` of `Organization/<id>` instead of `RelatedPerson/<id>`.
+
+**Architecture:** The `entitlements` Consent reference is resolved once, at authentication
+time (`AuthService.processUserInfo`), into the real `provision.purpose` code — never at
+audit-log-build time — so there is exactly one code path that guarantees a raw resource
+reference never reaches `purposeOfEvent`. The per-person Consent search
+(`DelegatedAccessRulesManager.fetchConsentResourcesAsync`) is skipped entirely for an
+`Organization` actor rather than adapted, since that flow's authorizing Consent is org-level
+(no `patient` field) and could never satisfy that query anyway — fhir-server trusts BIG's
+mint-time verification for this actor type instead.
+
+**Tech Stack:** Node.js / CommonJS, passport-jwt, MongoDB, Jest.
+
+## Global Constraints
+
+- A bare-code (legacy) `entitlements` value must stay byte-for-byte unchanged and fully
+  synchronous — `processUserInfo` only awaits anything when a `Consent/<id>`-shaped entry is
+  actually present, so ~40+ pre-existing synchronous test assertions across the codebase
+  don't need to change.
+- `null` vs `[]` is a load-bearing distinction throughout: `null` = "genuinely unresolvable"
+  (not found, or ambiguous) → caller fails closed; `[]` = "resolved successfully, no codes" →
+  request still succeeds with an empty `purposeOfEvent`.
+- A transient DB/lookup failure must never be indistinguishable from "Consent not found" —
+  it rejects (`isTransient`/`statusCode: 503`, this codebase's INC-322 convention) rather than
+  resolving to `null`, since `verify()` re-resolves entitlements on every request (no
+  cross-request caching) and a permanent 401 for a brief Mongo hiccup would be wrong.
+- No tenant/access-tag re-validation of the entitlements Consent's authorization itself — that
+  was already verified by BIG before minting the token; fhir-server only guards against
+  resolving to the *wrong* resource (ambiguous bare-id match), not re-deriving authorization.
+
+---
+
+## Task 1: Accept `Organization` as a valid delegated-actor type
+
+- [x] Added `DELEGATED_ACCESS.ALLOWED_ACTOR_RESOURCE_TYPES: ['RelatedPerson', 'Organization']`
+      (`src/constants.js`).
+- [x] `AuthService.processForDelegatedActor` checks the JWT `act.reference`'s resource type
+      against that allow-list instead of a hardcoded `.startsWith('RelatedPerson/')`
+      (`src/strategies/authService.js`).
+
+## Task 2: Resolve `Consent/<id>` entitlements into `purposeOfEvent`
+
+- [x] `DelegatedAccessRulesManager.resolvePurposeOfEventCodesAsync` / `resolveConsentPurposeCodesAsync`
+      (`src/utils/delegatedAccessRulesManager.js`): dispatches per-entitlement (bare code
+      passthrough vs. Consent dereference by id), returns `null` on unresolvable/ambiguous,
+      `[]` on resolved-but-empty, and rethrows (marked transient/503) on a genuine lookup error.
+- [x] `AuthService.processUserInfo` calls it only when an entitlement actually parses to a
+      `Consent` reference; on `null` it rejects with `done(null, false, { reason:
+      'delegated_actor_consent_not_found' })` (401); on a rejection it lets the promise
+      propagate to `verify()`'s existing `.catch()` chain (503).
+- [x] `verify()`'s three call sites into `processUserInfo` updated (`return`/`.catch()`) so a
+      rejection from the now-`async` `processUserInfo` can't become an unhandled rejection.
+
+## Task 3: Skip the per-person Consent gate for `Organization` actors
+
+- [x] `DelegatedAccessRulesManager.getFilteringRulesAsync` returns a trust-everything result
+      (no `consentId`, empty `deniedSensitiveCategories`) without querying Mongo when the actor
+      is `Organization/<id>`.
+- [x] `hasValidConsentAsync` guards `actor.consentPolicy` assignment behind `if (consentId)` so
+      it doesn't produce `"Consent/null"` for this actor type.
+
+## Task 4: Surface the entitlements Consent as `agent.policy`
+
+- [x] `AuthService.processUserInfo` stores the raw (successfully-resolved) Consent reference(s)
+      on `context.actor.entitlementsConsentPolicies`.
+- [x] `AuditLogger.buildAgents` merges `actor.consentPolicy` (per-person, `RelatedPerson` flow)
+      and `actor.entitlementsConsentPolicies` (org-level, `entitlements`-derived) into a single
+      `agent.policy` array — either, both, or neither may be present.
+
+## Task 5: Security-review fixes (from `claude[bot]`'s review of PR #2576)
+
+- [x] Transient-error/401 conflation: fixed as described under Global Constraints.
+- [x] Bare, authority-less Consent id lookup (`{ id }`, no UUID/authority) now checks for
+      multiple matches and returns `null` instead of blindly taking `consents[0]` — mirrors
+      `getFilteringRulesAsync`'s existing ambiguous-match handling; prevents a same-id Consent
+      collision across tenants from substituting the wrong org's `provision.purpose` codes.
+
+## Task 6: Local testing infrastructure
+
+- [x] `keycloak-config/realm-import.json` + `docker-compose.yml`: new `delegated-org-client`
+      test user minting an `Organization` actor + `Consent/<id>` entitlement token.
+- [x] `readme/delegatedActorAccess.md`: documents both actor shapes, both entitlements shapes,
+      the fail-closed behavior, the Organization Consent-gate bypass, and `agent.policy`.
+- [x] Verified end-to-end against the local stack: seeded a matching `Consent`, generated a
+      token via the new Keycloak user, confirmed `$everything` succeeds and the resulting
+      AuditEvent's `purposeOfEvent` resolves to `TREAT` (not the raw reference); confirmed an
+      unresolvable Consent now rejects at auth time instead of succeeding with an empty
+      `purposeOfEvent`.
+- [x] Verified against `fhir.dev.bwell.zone`: confirmed `Organization/50d67a31-af1f-4f30-8d41-51e90a5054fa`
+      ("Network Demo") is a real dev tenant, created a matching org-level `Consent`
+      (`Consent/9334b9dc-ea90-4a26-b1a0-1011c586c6ff`) there for future end-to-end testing.
+
+## Task 7: Cross-team follow-up
+
+- [x] Filed [CIE-8632](https://icanbwell.atlassian.net/browse/CIE-8632) asking Cloud
+      Infrastructure Engineering to register FHIR app scopes for CRS (`user/Consent.*`, since it
+      creates the org-level Consent at onboarding) and BIG (`user/Consent.read` only, since it
+      only ever verifies the Consent — never creates/modifies it, per the RFC's
+      self-approval-loop closure).
+
+## Explicitly out of scope
+
+- BIG/CRS's own client registration and scope configuration (tracked in CIE-8632, owned by
+  another team).
+- Re-validating the entitlements Consent's own authorization shape (status/category/period) —
+  that's BIG's job at mint time; fhir-server only dereferences it for the purpose code.
+- Deploying to sandbox (a deployment step, not a code change).

--- a/keycloak-config/realm-import.json
+++ b/keycloak-config/realm-import.json
@@ -129,6 +129,44 @@
       }
     },
     {
+      "id": "b8c4d2e3-f5a6-4789-9bcd-ef0123456790",
+      "username": "${MY_DELEGATED_ORG_ACCESS_USER_NAME}",
+      "firstName": "Tester",
+      "lastName": "WithOrgActor",
+      "email": "tester-with-org-actor@tester.com",
+      "emailVerified": true,
+      "createdTimestamp": 1718982320512,
+      "enabled": true,
+      "totp": false,
+      "credentials": [
+        {
+          "id": "b1c2d3e4-f5a6-7890-bcde-f01234567891",
+          "type": "password",
+          "createdDate": 1718987296927,
+          "value": "${MY_DELEGATED_ORG_ACCESS_USER_PASSWORD}",
+          "temporary": false
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "notBefore": 0,
+      "realmRoles": [
+      ],
+      "attributes": {
+        "custom:scope": "${MY_DELEGATED_ORG_ACCESS_USER_SCOPE}",
+        "clientFhirPersonId": "${MY_DELEGATED_ORG_ACCESS_USER_CLIENT_PERSON_ID}",
+        "clientFhirPatientId": "${MY_DELEGATED_ORG_ACCESS_USER_CLIENT_PATIENT_ID}",
+        "bwellFhirPersonId": "${MY_DELEGATED_ORG_ACCESS_USER_MASTER_PERSON_ID}",
+        "bwellFhirPatientId": "${MY_DELEGATED_ORG_ACCESS_USER_MASTER_PATIENT_ID}",
+        "token_use": "access",
+        "username": "${MY_DELEGATED_ORG_ACCESS_USER_TOKEN_USERNAME}",
+        "act.reference": "${DELEGATED_ORG_ACT_REFERENCE}",
+        "act.sub": "${DELEGATED_ORG_ACT_SUB}",
+        "managingOrganization": "${DELEGATED_ORG_MANAGING_ORGANIZATION}",
+        "entitlements": "${DELEGATED_ORG_ACCESS_USER_ENTITLEMENT}"
+      }
+    },
+    {
       "id": "1ecaa0de-a3e9-532c-8a3b-7c0018cb3428",
       "username": "${CMS_USER_NAME}",
       "firstName": "CMS",

--- a/readme/delegatedActorAccess.md
+++ b/readme/delegatedActorAccess.md
@@ -29,8 +29,13 @@ When `ENABLE_DELEGATED_ACCESS_DETECTION` is enabled, the server inspects the JWT
 
 1. **No `act` claim**: proceeds normally (no delegated actor)
 2. **`act` is a string**: logged and skipped (future format, not yet supported)
-3. **`act` is an object with `reference: "RelatedPerson/<id>" and sub: "<sub>"`**: delegated actor is detected and set on `context.actor`
+3. **`act` is an object with `reference: "RelatedPerson/<id>"` (or, since DCON-5395, `"Organization/<id>"`) and `sub: "<sub>"`**: delegated actor is detected and set on `context.actor`
 4. **Any other format**: authentication fails (401) with message indicating the expected format
+
+Two actor shapes are supported for `act.reference`:
+
+- **`RelatedPerson/<id>`** — a human delegate acting on a grantor's behalf, via the Health Circle / Appointment-of-Representative flow (PARS/BIG's `POST /token/delegate`).
+- **`Organization/<id>`** (DCON-5395/DCON-5236) — a backend/service-integration client acting on a Person it has itself onboarded, with no human grantee anywhere in the flow. Minted by BIG's RFC 8693 token-exchange grant for client-initiated access (see [RFC: Delegated Token Generation for Client-Initiated Access](https://icanbwell.atlassian.net/wiki/spaces/ENTARCH/pages/6652493827)). See "Organization Actors" below — the Consent lookup and filtering-rules flow differ for this actor type.
 
 When a delegated actor is detected, `userType` is set to `delegatedUser` regardless of what the token claims.
 
@@ -72,6 +77,18 @@ After the query returns:
 - No active Consent found: Forbidden 403 — `"actor {actor} doesn't have enough permissions to perform this action"`
 - Multiple Consents found: Forbidden 403 — `"ambiguous permissions found for the actor {actor}"`
 - Invalid `act` claim format (when detection enabled): 401 Unauthorized — the `act` must be an object with `reference` and `sub` field.
+
+## Organization Actors (DCON-5395/DCON-5236)
+
+The Consent Query above ties a grantor **person** to a delegated actor via a `patient`-scoped Consent. That model doesn't apply when the delegated actor is an `Organization` (BIG's token-exchange grant for client-initiated access): the authorizing Consent for that flow is an **org-level grant, established once at client onboarding, with no `patient` field at all** — it authorizes the Organization generally, not a specific person (see the RFC for the full Consent shape).
+
+Because that Consent can never satisfy the `patient.reference` match above, `DelegatedAccessRulesManager.getFilteringRulesAsync` **skips the per-person Consent lookup entirely** when the actor reference is `Organization/<id>`, rather than trying to adapt the query. This is a deliberate trust boundary, not an oversight: BIG already verifies Person ownership and an active org-level Consent (`dataSharingAccess` category, Treatment scope, matching `provision.actor`) before it ever mints the token — fhir-server trusts that mint-time verification for this actor type, the same way it trusts every other signed JWT claim, rather than re-deriving a per-person consent that was never meant to exist.
+
+Consequences of the skip:
+- `hasValidConsentAsync` returns `true` unconditionally for an `Organization` actor — no database query, no ambiguous/no-consent rejection path.
+- No `deniedSensitiveCategories` are derived from a Consent (there is no nested `provision.provision` to walk) — the sensitive-data exclusion filter falls back to its always-on `unclassified` exclusion only (see "Filtering of Unclassified Resources" below).
+- `actor.consentPolicy` is left unset for this actor type — there is no per-person Consent reference to point at.
+- The org-level Consent named in the JWT's `entitlements` claim is unrelated to this gate (`hasValidConsentAsync` never dereferences it). It's used for two other things instead: `purposeOfEvent` resolution, and populating `agent.policy` on the AuditEvent (see below) — both handled in `AuthService.processUserInfo` at authentication time, not here.
 
 ## Building Filtering Rules
 
@@ -163,12 +180,18 @@ The `source.observer` references the delegated actor.
 
 ### Purpose of Event (Entitlements)
 
-If the delegated user's JWT carries an `entitlements` array, those values are copied verbatim into `context.purposeOfUse` during authentication and then surface as `purposeOfEvent.coding` on the two-agent AuditEvent.
+If the delegated user's JWT carries an `entitlements` array, those values are copied into `context.purposeOfUse` during authentication and then surface as `purposeOfEvent.coding` on the two-agent AuditEvent. `entitlements` supports two shapes:
 
-- Each entitlement code becomes one `purposeOfEvent[].coding[]` entry.
-- The `system` is always `http://terminology.hl7.org/CodeSystem/v3-ActReason`.
-- The codes are passed through **as-is** — no validation or mapping is performed on the values.
-- If the JWT has no `entitlements` array (or it is empty), `purposeOfEvent` is omitted from the audit event.
+1. **Legacy: bare v3-ActReason code(s)** — e.g. `"entitlements": ["FAMRQT"]`. Each code is copied through **as-is**, with no validation or mapping, and becomes one `purposeOfEvent[].coding[]` entry.
+2. **Consent reference (DCON-5395)** — e.g. `"entitlements": ["Consent/<id>"]`. This is the shape minted by BIG's token-exchange grant for client-initiated access (DCON-5236): the token has no live end-user session to carry a bare ActReason code, so it instead points at the org-level `Consent` created during client onboarding. During authentication, `AuthService.processUserInfo` detects the `Consent/<id>` shape and calls `DelegatedAccessRulesManager.resolvePurposeOfEventCodesAsync` to dereference the `Consent`, substituting its `provision.purpose[].code` values in place of the raw reference before it is ever stored on `context.purposeOfUse`. A bare-code `entitlements` array skips this resolution entirely and stays synchronous.
+
+**If the Consent named in `entitlements` cannot be resolved** (deleted, wrong id, transient DB error), authentication fails closed: `processUserInfo` rejects with `done(null, false, { reason: 'delegated_actor_consent_not_found' })` (401), the same way any other malformed/unverifiable claim is rejected. This is a fail-closed change from an earlier iteration that silently proceeded with an empty `purposeOfEvent` — a `Consent/<id>` entitlement is supposed to be verifiable proof of a purpose, so failing to verify it now denies the request rather than degrading quietly. This is distinct from "the Consent was found but has no `provision.purpose` codes," which still just produces an empty `purposeOfEvent` on an otherwise-successful request (a data-quality issue, not an authorization failure).
+
+In both cases the resulting codes are rendered into `purposeOfEvent[].coding[]` with `system` always `http://terminology.hl7.org/CodeSystem/v3-ActReason`. If the JWT has no `entitlements` array (or it is empty), or a resolved Consent has no purpose codes, `purposeOfEvent` is omitted from the audit event.
+
+### Consent Policy (agent.policy)
+
+Separately from `purposeOfEvent`, each successfully-resolved `Consent/<id>` entitlement is also recorded as-is (the raw reference, not dereferenced further) on `context.actor.entitlementsConsentPolicies`, and `AuditLogger.buildAgents` folds it into the delegated actor agent's `agent.policy` — FHIR's designated slot for "the specific patient consent, guarantor funding, etc." that authorized the event. This is independent of the *other* source of `agent.policy`, `actor.consentPolicy` (the per-person grantor↔actor Consent from the `RelatedPerson` flow, set by `hasValidConsentAsync`) — the two are merged into a single array when both happen to be present, but neither implies the other. An `Organization` actor typically has only `entitlementsConsentPolicies` (no per-person consent exists for that flow); a `RelatedPerson` actor typically has only `consentPolicy` (its `entitlements` is usually a bare code, not a Consent reference).
 
 For example, a JWT with `"entitlements": ["FAMRQT"]` produces:
 
@@ -179,6 +202,21 @@ For example, a JWT with `"entitlements": ["FAMRQT"]` produces:
       {
         "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
         "code": "FAMRQT"
+      }
+    ]
+  }
+]
+```
+
+A JWT with `"entitlements": ["Consent/consent-uuid-123"]`, where that Consent has `provision.purpose: [{ "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason", "code": "TREAT" }]`, produces the same shape but with the Consent's code substituted in:
+
+```json
+"purposeOfEvent": [
+  {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
+        "code": "TREAT"
       }
     ]
   }
@@ -213,6 +251,36 @@ The generated token will contain:
   "entitlements": ["FAMRQT"]
 }
 ```
+
+### Generate a delegated access token (Organization actor, DCON-5395/DCON-5236)
+
+```
+curl --request POST \
+  --url http://localhost:8080/realms/master/protocol/openid-connect/token \
+  --header 'content-type: application/x-www-form-urlencoded' \
+  --data client_id=bwell-client-id \
+  --data client_secret=bwell-secret \
+  --data 'username=delegated-org-client@example.com' \
+  --data password=password \
+  --data grant_type=password \
+  --data 'scope=patient/Patient.read patient/Observation.read patient/Condition.read access/*.read'
+```
+
+The generated token will contain:
+```json
+{
+  "clientFhirPersonId": "0b2ad38a-20bc-5cf5-9739-13f242b05892",
+  "clientFhirPatientId": "22aa18af-af51-5799-bc55-367c22c85407",
+  "act": {
+    "reference": "Organization/50d67a31-af1f-4f30-8d41-51e90a5054fa",
+    "sub": "client-abc"
+  },
+  "managingOrganization": "50d67a31-af1f-4f30-8d41-51e90a5054fa",
+  "entitlements": ["Consent/8e4a1f26-3c9d-4b7e-9a02-6f1d5c8b2e90"]
+}
+```
+
+A `Consent` with that exact `id`, matching the RFC's resource shape (org-level, no `patient` field, `provision.actor.reference` = the same `Organization/<id>` as `act.reference`, `provision.purpose` carrying the code you expect to see on the audit event), must actually exist before generating the token -- an unresolvable `Consent/<id>` entitlement now fails authentication closed (401, `delegated_actor_consent_not_found`) rather than just producing an empty `purposeOfEvent`.
 
 ## Composition Sensitive Section Filtering
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -358,6 +358,14 @@ module.exports = {
             'searchById',
             'everything',
             'graph'
-        ]
+        ],
+        /**
+         * Resource types a JWT `act` claim's `reference` may name as the delegated actor.
+         * - RelatedPerson: a human delegate acting on a grantor's behalf (Health Circle / AoR flow).
+         * - Organization: a backend/service-integration client acting on a Person it has itself
+         *   onboarded, with no human grantee -- BIG's token-exchange grant for client-initiated
+         *   access (RFC: Delegated Token Generation for Client-Initiated Access, DCON-5236/DCON-5395).
+         */
+        ALLOWED_ACTOR_RESOURCE_TYPES: ['RelatedPerson', 'Organization']
     }
 };

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -1427,7 +1427,8 @@ const createContainer = function () {
         return new AuthService
         ({
             configManager: c.configManager,
-            wellKnownConfigurationManager: c.wellKnownConfigurationManager
+            wellKnownConfigurationManager: c.wellKnownConfigurationManager,
+            delegatedAccessRulesManager: c.delegatedAccessRulesManager
         });
     });
 

--- a/src/routeHandlers/healthCheck.js
+++ b/src/routeHandlers/healthCheck.js
@@ -19,7 +19,8 @@ module.exports.handleHealthCheck = async (fnGetContainer, req, res) => {
     const authService = new AuthService(
         {
             configManager: configManager,
-            wellKnownConfigurationManager: container.wellKnownConfigurationManager
+            wellKnownConfigurationManager: container.wellKnownConfigurationManager,
+            delegatedAccessRulesManager: container.delegatedAccessRulesManager
         }
     );
     try {

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -5,12 +5,15 @@ const {
     DEFAULT_CACHE_EXPIRY_TIME,
     DEFAULT_CACHE_MAX_COUNT,
     USER_INFO_CACHE_EXPIRY_TIME,
-    AUTH_USER_TYPES
+    AUTH_USER_TYPES,
+    DELEGATED_ACCESS
 } = require('../constants');
 const {logDebug, logError, logInfo, logWarn} = require('../operations/common/logging');
 const {WellKnownConfigurationManager} = require('../utils/wellKnownConfiguration/wellKnownConfigurationManager');
 const {assertTypeEquals} = require("../utils/assertType");
 const {ConfigManager} = require("../utils/configManager");
+const {DelegatedAccessRulesManager} = require('../utils/delegatedAccessRulesManager');
+const {ReferenceParser} = require('../utils/referenceParser');
 
 /**
  * @typedef {Object} UserInfo
@@ -47,10 +50,12 @@ class AuthService {
      * Constructor for the AuthService
      * @param {ConfigManager} configManager
      * @param {WellKnownConfigurationManager} wellKnownConfigurationManager
+     * @param {DelegatedAccessRulesManager} delegatedAccessRulesManager
      */
     constructor({
                     configManager,
-                    wellKnownConfigurationManager
+                    wellKnownConfigurationManager,
+                    delegatedAccessRulesManager
                 }) {
         /**
          * @type {ConfigManager}
@@ -63,6 +68,12 @@ class AuthService {
          */
         this.wellKnownConfigurationManager = wellKnownConfigurationManager;
         assertTypeEquals(wellKnownConfigurationManager, WellKnownConfigurationManager);
+
+        /**
+         * @type {DelegatedAccessRulesManager}
+         */
+        this.delegatedAccessRulesManager = delegatedAccessRulesManager;
+        assertTypeEquals(delegatedAccessRulesManager, DelegatedAccessRulesManager);
 
         this.requestTimeout = (this.configManager.externalRequestTimeoutSec || 30) * 1000;
         this.requiredJWTFields = {
@@ -261,9 +272,9 @@ class AuthService {
      * @param {import("passport-jwt").VerifiedCallback} done
      * @param {string} client_id
      * @param {string} scope
-     * @return {void}
+     * @return {Promise<void>}
      */
-    processUserInfo({username, subject, isUser, jwt_payload, done, client_id, scope}) {
+    async processUserInfo({username, subject, isUser, jwt_payload, done, client_id, scope}) {
         // A token that resolves to a completely empty scope (nothing on the JWT itself,
         // no groups, and userinfo enrichment -- if attempted -- found nothing either) is
         // authenticated but carries zero permissions; treat it as an auth failure (401),
@@ -331,6 +342,39 @@ class AuthService {
 
                     if (Array.isArray(jwt_payload.entitlements)) {
                         context.purposeOfUse = jwt_payload.entitlements;
+                        // DCON-5395: BIG's token-exchange grant for client-initiated access
+                        // (DCON-5236) mints `entitlements` as a `Consent/<id>` reference instead
+                        // of a bare v3-ActReason code. Only take the async Consent-dereference
+                        // path when that shape is actually present -- the common case (a bare
+                        // code, or no entitlements) must stay fully synchronous so `done()` below
+                        // still fires in the same tick, matching every other branch in this method.
+                        const consentReferences = jwt_payload.entitlements.filter(
+                            (entitlement) => ReferenceParser.parseReference(entitlement).resourceType === 'Consent'
+                        );
+                        if (consentReferences.length > 0) {
+                            const resolvedPurposeOfUse = await this.delegatedAccessRulesManager.resolvePurposeOfEventCodesAsync({
+                                entitlements: jwt_payload.entitlements
+                            });
+                            // null means a Consent/<id> entitlement could not be resolved (the
+                            // Consent doesn't exist, or the lookup errored) -- fail closed rather
+                            // than silently proceeding with an empty purposeOfEvent on an
+                            // otherwise-successful request.
+                            if (resolvedPurposeOfUse === null) {
+                                logWarn('Auth rejected', {
+                                    reason: 'delegated_actor_consent_not_found',
+                                    username,
+                                    subject
+                                });
+                                done(null, false, { reason: 'delegated_actor_consent_not_found' });
+                                return;
+                            }
+                            context.purposeOfUse = resolvedPurposeOfUse;
+                            // Surface the org-level Consent that authorized this access as
+                            // agent.policy on the AuditEvent (FHIR's designated slot for "the
+                            // consent/policy that authorized this event"), alongside the
+                            // resolved purposeOfEvent code -- see AuditLogger.buildAgents.
+                            context.actor.entitlementsConsentPolicies = consentReferences;
+                        }
                     }
                 }
             }
@@ -530,8 +574,13 @@ class AuthService {
         }
 
         let isValidInput = true;
-        // validate reference
-        isValidInput &&= typeof act[this.requiredActorFields.reference] === 'string' && act[this.requiredActorFields.reference].startsWith('RelatedPerson/');
+        // validate reference: a human delegate (RelatedPerson, Health Circle/AoR flow) or a
+        // backend/service-integration client (Organization, BIG's token-exchange flow for
+        // client-initiated access -- RFC: Delegated Token Generation for Client-Initiated Access).
+        isValidInput &&= typeof act[this.requiredActorFields.reference] === 'string' &&
+            DELEGATED_ACCESS.ALLOWED_ACTOR_RESOURCE_TYPES.includes(
+                ReferenceParser.parseReference(act[this.requiredActorFields.reference]).resourceType
+            );
         // validate sub
         isValidInput &&= typeof act[this.requiredActorFields.sub] === 'string';
 
@@ -590,7 +639,7 @@ class AuthService {
                             subject: subject1,
                             clientId: clientId1
                         } = userInfo;
-                        this.processUserInfo({
+                        return this.processUserInfo({
                             username: username1 || username,
                             subject: subject1 || subject,
                             isUser: isUser1 || isUser,
@@ -600,7 +649,7 @@ class AuthService {
                             scope: scope1 || scope
                         });
                     } else {
-                        this.processUserInfo({
+                        return this.processUserInfo({
                             username: username,
                             subject: subject,
                             isUser,
@@ -648,6 +697,16 @@ class AuthService {
                     done,
                     client_id: clientId,
                     scope
+                }).catch((error) => {
+                    // processUserInfo is now async (DCON-5395: it may await a Consent lookup),
+                    // so a synchronous throw here would reject rather than propagate directly --
+                    // surface it the same way the userinfo-endpoint failure path above does,
+                    // rather than letting it become an unhandled rejection.
+                    logError(`Error while processing user info: ${error.message}`, {
+                        reason: 'process_user_info_error',
+                        error
+                    });
+                    done(error);
                 });
             }
         } else {

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -355,10 +355,14 @@ class AuthService {
                             const resolvedPurposeOfUse = await this.delegatedAccessRulesManager.resolvePurposeOfEventCodesAsync({
                                 entitlements: jwt_payload.entitlements
                             });
-                            // null means a Consent/<id> entitlement could not be resolved (the
-                            // Consent doesn't exist, or the lookup errored) -- fail closed rather
-                            // than silently proceeding with an empty purposeOfEvent on an
-                            // otherwise-successful request.
+                            // null means a Consent/<id> entitlement genuinely could not be
+                            // resolved (not found, or ambiguous) -- fail closed rather than
+                            // silently proceeding with an empty purposeOfEvent on an otherwise-
+                            // successful request. A transient lookup failure (DB timeout,
+                            // network blip) does NOT resolve to null here -- it rejects instead
+                            // (isTransient/statusCode set, INC-322 convention), letting it
+                            // propagate to verify()'s existing .catch() as a retryable error
+                            // rather than a permanent-looking 401.
                             if (resolvedPurposeOfUse === null) {
                                 logWarn('Auth rejected', {
                                     reason: 'delegated_actor_consent_not_found',

--- a/src/strategies/authService.js
+++ b/src/strategies/authService.js
@@ -342,12 +342,8 @@ class AuthService {
 
                     if (Array.isArray(jwt_payload.entitlements)) {
                         context.purposeOfUse = jwt_payload.entitlements;
-                        // DCON-5395: BIG's token-exchange grant for client-initiated access
-                        // (DCON-5236) mints `entitlements` as a `Consent/<id>` reference instead
-                        // of a bare v3-ActReason code. Only take the async Consent-dereference
-                        // path when that shape is actually present -- the common case (a bare
-                        // code, or no entitlements) must stay fully synchronous so `done()` below
-                        // still fires in the same tick, matching every other branch in this method.
+                        // Only take the async Consent-dereference path when entitlements
+                        // actually names one (DCON-5395) -- bare codes stay fully synchronous.
                         const consentReferences = jwt_payload.entitlements.filter(
                             (entitlement) => ReferenceParser.parseReference(entitlement).resourceType === 'Consent'
                         );
@@ -355,14 +351,8 @@ class AuthService {
                             const resolvedPurposeOfUse = await this.delegatedAccessRulesManager.resolvePurposeOfEventCodesAsync({
                                 entitlements: jwt_payload.entitlements
                             });
-                            // null means a Consent/<id> entitlement genuinely could not be
-                            // resolved (not found, or ambiguous) -- fail closed rather than
-                            // silently proceeding with an empty purposeOfEvent on an otherwise-
-                            // successful request. A transient lookup failure (DB timeout,
-                            // network blip) does NOT resolve to null here -- it rejects instead
-                            // (isTransient/statusCode set, INC-322 convention), letting it
-                            // propagate to verify()'s existing .catch() as a retryable error
-                            // rather than a permanent-looking 401.
+                            // null = Consent genuinely unresolvable -> fail closed (401). A
+                            // transient lookup error rejects instead (503 via verify()'s catch).
                             if (resolvedPurposeOfUse === null) {
                                 logWarn('Auth rejected', {
                                     reason: 'delegated_actor_consent_not_found',
@@ -373,10 +363,7 @@ class AuthService {
                                 return;
                             }
                             context.purposeOfUse = resolvedPurposeOfUse;
-                            // Surface the org-level Consent that authorized this access as
-                            // agent.policy on the AuditEvent (FHIR's designated slot for "the
-                            // consent/policy that authorized this event"), alongside the
-                            // resolved purposeOfEvent code -- see AuditLogger.buildAgents.
+                            // Surfaced as agent.policy on the AuditEvent -- see AuditLogger.buildAgents.
                             context.actor.entitlementsConsentPolicies = consentReferences;
                         }
                     }
@@ -578,9 +565,7 @@ class AuthService {
         }
 
         let isValidInput = true;
-        // validate reference: a human delegate (RelatedPerson, Health Circle/AoR flow) or a
-        // backend/service-integration client (Organization, BIG's token-exchange flow for
-        // client-initiated access -- RFC: Delegated Token Generation for Client-Initiated Access).
+        // validate reference: human delegate (RelatedPerson) or client (Organization, DCON-5395)
         isValidInput &&= typeof act[this.requiredActorFields.reference] === 'string' &&
             DELEGATED_ACCESS.ALLOWED_ACTOR_RESOURCE_TYPES.includes(
                 ReferenceParser.parseReference(act[this.requiredActorFields.reference]).resourceType
@@ -702,10 +687,8 @@ class AuthService {
                     client_id: clientId,
                     scope
                 }).catch((error) => {
-                    // processUserInfo is now async (DCON-5395: it may await a Consent lookup),
-                    // so a synchronous throw here would reject rather than propagate directly --
-                    // surface it the same way the userinfo-endpoint failure path above does,
-                    // rather than letting it become an unhandled rejection.
+                    // processUserInfo is async now (may await a Consent lookup) -- catch here
+                    // too, so a rejection doesn't become an unhandled rejection.
                     logError(`Error while processing user info: ${error.message}`, {
                         reason: 'process_user_info_error',
                         error

--- a/src/tests/integration/strategies/authService.test.js
+++ b/src/tests/integration/strategies/authService.test.js
@@ -3,6 +3,7 @@ const nock = require('nock');
 const {WellKnownConfigurationManager} = require("../../../utils/wellKnownConfiguration/wellKnownConfigurationManager");
 const {AuthService} = require("../../../strategies/authService");
 const {ConfigManager} = require("../../../utils/configManager");
+const {DelegatedAccessRulesManager} = require("../../../utils/delegatedAccessRulesManager");
 describe('JWT Bearer Strategy', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -38,7 +39,8 @@ describe('JWT Bearer Strategy', () => {
                     {
                         configManager
                     }
-                )
+                ),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }
         );
 
@@ -82,7 +84,8 @@ describe('JWT Bearer Strategy', () => {
                     {
                         configManager
                     }
-                )
+                ),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }
         );
         authService.clearAuthCache();
@@ -124,7 +127,8 @@ describe('JWT Bearer Strategy', () => {
                     {
                         configManager
                     }
-                )
+                ),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }
         );
         const result = await authService.getExternalJwksAsync();
@@ -155,7 +159,8 @@ describe('JWT Bearer Strategy', () => {
                     {
                         configManager: configManager
                     }
-                )
+                ),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }
         );
         const result = await authService.getExternalJwksAsync();
@@ -211,7 +216,8 @@ describe('JWT Bearer Strategy', () => {
         const authService = new AuthService(
             {
                 configManager: configManager,
-                wellKnownConfigurationManager: wellKnownManager
+                wellKnownConfigurationManager: wellKnownManager,
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }
         );
         // mockWellKnownConfig has no jwks_uri, so the well-known fallback resolves to

--- a/src/tests/integration/strategies/jwt.bearer.strategy.test.js
+++ b/src/tests/integration/strategies/jwt.bearer.strategy.test.js
@@ -8,6 +8,7 @@ const {WellKnownConfigurationManager} = require("../../../utils/wellKnownConfigu
 const jwt = require("jsonwebtoken");
 const {AuthService} = require("../../../strategies/authService");
 const {ConfigManager} = require("../../../utils/configManager");
+const {DelegatedAccessRulesManager} = require("../../../utils/delegatedAccessRulesManager");
 const {IncomingMessage} = require('http');
 
 
@@ -64,7 +65,8 @@ describe('JWT Bearer Strategy', () => {
                     {
                         configManager
                     }
-                )
+                ),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }
         );
         const strategy = new MyJwtStrategy({
@@ -107,7 +109,8 @@ describe('JWT Bearer Strategy', () => {
                     {
                         configManager
                     }
-                )
+                ),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }
         );
 
@@ -207,7 +210,8 @@ describe('JWT Bearer Strategy', () => {
                         {
                             configManager: configManager
                         }
-                    )
+                    ),
+                    delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
                 }
             ),
             configManager: configManager
@@ -303,7 +307,8 @@ describe('JWT Bearer Strategy', () => {
                         {
                             configManager: configManager
                         }
-                    )
+                    ),
+                    delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
                 }
             ),
             configManager: configManager
@@ -427,7 +432,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -526,7 +532,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -631,7 +638,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -717,7 +725,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -804,7 +813,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -891,7 +901,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -978,7 +989,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -1060,7 +1072,8 @@ describe('JWT Bearer Strategy', () => {
                         {
                             configManager: configManager
                         }
-                    )
+                    ),
+                    delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
                 }
             ),
             configManager: configManager
@@ -1141,7 +1154,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -1220,7 +1234,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -1299,7 +1314,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -1379,7 +1395,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -1459,7 +1476,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -1538,7 +1556,8 @@ describe('JWT Bearer Strategy', () => {
                 configManager: configManager,
                 wellKnownConfigurationManager: new WellKnownConfigurationManager({
                     configManager: configManager
-                })
+                }),
+                delegatedAccessRulesManager: Object.create(DelegatedAccessRulesManager.prototype)
             }),
             configManager: configManager
         });
@@ -1562,11 +1581,20 @@ describe('JWT Bearer Strategy', () => {
 });
 
 describe('AuthService.processUserInfo - purposeOfUse claim parsing', () => {
-    const makeAuthService = () => new AuthService({
+    const makeMockDelegatedAccessRulesManager = () => {
+        const instance = Object.create(DelegatedAccessRulesManager.prototype);
+        instance.resolvePurposeOfEventCodesAsync = jest.fn().mockImplementation(
+            ({ entitlements }) => Promise.resolve(entitlements ?? null)
+        );
+        return instance;
+    };
+
+    const makeAuthService = ({ delegatedAccessRulesManager } = {}) => new AuthService({
         configManager: new ConfigManager(),
         wellKnownConfigurationManager: new WellKnownConfigurationManager({
             configManager: new ConfigManager()
-        })
+        }),
+        delegatedAccessRulesManager: delegatedAccessRulesManager || makeMockDelegatedAccessRulesManager()
     });
 
     const basePayload = () => ({
@@ -1619,6 +1647,72 @@ describe('AuthService.processUserInfo - purposeOfUse claim parsing', () => {
         })
 
     })
+
+    test('DCON-5395: resolves a Consent/<id> entitlement to the Consent purpose codes for a delegated user', (done) => {
+        const mockDelegatedAccessRulesManager = makeMockDelegatedAccessRulesManager();
+        mockDelegatedAccessRulesManager.resolvePurposeOfEventCodesAsync.mockResolvedValue(['TREAT']);
+        const authService = makeAuthService({ delegatedAccessRulesManager: mockDelegatedAccessRulesManager });
+
+        // Override configManager for enabling delegated access detection.
+        authService.configManager = new (class extends ConfigManager {
+            get enableDelegatedAccessDetection() { return true; }
+        });
+        const jwt_payload = {
+            ...basePayload(),
+            // BIG's token-exchange grant for client-initiated access (DCON-5236) mints
+            // `entitlements` as a Consent/<id> reference instead of a bare ActReason code.
+            entitlements: ['Consent/consent-uuid-123'],
+            act: {
+                reference: 'RelatedPerson/8d5fcbff-3707-405c-b0b2-3053a3adc013',
+                sub: 'patient-1'
+            }
+        };
+
+        authService.processUserInfo({
+            username: 'u', subject: 's', isUser: true,
+            jwt_payload, client_id: 'c', scope: 'patient/*.read',
+            done: (err, user, info) => {
+                expect(err).toBeNull();
+                expect(mockDelegatedAccessRulesManager.resolvePurposeOfEventCodesAsync).toHaveBeenCalledWith({
+                    entitlements: ['Consent/consent-uuid-123']
+                });
+                // The raw reference must never leak into purposeOfUse -- only the resolved code.
+                expect(info.context.purposeOfUse).toEqual(['TREAT']);
+                done();
+            }
+        });
+    });
+
+    test('DCON-5395: rejects (401-style) when a Consent/<id> entitlement cannot be resolved', (done) => {
+        const mockDelegatedAccessRulesManager = makeMockDelegatedAccessRulesManager();
+        // null signals "could not resolve" (Consent not found / lookup error) -- distinct from
+        // [] ("resolved successfully to no codes"). Only null must fail the request closed.
+        mockDelegatedAccessRulesManager.resolvePurposeOfEventCodesAsync.mockResolvedValue(null);
+        const authService = makeAuthService({ delegatedAccessRulesManager: mockDelegatedAccessRulesManager });
+
+        authService.configManager = new (class extends ConfigManager {
+            get enableDelegatedAccessDetection() { return true; }
+        });
+        const jwt_payload = {
+            ...basePayload(),
+            entitlements: ['Consent/does-not-exist'],
+            act: {
+                reference: 'RelatedPerson/8d5fcbff-3707-405c-b0b2-3053a3adc013',
+                sub: 'patient-1'
+            }
+        };
+
+        authService.processUserInfo({
+            username: 'u', subject: 's', isUser: true,
+            jwt_payload, client_id: 'c', scope: 'patient/*.read',
+            done: (err, user, info) => {
+                expect(err).toBeNull();
+                expect(user).toBe(false);
+                expect(info).toEqual({ reason: 'delegated_actor_consent_not_found' });
+                done();
+            }
+        });
+    });
 
     test('leaves purposeOfUse unset when claim is absent', (done) => {
         const authService = makeAuthService();

--- a/src/tests/unit/resourceAuthorization/04_callerAccountType.test.js
+++ b/src/tests/unit/resourceAuthorization/04_callerAccountType.test.js
@@ -40,6 +40,7 @@ jest.mock('../../../operations/common/logging', () => ({
 const { AuthService } = require('../../../strategies/authService');
 const { ConfigManager } = require('../../../utils/configManager');
 const { WellKnownConfigurationManager } = require('../../../utils/wellKnownConfiguration/wellKnownConfigurationManager');
+const { DelegatedAccessRulesManager } = require('../../../utils/delegatedAccessRulesManager');
 const { AUTH_USER_TYPES } = require('../../../constants');
 
 function createMockInstance (ClassType) {
@@ -84,9 +85,12 @@ describe('Resource Authorization §4 — Caller / account type', () => {
 
         mockWellKnownConfigurationManager = createMockInstance(WellKnownConfigurationManager);
 
+        const mockDelegatedAccessRulesManager = createMockInstance(DelegatedAccessRulesManager);
+
         authService = new AuthService({
             configManager: mockConfigManager,
-            wellKnownConfigurationManager: mockWellKnownConfigurationManager
+            wellKnownConfigurationManager: mockWellKnownConfigurationManager,
+            delegatedAccessRulesManager: mockDelegatedAccessRulesManager
         });
     });
 

--- a/src/tests/unit/resourceAuthorization/10_delegatedActorAccess.test.js
+++ b/src/tests/unit/resourceAuthorization/10_delegatedActorAccess.test.js
@@ -106,6 +106,7 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
         let authService;
         let mockConfigManager;
         let mockWellKnownConfigManager;
+        let mockDelegatedAccessRulesManagerForAuth;
 
         beforeEach(() => {
             AuthService.jwksCache = undefined;
@@ -167,9 +168,15 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
                 .fn()
                 .mockResolvedValue(null);
 
+            mockDelegatedAccessRulesManagerForAuth = createMockInstance(DelegatedAccessRulesManager);
+            mockDelegatedAccessRulesManagerForAuth.resolvePurposeOfEventCodesAsync = jest.fn().mockImplementation(
+                ({ entitlements }) => Promise.resolve(entitlements ?? null)
+            );
+
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManagerForAuth
             });
         });
 
@@ -233,6 +240,36 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
             );
         });
 
+        test('DCON-5395: a `Consent/<id>` entitlement is resolved via delegatedAccessRulesManager instead of passed through verbatim', async () => {
+            mockDelegatedAccessRulesManagerForAuth.resolvePurposeOfEventCodesAsync.mockResolvedValue(['TREAT']);
+
+            const done = jest.fn();
+            await authService.processUserInfo({
+                username: 'testuser',
+                subject: 'sub1',
+                isUser: true,
+                jwt_payload: {
+                    ...requiredJwtFields,
+                    act: { reference: 'RelatedPerson/rp-1', sub: 'delegate-sub' },
+                    entitlements: ['Consent/consent-uuid-1']
+                },
+                done,
+                client_id: 'client1',
+                scope: 'patient/Patient.read'
+            });
+
+            expect(mockDelegatedAccessRulesManagerForAuth.resolvePurposeOfEventCodesAsync).toHaveBeenCalledWith({
+                entitlements: ['Consent/consent-uuid-1']
+            });
+            expect(done).toHaveBeenCalledWith(
+                null,
+                expect.any(Object),
+                expect.objectContaining({
+                    context: expect.objectContaining({ purposeOfUse: ['TREAT'] })
+                })
+            );
+        });
+
         test('gated by configManager.enableDelegatedAccessDetection: `act` claim is ignored entirely when the flag is off', () => {
             Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', {
                 get: () => false,
@@ -242,7 +279,8 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
             AuthService.userInfoCache = undefined;
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManagerForAuth
             });
 
             const done = jest.fn();
@@ -286,6 +324,58 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
             });
             expect(result.failure).toBe(false);
             expect(result.actor).toEqual({ reference: 'RelatedPerson/rp-1', sub: 'delegate-sub' });
+        });
+
+        test('DCON-5395/RFC: processForDelegatedActor accepts an Organization act reference (client-initiated access)', () => {
+            const result = authService.processForDelegatedActor({
+                jwt_payload: {
+                    act: {
+                        reference: 'Organization/50d67a31-af1f-4f30-8d41-51e90a5054fa',
+                        sub: 'client-abc'
+                    }
+                }
+            });
+            expect(result.failure).toBe(false);
+            expect(result.actor).toEqual({
+                reference: 'Organization/50d67a31-af1f-4f30-8d41-51e90a5054fa',
+                sub: 'client-abc'
+            });
+        });
+
+        test('DCON-5395/RFC: an Organization `act` claim sets userType=delegatedUser and actor on the context, same as RelatedPerson', () => {
+            const done = jest.fn();
+            authService.processUserInfo({
+                username: 'testuser',
+                subject: 'sub1',
+                isUser: true,
+                jwt_payload: {
+                    ...requiredJwtFields,
+                    act: {
+                        reference: 'Organization/50d67a31-af1f-4f30-8d41-51e90a5054fa',
+                        sub: 'client-abc'
+                    }
+                    // No entitlements here -- resolving a Consent-reference entitlement is
+                    // covered separately above; this test is only about actor-type detection,
+                    // and must stay synchronous (no entitlements means no async branch at all).
+                },
+                done,
+                client_id: 'client1',
+                scope: 'patient/Patient.read'
+            });
+
+            expect(done).toHaveBeenCalledWith(
+                null,
+                expect.any(Object),
+                expect.objectContaining({
+                    context: expect.objectContaining({
+                        userType: AUTH_USER_TYPES.delegatedUser,
+                        actor: expect.objectContaining({
+                            reference: 'Organization/50d67a31-af1f-4f30-8d41-51e90a5054fa',
+                            sub: 'client-abc'
+                        })
+                    })
+                })
+            );
         });
     });
 
@@ -498,6 +588,24 @@ describe('Resource Authorization §10 — Delegated actor access', () => {
             });
 
             expect(result).toEqual({ _uuid: '__invalid__' });
+        });
+
+        test('DCON-5395/RFC: an Organization actor skips the per-person Consent lookup entirely and only excludes unclassified', async () => {
+            const result = await dataSharingManager.updateQueryForDelegatedAccessSensitiveData({
+                base_version: '4_0_0',
+                query: { resourceType: 'Observation' },
+                actor: { reference: 'Organization/50d67a31-af1f-4f30-8d41-51e90a5054fa' },
+                personIdFromJwtToken: 'person-1'
+            });
+
+            // No per-person Consent for this actor type by design -- BIG already verified
+            // Person ownership + an org-level Consent before minting. Must not hit the DB at all,
+            // and must not fall into the "no consent -> impossible query" safety net either.
+            expect(mockDatabaseQueryFactory.createQuery).not.toHaveBeenCalled();
+            expect(result).not.toEqual({ _uuid: '__invalid__' });
+
+            const excludedCode = result.$and[1]['meta.security'].$not.$elemMatch.code;
+            expect(excludedCode).toBe('unclassified');
         });
 
         test('MORE THAN ONE active Consent found -> throws ForbiddenError (ambiguous, fails closed)', async () => {

--- a/src/tests/unit/strategies/authFailureMode.test.js
+++ b/src/tests/unit/strategies/authFailureMode.test.js
@@ -48,6 +48,7 @@ jest.mock('../../../operations/common/logging', () => {
 const { AuthService } = require('../../../strategies/authService');
 const { ConfigManager } = require('../../../utils/configManager');
 const { WellKnownConfigurationManager } = require('../../../utils/wellKnownConfiguration/wellKnownConfigurationManager');
+const { DelegatedAccessRulesManager } = require('../../../utils/delegatedAccessRulesManager');
 const { authenticateWithJsonFailure } = require('../../../middleware/fhir/authentication.middleware');
 
 function createMockInstance(ClassType) {
@@ -76,9 +77,12 @@ function createAuthService() {
     mockWellKnownConfigManager.getJwksUrlsAsync = jest.fn().mockResolvedValue([]);
     mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync = jest.fn().mockResolvedValue(null);
 
+    const mockDelegatedAccessRulesManager = createMockInstance(DelegatedAccessRulesManager);
+
     return new AuthService({
         configManager: mockConfigManager,
-        wellKnownConfigurationManager: mockWellKnownConfigManager
+        wellKnownConfigurationManager: mockWellKnownConfigManager,
+        delegatedAccessRulesManager: mockDelegatedAccessRulesManager
     });
 }
 
@@ -277,7 +281,8 @@ describe('INC-322: Auth failure mode — transient errors must not produce 401',
 
             const svc = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: createMockInstance(DelegatedAccessRulesManager)
             });
 
             // Make the userinfo fetch fail with a transient error

--- a/src/tests/unit/strategies/authService.test.js
+++ b/src/tests/unit/strategies/authService.test.js
@@ -26,6 +26,7 @@ jest.mock('../../../operations/common/logging', () => {
 const { AuthService } = require('../../../strategies/authService');
 const { ConfigManager } = require('../../../utils/configManager');
 const { WellKnownConfigurationManager } = require('../../../utils/wellKnownConfiguration/wellKnownConfigurationManager');
+const { DelegatedAccessRulesManager } = require('../../../utils/delegatedAccessRulesManager');
 const { logError, logWarn, logInfo } = require('../../../operations/common/logging');
 const superagent = require('superagent');
 
@@ -38,6 +39,7 @@ describe('AuthService', () => {
     let authService;
     let mockConfigManager;
     let mockWellKnownConfigManager;
+    let mockDelegatedAccessRulesManager;
 
     beforeEach(() => {
         // Clear static caches
@@ -62,9 +64,17 @@ describe('AuthService', () => {
         mockWellKnownConfigManager.getJwksUrlsAsync = jest.fn().mockResolvedValue([]);
         mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync = jest.fn().mockResolvedValue(null);
 
+        // Default: pass entitlements through unchanged, matching legacy bare-code behavior.
+        // DCON-5395 tests below override this to exercise Consent-reference resolution.
+        mockDelegatedAccessRulesManager = createMockInstance(DelegatedAccessRulesManager);
+        mockDelegatedAccessRulesManager.resolvePurposeOfEventCodesAsync = jest.fn().mockImplementation(
+            ({ entitlements }) => Promise.resolve(entitlements ?? null)
+        );
+
         authService = new AuthService({
             configManager: mockConfigManager,
-            wellKnownConfigurationManager: mockWellKnownConfigManager
+            wellKnownConfigurationManager: mockWellKnownConfigManager,
+            delegatedAccessRulesManager: mockDelegatedAccessRulesManager
         });
     });
 
@@ -79,7 +89,8 @@ describe('AuthService', () => {
             AuthService.userInfoCache = undefined;
             const svc = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             expect(svc.requestTimeout).toBe(30000);
         });
@@ -96,7 +107,8 @@ describe('AuthService', () => {
         test('initializes caches only once (static)', () => {
             const authService2 = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             expect(AuthService.jwksCache).toBeDefined();
             expect(AuthService.userInfoCache).toBeDefined();
@@ -109,7 +121,8 @@ describe('AuthService', () => {
             AuthService.userInfoCache = undefined;
             const svc = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             expect(svc.cidCheckIssuer).toBe('http://myissuer.com');
             expect(svc.cidCheckClientIds).toEqual(['cid-1', 'cid-2']);
@@ -169,7 +182,8 @@ describe('AuthService', () => {
             });
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = await authService.getExternalJwksAsync();
             expect(result).toEqual([{ kid: 'key1' }]);
@@ -182,7 +196,8 @@ describe('AuthService', () => {
 
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = await authService.getExternalJwksAsync();
             expect(mockWellKnownConfigManager.getJwksUrlsAsync).toHaveBeenCalled();
@@ -196,7 +211,8 @@ describe('AuthService', () => {
 
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = await authService.getExternalJwksAsync();
             expect(result).toEqual([]);
@@ -208,7 +224,8 @@ describe('AuthService', () => {
             });
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = await authService.getExternalJwksAsync();
             // Both return {keys: [{kid: 'key1'}]} so we get two keys flattened
@@ -223,7 +240,8 @@ describe('AuthService', () => {
             superagent.timeout.mockRejectedValueOnce(new Error('network error'));
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             // getJwksByUrlAsync now rejects on infra failure rather than swallowing to
             // {keys: []}, so getExternalJwksAsync must propagate that failure too,
@@ -250,7 +268,8 @@ describe('AuthService', () => {
             superagent.timeout.mockRejectedValueOnce(new Error('ECONNREFUSED'));
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = await authService.getExternalJwksAsync();
             expect(result).toEqual([{ kid: 'key1' }]);
@@ -273,7 +292,8 @@ describe('AuthService', () => {
                 .mockRejectedValueOnce(new Error('ECONNREFUSED'));
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             // Only when EVERY configured provider fails (zero usable keys) should this
             // surface a transient/503 error.
@@ -304,7 +324,8 @@ describe('AuthService', () => {
 
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
 
             await expect(
@@ -318,7 +339,8 @@ describe('AuthService', () => {
             });
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = await authService.getExternalJwksAsync();
             expect(result).toEqual([{ kid: 'key1' }]);
@@ -386,7 +408,8 @@ describe('AuthService', () => {
             Object.defineProperty(mockConfigManager, 'authCustomScope', { get: () => ['scp'], configurable: true });
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = authService.getFieldsFromToken({ scp: 'user/*.read patient/Patient.read' });
             expect(result.scope).toContain('user/*.read');
@@ -397,7 +420,8 @@ describe('AuthService', () => {
             Object.defineProperty(mockConfigManager, 'authCustomUserName', { get: () => ['preferred_username'], configurable: true });
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = authService.getFieldsFromToken({ scope: 'user/*.read', preferred_username: 'custom-user' });
             expect(result.username).toBe('custom-user');
@@ -407,7 +431,8 @@ describe('AuthService', () => {
             Object.defineProperty(mockConfigManager, 'authCustomSubject', { get: () => ['sub'], configurable: true });
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = authService.getFieldsFromToken({ scope: 'user/*.read', sub: 'my-sub' });
             expect(result.subject).toBe('my-sub');
@@ -417,7 +442,8 @@ describe('AuthService', () => {
             Object.defineProperty(mockConfigManager, 'authCustomClientId', { get: () => ['cid'], configurable: true });
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = authService.getFieldsFromToken({ scope: 'user/*.read', cid: 'custom-cid' });
             expect(result.clientId).toBe('custom-cid');
@@ -427,7 +453,8 @@ describe('AuthService', () => {
             Object.defineProperty(mockConfigManager, 'authCustomGroup', { get: () => ['groups'], configurable: true });
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = authService.getFieldsFromToken({
                 scope: 'user/*.read',
@@ -441,7 +468,8 @@ describe('AuthService', () => {
             Object.defineProperty(mockConfigManager, 'authCustomGroup', { get: () => ['groups'], configurable: true });
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = authService.getFieldsFromToken({ groups: 'patient/Patient.read' });
             expect(result.scope).toBe('patient/Patient.read');
@@ -454,7 +482,8 @@ describe('AuthService', () => {
             });
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = authService.getFieldsFromToken({
                 scope: 'myapp:user/*.read myapp:patient/Patient.read'
@@ -469,7 +498,8 @@ describe('AuthService', () => {
             });
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = authService.getFieldsFromToken({ scope: 'user/*.read' });
             expect(result.scope).toBe('user/*.read');
@@ -487,7 +517,8 @@ describe('AuthService', () => {
             });
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
             const result = authService.getFieldsFromToken({ scope: 'short:user/*.read' });
             expect(result.scope).toBe('user/*.read');
@@ -695,7 +726,8 @@ describe('AuthService', () => {
             AuthService.userInfoCache = undefined;
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
 
             const done = jest.fn();
@@ -729,13 +761,139 @@ describe('AuthService', () => {
             );
         });
 
+        test('resolves a Consent/<id> entitlement to the Consent purpose codes (DCON-5395)', async () => {
+            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => true, configurable: true });
+            AuthService.jwksCache = undefined;
+            AuthService.userInfoCache = undefined;
+            mockDelegatedAccessRulesManager.resolvePurposeOfEventCodesAsync.mockResolvedValue(['TREAT']);
+            authService = new AuthService({
+                configManager: mockConfigManager,
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
+            });
+
+            const done = jest.fn();
+            await authService.processUserInfo({
+                username: 'testuser',
+                subject: 'sub1',
+                isUser: true,
+                jwt_payload: {
+                    clientFhirPersonId: 'person-1',
+                    clientFhirPatientId: 'patient-1',
+                    bwellFhirPersonId: 'bwell-person-1',
+                    bwellFhirPatientId: 'bwell-patient-1',
+                    sub: 'subject-1',
+                    act: { reference: 'RelatedPerson/rp-1', sub: 'delegate-sub' },
+                    entitlements: ['Consent/consent-uuid-123']
+                },
+                done,
+                client_id: 'client1',
+                scope: 'patient/Patient.read'
+            });
+
+            expect(mockDelegatedAccessRulesManager.resolvePurposeOfEventCodesAsync).toHaveBeenCalledWith({
+                entitlements: ['Consent/consent-uuid-123']
+            });
+            expect(done).toHaveBeenCalledWith(
+                null,
+                expect.any(Object),
+                expect.objectContaining({
+                    context: expect.objectContaining({
+                        purposeOfUse: ['TREAT'],
+                        actor: expect.objectContaining({
+                            entitlementsConsentPolicies: ['Consent/consent-uuid-123']
+                        })
+                    })
+                })
+            );
+        });
+
+        test('rejects auth (401-style) when a Consent/<id> entitlement cannot be resolved', async () => {
+            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => true, configurable: true });
+            AuthService.jwksCache = undefined;
+            AuthService.userInfoCache = undefined;
+            // null signals "could not resolve" -- distinct from [] ("resolved to no codes").
+            mockDelegatedAccessRulesManager.resolvePurposeOfEventCodesAsync.mockResolvedValue(null);
+            authService = new AuthService({
+                configManager: mockConfigManager,
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
+            });
+
+            const done = jest.fn();
+            await authService.processUserInfo({
+                username: 'testuser',
+                subject: 'sub1',
+                isUser: true,
+                jwt_payload: {
+                    clientFhirPersonId: 'person-1',
+                    clientFhirPatientId: 'patient-1',
+                    bwellFhirPersonId: 'bwell-person-1',
+                    bwellFhirPatientId: 'bwell-patient-1',
+                    sub: 'subject-1',
+                    act: { reference: 'RelatedPerson/rp-1', sub: 'delegate-sub' },
+                    entitlements: ['Consent/does-not-exist']
+                },
+                done,
+                client_id: 'client1',
+                scope: 'patient/Patient.read'
+            });
+
+            expect(done).toHaveBeenCalledWith(null, false, { reason: 'delegated_actor_consent_not_found' });
+        });
+
+        test('does not touch delegatedAccessRulesManager for a bare v3-ActReason entitlement, and stays synchronous', () => {
+            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => true, configurable: true });
+            AuthService.jwksCache = undefined;
+            AuthService.userInfoCache = undefined;
+            authService = new AuthService({
+                configManager: mockConfigManager,
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
+            });
+
+            const done = jest.fn();
+            // Deliberately not awaited: a bare-code entitlement must still call done() in the
+            // same tick, without ever touching delegatedAccessRulesManager. This is what lets
+            // every other synchronous test in this file keep passing unmodified now that
+            // processUserInfo is declared `async` -- the await introduced for DCON-5395 must
+            // only ever be reached on the Consent-reference branch above.
+            authService.processUserInfo({
+                username: 'testuser',
+                subject: 'sub1',
+                isUser: true,
+                jwt_payload: {
+                    clientFhirPersonId: 'person-1',
+                    clientFhirPatientId: 'patient-1',
+                    bwellFhirPersonId: 'bwell-person-1',
+                    bwellFhirPatientId: 'bwell-patient-1',
+                    sub: 'subject-1',
+                    act: { reference: 'RelatedPerson/rp-1', sub: 'delegate-sub' },
+                    entitlements: ['FAMRQT']
+                },
+                done,
+                client_id: 'client1',
+                scope: 'patient/Patient.read'
+            });
+
+            expect(mockDelegatedAccessRulesManager.resolvePurposeOfEventCodesAsync).not.toHaveBeenCalled();
+            expect(done).toHaveBeenCalledWith(
+                null,
+                expect.any(Object),
+                expect.objectContaining({
+                    context: expect.objectContaining({ purposeOfUse: ['FAMRQT'] })
+                })
+            );
+        });
+
         test('rejects when delegated actor processing fails', () => {
             Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => true, configurable: true });
             AuthService.jwksCache = undefined;
             AuthService.userInfoCache = undefined;
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
 
             const done = jest.fn();
@@ -796,7 +954,8 @@ describe('AuthService', () => {
             AuthService.userInfoCache = undefined;
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
 
             const done = jest.fn();
@@ -953,7 +1112,8 @@ describe('AuthService', () => {
             AuthService.userInfoCache = undefined;
             authService = new AuthService({
                 configManager: mockConfigManager,
-                wellKnownConfigurationManager: mockWellKnownConfigManager
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
             });
 
             const done = jest.fn();

--- a/src/tests/unit/strategies/authService.test.js
+++ b/src/tests/unit/strategies/authService.test.js
@@ -842,6 +842,46 @@ describe('AuthService', () => {
             expect(done).toHaveBeenCalledWith(null, false, { reason: 'delegated_actor_consent_not_found' });
         });
 
+        test('propagates (does not swallow into done()) when Consent resolution rejects with a transient error', async () => {
+            // A transient DB/lookup failure must reject processUserInfo's own promise rather
+            // than being treated as "consent not found" -- verify()'s existing .catch() chain
+            // (INC-322 convention) is what turns this into a 503, not a 401 via done(null,
+            // false, ...). If this resolved instead of rejecting, that chain would never fire.
+            Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => true, configurable: true });
+            AuthService.jwksCache = undefined;
+            AuthService.userInfoCache = undefined;
+            const transientError = new Error('mongo timeout');
+            transientError.isTransient = true;
+            transientError.statusCode = 503;
+            mockDelegatedAccessRulesManager.resolvePurposeOfEventCodesAsync.mockRejectedValue(transientError);
+            authService = new AuthService({
+                configManager: mockConfigManager,
+                wellKnownConfigurationManager: mockWellKnownConfigManager,
+                delegatedAccessRulesManager: mockDelegatedAccessRulesManager
+            });
+
+            const done = jest.fn();
+            await expect(authService.processUserInfo({
+                username: 'testuser',
+                subject: 'sub1',
+                isUser: true,
+                jwt_payload: {
+                    clientFhirPersonId: 'person-1',
+                    clientFhirPatientId: 'patient-1',
+                    bwellFhirPersonId: 'bwell-person-1',
+                    bwellFhirPatientId: 'bwell-patient-1',
+                    sub: 'subject-1',
+                    act: { reference: 'RelatedPerson/rp-1', sub: 'delegate-sub' },
+                    entitlements: ['Consent/consent-uuid-123']
+                },
+                done,
+                client_id: 'client1',
+                scope: 'patient/Patient.read'
+            })).rejects.toMatchObject({ isTransient: true, statusCode: 503 });
+
+            expect(done).not.toHaveBeenCalled();
+        });
+
         test('does not touch delegatedAccessRulesManager for a bare v3-ActReason entitlement, and stays synchronous', () => {
             Object.defineProperty(mockConfigManager, 'enableDelegatedAccessDetection', { get: () => true, configurable: true });
             AuthService.jwksCache = undefined;

--- a/src/tests/unit/strategies/jwtCacheThunderingHerd.test.js
+++ b/src/tests/unit/strategies/jwtCacheThunderingHerd.test.js
@@ -52,6 +52,7 @@ jest.mock('../../../operations/common/logging', () => {
 const { AuthService } = require('../../../strategies/authService');
 const { ConfigManager } = require('../../../utils/configManager');
 const { WellKnownConfigurationManager } = require('../../../utils/wellKnownConfiguration/wellKnownConfigurationManager');
+const { DelegatedAccessRulesManager } = require('../../../utils/delegatedAccessRulesManager');
 
 function createMockInstance(ClassType) {
     const instance = Object.create(ClassType.prototype);
@@ -89,9 +90,12 @@ describe('INC-311/315: JWKS Cache Thundering Herd', () => {
         mockWellKnownConfigManager.getJwksUrlsAsync = jest.fn().mockResolvedValue([]);
         mockWellKnownConfigManager.getWellKnownConfigurationForIssuerAsync = jest.fn().mockResolvedValue(null);
 
+        const mockDelegatedAccessRulesManager = createMockInstance(DelegatedAccessRulesManager);
+
         authService = new AuthService({
             configManager: mockConfigManager,
-            wellKnownConfigurationManager: mockWellKnownConfigManager
+            wellKnownConfigurationManager: mockWellKnownConfigManager,
+            delegatedAccessRulesManager: mockDelegatedAccessRulesManager
         });
     });
 

--- a/src/tests/unit/utils/auditLogger.test.js
+++ b/src/tests/unit/utils/auditLogger.test.js
@@ -114,6 +114,57 @@ describe('AuditLogger', () => {
             expect(agents[1].policy).toEqual(['http://example.com/consent']);
         });
 
+        test('DCON-5395: includes entitlementsConsentPolicies alongside consentPolicy for a delegated user', () => {
+            const requestInfo = {
+                isUser: true,
+                user: 'patient-1',
+                userType: 'delegatedUser',
+                alternateUserId: 'alt-1',
+                remoteIpAddress: '192.168.1.1',
+                actor: {
+                    reference: 'Organization/org-1',
+                    sub: 'client-abc',
+                    entitlementsConsentPolicies: ['Consent/8e4a1f26-3c9d-4b7e-9a02-6f1d5c8b2e90']
+                }
+            };
+            const agents = auditLogger.buildAgents(requestInfo);
+            expect(agents[1].policy).toEqual(['Consent/8e4a1f26-3c9d-4b7e-9a02-6f1d5c8b2e90']);
+        });
+
+        test('DCON-5395: merges consentPolicy and entitlementsConsentPolicies when both are present', () => {
+            const requestInfo = {
+                isUser: true,
+                user: 'patient-1',
+                userType: 'delegatedUser',
+                alternateUserId: 'alt-1',
+                remoteIpAddress: '192.168.1.1',
+                actor: {
+                    reference: 'RelatedPerson/rp-1',
+                    sub: 'sub-1',
+                    consentPolicy: 'Consent/per-person-consent',
+                    entitlementsConsentPolicies: ['Consent/org-level-consent']
+                }
+            };
+            const agents = auditLogger.buildAgents(requestInfo);
+            expect(agents[1].policy).toEqual(['Consent/per-person-consent', 'Consent/org-level-consent']);
+        });
+
+        test('does not set policy for a delegated user with neither consentPolicy nor entitlementsConsentPolicies', () => {
+            const requestInfo = {
+                isUser: true,
+                user: 'patient-1',
+                userType: 'delegatedUser',
+                alternateUserId: 'alt-1',
+                remoteIpAddress: '192.168.1.1',
+                actor: {
+                    reference: 'Organization/org-1',
+                    sub: 'client-abc'
+                }
+            };
+            const agents = auditLogger.buildAgents(requestInfo);
+            expect(agents[1].policy).toBeUndefined();
+        });
+
         test('should handle null requestInfo gracefully with optional chaining', () => {
             const requestInfo = {};
             const agents = auditLogger.buildAgents(requestInfo);

--- a/src/tests/unit/utils/delegatedAccessRulesManager.test.js
+++ b/src/tests/unit/utils/delegatedAccessRulesManager.test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const { describe, beforeEach, it, expect, jest } = require('@jest/globals');
+const { describe, beforeEach, afterEach, it, expect, jest } = require('@jest/globals');
 
-const { DelegatedAccessRulesManager } = require('../../../utils/delegatedAccessRulesManager');
-const { ConfigManager } = require('../../../utils/configManager');
-const { DatabaseQueryFactory } = require('../../../dataLayer/databaseQueryFactory');
-const { CustomTracer } = require('../../../utils/customTracer');
-
+// NOTE: this project's jest config applies no transform to source files, so babel-jest's
+// automatic hoisting of `jest.mock()` above requires does not happen here. Every `jest.mock()`
+// below MUST stay physically above the `require('../../../utils/delegatedAccessRulesManager')`
+// line (and any other require of a mocked module) -- otherwise the module under test captures
+// the real (unmocked) dependency in its own closure at require-time, silently.
 jest.mock('../../../utils/mongoQuerySimplifier', () => ({
     MongoQuerySimplifier: {
         simplifyFilter: jest.fn(({ filter }) => filter)
@@ -32,6 +32,18 @@ jest.mock('../../../utils/referenceParser', () => ({
 jest.mock('../../../utils/querybuilder.util', () => ({
     dateQueryBuilder: jest.fn().mockReturnValue({ $lte: '2026-01-01' })
 }));
+
+jest.mock('../../../operations/common/logging', () => ({
+    logWarn: jest.fn()
+}));
+
+const { DelegatedAccessRulesManager } = require('../../../utils/delegatedAccessRulesManager');
+const { ConfigManager } = require('../../../utils/configManager');
+const { DatabaseQueryFactory } = require('../../../dataLayer/databaseQueryFactory');
+const { CustomTracer } = require('../../../utils/customTracer');
+const { ReferenceParser } = require('../../../utils/referenceParser');
+const { generateUUIDv5 } = require('../../../utils/uid.util');
+const { logWarn } = require('../../../operations/common/logging');
 
 describe('DelegatedAccessRulesManager', () => {
     let manager;
@@ -425,6 +437,32 @@ describe('DelegatedAccessRulesManager', () => {
     });
 
     describe('hasValidConsentAsync', () => {
+        afterEach(() => {
+            ReferenceParser.parseReference.mockReturnValue({
+                id: 'actor-1',
+                resourceType: 'Practitioner',
+                sourceAssigningAuthority: undefined
+            });
+        });
+
+        it('DCON-5395/RFC: returns true for an Organization actor without querying the database or setting a bogus consentPolicy', async () => {
+            ReferenceParser.parseReference.mockReturnValueOnce({
+                id: 'org-1',
+                resourceType: 'Organization',
+                sourceAssigningAuthority: undefined
+            });
+            const actor = { reference: 'Organization/org-1' };
+
+            const result = await manager.hasValidConsentAsync({
+                actor,
+                personIdFromJwtToken: 'person-123'
+            });
+
+            expect(result).toBe(true);
+            expect(mockDatabaseQueryFactory.createQuery).not.toHaveBeenCalled();
+            expect(actor.consentPolicy).toBeUndefined();
+        });
+
         it('should return false when no consent found', async () => {
             const actor = { reference: 'Practitioner/actor-1' };
 
@@ -510,6 +548,272 @@ describe('DelegatedAccessRulesManager', () => {
             // EXPECTED: correct behavior (will fail until bug is fixed)
             // consentPolicy should NOT contain "version=undefined" - should omit version or handle gracefully
             expect(actor.consentPolicy).not.toContain('undefined');
+        });
+    });
+
+    describe('resolvePurposeOfEventCodesAsync (DCON-5395)', () => {
+        afterEach(() => {
+            ReferenceParser.parseReference.mockReset();
+            ReferenceParser.parseReference.mockReturnValue({
+                id: 'actor-1',
+                resourceType: 'Practitioner',
+                sourceAssigningAuthority: undefined
+            });
+        });
+
+        it('should return null when entitlements is null', async () => {
+            const result = await manager.resolvePurposeOfEventCodesAsync({ entitlements: null });
+            expect(result).toBeNull();
+        });
+
+        it('should return an empty array unchanged when entitlements is empty', async () => {
+            const result = await manager.resolvePurposeOfEventCodesAsync({ entitlements: [] });
+            expect(result).toEqual([]);
+        });
+
+        it('should pass legacy bare v3-ActReason codes through unchanged', async () => {
+            ReferenceParser.parseReference.mockImplementation((reference) => ({
+                id: reference,
+                resourceType: undefined,
+                sourceAssigningAuthority: undefined
+            }));
+
+            const result = await manager.resolvePurposeOfEventCodesAsync({
+                entitlements: ['FAMRQT', 'TREAT']
+            });
+
+            expect(result).toEqual(['FAMRQT', 'TREAT']);
+            expect(mockDatabaseQueryFactory.createQuery).not.toHaveBeenCalled();
+        });
+
+        it("should resolve a Consent/<id> reference to the Consent's provision.purpose codes", async () => {
+            const consentUuid = '123e4567-e89b-12d3-a456-426614174000';
+            ReferenceParser.parseReference.mockReturnValue({
+                id: consentUuid,
+                resourceType: 'Consent',
+                sourceAssigningAuthority: undefined
+            });
+
+            const mockCursor = {
+                maxTimeMS: jest.fn(),
+                toArrayAsync: jest.fn().mockResolvedValue([
+                    {
+                        provision: {
+                            purpose: [
+                                { system: 'http://terminology.hl7.org/CodeSystem/v3-ActReason', code: 'TREAT' }
+                            ]
+                        }
+                    }
+                ])
+            };
+            const mockDatabaseQueryManager = { findAsync: jest.fn().mockResolvedValue(mockCursor) };
+            mockDatabaseQueryFactory.createQuery.mockReturnValue(mockDatabaseQueryManager);
+
+            const result = await manager.resolvePurposeOfEventCodesAsync({
+                entitlements: [`Consent/${consentUuid}`]
+            });
+
+            expect(result).toEqual(['TREAT']);
+            expect(mockDatabaseQueryFactory.createQuery).toHaveBeenCalledWith({
+                resourceType: 'Consent',
+                base_version: '4_0_0'
+            });
+            expect(mockDatabaseQueryManager.findAsync).toHaveBeenCalledWith({
+                query: { _uuid: consentUuid }
+            });
+        });
+
+        it('should resolve multiple purpose codings from a single Consent', async () => {
+            const consentUuid = '123e4567-e89b-12d3-a456-426614174001';
+            ReferenceParser.parseReference.mockReturnValue({
+                id: consentUuid,
+                resourceType: 'Consent',
+                sourceAssigningAuthority: undefined
+            });
+
+            const mockCursor = {
+                maxTimeMS: jest.fn(),
+                toArrayAsync: jest.fn().mockResolvedValue([
+                    {
+                        provision: {
+                            purpose: [
+                                { system: 'http://terminology.hl7.org/CodeSystem/v3-ActReason', code: 'TREAT' },
+                                { system: 'http://terminology.hl7.org/CodeSystem/v3-ActReason', code: 'HPAYMT' }
+                            ]
+                        }
+                    }
+                ])
+            };
+            mockDatabaseQueryFactory.createQuery.mockReturnValue({
+                findAsync: jest.fn().mockResolvedValue(mockCursor)
+            });
+
+            const result = await manager.resolvePurposeOfEventCodesAsync({
+                entitlements: [`Consent/${consentUuid}`]
+            });
+
+            expect(result).toEqual(['TREAT', 'HPAYMT']);
+        });
+
+        it('should mix legacy bare codes and a resolved Consent reference in one entitlements array', async () => {
+            const consentUuid = '123e4567-e89b-12d3-a456-426614174002';
+            ReferenceParser.parseReference.mockImplementation((reference) => {
+                if (reference === `Consent/${consentUuid}`) {
+                    return { id: consentUuid, resourceType: 'Consent', sourceAssigningAuthority: undefined };
+                }
+                return { id: reference, resourceType: undefined, sourceAssigningAuthority: undefined };
+            });
+
+            const mockCursor = {
+                maxTimeMS: jest.fn(),
+                toArrayAsync: jest.fn().mockResolvedValue([
+                    { provision: { purpose: [{ code: 'TREAT' }] } }
+                ])
+            };
+            mockDatabaseQueryFactory.createQuery.mockReturnValue({
+                findAsync: jest.fn().mockResolvedValue(mockCursor)
+            });
+
+            const result = await manager.resolvePurposeOfEventCodesAsync({
+                entitlements: ['FAMRQT', `Consent/${consentUuid}`]
+            });
+
+            expect(result).toEqual(['FAMRQT', 'TREAT']);
+        });
+
+        it('should return null (and log a warning), not throw, when the referenced Consent cannot be found', async () => {
+            ReferenceParser.parseReference.mockReturnValue({
+                id: 'missing-consent-id',
+                resourceType: 'Consent',
+                sourceAssigningAuthority: undefined
+            });
+
+            const mockCursor = {
+                maxTimeMS: jest.fn(),
+                toArrayAsync: jest.fn().mockResolvedValue([])
+            };
+            mockDatabaseQueryFactory.createQuery.mockReturnValue({
+                findAsync: jest.fn().mockResolvedValue(mockCursor)
+            });
+
+            const result = await manager.resolvePurposeOfEventCodesAsync({
+                entitlements: ['Consent/missing-consent-id']
+            });
+
+            // null (not []) signals "could not resolve" to the caller, which now fails the
+            // request closed instead of silently proceeding with an empty purposeOfEvent.
+            expect(result).toBeNull();
+            expect(logWarn).toHaveBeenCalled();
+        });
+
+        it('should return null (and log a warning), not throw, when the Consent lookup errors', async () => {
+            ReferenceParser.parseReference.mockReturnValue({
+                id: 'consent-id',
+                resourceType: 'Consent',
+                sourceAssigningAuthority: undefined
+            });
+
+            mockDatabaseQueryFactory.createQuery.mockReturnValue({
+                findAsync: jest.fn().mockRejectedValue(new Error('mongo timeout'))
+            });
+
+            const result = await manager.resolvePurposeOfEventCodesAsync({
+                entitlements: ['Consent/consent-id']
+            });
+
+            expect(result).toBeNull();
+            expect(logWarn).toHaveBeenCalled();
+        });
+
+        it('should return null overall when a Consent-reference entitlement is unresolvable, even alongside other entitlements', async () => {
+            ReferenceParser.parseReference.mockImplementation((reference) => {
+                if (reference === 'Consent/missing-consent-id') {
+                    return { id: 'missing-consent-id', resourceType: 'Consent', sourceAssigningAuthority: undefined };
+                }
+                return { id: reference, resourceType: undefined, sourceAssigningAuthority: undefined };
+            });
+
+            mockDatabaseQueryFactory.createQuery.mockReturnValue({
+                findAsync: jest.fn().mockResolvedValue({
+                    maxTimeMS: jest.fn(),
+                    toArrayAsync: jest.fn().mockResolvedValue([])
+                })
+            });
+
+            const result = await manager.resolvePurposeOfEventCodesAsync({
+                entitlements: ['FAMRQT', 'Consent/missing-consent-id']
+            });
+
+            expect(result).toBeNull();
+        });
+
+        it('should query by a deterministic uuid when the reference carries a sourceAssigningAuthority', async () => {
+            ReferenceParser.parseReference.mockReturnValue({
+                id: 'raw-id-123',
+                resourceType: 'Consent',
+                sourceAssigningAuthority: 'authority-1'
+            });
+
+            const mockCursor = {
+                maxTimeMS: jest.fn(),
+                toArrayAsync: jest.fn().mockResolvedValue([{ provision: { purpose: [{ code: 'TREAT' }] } }])
+            };
+            const mockDatabaseQueryManager = { findAsync: jest.fn().mockResolvedValue(mockCursor) };
+            mockDatabaseQueryFactory.createQuery.mockReturnValue(mockDatabaseQueryManager);
+
+            await manager.resolvePurposeOfEventCodesAsync({
+                entitlements: ['Consent/raw-id-123|authority-1']
+            });
+
+            expect(mockDatabaseQueryManager.findAsync).toHaveBeenCalledWith({
+                query: { _uuid: generateUUIDv5('raw-id-123|authority-1') }
+            });
+        });
+
+        it('should query by bare id when there is no uuid and no sourceAssigningAuthority', async () => {
+            ReferenceParser.parseReference.mockReturnValue({
+                id: 'raw-id-456',
+                resourceType: 'Consent',
+                sourceAssigningAuthority: undefined
+            });
+
+            const mockCursor = {
+                maxTimeMS: jest.fn(),
+                toArrayAsync: jest.fn().mockResolvedValue([{ provision: { purpose: [{ code: 'TREAT' }] } }])
+            };
+            const mockDatabaseQueryManager = { findAsync: jest.fn().mockResolvedValue(mockCursor) };
+            mockDatabaseQueryFactory.createQuery.mockReturnValue(mockDatabaseQueryManager);
+
+            await manager.resolvePurposeOfEventCodesAsync({
+                entitlements: ['Consent/raw-id-456']
+            });
+
+            expect(mockDatabaseQueryManager.findAsync).toHaveBeenCalledWith({
+                query: { id: 'raw-id-456' }
+            });
+        });
+
+        it('should return an empty array when the Consent has no provision.purpose', async () => {
+            const consentUuid = '123e4567-e89b-12d3-a456-426614174003';
+            ReferenceParser.parseReference.mockReturnValue({
+                id: consentUuid,
+                resourceType: 'Consent',
+                sourceAssigningAuthority: undefined
+            });
+
+            const mockCursor = {
+                maxTimeMS: jest.fn(),
+                toArrayAsync: jest.fn().mockResolvedValue([{ provision: {} }])
+            };
+            mockDatabaseQueryFactory.createQuery.mockReturnValue({
+                findAsync: jest.fn().mockResolvedValue(mockCursor)
+            });
+
+            const result = await manager.resolvePurposeOfEventCodesAsync({
+                entitlements: [`Consent/${consentUuid}`]
+            });
+
+            expect(result).toEqual([]);
         });
     });
 });

--- a/src/tests/unit/utils/delegatedAccessRulesManager.test.js
+++ b/src/tests/unit/utils/delegatedAccessRulesManager.test.js
@@ -706,7 +706,11 @@ describe('DelegatedAccessRulesManager', () => {
             expect(logWarn).toHaveBeenCalled();
         });
 
-        it('should return null (and log a warning), not throw, when the Consent lookup errors', async () => {
+        it('should reject as a transient error (isTransient/503), not resolve to null, when the Consent lookup errors', async () => {
+            // A DB/lookup error is not proof the Consent doesn't exist -- it must surface as a
+            // retryable error (INC-322 convention), not the permanent 401 a genuine "not found"
+            // produces. See authService.verify()'s existing .catch() handling for this class of
+            // error (mirrors getUserInfoFromUserInfoEndpoint/JWKS failures).
             ReferenceParser.parseReference.mockReturnValue({
                 id: 'consent-id',
                 resourceType: 'Consent',
@@ -717,11 +721,57 @@ describe('DelegatedAccessRulesManager', () => {
                 findAsync: jest.fn().mockRejectedValue(new Error('mongo timeout'))
             });
 
+            await expect(
+                manager.resolvePurposeOfEventCodesAsync({ entitlements: ['Consent/consent-id'] })
+            ).rejects.toMatchObject({
+                message: 'mongo timeout',
+                isTransient: true,
+                statusCode: 503
+            });
+            expect(logWarn).toHaveBeenCalled();
+        });
+
+        it('should not overwrite an already-set statusCode on a transient lookup error', async () => {
+            ReferenceParser.parseReference.mockReturnValue({
+                id: 'consent-id',
+                resourceType: 'Consent',
+                sourceAssigningAuthority: undefined
+            });
+
+            const customError = new Error('rate limited');
+            customError.statusCode = 429;
+            mockDatabaseQueryFactory.createQuery.mockReturnValue({
+                findAsync: jest.fn().mockRejectedValue(customError)
+            });
+
+            await expect(
+                manager.resolvePurposeOfEventCodesAsync({ entitlements: ['Consent/consent-id'] })
+            ).rejects.toMatchObject({ isTransient: true, statusCode: 429 });
+        });
+
+        it('should return null (ambiguous) when a bare, authority-less id matches more than one Consent, without leaking either match', async () => {
+            ReferenceParser.parseReference.mockReturnValue({
+                id: 'shared-bare-id',
+                resourceType: 'Consent',
+                sourceAssigningAuthority: undefined
+            });
+
+            const mockCursor = {
+                maxTimeMS: jest.fn(),
+                toArrayAsync: jest.fn().mockResolvedValue([
+                    { provision: { purpose: [{ code: 'TREAT' }] } },
+                    { provision: { purpose: [{ code: 'HPAYMT' }] } }
+                ])
+            };
+            const mockDatabaseQueryManager = { findAsync: jest.fn().mockResolvedValue(mockCursor) };
+            mockDatabaseQueryFactory.createQuery.mockReturnValue(mockDatabaseQueryManager);
+
             const result = await manager.resolvePurposeOfEventCodesAsync({
-                entitlements: ['Consent/consent-id']
+                entitlements: ['Consent/shared-bare-id']
             });
 
             expect(result).toBeNull();
+            expect(mockDatabaseQueryManager.findAsync).toHaveBeenCalledWith({ query: { id: 'shared-bare-id' } });
             expect(logWarn).toHaveBeenCalled();
         });
 

--- a/src/utils/auditLogger.js
+++ b/src/utils/auditLogger.js
@@ -91,7 +91,11 @@ class AuditLogger {
             : undefined;
 
         if (requestInfo?.userType === AUTH_USER_TYPES.delegatedUser) {
-            const consentPolicy = requestInfo.actor?.consentPolicy;
+            // consentPolicy and entitlementsConsentPolicies come from independent flows; neither implies the other.
+            const policies = [
+                requestInfo.actor?.consentPolicy,
+                ...(requestInfo.actor?.entitlementsConsentPolicies || [])
+            ].filter(Boolean);
             return [
                 {
                     who: whoReference,
@@ -101,7 +105,7 @@ class AuditLogger {
                 },
                 {
                     who: { reference: requestInfo.actor?.reference },
-                    policy: consentPolicy ? [consentPolicy] : undefined,
+                    policy: policies.length ? policies : undefined,
                     altId: requestInfo.actor?.sub,
                     requestor: true,
                     network: {

--- a/src/utils/delegatedAccessRulesManager.js
+++ b/src/utils/delegatedAccessRulesManager.js
@@ -96,14 +96,8 @@ class DelegatedAccessRulesManager {
 
         const actorReference = actor.reference;
 
-        // RFC: Delegated Token Generation for Client-Initiated Access (DCON-5236/DCON-5395).
-        // An Organization-actor delegated token has no per-person Consent to fetch by design --
-        // BIG already verifies Person ownership and an org-level Consent before minting the
-        // token, and that org-level Consent has no `patient` field at all (it authorizes the
-        // Organization generally, not a specific person), so it can never satisfy this query's
-        // patient-match filter below. Skip the lookup entirely for this actor type rather than
-        // re-deriving a per-person consent that was never meant to exist -- fhir-server trusts
-        // BIG's mint-time verification here, the same way it trusts every other signed JWT claim.
+        // DCON-5395: an Organization actor's Consent is org-level (no `patient` field), so it
+        // can never match the query below. Skip the lookup and trust BIG's mint-time check.
         if (ReferenceParser.parseReference(actorReference).resourceType === 'Organization') {
             const filteringRules = {
                 consentId: null,
@@ -394,9 +388,7 @@ class DelegatedAccessRulesManager {
             return false;
         }
         const { consentId, consentVersion } = filteringRules;
-        // set the actor policy -- only when there's an actual per-person Consent to point at.
-        // An Organization actor's filteringRules carries no consentId (see getFilteringRulesAsync)
-        // since there is no per-person Consent for this flow by design.
+        // Only set when there's a real per-person Consent (Organization actors have none).
         if (consentId) {
             actor.consentPolicy = consentVersion
                 ? `Consent/${consentId}?version=${consentVersion}`
@@ -406,28 +398,13 @@ class DelegatedAccessRulesManager {
     }
 
     /**
-     * Resolves the codes to surface as `purposeOfEvent.coding.code` on the AuditEvent from a
-     * delegated actor's JWT `entitlements` claim.
+     * Resolves `purposeOfEvent.coding.code` from a JWT `entitlements` claim: a bare
+     * v3-ActReason code passes through unchanged; a `Consent/<id>` reference (DCON-5395) is
+     * dereferenced into the Consent's `provision.purpose` codes.
      *
-     * Two shapes are supported:
-     * - Legacy: bare v3-ActReason codes (e.g. "FAMRQT") -- returned unchanged.
-     * - DCON-5395: a `Consent/<id>` reference (minted by BIG's token-exchange flow for
-     *   client-initiated access, DCON-5236), pointing at the org-level Consent created during
-     *   client onboarding -- the Consent is dereferenced and its `provision.purpose` codes are
-     *   substituted, so the audit event never carries a raw resource reference where an
-     *   ActReason code belongs.
-     *
-     * Returns `null` if any `Consent/<id>` entitlement genuinely can't be resolved (not found,
-     * or ambiguous) -- distinct from an empty array, which means every entitlement resolved
-     * successfully but yielded no codes. The caller treats `null` as an authentication
-     * failure: entitlements naming a Consent that can't be found is treated the same as any
-     * other malformed/unverifiable claim, not silently downgraded to an empty `purposeOfEvent`
-     * on an otherwise-successful request.
-     *
-     * Rejects (does not resolve to `null`) if the Consent lookup itself fails transiently (DB
-     * timeout, network blip) -- see `resolveConsentPurposeCodesAsync`. Callers must let that
-     * rejection propagate rather than catching it into `null`, so it surfaces as a retryable
-     * error rather than a permanent auth failure.
+     * Returns `null` if a Consent reference can't be resolved (not found/ambiguous) -- callers
+     * treat that as an auth failure. Rejects instead of returning `null` on a transient lookup
+     * error (see resolveConsentPurposeCodesAsync); callers must let that propagate.
      *
      * @param {Object} params
      * @param {string[]|null} [params.entitlements]
@@ -462,18 +439,9 @@ class DelegatedAccessRulesManager {
     /**
      * Dereferences a `Consent/<id>` reference and returns its `provision.purpose` codes.
      *
-     * Returns `null` when the Consent genuinely can't be resolved -- deleted/wrong id, or
-     * ambiguous (more than one Consent shares a bare, authority-less id; see below) -- `[]` is
-     * reserved for "the Consent exists but has no `provision.purpose` codes," a distinct, more
-     * benign case. Callers that fail closed on an unresolvable reference check for `null`.
-     *
-     * A transient lookup failure (DB timeout, network blip) is NOT treated as "not found" --
-     * it's re-thrown with `isTransient`/`statusCode` set, mirroring this codebase's INC-322
-     * convention for `getUserInfoFromUserInfoEndpoint`/JWKS failures elsewhere in
-     * `authService.js`. `AuthService.processUserInfo` calls `verify()` runs this on every
-     * request for an Organization-actor JWT (no cross-request caching), so conflating a
-     * transient blip with "Consent doesn't exist" would turn a brief Mongo hiccup into a hard,
-     * permanent-looking 401 for every request from that client instead of a retryable 503.
+     * `null` = can't resolve (not found, or ambiguous bare-id match) -- distinct from `[]`
+     * (found, no purpose codes). Rethrows transient lookup errors (isTransient/503, INC-322
+     * convention) instead of conflating them with "not found".
      *
      * @param {Object} params
      * @param {string} params.consentReference
@@ -515,12 +483,8 @@ class DelegatedAccessRulesManager {
                 return null;
             }
 
-            // A bare, authority-less id (the `else { query = { id } }` branch above) is
-            // ambiguous across tenants by construction -- unlike the UUID/authority-qualified
-            // branches, which resolve to exactly one resource. Never substitute an arbitrary
-            // match's provision.purpose into this request's audit purposeOfEvent; fail closed
-            // the same way getFilteringRulesAsync already does for an ambiguous per-person
-            // Consent match, instead of picking whichever document Mongo returns first.
+            // Bare, authority-less id is ambiguous across tenants -- never substitute an
+            // arbitrary match's purpose codes; fail closed like getFilteringRulesAsync does.
             if (consents.length > 1) {
                 logWarn(`Consent referenced by entitlements is ambiguous (${consents.length} matches): ${consentReference}`, {
                     source: 'DelegatedAccessRulesManager.resolveConsentPurposeCodesAsync'

--- a/src/utils/delegatedAccessRulesManager.js
+++ b/src/utils/delegatedAccessRulesManager.js
@@ -17,6 +17,8 @@ const {
     CONSENT_CATEGORY
 } = require('../constants');
 const { dateQueryBuilder } = require('./querybuilder.util');
+const { isUuid, generateUUIDv5 } = require('./uid.util');
+const { logWarn } = require('../operations/common/logging');
 
 /**
  * @typedef DelegatedAccessFilteringRules
@@ -93,6 +95,34 @@ class DelegatedAccessRulesManager {
         }
 
         const actorReference = actor.reference;
+
+        // RFC: Delegated Token Generation for Client-Initiated Access (DCON-5236/DCON-5395).
+        // An Organization-actor delegated token has no per-person Consent to fetch by design --
+        // BIG already verifies Person ownership and an org-level Consent before minting the
+        // token, and that org-level Consent has no `patient` field at all (it authorizes the
+        // Organization generally, not a specific person), so it can never satisfy this query's
+        // patient-match filter below. Skip the lookup entirely for this actor type rather than
+        // re-deriving a per-person consent that was never meant to exist -- fhir-server trusts
+        // BIG's mint-time verification here, the same way it trusts every other signed JWT claim.
+        if (ReferenceParser.parseReference(actorReference).resourceType === 'Organization') {
+            const filteringRules = {
+                consentId: null,
+                consentVersion: null,
+                provisionPeriodStart: null,
+                provisionPeriodEnd: null
+            };
+            Object.defineProperty(filteringRules, 'deniedSensitiveCategories', {
+                value: [],
+                enumerable: false
+            });
+            actor._filteringRules = filteringRules;
+            return {
+                filteringRules,
+                actorConsentQueries: [],
+                actorConsentQueryOptions: []
+            };
+        }
+
         const filteringRulesObj = await this.customTracer.trace({
             name: 'DelegatedAccessRulesManager.getFilteringRulesAsync',
             func: async () => {
@@ -364,11 +394,126 @@ class DelegatedAccessRulesManager {
             return false;
         }
         const { consentId, consentVersion } = filteringRules;
-        // set the actor policy
-        actor.consentPolicy = consentVersion
-            ? `Consent/${consentId}?version=${consentVersion}`
-            : `Consent/${consentId}`;
+        // set the actor policy -- only when there's an actual per-person Consent to point at.
+        // An Organization actor's filteringRules carries no consentId (see getFilteringRulesAsync)
+        // since there is no per-person Consent for this flow by design.
+        if (consentId) {
+            actor.consentPolicy = consentVersion
+                ? `Consent/${consentId}?version=${consentVersion}`
+                : `Consent/${consentId}`;
+        }
         return true;
+    }
+
+    /**
+     * Resolves the codes to surface as `purposeOfEvent.coding.code` on the AuditEvent from a
+     * delegated actor's JWT `entitlements` claim.
+     *
+     * Two shapes are supported:
+     * - Legacy: bare v3-ActReason codes (e.g. "FAMRQT") -- returned unchanged.
+     * - DCON-5395: a `Consent/<id>` reference (minted by BIG's token-exchange flow for
+     *   client-initiated access, DCON-5236), pointing at the org-level Consent created during
+     *   client onboarding -- the Consent is dereferenced and its `provision.purpose` codes are
+     *   substituted, so the audit event never carries a raw resource reference where an
+     *   ActReason code belongs.
+     *
+     * Returns `null` if any `Consent/<id>` entitlement could not be resolved (the Consent
+     * doesn't exist, or the lookup errored) -- distinct from an empty array, which means every
+     * entitlement resolved successfully but yielded no codes. The caller treats `null` as an
+     * authentication failure: entitlements naming a Consent that can't be found is treated the
+     * same as any other malformed/unverifiable claim, not silently downgraded to an empty
+     * `purposeOfEvent` on an otherwise-successful request.
+     *
+     * @param {Object} params
+     * @param {string[]|null} [params.entitlements]
+     * @param {string} [params.base_version]
+     * @return {Promise<string[]|null>}
+     */
+    async resolvePurposeOfEventCodesAsync({ entitlements, base_version = '4_0_0' }) {
+        if (!Array.isArray(entitlements) || entitlements.length === 0) {
+            return entitlements ?? null;
+        }
+
+        const resolvedCodes = [];
+        for (const entitlement of entitlements) {
+            const { resourceType } = ReferenceParser.parseReference(entitlement);
+            if (resourceType === 'Consent') {
+                const purposeCodes = await this.resolveConsentPurposeCodesAsync({
+                    consentReference: entitlement,
+                    base_version
+                });
+                if (purposeCodes === null) {
+                    return null;
+                }
+                resolvedCodes.push(...purposeCodes);
+            } else {
+                // Legacy shape: a bare v3-ActReason code, passed through unchanged.
+                resolvedCodes.push(entitlement);
+            }
+        }
+        return resolvedCodes;
+    }
+
+    /**
+     * Dereferences a `Consent/<id>` reference and returns its `provision.purpose` codes.
+     *
+     * Returns `null` (not `[]`) when the Consent can't be resolved (deleted, wrong id, transient
+     * DB error) -- `[]` is reserved for "the Consent exists but has no `provision.purpose`
+     * codes," a distinct, more benign case. Callers that need to fail closed on an unresolvable
+     * reference check specifically for `null`.
+     *
+     * @param {Object} params
+     * @param {string} params.consentReference
+     * @param {string} params.base_version
+     * @return {Promise<string[]|null>}
+     */
+    async resolveConsentPurposeCodesAsync({ consentReference, base_version }) {
+        try {
+            const { id, sourceAssigningAuthority } = ReferenceParser.parseReference(consentReference);
+            if (!id) {
+                return null;
+            }
+
+            // Mirrors the by-reference lookup convention used elsewhere (e.g.
+            // resourceValidator.validateNewPersonLinkTargetsBelongToCallersTenant): a reference
+            // that names its target explicitly (UUID, or bare id + explicit authority) resolves
+            // to exactly one resource by construction.
+            let query;
+            if (isUuid(id)) {
+                query = { _uuid: id };
+            } else if (sourceAssigningAuthority) {
+                query = { _uuid: generateUUIDv5(`${id}|${sourceAssigningAuthority}`) };
+            } else {
+                query = { id };
+            }
+
+            const databaseQueryManager = this.databaseQueryFactory.createQuery({
+                resourceType: 'Consent',
+                base_version
+            });
+            const cursor = await databaseQueryManager.findAsync({ query });
+            cursor.maxTimeMS({ milliSecs: this.configManager.mongoTimeout });
+            const consents = await cursor.toArrayAsync();
+            const [consent] = consents;
+
+            if (!consent) {
+                logWarn(`Consent referenced by entitlements could not be resolved: ${consentReference}`, {
+                    source: 'DelegatedAccessRulesManager.resolveConsentPurposeCodesAsync'
+                });
+                return null;
+            }
+
+            const purposeCodings = consent.provision?.purpose;
+            return Array.isArray(purposeCodings)
+                ? purposeCodings.map(coding => coding?.code).filter(Boolean)
+                : [];
+        } catch (error) {
+            logWarn(`Error resolving Consent referenced by entitlements: ${consentReference}`, {
+                source: 'DelegatedAccessRulesManager.resolveConsentPurposeCodesAsync',
+                error
+            });
+            return null;
+        }
     }
 }
 

--- a/src/utils/delegatedAccessRulesManager.js
+++ b/src/utils/delegatedAccessRulesManager.js
@@ -417,12 +417,17 @@ class DelegatedAccessRulesManager {
      *   substituted, so the audit event never carries a raw resource reference where an
      *   ActReason code belongs.
      *
-     * Returns `null` if any `Consent/<id>` entitlement could not be resolved (the Consent
-     * doesn't exist, or the lookup errored) -- distinct from an empty array, which means every
-     * entitlement resolved successfully but yielded no codes. The caller treats `null` as an
-     * authentication failure: entitlements naming a Consent that can't be found is treated the
-     * same as any other malformed/unverifiable claim, not silently downgraded to an empty
-     * `purposeOfEvent` on an otherwise-successful request.
+     * Returns `null` if any `Consent/<id>` entitlement genuinely can't be resolved (not found,
+     * or ambiguous) -- distinct from an empty array, which means every entitlement resolved
+     * successfully but yielded no codes. The caller treats `null` as an authentication
+     * failure: entitlements naming a Consent that can't be found is treated the same as any
+     * other malformed/unverifiable claim, not silently downgraded to an empty `purposeOfEvent`
+     * on an otherwise-successful request.
+     *
+     * Rejects (does not resolve to `null`) if the Consent lookup itself fails transiently (DB
+     * timeout, network blip) -- see `resolveConsentPurposeCodesAsync`. Callers must let that
+     * rejection propagate rather than catching it into `null`, so it surfaces as a retryable
+     * error rather than a permanent auth failure.
      *
      * @param {Object} params
      * @param {string[]|null} [params.entitlements]
@@ -457,10 +462,18 @@ class DelegatedAccessRulesManager {
     /**
      * Dereferences a `Consent/<id>` reference and returns its `provision.purpose` codes.
      *
-     * Returns `null` (not `[]`) when the Consent can't be resolved (deleted, wrong id, transient
-     * DB error) -- `[]` is reserved for "the Consent exists but has no `provision.purpose`
-     * codes," a distinct, more benign case. Callers that need to fail closed on an unresolvable
-     * reference check specifically for `null`.
+     * Returns `null` when the Consent genuinely can't be resolved -- deleted/wrong id, or
+     * ambiguous (more than one Consent shares a bare, authority-less id; see below) -- `[]` is
+     * reserved for "the Consent exists but has no `provision.purpose` codes," a distinct, more
+     * benign case. Callers that fail closed on an unresolvable reference check for `null`.
+     *
+     * A transient lookup failure (DB timeout, network blip) is NOT treated as "not found" --
+     * it's re-thrown with `isTransient`/`statusCode` set, mirroring this codebase's INC-322
+     * convention for `getUserInfoFromUserInfoEndpoint`/JWKS failures elsewhere in
+     * `authService.js`. `AuthService.processUserInfo` calls `verify()` runs this on every
+     * request for an Organization-actor JWT (no cross-request caching), so conflating a
+     * transient blip with "Consent doesn't exist" would turn a brief Mongo hiccup into a hard,
+     * permanent-looking 401 for every request from that client instead of a retryable 503.
      *
      * @param {Object} params
      * @param {string} params.consentReference
@@ -494,15 +507,28 @@ class DelegatedAccessRulesManager {
             const cursor = await databaseQueryManager.findAsync({ query });
             cursor.maxTimeMS({ milliSecs: this.configManager.mongoTimeout });
             const consents = await cursor.toArrayAsync();
-            const [consent] = consents;
 
-            if (!consent) {
+            if (consents.length === 0) {
                 logWarn(`Consent referenced by entitlements could not be resolved: ${consentReference}`, {
                     source: 'DelegatedAccessRulesManager.resolveConsentPurposeCodesAsync'
                 });
                 return null;
             }
 
+            // A bare, authority-less id (the `else { query = { id } }` branch above) is
+            // ambiguous across tenants by construction -- unlike the UUID/authority-qualified
+            // branches, which resolve to exactly one resource. Never substitute an arbitrary
+            // match's provision.purpose into this request's audit purposeOfEvent; fail closed
+            // the same way getFilteringRulesAsync already does for an ambiguous per-person
+            // Consent match, instead of picking whichever document Mongo returns first.
+            if (consents.length > 1) {
+                logWarn(`Consent referenced by entitlements is ambiguous (${consents.length} matches): ${consentReference}`, {
+                    source: 'DelegatedAccessRulesManager.resolveConsentPurposeCodesAsync'
+                });
+                return null;
+            }
+
+            const [consent] = consents;
             const purposeCodings = consent.provision?.purpose;
             return Array.isArray(purposeCodings)
                 ? purposeCodings.map(coding => coding?.code).filter(Boolean)
@@ -512,7 +538,11 @@ class DelegatedAccessRulesManager {
                 source: 'DelegatedAccessRulesManager.resolveConsentPurposeCodesAsync',
                 error
             });
-            return null;
+            error.isTransient = true;
+            if (!error.statusCode) {
+                error.statusCode = 503;
+            }
+            throw error;
         }
     }
 }


### PR DESCRIPTION
…erence entitlements

BIG's token-exchange grant for client-initiated access (DCON-5236, per the RFC) mints delegated tokens with an act.reference of Organization/<id> (instead of RelatedPerson/<id>) and an entitlements claim carrying a Consent/<id> reference (instead of a bare v3-ActReason code). This updates fhir-server's delegated-actor flow to support both:

- authService.processForDelegatedActor now accepts Organization as a valid act.reference type, gated via the new DELEGATED_ACCESS.ALLOWED_ACTOR_RESOURCE_TYPES allow-list.
- authService.processUserInfo resolves a Consent/<id> entitlement into the referenced Consent's provision.purpose codes (via DelegatedAccessRulesManager) before it's ever stored as purposeOfUse, so purposeOfEvent on the AuditEvent never carries a raw resource reference. Bare-code entitlements are unaffected and stay fully synchronous. An unresolvable Consent/<id> now fails authentication closed (401) rather than silently producing an empty purposeOfEvent.
- DelegatedAccessRulesManager.getFilteringRulesAsync skips the per-person Consent lookup entirely for an Organization actor -- that flow's authorizing Consent is an org-level grant with no patient field, which could never satisfy that query; fhir-server trusts BIG's mint-time verification for this actor type instead.
- The resolved Consent reference is also surfaced on the delegated actor's agent.policy (alongside the existing per-person consentPolicy, when both are present).
- Local Keycloak realm config and docker-compose gain a delegated-org-client test user minting this new token shape, for local end-to-end testing.

readme/delegatedActorAccess.md documents both actor shapes and both entitlements shapes.