### PR TITLE
DCON-000 Bump @icanbwell/fhirpatientsummary to 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@graphql-tools/load-files": "^7.0.1",
     "@graphql-tools/merge": "^9.1.9",
     "@icanbwell/fhir-to-csv": "^1.0.16",
-    "@icanbwell/fhirpatientsummary": "^2.0.2",
+    "@icanbwell/fhirpatientsummary": "^2.0.4",
     "@json2csv/node": "^7.0.6",
     "@json2csv/transforms": "^7.0.6",
     "@kubernetes/client-node": "1.4.0",


### PR DESCRIPTION
## Summary

Bumps `@icanbwell/fhirpatientsummary` from `^2.0.2` to `^2.0.4`.

**Draft — blocked, do not merge yet.** `yarn.lock` is intentionally not updated in this PR, so CI will fail until the blocker below clears.

## Why this is blocked

`.yarnrc.yml` sets `npmMinimalAgeGate: 2d` — a Yarn 4 supply-chain control that refuses any package version published less than 2 days ago. Both target versions are still inside that window:

| Version | Published | Gate clears |
|---|---|---|
| 2.0.2 (current) | 2026-09-07 07:04 UTC | installable |
| 2.0.3 | 2026-09-10 18:08 UTC | 2026-09-12 18:08 UTC |
| 2.0.4 | 2026-09-11 10:22 UTC | **2026-09-13 10:22 UTC** |

`yarn install` currently fails with:

```
YN0016: @icanbwell/fhirpatientsummary@npm:^2.0.4: All versions satisfying "^2.0.4" are quarantined
```

This is the gate working as intended, not a registry or publish problem — 2.0.4 is live on npm with a signed provenance statement.

## To finish this PR (on/after 2026-09-13 10:22 UTC)

1. `nvm use && corepack enable && yarn install` — regenerates `yarn.lock`
2. Commit the lockfile
3. Confirm CI green, mark ready for review

## Scope note: no runtime change from 2.0.4

2.0.4 delivers **nothing at runtime** to this service. Its entire contents are devDependency `resolutions` overrides inside fhir-patient-summary's own build tooling (icanbwell/fhir-patient-summary#102–#109). The published tarball's runtime dependencies are identical across all three versions:

```
html-minifier-terser ^7.2.0, luxon ^3.7.2, turndown ^7.2.2, turndown-plugin-gfm ^1.0.2
```

So this bump closes **zero advisories** for `fhir-server`.

The only behavioural delta comes from **2.0.3**, which removed the `WEARABLES` section and reworked `DEVICE_METRICS` aggregate stats (icanbwell/fhir-patient-summary#94). This service imports only `ComprehensiveIPSCompositionBuilder` and `TBundle` (`src/operations/summary/summary.js:8`) and has zero references to either section, so nothing breaks at the API level — but `$summary` **output will change** for consumers. That's the part worth an intentional review rather than treating this as a routine patch bump.

## Also affected

`icanbwell/bwell-fhir-server` pins the same `^2.0.2` and would need the same treatment if this is meant to be fleet-wide.

## Housekeeping

Title uses the `DCON-000` placeholder (precedent: #2542) — please retitle with a real ticket before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)