### PR TITLE
DCON-5480 Bump hono to 4.13.7 to fix AIKIDO-2026-989111

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "graphql-fields": "^2.0.3",
     "graphql-parse-resolve-info": "^4.14.1",
     "helmet": "^8.2.0",
-    "hono": "^4.13.5",
+    "hono": "^4.13.7",
     "jwks-rsa": "^4.0.1",
     "kafkajs": "^2.2.4",
     "lru-cache": "^11.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5386,7 +5386,7 @@ __metadata:
     graphql-parse-resolve-info: "npm:^4.14.1"
     graphql-schema-linter: "npm:^3.0.1"
     helmet: "npm:^8.2.0"
-    hono: "npm:^4.13.5"
+    hono: "npm:^4.13.7"
     jest: "npm:^30.4.2"
     jest-diff: "npm:^30.4.1"
     jest-extended: "npm:^7.0.0"
@@ -7333,10 +7333,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.13.5":
-  version: 4.13.5
-  resolution: "hono@npm:4.13.5"
-  checksum: 10c0/c4ec94e9d6fdefbdfc011b3f06a201ed134c38c8db77fb65ef7282ef445526ce188ce3f80a2f2638ad30d93bb2a03e43bb34ed254a82b8e82011e5d7e0dc02ba
+"hono@npm:^4.13.7":
+  version: 4.13.7
+  resolution: "hono@npm:4.13.7"
+  checksum: 10c0/29672a94a4f2be7f3f4d959ad69808dd3bbc220909ca4f9660997022ff45d48ae71e42a460e417d808809d68110196f19359aaab2b14ae6a750331d789601b5a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Aikido's container scan flagged `hono@4.13.5` (medium severity, finding `AIKIDO-2026-989111`). Hono was already bumped to `4.13.5` under DCON-5398; this is a newer CVE disclosed against that same version, requiring a further bump to `4.13.7`.
- `hono` is a direct dependency here (unlike DCON-5478/5479), consumed in production by the MCP endpoint (`src/routeHandlers/mcpServer.js`, via `@modelcontextprotocol/node`/`@modelcontextprotocol/server`, which use `hono` as their HTTP layer).
- Diffed the `4.13.5` -> `4.13.7` tarballs: the disclosed fix is `GHSA-hxh3-vqpv-xpqv`, an XSS in `hono/jsx`'s `Suspense`/`ErrorBoundary`/`Context.Provider` (unescaped string rendering). This app's MCP handler is pure JSON-RPC over Express + Node's raw handler, no JSX/HTML rendering anywhere in that path, so the vulnerability isn't reachable here - but the bump is still the correct, low-risk fix per the ticket.
- No dependency/engine changes in `hono`'s own `package.json` between the two versions.

## Test plan
- [x] MCP endpoint integration test (the actual `hono` consumer): 14/14 pass
- [x] Full unit suite: 506/506 suites, 8808/8808 tests pass, 0 failures
- [x] Confirmed installed version is `4.13.7` post-install

Jira: [DCON-5480](https://icanbwell.atlassian.net/browse/DCON-5480)
Related: DCON-5398 (PR #2559)

[DCON-5480]: https://icanbwell.atlassian.net/browse/DCON-5480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ