### PR TITLE
DCON-5478 Bump js-yaml to 4.3.2 to fix AIKIDO-2026-641142

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
   "resolutions": {
     "uuid": "^14.0.0",
     "yargs": "^18.1.0",
-    "@hono/node-server": "^2.0.5"
+    "@hono/node-server": "^2.0.5",
+    "js-yaml@^4.1.0": "^4.3.2"
   },
   "dependencies": {
     "@apollo/server": "5.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8253,14 +8253,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0":
-  version: 4.3.1
-  resolution: "js-yaml@npm:4.3.1"
+"js-yaml@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
+  checksum: 10c0/dedd34c2e8fef1d504687f1bc94ed0ee1311a1f78770fa2800352c6d59c635ccf555009d74e9afe529ae62199da2b1ccef30e53dc84dcd8d2d8187c22574bc97
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Aikido's container scan flagged `js-yaml@4.3.1` (high severity, finding `AIKIDO-2026-641142`) as an app-level transitive dependency, pulled in via `@kubernetes/client-node` and `cosmiconfig`.
- `js-yaml` is not a direct dependency, so the fix is a version-scoped Yarn `resolutions` entry (`"js-yaml@^4.1.0": "^4.3.2"`) rather than a `package.json` dependency bump.
- Scoped intentionally to the `^4.1.0` descriptor range so the separate `js-yaml@3.15.2` line (pulled in by `graphql-schema-linter`'s `cosmiconfig@5.2.1`, which expects the removed v3 API like `safeLoad`) is left untouched.
- Diffed the `4.3.1` → `4.3.2` npm tarballs directly: the only functional change is in `lib/loader.js`, tightening the existing `maxTotalMergeKeys` DoS guard (counts empty-mapping merges toward the budget, caps merge sequences at 100 entries). Patch-level, no breaking API changes.

## Test plan
- [x] `k8sClient` unit tests (the actual production runtime consumer via `@kubernetes/client-node`): 28/28 pass
- [x] `graphql-schema-linter` smoke run confirms the untouched 3.x `js-yaml` line still resolves and runs without error
- [x] Full unit suite: 506/506 suites, 8808/8808 tests pass, 0 failures

Jira: [DCON-5478](https://icanbwell.atlassian.net/browse/DCON-5478)

[DCON-5478]: https://icanbwell.atlassian.net/browse/DCON-5478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ