### PR TITLE
DCON-5479 Bump undici to 8.10.2 to fix AIKIDO-2026-54683

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
   "resolutions": {
     "uuid": "^14.0.0",
     "yargs": "^18.1.0",
-    "@hono/node-server": "^2.0.5"
+    "@hono/node-server": "^2.0.5",
+    "undici@^8.4.1": "^8.10.2"
   },
   "dependencies": {
     "@apollo/server": "5.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11023,10 +11023,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^8.4.1, undici@npm:^8.9.0":
-  version: 8.10.0
-  resolution: "undici@npm:8.10.0"
-  checksum: 10c0/37ae2b1db8f65c3a003504e2040e96887b99f9db16ba07dcf49c37ed8b7f8c72f4452f2d46f52f7c9e49518fe8325e3b5e7e02ac3a2424886bd67d4b62a0ecab
+"undici@npm:^8.10.2, undici@npm:^8.9.0":
+  version: 8.10.2
+  resolution: "undici@npm:8.10.2"
+  checksum: 10c0/66d7fc69149207cab570d6abbc9e965b6afe1ae889a7d46945b431165c973d6a56f3dd8b70a856e7ae1e550b6366a1cde6f06e68640587f0dadca38de72995ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Aikido's container scan flagged `undici@8.10.0` (medium severity, finding `AIKIDO-2026-54683`) as an app-level transitive dependency.
- `undici` is not a direct dependency. `npm ls undici` confirms it's only pulled in by `node-gyp` (`^8.4.1`) and `testcontainers`/`@testcontainers/clickhouse` (`^8.9.0`) - both dev/build-time only, no production runtime consumer.
- Fix is a single version-scoped Yarn `resolutions` entry: `"undici@^8.4.1": "^8.10.2"`. Verified empirically that `testcontainers`' own `^8.9.0` range is already satisfied by `8.10.2`, so Yarn dedupes both requesters onto the same resolved copy - no second scoped entry needed.
- `8.10.2` isn't just a version bump: it fixes 9 disclosed vulnerabilities in the `8.10.x` line, including a high-severity cache cross-origin-poisoning regression introduced in `8.10.0` itself.
- Other `undici` version buckets in the tree (`^7.x` wanted by `oauth4webapi`/`openid-client`/`@mswjs/interceptors`, `6.24.0` wanted by `@opentelemetry/instrumentation-undici`) are untouched by this scoped resolution.

## Test plan
- [x] Full unit suite: 506/506 suites, 8808/8808 tests pass, 0 failures
- [x] Confirmed installed version is `8.10.2` post-install
- [x] Confirmed unrelated `undici` version buckets (7.x, 6.24.0) remain unaffected

Jira: [DCON-5479](https://icanbwell.atlassian.net/browse/DCON-5479)

[DCON-5479]: https://icanbwell.atlassian.net/browse/DCON-5479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ