### PR TITLE
DCON-5481 Bump axios to 1.20.0 to fix AIKIDO-2026-872099

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "async": "^3.2.6",
     "async-mutex": "^0.5.0",
     "aws-msk-iam-sasl-signer-js": "^1.0.3",
-    "axios": "^1.16.1",
+    "axios": "^1.20.0",
     "bytes": "^3.1.2",
     "cloudevents": "^10.0.0",
     "compression": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4933,15 +4933,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.16.1":
-  version: 1.19.0
-  resolution: "axios@npm:1.19.0"
+"axios@npm:^1.20.0":
+  version: 1.20.0
+  resolution: "axios@npm:1.20.0"
   dependencies:
     follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.6"
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/559fe7d51291787def61566a3db78b87510c8faf9c8a8c006d9d8b933808628ff0d8eca7756b40ae25e07da96d946c68c1ffba3da9075ed0b5d3661801d76869
+  checksum: 10c0/976088acf532286356f4c2e65df1ef47ba7da3936d83e928d0d64357bbf5370456abd3eb5826c15df322335fcb1fe200d4a84b4fcf20ffccdd63b40d80fa495c
   languageName: node
   linkType: hard
 
@@ -5361,7 +5361,7 @@ __metadata:
     async: "npm:^3.2.6"
     async-mutex: "npm:^0.5.0"
     aws-msk-iam-sasl-signer-js: "npm:^1.0.3"
-    axios: "npm:^1.16.1"
+    axios: "npm:^1.20.0"
     bytes: "npm:^3.1.2"
     cloudevents: "npm:^10.0.0"
     compression: "npm:^1.8.1"


### PR DESCRIPTION
## Summary
- Aikido's container scan flagged `axios@1.19.0` (low severity, finding `AIKIDO-2026-872099`).
- Verified via GitHub's real advisory-search API (not summarized web content) that no publicly indexed CVE currently covers this exact bump - consistent with Aikido's own low-severity rating.
- Pulled the actual GitHub Release notes and linked PR (axios/axios#11141) directly via the API. The security fix hardens runtime option handling against shared/foreign-prototype pollution, and the PR explicitly documents "intentional compatibility changes": interceptor-replacement snapshotting, custom `fetch` adapter argument changes, `maxRedirects: 0` behavior on the Fetch adapter, HTTP/2 + explicit proxy now rejecting instead of silently no-op, and data-URI validation tightening.
- Checked all of the above against actual usage: `axios` has zero `require()` calls anywhere in this repo (production or test, repo-wide grep). The only source reference (`src/oauth/redirect.js` / `callback.html`) loads `axios` from a CDN (`cdnjs.cloudflare.com/.../axios/0.21.1/`) in a static browser page, entirely unrelated to this npm package. None of the documented compatibility changes are reachable.

## Test plan
- [x] Full unit suite: 506/506 suites, 8808/8808 tests pass, 0 failures
- [x] Confirmed installed version is `1.20.0` post-install
- [x] Repo-wide grep confirms no code path exercises the changed behavior

Jira: [DCON-5481](https://icanbwell.atlassian.net/browse/DCON-5481)

[DCON-5481]: https://icanbwell.atlassian.net/browse/DCON-5481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ